### PR TITLE
BF: fix face and edge byte order for sphere load

### DIFF
--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -134,7 +134,8 @@ def get_sphere(name='symmetric362'):
     res = np.load(fname)
     # Set to native byte order to avoid errors in compiled routines for
     # big-endian platforms, when using these spheres.
-    return Sphere(xyz=as_native_array(res['vertices']), faces=res['faces'])
+    return Sphere(xyz=as_native_array(res['vertices']),
+                  faces=as_native_array(res['faces']))
 
 
 def get_data(name='small_64D'):


### PR DESCRIPTION
We'd fixed the byte order (to native) for the edges of the example
sphere, but not the faces, giving byte order errors on numpy 1.4.1 at
least.  Fix face ordering as well.
