### PR TITLE
RF: bdist_wininst, add bdist_mpkg as setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ def main(**extra_args):
                           ]},
           data_files=[('share/doc/dipy/examples',
                        glob(pjoin('doc','examples','*.py')))],
-          scripts      = glob(pjoin('scripts', '*')),
+          scripts      = glob(pjoin('bin', '*')),
           cmdclass = cmdclass,
           **extra_args
          )


### PR DESCRIPTION
bdist_wininst does not need to be setuptools, so remove it from the list
of commands requiring setuptools.

We use bdist_mpkg to make OSX installers, so add this as a setuptools
command.
