### PR TITLE
RF: fix vec_val_vect logic, generalize for shape

### DIFF
--- a/dipy/reconst/tests/test_vec_val_vect.py
+++ b/dipy/reconst/tests/test_vec_val_vect.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal, dec
 from ..vec_val_sum import vec_val_vect
 
 def make_vecs_vals(shape):
-    return randn(*(shape + (3, 3))), randn(*(shape + (3,)))
+    return randn(*(shape)), randn(*(shape[:-2] + shape[-1:]))
 
 
 try:
@@ -18,24 +18,28 @@ else:
 
 @with_einsum
 def test_vec_val_vect():
-    for shape in ((10,), (100,), (10, 12), (12, 10, 5)):
-        evecs, evals = make_vecs_vals(shape)
-        res1 = np.einsum('...ij,...j,...kj->...ik', evecs, evals, evecs)
-        assert_almost_equal(res1, vec_val_vect(evecs, evals))
+    for shape0 in ((10,), (100,), (10, 12), (12, 10, 5)):
+        for shape1 in ((3, 3), (4, 3), (3, 4)):
+            shape = shape0 + shape1
+            evecs, evals = make_vecs_vals(shape)
+            res1 = np.einsum('...ij,...j,...kj->...ik', evecs, evals, evecs)
+            assert_almost_equal(res1, vec_val_vect(evecs, evals))
 
 
 def dumb_sum(vecs, vals):
-    N = vecs.shape[0]
-    res2 = np.zeros(vecs.shape)
+    N, rows, cols = vecs.shape
+    res2 = np.zeros((N, rows, rows))
     for i in range(N):
         Q = vecs[i]
         L = vals[i]
-        res2[i] = np.dot(Q * L, Q.T)
+        res2[i] = np.dot(Q, np.dot(np.diag(L), Q.T))
     return res2
 
 
 def test_vec_val_vect_dumber():
-    for shape in ((10,), (100,)):
-        evecs, evals = make_vecs_vals(shape)
-        res1 = dumb_sum(evecs, evals)
-        assert_almost_equal(res1, vec_val_vect(evecs, evals))
+    for shape0 in ((10,), (100,)):
+        for shape1 in ((3, 3), (4, 3), (3, 4)):
+            shape = shape0 + shape1
+            evecs, evals = make_vecs_vals(shape)
+            res1 = dumb_sum(evecs, evals)
+            assert_almost_equal(res1, vec_val_vect(evecs, evals))


### PR DESCRIPTION
There was no need to enforce the input vec array to have the same length
for dimensions [-2:], I got confused, possibly because I had had a
couple of glasses of wine when I was writing this.  Remove that
requirement and test for other values of shape[-2], shape[-1].

The routine could easily be generalized to accept another input array
for the vec.T part.
