### PR TITLE
Calculation for mode of a tensor

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -42,8 +42,8 @@ def fractional_anisotropy(evals, axis=-1):
     # Make sure not to get nans
     all_zero = (evals == 0).all(axis=0)
     ev1, ev2, ev3 = evals
-    fa = np.sqrt(0.5 * ((ev1 - ev2)**2 + (ev2 - ev3)**2 + (ev3 - ev1)**2)
-                  / ((evals*evals).sum(0) + all_zero))
+    fa = np.sqrt(0.5 * ((ev1 - ev2) ** 2 + (ev2 - ev3) ** 2 + (ev3 - ev1) ** 2)
+                  / ((evals * evals).sum(0) + all_zero))
 
     return fa
 
@@ -63,7 +63,7 @@ def mean_diffusivity(evals, axis=-1):
     Returns
     -------
     md : array
-        Calculated MD. 
+        Calculated MD.
 
     Notes
     --------
@@ -98,7 +98,7 @@ def axial_diffusivity(evals, axis=-1):
     Returns
     -------
     ad : array
-        Calculated AD. 
+        Calculated AD.
 
     Notes
     --------
@@ -134,7 +134,7 @@ def radial_diffusivity(evals, axis=-1):
         Returns
     -------
     rd : array
-        Calculated RD. 
+        Calculated RD.
 
     Notes
     --------
@@ -152,6 +152,7 @@ def radial_diffusivity(evals, axis=-1):
 
     return evals[1:].mean(0)
 
+
 def trace(evals, axis=-1):
     r"""
     Trace of a diffusion tensor.
@@ -166,7 +167,7 @@ def trace(evals, axis=-1):
     Returns
     -------
     trace : array
-        Calculated trace of the diffusion tensor. 
+        Calculated trace of the diffusion tensor.
 
     Notes
     --------
@@ -229,7 +230,7 @@ def tensor_determinant(q_form):
     ----------
     q_form : ndarray
         The quadratic form of a tensor, or an array with quadratic forms of
-        tensors. Should be of shape (x,y,z,3,3) or (n, 3, 3) or (3,3).
+        tensors. Should be of shape (x, y, z, 3, 3) or (n, 3, 3) or (3, 3).
 
     Returns
     -------
@@ -239,7 +240,7 @@ def tensor_determinant(q_form):
 
     # Following the conventions used here:
     # http://en.wikipedia.org/wiki/Determinant
-    aei = q_form[..., 0 ,0] * q_form[..., 1, 1] * q_form[..., 2, 2]
+    aei = q_form[..., 0, 0] * q_form[..., 1, 1] * q_form[..., 2, 2]
     bfg = q_form[..., 0, 1] * q_form[..., 1, 2] * q_form[..., 2, 0]
     cdh = q_form[..., 0, 2] * q_form[..., 1, 0] * q_form[..., 2, 1]
     ceg = q_form[..., 0, 2] * q_form[..., 1, 1] * q_form[..., 2, 0]
@@ -346,7 +347,7 @@ def tensor_norm(q_form):
     """
     return np.sqrt(np.sum(np.sum(np.abs(q_form ** 2), -1), -1))
 
-    
+
 def tensor_mode(q_form):
     r"""
     Mode (MO) of a diffusion tensor [1]_.
@@ -355,7 +356,7 @@ def tensor_mode(q_form):
     ----------
     q_form : ndarray
         The quadratic form of a tensor, or an array with quadratic forms of
-        tensors. Should be of shape (x,y,z,3,3) or (n, 3, 3) or (3,3).
+        tensors. Should be of shape (x, y, z, 3, 3) or (n, 3, 3) or (3, 3).
 
     Returns
     -------
@@ -365,7 +366,7 @@ def tensor_mode(q_form):
     Notes
     -----
     Mode ranges between -1 (linear anisotropy) and +1 (planar anisotropy)
-    with 0 representing orthotropy. Mode is calculated with the 
+    with 0 representing orthotropy. Mode is calculated with the
     following equation (equation 9 in [1]_):
 
     .. math::
@@ -373,14 +374,14 @@ def tensor_mode(q_form):
         Mode = 3*\sqrt{6}*det(\widetilde{A}/norm(\widetilde{A}))
 
     Where $\widetilde{A}$ is the deviatoric part of the tensor quadratic form.
- 
+
     References
     ----------
 
     .. [1] Daniel B. Ennis and G. Kindlmann, "Orthogonal Tensor
         Invariants and the Analysis of Diffusion Tensor Magnetic Resonance
         Images", Magnetic Resonance in Medicine, vol. 55, no. 1, pp. 136-146,
-        2006. 
+        2006.
     """
 
     A_squiggle = deviatoric(q_form)
@@ -426,7 +427,7 @@ class TensorModel(object):
             try:
                 self.fit_method = common_fit_methods[fit_method]
             except KeyError:
-                raise ValueError('"'+str(fit_method)+'" is not a known fit '
+                raise ValueError('"' + str(fit_method) + '" is not a known fit '
                                  'method, the fit method should either be a '
                                  'function or one of the common fit methods')
         self.bvec = gtab.bvecs
@@ -434,7 +435,6 @@ class TensorModel(object):
         self.design_matrix = design_matrix(self.bvec.T, self.bval)
         self.args = args
         self.kwargs = kwargs
-
 
     def fit(self, data, mask=None):
         """ Fit method of the DTI model class
@@ -461,7 +461,7 @@ class TensorModel(object):
 
         dti_params = np.zeros(data.shape[:-1] + (12,))
 
-        dti_params[mask,:] = params_in_mask
+        dti_params[mask, :] = params_in_mask
 
         return TensorFit(self, dti_params)
 
@@ -473,7 +473,6 @@ class TensorFit(object):
         self.model = model
         self.model_params = model_params
 
-
     def __getitem__(self, index):
         model_params = self.model_params
         N = model_params.ndim
@@ -484,11 +483,9 @@ class TensorFit(object):
         index = index + (slice(None),) * (N - len(index))
         return type(self)(self.model, model_params[index])
 
-
     @property
     def shape(self):
         return self.model_params.shape[:-1]
-
 
     @property
     def directions(self):
@@ -497,14 +494,12 @@ class TensorFit(object):
         """
         return self.evecs[..., None, :, 0]
 
-
     @property
     def evals(self):
         """
         Returns the eigenvalues of the tensor as an array
         """
         return self.model_params[..., :3]
-
 
     @property
     def evecs(self):
@@ -515,7 +510,6 @@ class TensorFit(object):
         evecs = self.model_params[..., 3:]
         return evecs.reshape(self.shape + (3, 3))
 
-
     @property
     def quadratic_form(self):
         """Calculates the 3x3 diffusion tensor for each voxel"""
@@ -524,16 +518,13 @@ class TensorFit(object):
         # np.einsum('...ij,...j,...kj->...ik', evecs, evals, evecs)
         return vec_val_vect(self.evecs, self.evals)
 
-
     def lower_triangular(self, b0=None):
         return lower_triangular(self.quadratic_form, b0)
-
 
     @auto_attr
     def fa(self):
         """Fractional anisotropy (FA) calculated from cached eigenvalues."""
         return fractional_anisotropy(self.evals)
-
 
     @auto_attr
     def mode(self):
@@ -542,8 +533,6 @@ class TensorFit(object):
 
         """
         return tensor_mode(self.quadratic_form)
-        
-
 
     @auto_attr
     def md(self):
@@ -564,8 +553,8 @@ class TensorFit(object):
             MD = \frac{\lambda_1+\lambda_2+\lambda_3}{3}
 
         """
-        return self.trace/3.0
-    
+        return self.trace / 3.0
+
     @auto_attr
     def rd(self):
         r"""
@@ -588,7 +577,6 @@ class TensorFit(object):
         """
         return radial_diffusivity(self.evals)
 
-
     @auto_attr
     def ad(self):
         r"""
@@ -610,7 +598,7 @@ class TensorFit(object):
 
         """
         return axial_diffusivity(self.evals)
-    
+
     @auto_attr
     def trace(self):
         r"""
@@ -636,7 +624,7 @@ class TensorFit(object):
         projection = np.dot(sphere.vertices, self.evecs)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            projection /=  np.sqrt(self.evals)
+            projection /= np.sqrt(self.evals)
             odf = (vector_norm(projection) ** -3) / lower
         # Zero evals are non-physical, we replace nans with zeros
         any_zero = (self.evals == 0).any(-1)
@@ -725,7 +713,7 @@ def wls_fit_tensor(design_matrix, data, min_signal=1):
     for param, sig in zip(dti_params, data_flat):
         param[0], param[1:] = _wls_iter(ols_fit, design_matrix, sig,
                                         min_signal, min_diffusivity)
-    dti_params.shape = data.shape[:-1]+(12,)
+    dti_params.shape = data.shape[:-1] + (12,)
     dti_params = dti_params
     return dti_params
 
@@ -733,10 +721,10 @@ def wls_fit_tensor(design_matrix, data, min_signal=1):
 def _wls_iter(ols_fit, design_matrix, sig, min_signal, min_diffusivity):
     ''' Function used by wls_fit_tensor for later optimization.
     '''
-    sig = np.maximum(sig, min_signal) #throw out zero signals
+    sig = np.maximum(sig, min_signal)  # throw out zero signals
     log_s = np.log(sig)
     w = np.exp(np.dot(ols_fit, log_s))
-    D = np.dot(np.linalg.pinv(design_matrix * w[:,None]), w*log_s)
+    D = np.dot(np.linalg.pinv(design_matrix * w[:, None]), w * log_s)
     # D, _, _, _ = np.linalg.lstsq(design_matrix * w[:, None], log_s)
     tensor = from_lower_triangular(D)
     return decompose_tensor(tensor, min_diffusivity=min_diffusivity)
@@ -745,7 +733,7 @@ def _wls_iter(ols_fit, design_matrix, sig, min_signal, min_diffusivity):
 def _ols_iter(inv_design, sig, min_signal, min_diffusivity):
     ''' Function used by ols_fit_tensor for later optimization.
     '''
-    sig = np.maximum(sig, min_signal) #throw out zero signals
+    sig = np.maximum(sig, min_signal)  # throw out zero signals
     log_s = np.log(sig)
     D = np.dot(inv_design, log_s)
     tensor = from_lower_triangular(D)
@@ -819,9 +807,10 @@ def ols_fit_tensor(design_matrix, data, min_signal=1):
     inv_design = np.linalg.pinv(design_matrix)
 
     for param, sig in zip(dti_params, data_flat):
-        param[0], param[1:] = _ols_iter(inv_design, sig, min_signal, min_diffusivity)
+        param[0], param[1:] = _ols_iter(inv_design, sig,
+            min_signal, min_diffusivity)
 
-    dti_params.shape = data.shape[:-1]+(12,)
+    dti_params.shape = data.shape[:-1] + (12,)
     dti_params = dti_params
     return dti_params
 
@@ -842,7 +831,7 @@ def _ols_fit_matrix(design_matrix):
     ols_data = np.dot(ols_fit, data)
     """
 
-    U,S,V = np.linalg.svd(design_matrix, False)
+    U, S, V = np.linalg.svd(design_matrix, False)
     return np.dot(U, U.T)
 
 
@@ -932,7 +921,7 @@ def tensor_eig_from_lo_tri(data):
         dti_params[ii, 0] = eigvals
         dti_params[ii, 1:] = eigvecs
 
-    dti_params.shape = data.shape[:-1]+(12,)
+    dti_params.shape = data.shape[:-1] + (12,)
     return dti_params
 
 
@@ -994,19 +983,19 @@ def design_matrix(gtab, bval, dtype=None):
     -------
     design_matrix : array (g,7)
         Design matrix or B matrix assuming Gaussian distributed tensor model
-        design_matrix[j,:] = (Bxx,Byy,Bzz,Bxy,Bxz,Byz,dummy)
+        design_matrix[j, :] = (Bxx, Byy, Bzz, Bxy, Bxz, Byz, dummy)
     """
     G = gtab
-    B = np.zeros((bval.size, 7), dtype = G.dtype)
+    B = np.zeros((bval.size, 7), dtype=G.dtype)
     if gtab.shape[1] != bval.shape[0]:
         raise ValueError('The number of b values and gradient directions must'
-                          +' be the same')
-    B[:, 0] = G[0, :] * G[0, :] * 1. * bval   #Bxx
-    B[:, 1] = G[0, :] * G[1, :] * 2. * bval   #Bxy
-    B[:, 2] = G[1, :] * G[1, :] * 1. * bval   #Byy
-    B[:, 3] = G[0, :] * G[2, :] * 2. * bval   #Bxz
-    B[:, 4] = G[1, :] * G[2, :] * 2. * bval   #Byz
-    B[:, 5] = G[2, :] * G[2, :] * 1. * bval   #Bzz
+                          + ' be the same')
+    B[:, 0] = G[0, :] * G[0, :] * 1. * bval   # Bxx
+    B[:, 1] = G[0, :] * G[1, :] * 2. * bval   # Bxy
+    B[:, 2] = G[1, :] * G[1, :] * 1. * bval   # Byy
+    B[:, 3] = G[0, :] * G[2, :] * 2. * bval   # Bxz
+    B[:, 4] = G[1, :] * G[2, :] * 2. * bval   # Byz
+    B[:, 5] = G[2, :] * G[2, :] * 1. * bval   # Bzz
     B[:, 6] = np.ones(bval.size)
     return -B
 
@@ -1025,13 +1014,13 @@ def quantize_evecs(evecs, odf_vertices=None):
     -------
     IN : ndarray
     """
-    max_evecs=evecs[...,:,0]
-    if odf_vertices==None:
+    max_evecs = evecs[..., :, 0]
+    if odf_vertices == None:
         odf_vertices = get_sphere('symmetric362').vertices
-    tup=max_evecs.shape[:-1]
-    mec=max_evecs.reshape(np.prod(np.array(tup)),3)
-    IN=np.array([np.argmin(np.dot(odf_vertices,m)) for m in mec])
-    IN=IN.reshape(tup)
+    tup = max_evecs.shape[:-1]
+    mec = max_evecs.reshape(np.prod(np.array(tup)), 3)
+    IN = np.array([np.argmin(np.dot(odf_vertices, m)) for m in mec])
+    IN = IN.reshape(tup)
     return IN
 
 common_fit_methods = {'WLS': wls_fit_tensor,

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -23,10 +23,10 @@ def test_tensor_algebra():
     """
     Test that the computation of tensor determinant and norm is correct
     """
-    test_arr = np.random.rand(10,3,3)
+    test_arr = np.random.rand(10, 3, 3)
     t_det = dti.tensor_determinant(test_arr)
     t_norm = dti.tensor_norm(test_arr)
-    for i,x in enumerate(test_arr):
+    for i, x in enumerate(test_arr):
         assert_almost_equal(np.linalg.det(x), t_det[i])
         assert_almost_equal(np.linalg.norm(x), t_norm[i])
 
@@ -64,13 +64,13 @@ def test_TensorModel():
     evals = np.array([2., 1., 0.]) / B
     md = evals.mean()
     tensor = from_lower_triangular(D)
-    A_squiggle = tensor - (1/3.0) * np.trace(tensor) * np.eye(3)
-    mode = 3 * np.sqrt(6) * np.linalg.det(A_squiggle/np.linalg.norm(A_squiggle))
+    A_squiggle = tensor - (1 / 3.0) * np.trace(tensor) * np.eye(3)
+    mode = 3 * np.sqrt(6) * np.linalg.det(A_squiggle / np.linalg.norm(A_squiggle))
     evecs = np.linalg.eigh(tensor)[1]
     #Design Matrix
     X = dti.design_matrix(bvecs, bvals)
     #Signals
-    Y = np.exp(np.dot(X,D))
+    Y = np.exp(np.dot(X, D))
     assert_almost_equal(Y[0], b0)
     Y.shape = (-1,) + Y.shape
 
@@ -85,7 +85,7 @@ def test_TensorModel():
         assert_array_almost_equal(tensor_fit.evals[0], evals)
 
         assert_array_almost_equal(tensor_fit.quadratic_form[0], tensor,
-                                  err_msg =\
+                                  err_msg=\
         "Calculation of tensor from Y does not compare to analytical solution")
 
         assert_almost_equal(tensor_fit.md[0], md)
@@ -132,19 +132,19 @@ def test_diffusivities():
     bvals = np.zeros(len(bvecs)) + 1000
     bvals[0] = 0
     gtab = grad.gradient_table(bvals, bvecs)
-    mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003] ))
+    mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
     mevecs = [ np.array( [ [1,0,0], [0,1,0], [0,0,1] ] ),
                np.array( [ [0,0,1], [0,1,0], [1,0,0] ] ) ]
     S = single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )
 
     dm = dti.TensorModel(gtab, 'LS')
     dmfit = dm.fit(S)
-    
+
     md = mean_diffusivity(dmfit.evals)
     Trace = trace(dmfit.evals)
     rd = radial_diffusivity(dmfit.evals)
     ad = axial_diffusivity(dmfit.evals)
-    
+
     assert_almost_equal(md, (0.0015 + 0.0003 + 0.0001) / 3)
     assert_almost_equal(Trace, (0.0015 + 0.0003 + 0.0001))
     assert_almost_equal(ad, 0.0015)
@@ -166,7 +166,6 @@ def test_color_fa():
     assert_equal(fa.shape, evecs[..., 0, 0].shape)
     assert_equal((3, 3), evecs.shape[-2:])
 
-
     # 3D test case
     fa = np.ones((3, 3, 3))
     evecs = np.zeros(fa.shape + (3, 3))
@@ -176,7 +175,6 @@ def test_color_fa():
     true_cfa = np.reshape(np.tile(cfa_truth, 27), [3, 3, 3, 3])
 
     assert_array_equal(cfa, true_cfa)
-
 
     # 2D test case
     fa = np.ones((3, 3))
@@ -188,7 +186,6 @@ def test_color_fa():
 
     assert_array_equal(cfa, true_cfa)
 
-
     # 1D test case
     fa = np.ones((3))
     evecs = np.zeros(fa.shape + (3, 3))
@@ -198,7 +195,6 @@ def test_color_fa():
     true_cfa = np.reshape(np.tile(cfa_truth, 3), [3, 3])
 
     assert_array_equal(cfa, true_cfa)
-
 
 
 def test_WLS_and_LS_fit():
@@ -225,7 +221,7 @@ def test_WLS_and_LS_fit():
     #Design Matrix
     X = dti.design_matrix(bvec, bval)
     #Signals
-    Y = np.exp(np.dot(X,D))
+    Y = np.exp(np.dot(X, D))
     assert_almost_equal(Y[0], b0)
     Y.shape = (-1,) + Y.shape
 
@@ -238,7 +234,7 @@ def test_WLS_and_LS_fit():
     assert_equal(tensor_est.shape, Y.shape[:-1])
     assert_array_almost_equal(tensor_est.evals[0], evals)
     assert_array_almost_equal(tensor_est.quadratic_form[0], tensor,
-                              err_msg= "Calculation of tensor from Y does not "
+                              err_msg="Calculation of tensor from Y does not "
                                        "compare to analytical solution")
     assert_almost_equal(tensor_est.md[0], md)
 
@@ -262,7 +258,7 @@ def test_WLS_and_LS_fit():
 
 
 def test_masked_array_with_Tensor():
-    data = np.ones((2,4,56))
+    data = np.ones((2, 4, 56))
     mask = np.array([[True, False, False, True],
                      [True, False, True, False]])
 
@@ -271,22 +267,22 @@ def test_masked_array_with_Tensor():
 
     tensor_model = TensorModel(gtab, min_signal=1e-9)
     tensor = tensor_model.fit(data, mask=mask)
-    assert_equal(tensor.shape, (2,4))
-    assert_equal(tensor.fa.shape, (2,4))
-    assert_equal(tensor.evals.shape, (2,4,3))
-    assert_equal(tensor.evecs.shape, (2,4,3,3))
+    assert_equal(tensor.shape, (2, 4))
+    assert_equal(tensor.fa.shape, (2, 4))
+    assert_equal(tensor.evals.shape, (2, 4, 3))
+    assert_equal(tensor.evecs.shape, (2, 4, 3, 3))
 
     tensor = tensor[0]
     assert_equal(tensor.shape, (4,))
     assert_equal(tensor.fa.shape, (4,))
-    assert_equal(tensor.evals.shape, (4,3))
-    assert_equal(tensor.evecs.shape, (4,3,3))
+    assert_equal(tensor.evals.shape, (4, 3))
+    assert_equal(tensor.evecs.shape, (4, 3, 3))
 
     tensor = tensor[0]
     assert_equal(tensor.shape, tuple())
     assert_equal(tensor.fa.shape, tuple())
     assert_equal(tensor.evals.shape, (3,))
-    assert_equal(tensor.evecs.shape, (3,3))
+    assert_equal(tensor.evecs.shape, (3, 3))
     assert_equal(type(tensor.model_params), np.ndarray)
 
 
@@ -303,14 +299,14 @@ def test_fit_method_error():
 
 
 def test_lower_triangular():
-    tensor = np.arange(9).reshape((3,3))
+    tensor = np.arange(9).reshape((3, 3))
     D = lower_triangular(tensor)
     assert_array_equal(D, [0, 3, 4, 6, 7, 8])
     D = lower_triangular(tensor, 1)
     assert_array_equal(D, [0, 3, 4, 6, 7, 8, 0])
     assert_raises(ValueError, lower_triangular, np.zeros((2, 3)))
-    shape = (4,5,6)
-    many_tensors = np.empty(shape + (3,3))
+    shape = (4, 5, 6)
+    many_tensors = np.empty(shape + (3, 3))
     many_tensors[:] = tensor
     result = np.empty(shape + (6,))
     result[:] = [0, 3, 4, 6, 7, 8]


### PR DESCRIPTION
Hello!

My first PR to Dipy: calculating the "mode" of a tensor.

From a 2006 MRM paper (http://lmi.bwh.harvard.edu/papers/papers/ennisMRM06.html ):

> The mode of anisotropy is useful for resolving whether a region of anisotropy is linear
> anisotropic, orthotropic, or planar anisotropic"

It has also proven useful for identifying changes in regions of crossing fibers (http://www.ncbi.nlm.nih.gov/pubmed/21182970).

I've implemented it in Dipy based on the equations in the Ennis 2006 paper. I have a Nipype wrapper that will be sent as a PR as well (https://github.com/swederik/nipype/commit/313d6a02ca6c156298a2a8494fabcc3fe7ec4e20)

Tensor mode screenshot. Linearly anisotropic (i.e. one direction) diffusion areas like the corpus callosum have high values (white), lower values are found in regions of crossing fiber bundles, indicating planar anisotropy.

![Screen Shot 2013-04-02 at 23 05 47](https://f.cloud.github.com/assets/607793/330988/0afeac42-9bdd-11e2-9e72-35386a4b2abb.png)
