### PR TITLE
BF(?): cart2sphere and sphere2cart are now invertible.

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -126,6 +126,13 @@ def cart2sphere(x, y, z):
     r = np.sqrt(x*x + y*y + z*z)
     theta = np.arccos(z/r)
     phi = np.arctan2(y, x)
+    # If there are values of phi outside this interval, move them back to the
+    # interval [0,2pi]: 
+    idx = np.where(phi < 0)
+    phi[idx] = 2 * np.pi + phi[idx]
+    idx = np.where(phi > 2 * np.pi)
+    phi[idx] = phi[idx] - (2 * np.pi)
+
     return r, theta, phi
 
 

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -38,7 +38,17 @@ def test_sphere_cart():
     r, theta, phi = cart2sphere(*pt)
     xyz = sphere2cart(r, theta, phi)
     yield assert_array_almost_equal(xyz, pt)
-    
+
+@parametric
+def test_invert_transform():
+    n = 100
+    theta = np.random.rand(n) * np.pi   # Limited to 0,pi 
+    phi = np.random.rand(n) * 2 * np.pi  # Limited to 0,2pi
+    x, y, z = sphere2cart(1, theta, phi)  # Let's assume they're all unit vectors
+    r, new_theta, new_phi = cart2sphere(x, y, z)  # Transform back
+
+    yield assert_array_almost_equal(theta, new_theta)
+    yield assert_array_almost_equal(phi, new_phi)
 
 @parametric    
 def test_nearest_pos_semi_def():


### PR DESCRIPTION
I am not sure about this one. Are these transformations supposed to be invertible? Have I introduced some other problems somewhere else? 

I should say, I am having trouble testing this on my machine. I am getting the following error: 
# 
## ERROR: test (dipy.core.tests.test_geometry.test_sphere_cart)

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/7.1/lib/python2.7/site-packages/nose/case.py", line 133, in run
    self.runTest(result)
  File "/Library/Frameworks/Python.framework/Versions/7.1/lib/python2.7/site-packages/nose/case.py", line 151, in runTest
    test(result)
  File "/Library/Frameworks/Python.framework/Versions/7.1/lib/python2.7/unittest/case.py", line 391, in **call**
    return self.run(_args, *_kwds)
  File "/Users/arokem/source/dipy/dipy/testing/_paramtestpy2.py", line 76, in run
    return self.run_parametric(result, testMethod)
  File "/Users/arokem/source/dipy/dipy/testing/_paramtestpy2.py", line 56, in run_parametric
    result.addError(self, self._exc_info())
AttributeError: 'test_sphere_cart' object has no attribute '_exc_info'

---

Other than that, the tests pass with this commit included. 
