### PR TITLE
BF - Brought back _filter peaks and associated test.

### DIFF
--- a/dipy/reconst/tests/test_peak_finding.py
+++ b/dipy/reconst/tests/test_peak_finding.py
@@ -66,7 +66,7 @@ def test_peak_finding():
     assert_equal(len(peaks), 2)
     assert_equal(len(peaks2), 2)
 
-def test_filter_peaks():
+def test_remove_similar_peaks():
     vertices = np.array([[1., 0., 0.],
                          [0., 1., 0.],
                          [0., 0., 1.],
@@ -86,6 +86,66 @@ def test_filter_peaks():
     uv, mapping = remove_similar_vertices(vertices, 60)
     assert_array_equal(uv, vertices[:3])
     assert_array_equal(mapping, range(3) + [0, 1, 0, 0])
+
+
+def test_filter_peaks():
+    # The setup
+    peak_values = np.array([1, .9, .8, .7, .6, .2, .1])
+    peak_points = np.array([[1., 0., 0.],
+                            [0., 0., 1.],
+                            [0., .9, .1],
+                            [0., 0., 1.],
+                            [0., 1., 0.],
+                            [0., 0., 1.],
+                            [.9, .1, 0.],
+                            [0., 0., 1.],
+                            [0., 0., 1.],
+                            [0., 0., 1.],
+                            [1., 1., 0.],
+                            [0., 0., 1.],
+                            [0., 1., 1.]])
+    norms = np.sqrt((peak_points*peak_points).sum(-1))
+    peak_points = peak_points/norms[:, None]
+
+    # Filter above peaks down to thre peaks
+    copy_peak_values = peak_values.copy()
+    ind = np.arange(0, len(peak_points), 2, dtype='int')
+    copy_ind = ind.copy()
+    print ind
+    sep_mat = abs(np.dot(peak_points, peak_points.T))
+    fvalues, find = _filter_peaks(peak_values, ind, sep_mat, .5, .9)
+    assert_array_equal(find, [0,2,8])
+    assert_array_equal(fvalues, [1., .9, .6])
+    # Check that the arguments have not been modified by _filter_peaks
+    assert_array_equal(ind, copy_ind)
+    assert_array_equal(peak_values, copy_peak_values)
+    # Test on a larger set of peaks
+    v, faces=get_sphere('symmetric724')
+    sep_mat = np.dot(v, v.T)
+    values = np.arange(len(v), 0., -1.)
+    ind = np.arange(len(values), dtype='int')
+    # Filter nothing if thresholds are 0. and 1.
+    fvalues, find = _filter_peaks(values, ind, sep_mat, 0., 1.)
+    assert_array_equal(find, ind)
+    assert_array_equal(fvalues, values)
+    # Return only the largest peak.
+    fvalues, find = _filter_peaks(values, ind, sep_mat, 0., -1.1)
+    assert_array_equal(find, [0])
+    assert_array_equal(fvalues, [len(values)])
+    fvalues, find = _filter_peaks(values, ind, sep_mat, 1., 0.)
+    assert_array_equal(find, [0])
+    assert_array_equal(fvalues, [len(values)])
+
+    fvalues, find = _filter_peaks(values, ind, sep_mat, .5, 1.)
+    assert_array_equal(fvalues, values[values >= .5*values[0]])
+    assert_array_equal(find, ind[values >= .5*values[0]])
+    values = values[1:].copy()
+    ind = ind[1:].copy()
+    sep_mat = sep_mat[1:, 1:].copy()
+    fvalues, find = _filter_peaks(values, ind, sep_mat, .5, 1.)
+    assert_array_equal(fvalues, values[values >= .5*values[0]])
+    assert_array_equal(find, ind[values >= .5*values[0]])
+
 
 if __name__ == '__main__':
     test_peak_finding()

--- a/dipy/tracking/gui_tools.py
+++ b/dipy/tracking/gui_tools.py
@@ -10,12 +10,11 @@ from .interfaces import InputData
 
 from ..tracking.interfaces import InputData, ShmTrackingInterface
 
-if have_traits:
-    I = InputData()
-    iview = I.trait_view()
-    iview.resizable = True
-    iview.width = 600
-    I.trait_view('traits_view', iview)
+I = InputData()
+iview = I.trait_view()
+iview.resizable = True
+iview.width = 600
+I.trait_view('traits_view', iview)
 
 main_view = View(Group(Group(
                              Item( 'dwi_images' ),


### PR DESCRIPTION
I pretty much brought back _filter_peaks the way it was. _filter_peaks and remove_similar_vertices are similar, but they are different enough that it was easier to have two functions than to try and shoehorn one function that did both things.

I also did some minor re-factor on remove_similar_vertices and fixed another failing test in gui_tools.
