### PR TITLE
NF - wrapper function for multi voxel models

### DIFF
--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,0 +1,98 @@
+"""Tools to easily make multi voxel models"""
+import numpy as np
+from numpy.lib.stride_tricks import as_strided
+from numpy import ndindex
+
+
+def multi_voxel_model(SingleVoxelModel):
+    """Class decorator to turn a single voxel model into a multi voxel model
+
+    See Also
+    --------
+    dipy/docs/examples/multiVoxelModel.py
+
+    """
+    class MultiVoxelModel(SingleVoxelModel):
+        """A subclass of SingleVoxelModel that fits many voxels"""
+
+        def fit(self, data, mask=None):
+            """Fit model for every voxel in data"""
+            # If only one voxel just return a normal fit
+            if data.ndim == 1:
+                return SingleVoxelModel.fit(self, data)
+
+            # Make a mask if mask is None
+            if mask is None:
+                shape = data.shape[:-1]
+                strides = (0,) * len(shape)
+                mask = as_strided(np.array(True), shape=shape, strides=strides)
+            # Check the shape of the mask if mask is not None
+            elif mask.shape != data.shape[:-1]:
+                raise ValueError("mask and data shape do not match")
+
+            # Fit data where mask is True
+            fit_array = np.empty(data.shape[:-1], dtype=object)
+            for ijk in ndindex(*data.shape[:-1]):
+                if mask[ijk]:
+                    fit_array[ijk] = SingleVoxelModel.fit(self, data[ijk])
+            return MultiVoxelFit(self, fit_array, mask)
+
+    return MultiVoxelModel
+
+
+class MultiVoxelFit(object):
+    """Holds an array of fits and allows access to their attributes and
+    methods"""
+    def __init__(self, model, fit_array, mask):
+        self.model = model
+        self.fit_array = fit_array
+        self.mask = mask
+
+    @property
+    def shape(self):
+        return self.fit_array.shape
+
+    def __getattribute__(self, attr):
+        try:
+            return object.__getattribute__(self, attr)
+        except AttributeError:
+            result = CallableArray(self.fit_array.shape, dtype=object)
+            for ijk in ndindex(*result.shape):
+                if self.mask[ijk]:
+                    result[ijk] = getattr(self.fit_array[ijk], attr)
+            return _squash(result, self.mask)
+
+    # I leave this in hesitantly, I'm not sure this will be be easy to support
+    # for all models
+    def __getitem__(self, index):
+        item = self.fit_array[index]
+        if isinstance(item, np.ndarray):
+            return MultiVoxelFit(self.model, item, self.mask[index])
+        else:
+            return item
+
+
+class CallableArray(np.ndarray):
+    """An array which can be called like a function"""
+    def __call__(self, *args, **kwargs):
+        result = np.empty(self.shape, dtype=object)
+        for ijk in ndindex(*self.shape):
+            item = self[ijk]
+            if item is not None:
+                result[ijk] = item(*args, **kwargs)
+        return _squash(result)
+
+
+def _squash(arr, mask=None):
+    """Makes a prettier array"""
+    if mask is None:
+        mask = arr != np.array(None)
+    not_none = arr[mask]
+    not_none = not_none.tolist()
+    tmp = np.array(not_none)
+    if tmp.dtype == object:
+        return arr
+    shape = arr.shape + tmp.shape[1:]
+    result = np.zeros(shape, tmp.dtype)
+    result[mask] = tmp
+    return result

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -1,0 +1,100 @@
+import numpy as np
+import numpy.testing as npt
+from dipy.reconst.multi_voxel import _squash, multi_voxel_model, CallableArray
+from dipy.reconst.shm import QballOdfModel
+from dipy.core.sphere import unit_icosahedron
+
+
+def test_squash():
+    A = np.ones((3, 3), dtype=float)
+    B = np.asarray(A, object)
+    npt.assert_array_equal(A, _squash(B))
+
+    B[2, 2] = None
+    A[2, 2] = 0
+    npt.assert_array_equal(A, _squash(B))
+
+    for ijk in np.ndindex(*B.shape):
+        B[ijk] = np.ones((2,))
+    A = np.ones((3, 3, 2))
+    npt.assert_array_equal(A, _squash(B))
+
+    B[2, 2] = None
+    A[2, 2] = 0
+    npt.assert_array_equal(A, _squash(B))
+
+
+def test_CallableArray():
+    callarray = CallableArray((2, 3), dtype=object)
+
+    # Test without Nones
+    callarray[:] = range
+    expected = np.empty([2, 3, 4])
+    expected[:] = range(4)
+    npt.assert_array_equal(callarray(4), expected)
+
+    # Test with Nones
+    callarray[0, 0] = None
+    expected[0, 0] = 0
+    npt.assert_array_equal(callarray(4), expected)
+
+
+def test_multi_voxel_model():
+
+    class SillyModel(object):
+
+        def fit(self, data, mask=None):
+            return SillyFit(model)
+
+    class SillyFit(object):
+
+        def __init__(self, model):
+            self.model = model
+
+        model_attr = 2.
+
+        def odf(self, sphere):
+            return np.ones(len(sphere.phi))
+
+        @property
+        def directions(self):
+            n = np.random.randint(0, 10)
+            return np.zeros((n, 3))
+
+    # Wrap the SillyModel
+    MultiVoxelSillyModel = multi_voxel_model(SillyModel)
+
+    # Test the single voxel case
+    model = MultiVoxelSillyModel()
+    single_voxel = np.zeros(64)
+    fit = model.fit(single_voxel)
+    npt.assert_equal(type(fit), SillyFit)
+
+    # Test without a mask
+    many_voxels = np.zeros((2, 3, 4, 64))
+    fit = model.fit(many_voxels)
+    expected = np.empty((2, 3, 4))
+    expected[:] = 2.
+    npt.assert_array_equal(fit.model_attr, expected)
+    expected = np.ones((2, 3, 4, 12))
+    npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
+    npt.assert_equal(fit.directions.shape, (2, 3, 4))
+
+    # Test with a mask
+    mask = np.eye(3).astype('bool')
+    data = np.zeros((3, 3, 64))
+    fit = model.fit(data, mask)
+    npt.assert_array_equal(fit.model_attr, np.eye(3)*2)
+    odf = fit.odf(unit_icosahedron)
+    npt.assert_equal(odf.shape, (3, 3, 12))
+    npt.assert_array_equal(odf[~mask], 0)
+    npt.assert_array_equal(odf[mask], 1)
+
+    # Test fit.shape
+    npt.assert_equal(fit.shape, (3, 3))
+
+    # Test indexing into a fit
+    npt.assert_equal(type(fit[0, 0]), SillyFit)
+    npt.assert_equal(fit[:2, :2].shape, (2, 2))
+
+

--- a/doc/examples/multiVoxelModel.py
+++ b/doc/examples/multiVoxelModel.py
@@ -1,0 +1,85 @@
+"""The `multi_voxel_model` is a class decorator to help easily write multi voxel
+models. A developer simply needs to write a description of the single voxel
+case and wrap it using `multi_voxel_model` like bellow."""
+
+import numpy as np
+from dipy.core.sphere import unit_icosahedron
+from dipy.reconst.multi_vox import multi_voxel_model
+
+"""First the developer should write out the single voxel as bellow and either
+wrap or decorate the Model Class"""
+
+class SingleVoxelModel(object):
+    def fit(self, data, mask=None):
+        n = np.max(data)
+        return SingleVoxelFit(self, n)
+
+class SingleVoxelFit(object):
+    model_attr = 1.0
+    def __init__(self, model, n):
+        self.model = model
+        self.n = n
+
+    def odf(self, sphere):
+        return np.ones(len(sphere.phi))
+
+    @property
+    def directions(self):
+        return np.zeros((self.n, 3))
+
+MultiVoxelModel = multi_voxel_model(SingleVoxelModel)
+
+@multi_voxel_model
+class DecoratedModel(SingleVoxelModel):
+    """Now to show how all this works
+
+    To show how the single voxel case works
+    ---------------------------------------
+    >>> model = SingleVoxelModel()
+    >>> fit = model.fit(4)
+    >>> fit.model_attr
+    1.0
+    >>> fit.directions.shape
+    (4, 3)
+    >>> fit.odf(unit_icosahedron).shape
+    (12,)
+
+
+    Now we use the MultiVoxelModel
+    ------------------------------
+    >>> model = MultiVoxelModel()
+    >>> data = np.arange(1, 6).reshape((2, 3, 1))
+    >>> fit = model.fit(data)
+    >>> fit.model_attr.shape
+    (2, 3)
+    >>> np.all(fit.model_attr == 1.)
+    True
+    >>> fit.directions.shape
+    (2, 3)
+    >>> fit.directions[0, 0].shape
+    (1, 3)
+    >>> fit.odf(unit_icosahedron).shape
+    (2, 3, 12)
+
+
+    Of course using using `multi_voxel_model` as a decorator or as a wrapper
+    function is exactly the same
+    -------------------------------------------------------------------------
+    >>> model = DecoratedModel()
+    >>> data = np.arange(1, 6).reshape((2, 3, 1))
+    >>> fit = model.fit(data)
+    >>> fit.model_attr.shape
+    (2, 3)
+    >>> np.all(fit.model_attr == 1.)
+    True
+    >>> fit.directions.shape
+    (2, 3)
+    >>> fit.directions[0, 0].shape
+    (1, 3)
+    >>> fit.odf(unit_icosahedron).shape
+    (2, 3, 12)
+
+
+    """
+    pass
+


### PR DESCRIPTION
Hi All,
I've been giving this multi voxel fit a lot of thought and here is what I've come up with. I would like to make the model API look like this: `fit = model.fit(data, mask)` where data can be an ndarray and mask is `None` by default. This api will allow developers to use any fitting scheme (global or local) for the model. In order to help developers code models that don't need to handle the multi-voxel case explicitly. I've written this decorator that should allow any single voxel model to easily be wrapped into a multi voxel model.

I'd like a little feedback on the implementation. I think it's a little more complex than it needs to be. I could simplify it quite a bit if we built into the API that all models should support something like `fit = model.fit(data=None, mask=False)`. This would simplify the multi-voxel wrapper because it would be able to delegate the handling of the mask values (ie True/False) to the model, but it would add a special case for the model that every developer would need to be aware of (It's a pretty trival case, I imagine we would just return a fit where the fit parameters were all set to zero, but it would still need to be handled by all models). My first thought is to put the complexity in the wrapper instead of the model and API but I want to know what you guys think.
