### PR TITLE
Implementation of DSI deconvolution from E.J. Canales-Rodriguez

### DIFF
--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -212,9 +212,9 @@ def dsi_voxels():
 
 def dsi_deconv_voxels():
     gtab = gradient_table(np.loadtxt(get_data('dsi515btable')))
-    data = np.zeros((5, 5, 2, 515))
-    for ix in range(5):
-        for iy in range(5):
+    data = np.zeros((2, 2, 2, 515))
+    for ix in range(2):
+        for iy in range(2):
             for iz in range(2):
                 data[ix,iy,iz], dirs = SticksAndBall(gtab, d=0.0015, S0=100, 
                                                      angles=[(0, 0), (90, 0)],

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -31,9 +31,9 @@ class DiffusionSpectrumModel(OdfModel, Cache):
                 \end{eqnarray}
 
         where $\mathbf{r}$ is the displacement vector and $\mathbf{q}$ is the
-        wavector which corresponds to different gradient directions. Method used to
-        calculate the ODFs. Here we implement the method proposed by Wedeen et.
-        al [1]_.
+        wavector which corresponds to different gradient directions. Method
+        used to calculate the ODFs. Here we implement the method proposed by
+        Wedeen et. al [1]_.
 
         The main assumption for this model is fast gradient switching and that
         the acquisition gradients will sit on a keyhole Cartesian grid in
@@ -62,8 +62,8 @@ class DiffusionSpectrumModel(OdfModel, Cache):
         .. [1]  Wedeen V.J et. al, "Mapping Complex Tissue Architecture With
         Diffusion Spectrum Magnetic Resonance Imaging", MRM 2005.
 
-        .. [2] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion Spectrum
-        Imaging", Neuroimage, 2010.
+        .. [2] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion
+        Spectrum Imaging", Neuroimage, 2010.
 
         .. [3] Garyfallidis E, "Towards an accurate brain tractography", PhD
         thesis, University of Cambridge, 2012.
@@ -165,7 +165,8 @@ class DiffusionSpectrumFit(OdfFit):
             qx, qy, qz = self.model.qgrid[i]
             Sq[qx, qy, qz] += values[i]
         #apply fourier transform
-        Pr = fftshift(np.abs(np.real(fftn(ifftshift(Sq), 3 * (self.qgrid_sz, )))))
+        Pr = fftshift(np.abs(np.real(fftn(ifftshift(Sq),
+                                          3 * (self.qgrid_sz, )))))
         return Pr
 
     def odf(self, sphere):
@@ -289,8 +290,8 @@ def pdf_odf(Pr, rradius, interp_coords):
 def half_to_full_qspace(data, gtab):
     """ Half to full Cartesian grid mapping
 
-    Useful when dMRI data are provided in one qspace hemisphere as DiffusionSpectrum
-    expects data to be in full qspace.
+    Useful when dMRI data are provided in one qspace hemisphere as
+    DiffusionSpectrum expects data to be in full qspace.
 
     Parameters
     ----------
@@ -308,7 +309,8 @@ def half_to_full_qspace(data, gtab):
     -----
     We assume here that only on b0 is provided with the initial data. If that
     is not the case then you will need to write your own preparation function
-    before providing the gradients and the data to the DiffusionSpectrumModel class.
+    before providing the gradients and the data to the DiffusionSpectrumModel
+    class.
     """
     bvals = gtab.bvals
     bvecs = gtab.bvecs
@@ -361,11 +363,6 @@ class DiffusionSpectrumDeconvModel(DiffusionSpectrumModel):
 
     def __init__(self, gtab, qgrid_size=35, r_start=4.1, r_end=13.,
                  r_step=0.4, filter_width=np.inf, normalize_peaks=False):
-
-            DiffusionSpectrumModel.__init__(self, gtab, qgrid_size,
-                                            r_start, r_end, r_step,
-                                            filter_width,
-                                            normalize_peaks)
         r""" Diffusion Spectrum Deconvolution
 
         The idea is to remove the convolution on the DSI propagator that is
@@ -406,14 +403,19 @@ class DiffusionSpectrumDeconvModel(DiffusionSpectrumModel):
         References
         ----------
 
-        .. [1] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion 
+        .. [2] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion 
         Spectrum Imaging", Neuroimage, 2010.
 
-        .. [2] Biggs David S.C. et. al, "Acceleration of Iterative Image 
+        .. [4] Biggs David S.C. et. al, "Acceleration of Iterative Image 
         Restoration Algorithms", Applied Optics, vol. 36, No. 8, p. 1766-1775, 
         1997.
 
         """
+        DiffusionSpectrumModel.__init__(self, gtab, qgrid_size,
+                                        r_start, r_end, r_step,
+                                        filter_width,
+                                        normalize_peaks)
+
 
     def fit(self, data):
         return DiffusionSpectrumDeconvFit(self, data)
@@ -473,19 +475,23 @@ def gen_PSF(qgrid_sampling, siz_x, siz_y, siz_z):
     return Sq * np.real(np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(Sq))))
 
 
-# interp_coords = self.model.cache_get('interp_coords',
-#                                              key=sphere)
-#         if interp_coords is None:
-#             interp_coords = pdf_interp_coords(sphere,
-#                                               self.model.qradius,
-#                                               self.model.origin)
-#             self.model.cache_set('interp_coords', sphere, interp_coords)
-
-
-def LR_deconv(P, PSF, NUMIT=5, acceleration_factor=1):
+def LR_deconv(P, PSF, NUMIT=20, acceleration_factor=1):
     """
     Perform Lucy-Richardson deconvolution algorithm on a 3D array.
+
+    Parameters
+    ----------
+    P : 3D numpy.array (float),
+        The 3D volume to be deconvolve
+    PSF : 3D numpy.array (float),
+        The filter that will be used for the deconvolution.
+    NUMIT : int,
+        Number of Lucy-Richardson iteration to perform.
+    acceleration_factor : float,
+        Exponential acceleration factor as in [4]_. 
+
     """
+
     eps = 1e-16
     # Create the OTF (H) of the same size as P
     H = np.zeros_like(P)

--- a/dipy/reconst/tests/test_dsi_deconv.py
+++ b/dipy/reconst/tests/test_dsi_deconv.py
@@ -14,6 +14,7 @@ from dipy.data import get_sphere
 from numpy.testing import assert_equal
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
+from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
 
 
 def test_dsi():
@@ -22,8 +23,8 @@ def test_dsi():
     #load icosahedron sphere
     sphere2 = create_unit_sphere(5)
     btable = np.loadtxt(get_data('dsi515btable'))
-    gtab = gradient_table(btable[:,0], btable[:,1:])
-    data, golden_directions = SticksAndBall(gtab, d=0.0015, 
+    gtab = gradient_table(btable[:, 0], btable[:, 1:])
+    data, golden_directions = SticksAndBall(gtab, d=0.0015,
                                             S0=100, angles=[(0, 0), (90, 0)],
                                             fractions=[50, 50], snr=None)
 
@@ -37,7 +38,7 @@ def test_dsi():
     print(golden_directions)
     print(directions)
     assert_equal(len(directions), 2)
-    assert_almost_equal(angular_similarity(directions, golden_directions), 
+    assert_almost_equal(angular_similarity(directions, golden_directions),
                         2, 1)
 
     #use peak_directions instead
@@ -48,18 +49,18 @@ def test_dsi():
 
     #5 subdivisions
     ds.direction_finder.config(sphere=sphere2, min_separation_angle=25,
-                              relative_peak_threshold=.35)
+                               relative_peak_threshold=.35)
     dsfit = ds.fit(data)
     odf2 = dsfit.odf(sphere2)
     directions = dsfit.directions
     assert_equal(len(directions), 2)
-    assert_almost_equal(angular_similarity(directions, golden_directions), 
+    assert_almost_equal(angular_similarity(directions, golden_directions),
                         2, 1)
     #from dipy.viz._show_odfs import show_odfs
     #show_odfs(odf[None,None,None,:], (sphere.vertices, sphere.faces))
     #show_odfs(odf2[None,None,None,:], (sphere2.vertices, sphere2.faces))
     assert_equal(dsfit.pdf().shape, 3 * (ds.qgrid_size, ))
-    sb_dummies=sticks_and_ball_dummies(gtab)
+    sb_dummies = sticks_and_ball_dummies(gtab)
     for sbd in sb_dummies:
         data, golden_directions = sb_dummies[sbd]
         odf = ds.fit(data).odf(sphere2)
@@ -77,34 +78,13 @@ def test_multivox_dsi():
     data, gtab = dsi_deconv_voxels()
     DS = DiffusionSpectrumDeconvModel(gtab)
     sphere = get_sphere('symmetric724')
-    DS.direction_finder.config(sphere=sphere, 
+    DS.direction_finder.config(sphere=sphere,
                                min_separation_angle=25,
                                relative_peak_threshold=.35)
     DSfit = DS.fit(data)
     PDF = DSfit.pdf()
     assert_equal(data.shape[:-1] + (35, 35, 35), PDF.shape)
     assert_equal(np.alltrue(np.isreal(PDF)), True)
-
-
-def sticks_and_ball_dummies(gtab):
-    sb_dummies={}
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100, 
-                              angles=[(0, 0)], 
-                              fractions=[100], snr=None)   
-    sb_dummies['1fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100, 
-                              angles=[(0, 0), (90, 0)],
-                              fractions=[50, 50], snr=None)
-    sb_dummies['2fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100, 
-                              angles=[(0, 0), (90, 0), (90, 90)],
-                              fractions=[33, 33, 33], snr=None)
-    sb_dummies['3fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100, 
-                              angles=[(0, 0), (90, 0), (90, 90)],
-                              fractions=[0, 0, 0], snr=None)
-    sb_dummies['isotropic'] = (S, sticks)
-    return sb_dummies
 
 
 if __name__ == '__main__':

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -19,25 +19,25 @@ bvecs = np.load(fbvecs)
 gtab = gradient_table(bvals, bvecs)
 
 
-def diff2eigenvectors(dx,dy,dz):
+def diff2eigenvectors(dx, dy, dz):
     """ numerical derivatives 2 eigenvectors
     """
-    u=np.array([dx,dy,dz])
-    u=u/np.linalg.norm(u)
-    R=vec2vec_rotmat(basis[:,0],u)
-    eig0=u
-    eig1=np.dot(R,basis[:,1])
-    eig2=np.dot(R,basis[:,2])
-    eigs=np.zeros((3,3))
-    eigs[:,0]=eig0
-    eigs[:,1]=eig1
-    eigs[:,2]=eig2
+    u = np.array([dx, dy, dz])
+    u = u / np.linalg.norm(u)
+    R = vec2vec_rotmat(basis[:, 0], u)
+    eig0 = u
+    eig1 = np.dot(R, basis[:, 1])
+    eig2 = np.dot(R, basis[:, 2])
+    eigs = np.zeros((3, 3))
+    eigs[:, 0] = eig0
+    eigs[:, 1] = eig1
+    eigs[:, 2] = eig2
     return eigs, R
 
 
 def test_sticks_and_ball():
     d = 0.0015
-    S, sticks = sticks_and_ball(gtab, d=d, S0=1, angles=[(0,0),],
+    S, sticks = sticks_and_ball(gtab, d=d, S0=1, angles=[(0, 0), ],
                                 fractions=[100], snr=None)
     assert_array_equal(sticks, [[0, 0, 1]])
     S_st = SingleTensor(gtab, 1, evals=[d, 0, 0], evecs=[[0, 0, 0],
@@ -47,7 +47,7 @@ def test_sticks_and_ball():
 
 
 def test_single_tensor():
-    evals = np.array([1.4, .35, .35]) * 10**(-3)
+    evals = np.array([1.4, .35, .35]) * 10 ** (-3)
     evecs = np.eye(3)
     S = SingleTensor(gtab, 100, evals, evecs, snr=None)
     assert_array_almost_equal(S[gtab.b0s_mask], 100)
@@ -63,37 +63,30 @@ def test_single_tensor():
 def test_multi_tensor():
     sphere = get_sphere('symmetric724')
     vertices = sphere.vertices
-    mevals=np.array(([0.0015, 0.0003, 0.0003],
-                     [0.0015, 0.0003, 0.0003]))
-    e0 = np.array([0, 0, 1.])
-    e1 = np.array([1., 0., 0])
-    mevecs=[all_tensor_evecs(e0), all_tensor_evecs(e1)]
-    odf = multi_tensor_odf(vertices, [0.5, 0.5], mevals, mevecs)
+    mevals = np.array(([0.0015, 0.0003, 0.0003],
+                       [0.0015, 0.0003, 0.0003]))
+    e0 = np.array([np.sqrt(2) / 2., np.sqrt(2) / 2., 0])
+    e1 = np.array([0, np.sqrt(2) / 2., np.sqrt(2) / 2.])
+    mevecs = [all_tensor_evecs(e0), all_tensor_evecs(e1)]
+    # odf = multi_tensor_odf(vertices, [0.5, 0.5], mevals, mevecs)
 
-    assert_(odf.shape == (len(vertices),))
-    assert_(np.all(odf <= 1) & np.all(odf >= 0))
+    # assert_(odf.shape == (len(vertices),))
+    # assert_(np.all(odf <= 1) & np.all(odf >= 0))
 
     fimg, fbvals, fbvecs = get_data('small_101D')
     bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
     gtab = gradient_table(bvals, bvecs)
 
-    s1 = single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None)
-    s2 = single_tensor(gtab, 100, mevals[1], mevecs[1], snr=None)
+    s1 = single_tensor(gtab, 100, mevals[0], mevecs[0].T, snr=None)
+    s2 = single_tensor(gtab, 100, mevals[1], mevecs[1].T, snr=None)
 
-    Ssingle = 0.5*s1 + 0.5*s2
+    Ssingle = 0.5 * s1 + 0.5 * s2
 
-    S = MultiTensor(gtab, mevals, S0=100, angles=[(0, 0), (90, 0)],
-                    fractions=[50, 50], snr=None)
+    S, sticks = MultiTensor(gtab, mevals, S0=100, angles=[(90, 45), (45, 90)],
+                            fractions=[50, 50], snr=None)
 
     assert_array_almost_equal(S, Ssingle)
 
-    #from dipy.reconst.gqi import GeneralizedQSamplingModel
-    #gqmodel = GeneralizedQSamplingModel(gtab, sampling_length=3)
-    #gqfit = gqmodel.fit(S)
-    #odf = gqfit.odf(sphere)        
-    #from dipy.viz.mayavi.spheres import show_odfs
-    #show_odfs(odf[None, None, None], sphere)
-    
 
 def test_snr():
     np.random.seed(1978)
@@ -106,8 +99,7 @@ def test_snr():
         for j in range(1000):
             s_noise = add_noise(s, snr, 1, noise_type='rician')
 
-        assert_array_almost_equal(np.var(s_noise - s), sigma**2, decimal=2)
-
+        assert_array_almost_equal(np.var(s_noise - s), sigma ** 2, decimal=2)
 
 
 if __name__ == "__main__":

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -184,7 +184,8 @@ def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
         prolate white matter are used.
     evecs : (3, 3) ndarray
         Eigenvectors of the tensor.  You can also think of this as a rotation
-        matrix that transforms the direction of the tensor.
+        matrix that transforms the direction of the tensor. The eigenvectors
+        needs to be column wise.
     snr : float
         Signal to noise ratio, assuming Rician noise.  None implies no noise.
 
@@ -284,10 +285,10 @@ def multi_tensor(gtab, mevals, S0=100, angles=[(0, 0), (90, 0)],
 
     for i in range(len(fractions)):
             S = S + fractions[i] * single_tensor(gtab, S0=S0, evals=mevals[i],
-                                                 evecs=all_tensor_evecs(sticks[i]),
+                                                 evecs=all_tensor_evecs(sticks[i]).T,
                                                  snr=None)
     
-    return add_noise(S, snr, S0)
+    return add_noise(S, snr, S0), sticks 
 
 
 def single_tensor_odf(r, evals=None, evecs=None):


### PR DESCRIPTION
This is a method that uses the Lucy-Richardson deconvolution algoritmh to increase the angular resolution of DSI. It can be seen as a post-processing of the propagator obtained from classical DSI. This technique only works with full 515 directions DSI (or half q-space sampling + symmetry)
