### PR TITLE
RF: A.dot(B) => np.dot(A, B) for numpy < 1.5

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -26,7 +26,7 @@ where data is Y.T and sh_coef is x.T.
 """
 import numpy as np
 from numpy import (atleast_1d, concatenate, diag, diff, dot, empty, eye, sqrt,
-                   unique)
+                   unique, dot)
 from numpy.linalg import pinv, svd
 from numpy.random import randint
 from .odf import OdfModel, OdfFit
@@ -281,7 +281,7 @@ class SphHarmFit(OdfFit):
             sampling_matrix = real_sph_harm(self.model.m, self.model.n,
                                             phi, theta)
             self.model.cache_set("sampling_matrix", sphere, sampling_matrix)
-        return self._shm_coef.dot(sampling_matrix.T)
+        return dot(self._shm_coef, sampling_matrix.T)
 
 
 class CsaOdfModel(SphHarmModel):
@@ -307,7 +307,7 @@ class CsaOdfModel(SphHarmModel):
         data = data[..., self._where_dwi]
         data = data.clip(self.min, self.max)
         loglog_data = np.log(-np.log(data))
-        return loglog_data.dot(self._fit_matrix.T)
+        return dot(loglog_data, self._fit_matrix.T)
 
 
 class OpdtModel(SphHarmModel):

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 import numpy as np
+from numpy import dot
 from dipy.core.geometry import sphere2cart
 from dipy.core.geometry import vec2vec_rotmat
 
@@ -213,10 +214,10 @@ def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
 
     R = np.asarray(evecs)
     S = np.zeros(len(gradients))
-    D = R.dot(np.diag(evals)).dot(R.T)
+    D = dot(dot(R, np.diag(evals)), R.T)
 
     for (i, g) in enumerate(gradients):
-        S[i] = S0 * np.exp(-gtab.bvals[i] * g.T.dot(D).dot(g))
+        S[i] = S0 * np.exp(-gtab.bvals[i] * dot(dot(g.T, D), g))
 
     S = add_noise(S, snr, S0)
 
@@ -260,12 +261,12 @@ def single_tensor_odf(r, evals=None, evecs=None):
     out_shape = r.shape[:r.ndim - 1]
 
     R = np.asarray(evecs)
-    D = R.dot(np.diag(evals)).dot(R.T)
+    D = dot(dot(R, np.diag(evals)), R.T)
     Di = np.linalg.inv(D)
     r = r.reshape(-1, 3)
     P = np.zeros(len(r))
     for (i, u) in enumerate(r):
-        P[i] = (u.T.dot(Di).dot(u))**(3 / 2)
+        P[i] = (dot(dot(u.T, Di), u))**(3 / 2)
 
     return (1 / (4 * np.pi * np.prod(evals)**(1/2) * P)).reshape(out_shape)
 


### PR DESCRIPTION
Nice A.dot(B) syntax appeared in numpy 1.5.  It is more readable, but
for a slight decrease in readability, we get numpy 1.3 compatibility.
