### PR TITLE
RF: refactor pyx / c file stamping for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist/
 .pydevproject
 *.swp
 dipy.egg-info/
+pyx-stamps

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,5 @@ source-release: clean
 binary-release: clean
 	python setup_egg.py bdist_egg
 
+build-stamp-source:
+	python -c 'import cythexts; cythexts.build_stamp_source()'


### PR DESCRIPTION
Yarik was finding it annoying to have the stamping procedure inside the
sdist procedure, so pull it out so we can use it to build and stamp
pyx and c files in the source tree.
