### PR TITLE
BF: fix multiskip from setup_modules import

### DIFF
--- a/dipy/io/__init__.py
+++ b/dipy/io/__init__.py
@@ -1,6 +1,6 @@
 # init for io routines
 from .gradients import *
-from .dpy import *
+from .dpy import Dpy
 from .bvectxt import *
 from .pickles import *
-import utils 
+from . import utils

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -16,6 +16,9 @@ from ..utils.optpkg import optional_package
 # Allow import, but disable doctests, if we don't have pytables
 tables, have_tables, setup_module = optional_package('tables')
 
+# Make sure not to carry across setup module from * import
+__all__ = ['Dpy']
+
 
 class Dpy(object):
 

--- a/dipy/io/tests/test_io.py
+++ b/dipy/io/tests/test_io.py
@@ -1,0 +1,10 @@
+""" Tests for overall io sub-package
+"""
+
+from ... import io
+
+from nose.tools import assert_false
+
+def test_imports():
+    # Make sure io has not pulled in setup_module from dpy
+    assert_false(hasattr(io, 'setup_module'))


### PR DESCRIPTION
The import of everything from the `dpy` module pulled the
`setup_module` optional import test guarder, causing other modules,
such as `io`, skip tests with a confusing message about `tables`.

Stop importing `setup_modules` into `io` namespace, and make test to
make sure we don't do it again.
