### PR TITLE
BF: pyc and created trk files were in eg archive

### DIFF
--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -5,7 +5,7 @@ Steps are:
     analyze example index file for example py filenames
     check for any filenames in example directory not included
     do py to rst conversion, writing into build directory
-    run 
+    run
 """
 #-----------------------------------------------------------------------------
 # Library imports
@@ -90,7 +90,7 @@ for script in glob('*.py'):
 
 # clean up stray images, pickles, npy files, etc
 for globber in ('*.nii.gz', '*.dpy', '*.npy', '*.pkl', '*.mat', '*.img',
-                '*.hdr'):
+                '*.hdr', '*.pyc', '*.trk'):
     for fname in glob(globber):
         os.unlink(fname)
 


### PR DESCRIPTION
We are creating trk and pyc files in the examples, and then saving them
in the examples archive to upload with the docs, but they should not be
needed.
