### PR TITLE
RF: raise errors for Python version dependencies

### DIFF
--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -31,6 +31,12 @@ Utilities
  __version__   -- Dipy version
 
 """
+import sys
+if sys.version[0:3] < '2.6':
+    raise ImportError('Dipy needs Python version 2.6 or above')
+if sys.version[0] == '3':
+    raise ImportError('Dipy does not yet work with Python 3, feel free to '
+                      'remind us about this')
 
 from .info import __version__
 
@@ -43,4 +49,4 @@ del Tester
 import os
 from .pkg_info import get_pkg_info as _get_pkg_info
 get_info = lambda : _get_pkg_info(os.path.dirname(__file__))
-del os
+del os, sys

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -14,13 +14,14 @@ development - at least - we hope so - if we're developing fast enough!
 Note on python versions
 ***********************
 
-Sorry, but dipy_ does not yet work with python 3 - so all the instructions
-following instructions apply to python 2.5 or python 2.6 or python 2.7.
+Dipy needs python 2.6 or above.  Sorry to say, but dipy_ does not yet work with
+python 3 - so all the instructions following instructions apply to python 2.6 or
+python 2.7.
 
 On OSX we always use the python binaries available from the python.org
 downloads, and not the python that comes with the OSX system.  If you don't have
 the python.org python you need to go to http://python.org/downloads, then
-download and install the python version you want (2.7 or 2.6 or 2.5).  Check
+download and install the python version you want (2.7 or 2.6).  Check
 that you have this version on your path (perhaps after ``. ~/.bash_profile``)
 with ``which python``.  This should show something like::
 


### PR DESCRIPTION
Raise informative ImportError trying to import in Python < 2.6 and >=
3.0.  Update installation docs for Python 2.6 requirement.
