### PR TITLE
Fix directions on TensorFit and add getitem

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -92,6 +92,16 @@ class TensorFit(object):
         self.model = model
         self.model_params = model_params
 
+    def __getitem__(self, index):
+        model_params = self.model_params
+        N = model_params.ndim 
+        if type(index) is not tuple:
+            index = (index,)
+        elif len(index) >= model_params.ndim:
+            raise IndexError("IndexError: invalid index")
+        index = index + (slice(None),) * (N - len(index))
+        return type(self)(self.model, model_params[index])
+
     @property
     def shape(self):
         return self.model_params.shape[:-1]
@@ -609,7 +619,7 @@ common_fit_methods = {'WLS': wls_fit_tensor,
 
 
 # For backwards compatibility:
-class Tensor(TensorFit, ModelArray):
+class Tensor(ModelArray, TensorFit):
     """
     For backwards compatibility, we continue to support this form of the Tensor
     fitting.

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -74,8 +74,26 @@ def test_TensorModel():
                   gtab,
                   fit_method='crazy_method')
 
-    
-    
+
+def test_indexing_on_TensorFit():
+    params = np.zeros([2, 3, 4, 12])
+    fit = dti.TensorFit(None, params)
+
+    # Should return a TensorFit of appropriate shape
+    assert_equal(fit.shape, (2, 3, 4))
+    fit1 = fit[0]
+    assert_equal(fit1.shape, (3, 4))
+    assert_equal(type(fit1), dti.TensorFit)
+    fit1 = fit[0, 0, 0]
+    assert_equal(fit1.shape, ())
+    assert_equal(type(fit1), dti.TensorFit)
+    fit1 = fit[[0], slice(None)]
+    assert_equal(fit1.shape, (1, 3, 4))
+    assert_equal(type(fit1), dti.TensorFit)
+
+    # Should raise an index error if too many indices are passed
+    assert_raises(IndexError, fit.__getitem__, (0, 0, 0, 0))
+
 def test_tensor_scalar_attributes():
     """
     Tests that the tensor class scalar attributes (FA, ADC, etc...) are


### PR DESCRIPTION
I've fixed the directions property and added getitem to make the TensorFIt consistent with other fit classes.
