### PR TITLE
RF - Removed reduce_antipodal from sphere.

### DIFF
--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -1,5 +1,5 @@
 __all__ = ['Sphere', 'HemiSphere', 'faces_from_sphere_vertices', 'unique_edges',
-           'unique_faces', 'reduce_antipodal']
+           'unique_faces']
 
 import numpy as np
 import warnings
@@ -83,10 +83,6 @@ def unique_sets(sets):
     sets = [tuple(s) for s in sets]
     return np.array(sets)
 
-
-def reduce_antipodal(points, faces, tol=1e-5):
-    hs = HemiSphere(xyz=points, faces=faces, tol=tol)
-    return hs.vertices, hs.edges, hs.faces
 
 class Sphere(object):
     """Points on the unit sphere.

--- a/dipy/reconst/tests/test_dsi.py
+++ b/dipy/reconst/tests/test_dsi.py
@@ -8,7 +8,7 @@ from dipy.reconst.dsi import DiffusionSpectrumModel
 from dipy.sims.voxel import SticksAndBall
 from scipy.fftpack import fftn, fftshift
 from scipy.ndimage import map_coordinates
-from dipy.core.sphere import reduce_antipodal, unique_edges
+from dipy.core.sphere import unique_edges
 from dipy.utils.spheremakers import sphere_vf_from
 
 
@@ -82,7 +82,6 @@ def test_dsi():
     #load odf sphere
     vertices,faces = sphere_vf_from('symmetric724')
     edges = unique_edges(faces)
-    half_vertices,half_edges,half_faces=reduce_antipodal(vertices,faces)
 
     #load bvals and gradients
     btable=np.loadtxt(get_data('dsi515btable'))    

--- a/dipy/reconst/tests/test_eit.py
+++ b/dipy/reconst/tests/test_eit.py
@@ -6,7 +6,7 @@ from dipy.reconst.eit import DiffusionNablaModel, EquatorialInversionModel
 from dipy.sims.voxel import SticksAndBall
 from dipy.utils.spheremakers import sphere_vf_from
 from dipy.data import get_data
-from dipy.core.sphere import reduce_antipodal, unique_edges
+from dipy.core.sphere import unique_edges
 
 def sim_data(bvals,bvecs,d=0.0015,S0=100,snr=None):
 
@@ -90,7 +90,6 @@ def test_dni_eit():
     #load odf sphere
     vertices,faces = sphere_vf_from('symmetric724')
     edges = unique_edges(faces)
-    half_vertices,half_edges,half_faces=reduce_antipodal(vertices,faces)
     #create the sphere
     odf_sphere=(vertices,faces)
     dn=DiffusionNablaModel(bvals,bvecs,odf_sphere)

--- a/dipy/reconst/tests/test_gqi.py
+++ b/dipy/reconst/tests/test_gqi.py
@@ -10,7 +10,7 @@ from ...data import get_data, get_sphere
 
 from dipy.sims.voxel import SticksAndBall
 from dipy.reconst.gqi import GeneralizedQSamplingModel
-from dipy.core.sphere import reduce_antipodal, unique_edges
+from dipy.core.sphere import unique_edges
 from dipy.utils.spheremakers import sphere_vf_from
 
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
@@ -22,7 +22,6 @@ def test_gqi():
     #load odf sphere
     vertices,faces = sphere_vf_from('symmetric724')
     edges = unique_edges(faces)
-    half_vertices,half_edges,half_faces=reduce_antipodal(vertices,faces)
 
     #load bvals and gradients
     btable=np.loadtxt(get_data('dsi515btable'))    


### PR DESCRIPTION
reduce_antipodal is obsolete and broken so it was causing some tests to fail. Reduce antipodal was added recently during the re-factor so there shouldn't be anyone depending on it. Also reduce antipodal is not being used anywhere in the code or in the tests anymore so I think it is safe to remove. Some tests are still failing, but that is independent of reduce_antipodal. Now that the failure associated with reduce_antipodal is gone, we can address the later failure in those tests.
