### PR TITLE
TST: Following change to API in dipy.segment.quickbundles.

### DIFF
--- a/dipy/segment/tests/test_qb.py
+++ b/dipy/segment/tests/test_qb.py
@@ -14,4 +14,4 @@ def test_qbundles():
     Tqb=qb.virtuals()    
     #Tqbe,Tqbei=qb.exemplars(T)
     Tqbe,Tqbei=qb.exemplars()    
-    assert_equal(4,qb.total_clusters())
+    assert_equal(4,qb.total_clusters)


### PR DESCRIPTION
This recent commit/line:

https://github.com/nipy/dipy/commit/0095d4393244f6b500ceebd1c410437f489f5964#L0R87

Is a change in the API of QuickBundles, to make total_clusters a property, instead of a class method. This apparently slipped in together with the change to the large graphics file in the documentation. At any rate, it caused this test to fail and the current PR fixes this test failure.
