### PR TITLE
BF explicit type declaration and initialization for longest_track_len[AB] -- for cython 0.15 compatibility

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -489,7 +489,7 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
     # preprocess tracks
     cdef:
         size_t longest_track_len = 0, track_len
-        longest_track_lenA, longest_track_lenB
+        size_t longest_track_lenA = 0, longest_track_lenB = 0
         cnp.ndarray[object, ndim=1] tracksA32
         cnp.ndarray[object, ndim=1] tracksB32
         cnp.ndarray[cnp.double_t, ndim=2] DM


### PR DESCRIPTION
BF explicit type declaration and initialization for longest_track_len[AB]

Otherwise with cython 0.15 it would result in tests failure:
# 
## ERROR: dipy.tracking.tests.test_distances.test_bundles_distances_mam

Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/nose/case.py", line 187, in runTest
    self.test(*self.arg)
  File "/home/yoh/proj/nipy/nipy-suite/install/lib/python2.6/site-packages/dipy/tracking/tests/test_distances.py", line 117, in test_bundles_distances_mam
    DM2 = pf.bundles_distances_mam(tracksA, tracksB, metric=metric)
  File "distances.pyx", line 505, in dipy.tracking.distances.bundles_distances_mam (dipy/tracking/distances.c:5700)
UnboundLocalError: local variable longest_track_lenA referenced before assignment
