### PR TITLE
DOC: add comments and example to commit codes

### DIFF
--- a/doc/devel/commit_codes.rst
+++ b/doc/devel/commit_codes.rst
@@ -15,4 +15,17 @@ categories:
   * *BK* : breaks something and/or tests fail
   * *PL* : making pylint happier
   * *DOC*: for all kinds of documentation related commits
-  * *TEST*: for adding or changing tests
+  * *TEST* : for adding or changing tests
+  * *STYLE* : PEP8 conformance, whitespace changes etc that do not affect
+    function.
+
+So your commit message might look something like this::
+
+    TEST: relax test threshold slightly
+
+    Attempted fix for failure on windows test run when arrays are in fact
+    very close (within 6 dp).
+
+Keeping up a habit of doing this is useful because it makes it much easier to
+see at a glance which changes are likely to be important when you are looking
+for sources of bugs, fixes, large refactorings or new features.


### PR DESCRIPTION
The example specifies that the code should be followed by a colon
instead of (I think) the current policy of a ' - '.
