### PR TITLE
TST + STY: Use and assert_equal so that we get more information upon failure

### DIFF
--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -308,10 +308,10 @@ def test_mask():
     mask = np.zeros(data.shape[:-1], dtype=bool)
     mask[0, 0, 0] = True
     dtifit = dm.fit(data)
-    dtifit_w_mask = dm.fit(data,mask=mask)
+    dtifit_w_mask = dm.fit(data, mask=mask)
     # Without a mask it has some value
-    assert_(not np.isnan(dtifit.fa[0,0,0]))
+    assert_(not np.isnan(dtifit.fa[0, 0, 0]))
     # But with the mask, it's a nan:
-    assert_(np.isnan(dtifit_w_mask.fa[0,0,1]))
+    assert_(np.isnan(dtifit_w_mask.fa[0, 0, 1]))
     # Except for the one voxel that was selected by the mask:
-    assert_(dtifit_w_mask.fa[0,0,0] == dtifit.fa[0,0,0])
+    assert_equal(dtifit_w_mask.fa[0, 0, 0], dtifit.fa[0, 0, 0])


### PR DESCRIPTION
The better to test exotic platforms (such as XP) with. 
