### PR TITLE
Corrected test for Deconvolution after the discrete direction finder was removed

### DIFF
--- a/dipy/reconst/tests/test_dsi_deconv.py
+++ b/dipy/reconst/tests/test_dsi_deconv.py
@@ -18,9 +18,9 @@ from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
 
 
 def test_dsi():
-    #load symmetric 724 sphere
+    # load symmetric 724 sphere
     sphere = get_sphere('symmetric724')
-    #load icosahedron sphere
+    # load icosahedron sphere
     sphere2 = create_unit_sphere(5)
     btable = np.loadtxt(get_data('dsi515btable'))
     gtab = gradient_table(btable[:, 0], btable[:, 1:])
@@ -29,47 +29,33 @@ def test_dsi():
                                             fractions=[50, 50], snr=None)
 
     ds = DiffusionSpectrumDeconvModel(gtab)
-    #symmetric724
-    ds.direction_finder.config(sphere=sphere, min_separation_angle=25,
-                               relative_peak_threshold=.35)
+
+    # symmetric724
     dsfit = ds.fit(data)
     odf = dsfit.odf(sphere)
-    directions = dsfit.directions
-    print(golden_directions)
-    print(directions)
+    directions, _, _ = peak_directions(odf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(angular_similarity(directions, golden_directions),
                         2, 1)
 
-    #use peak_directions instead
-    dsnod = DiffusionSpectrumDeconvModel(gtab)
-    dsnodfit = dsnod.fit(data)
-    directionsnod, _, _ = peak_directions(dsnodfit.odf(sphere), sphere, .35, 25)
-    assert_array_equal(directions, directionsnod)
-
-    #5 subdivisions
-    ds.direction_finder.config(sphere=sphere2, min_separation_angle=25,
-                               relative_peak_threshold=.35)
+    # 5 subdivisions
     dsfit = ds.fit(data)
     odf2 = dsfit.odf(sphere2)
-    directions = dsfit.directions
+    directions, _, _ = peak_directions(odf2, sphere2, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(angular_similarity(directions, golden_directions),
                         2, 1)
-    #from dipy.viz._show_odfs import show_odfs
-    #show_odfs(odf[None,None,None,:], (sphere.vertices, sphere.faces))
-    #show_odfs(odf2[None,None,None,:], (sphere2.vertices, sphere2.faces))
+
     assert_equal(dsfit.pdf().shape, 3 * (ds.qgrid_size, ))
     sb_dummies = sticks_and_ball_dummies(gtab)
     for sbd in sb_dummies:
         data, golden_directions = sb_dummies[sbd]
         odf = ds.fit(data).odf(sphere2)
-        directions = ds.fit(data).directions
-        #show_odfs(odf[None, None, None, :], (sphere2.vertices, sphere2.faces))
+        directions, _, _ = peak_directions(odf, sphere2, .35, 25)
         if len(directions) <= 3:
-            assert_equal(len(ds.fit(data).directions), len(golden_directions))
+            assert_equal(len(directions), len(golden_directions))
         if len(directions) > 3:
-            assert_equal(gfa(ds.fit(data).odf(sphere2)) < 0.1, True)
+            assert_equal(gfa(odf) < 0.1, True)
 
     assert_raises(ValueError, DiffusionSpectrumDeconvModel, gtab, qgrid_size=16)
 
@@ -78,9 +64,7 @@ def test_multivox_dsi():
     data, gtab = dsi_deconv_voxels()
     DS = DiffusionSpectrumDeconvModel(gtab)
     sphere = get_sphere('symmetric724')
-    DS.direction_finder.config(sphere=sphere,
-                               min_separation_angle=25,
-                               relative_peak_threshold=.35)
+
     DSfit = DS.fit(data)
     PDF = DSfit.pdf()
     assert_equal(data.shape[:-1] + (35, 35, 35), PDF.shape)


### PR DESCRIPTION
Hi guys,

This is really a minor fix because of the last change we made  with the discrete direction finder. There is nothing interesting to see here. Test is fixed now and I will go ahead and merge this asap. With this included all tests are passing in my machine. Lets see what the buildbots will say. 
