### PR TITLE
RF/BF - removed duplicate vector_norm/L2norm

### DIFF
--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -4,7 +4,7 @@ __all__ = ['Sphere', 'HemiSphere', 'faces_from_sphere_vertices', 'unique_edges',
 import numpy as np
 import warnings
 
-from dipy.core.geometry import cart2sphere, sphere2cart
+from dipy.core.geometry import cart2sphere, sphere2cart, L2norm
 from dipy.core.onetime import auto_attr
 from dipy.reconst.recspeed import remove_similar_vertices
 
@@ -22,12 +22,6 @@ def _some_specified(*args):
             return True
     return False
 
-def L2norm(x, axis=-1):
-    """The L2 norm of x along `axis`"""
-    x_norm = np.sqrt((x * x).sum(axis))
-    shape = list(x.shape)
-    shape[axis] = 1
-    return x_norm.reshape(shape)
 
 def faces_from_sphere_vertices(vertices):
     """
@@ -241,7 +235,7 @@ class Sphere(object):
         for i in xrange(n):
             edges, mapping = unique_edges(faces, return_mapping=True)
             new_vertices = vertices[edges].sum(1)
-            new_vertices /= L2norm(new_vertices)
+            new_vertices /= L2norm(new_vertices, keepdims=True)
             mapping += len(vertices)
             vertices = np.vstack([vertices, new_vertices])
 
@@ -526,7 +520,7 @@ icosahedron_vertices = np.array(
      [  0,  t, -1], # 10
      [  0, -t, -1], # 11
     ])
-icosahedron_vertices /= L2norm(icosahedron_vertices)
+icosahedron_vertices /= L2norm(icosahedron_vertices, keepdims=True)
 icosahedron_faces = np.array(
     [[ 8,  4,  0],
      [ 2,  5,  0],

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -10,8 +10,11 @@ from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 cart_distance,
                                 vector_cosine,
                                 lambert_equal_area_projection_polar,
-                                circumradius
+                                circumradius,
+                                L2norm
                                 )
+
+
 
 from nose.tools import assert_true, assert_false, \
      assert_equal, assert_raises
@@ -19,6 +22,19 @@ from nose.tools import assert_true, assert_false, \
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from dipy.testing import parametric, sphere_points
+
+
+def test_L2norm():
+    A = np.array([[1, 0, 0],
+                  [3, 4, 0],
+                  [0, 5, 12],
+                  [1, 2, 3]])
+    expected = np.array([1, 5, 13, np.sqrt(14)])
+    assert_array_almost_equal(L2norm(A), expected)
+    expected.shape = (4, 1)
+    assert_array_almost_equal(L2norm(A, keepdims=True), expected)
+    assert_array_almost_equal(L2norm(A.T, axis=0, keepdims=True), expected.T)
+
 
 def test_sphere_cart():
     # test arrays of points

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -3,11 +3,11 @@ import numpy.testing as nt
 import warnings
 
 from dipy.core.sphere import (Sphere, HemiSphere, unique_edges, unique_sets,
-                              faces_from_sphere_vertices, HemiSphere, L2norm,
-                              disperse_charges, _get_forces, unit_octahedron,
-                              unit_icosahedron)
+                              faces_from_sphere_vertices, HemiSphere,
+                              disperse_charges, _get_forces,
+                              unit_octahedron, unit_icosahedron)
 from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.geometry import cart2sphere, sphere2cart
+from dipy.core.geometry import cart2sphere, sphere2cart, L2norm
 
 verts = unit_octahedron.vertices
 edges = unit_octahedron.edges
@@ -31,17 +31,6 @@ def test_edges_faces():
                   [1, 2],
                   [2, 0]],
            faces=[0, 1, 2])
-
-
-def test_L2norm():
-    A = np.array([[1, 0, 0],
-                  [3, 4, 0],
-                  [0, 5, 12],
-                  [1, 2, 3]])
-    expected = np.array([1, 5, 13, np.sqrt(14)])
-    expected.shape = (4, 1)
-    nt.assert_array_almost_equal(L2norm(A), expected)
-    nt.assert_array_almost_equal(L2norm(A.T, axis=0), expected.T)
 
 
 def test_sphere_not_unit():
@@ -245,7 +234,7 @@ def test_hemisphere_faces():
          [  0,  t,  1],
          [  0, -t,  1],
         ])
-    vertices /= L2norm(vertices)
+    vertices /= L2norm(vertices, keepdims=True)
     faces = np.array(
         [[0, 1, 2],
          [0, 1, 3],

--- a/scratch/very_scratch/make_eleftherios_tests.py
+++ b/scratch/very_scratch/make_eleftherios_tests.py
@@ -8,7 +8,7 @@ import dicom
 
 import nibabel.dicom.dicomreaders as didr
 
-from dipy.io.vectors import vector_norm
+from dipy.io.vectors import L2norm
 
 data_dir = os.path.expanduser(
     "~/data/20100114_195840/Series_012_CBU_DTI_64D_1A")
@@ -39,7 +39,7 @@ for (i,d) in enumerate(datae):
 
 #    data.append(d_data)
 #    q = didr.get_q_vector(data_file)
-#    b = vector_norm(q)
+#    b = L2norm(q)
 #    g = q / b
 #    gs.append(g)
 #    bs.append(b)


### PR DESCRIPTION
We had 3 implementations of this function (two with the same name in the same module, reduced it down to one). I like L2norm beter than vector_norm, but if you guys want, I can name it vector_norm.
