### PR TITLE
BF: doctest output difference workarounds

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -877,8 +877,9 @@ def lee_perpendicular_distance(start0, end0, start1, end1):
 
     Examples
     --------
-    >>> print(lee_perpendicular_distance([0,0,0],[1,0,0],[3,4,5],[5,4,3]))
-    5.78788757324
+    >>> d = lee_perpendicular_distance([0,0,0],[1,0,0],[3,4,5],[5,4,3])
+    >>> print('%.6f' % d)
+    5.787888
     '''
 
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1,fvec2,fvec3,fvec4
@@ -1340,8 +1341,9 @@ def track_dist_3pts(tracka,trackb):
     --------
     >>> a = np.array([[0,0,0],[1,0,0,],[2,0,0]])
     >>> b = np.array([[3,0,0],[3.5,1,0],[4,2,0]])
-    >>> print(track_dist_3pts(a, b))
-    2.72157287598
+    >>> c = track_dist_3pts(a, b)
+    >>> print('%.6f' % c)
+    2.721573
     '''
 
     cdef cnp.ndarray[cnp.float32_t, ndim=2] a,b

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -419,8 +419,8 @@ def longest_track_bundle(bundle,sort=False):
     >>> longest_track_bundle(bundle)
     array([[0, 0, 0],
            [4, 4, 4]])
-    >>> longest_track_bundle(bundle,True)
-    array([0, 1])
+    >>> longest_track_bundle(bundle, True) #doctest: +ELLIPSIS
+    array([0, 1]...)
 
     '''
     alllengths=[length(t) for t in bundle]

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -200,10 +200,10 @@ def reduce_labels(label_volume):
     >>> new_labels, lookup = reduce_labels(labels)
     >>> lookup
     array([1, 3, 7, 8, 9])
-    >>> new_labels
+    >>> new_labels #doctest: +ELLIPSIS
     array([[0, 1, 4],
            [0, 1, 3],
-           [0, 1, 2]])
+           [0, 1, 2]]...)
     >>> (lookup[new_labels] == labels).all()
     True
     """


### PR DESCRIPTION
We were getting trivial doctest failures from format differences; see:
http://nipy.bic.berkeley.edu/builders/dipy-bdist32-32/builds/2/steps/shell_4/logs/stdio
