### PR TITLE
DOC: replace soureforge.net links with nipy.org

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -38,13 +38,13 @@
 <h4> NIPY Community </h4>
   <ul class="simple">
     <li><a class="reference external"
-	href="http://nipy.sourceforge.net/">Community Home</a></li>
+	href="http://nipy.org/">Community Home</a></li>
     <li><a class="reference external"
-	href="http://nipy.sourceforge.net/software/projects/">NIPY Projects</a></li>
+	href="http://nipy.org/software/projects/">NIPY Projects</a></li>
     <li><a class="reference external"
 	href="http://mail.scipy.org/mailman/listinfo/nipy-devel">Mailing List</a></li>
     <li><a class="reference external"
-	href="http://nipy.sourceforge.net/software/license/index.html">License</a></li>
+	href="http://nipy.org/software/license/index.html">License</a></li>
   </ul>
 
 {% endblock %}

--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -15,9 +15,9 @@
 .. _dipy pypi: http://pypi.python.org/pypi/dipy
 .. _nipy issues: http://github.com/nipy/nipy/issues
 .. _dipy issues: http://github.com/nipy/dipy/issues
-.. _nibabel: http://nipy.sourceforge.net/nibabel
+.. _nibabel: http://nipy.org/nibabel
 .. _nibabel pypi: http://pypi.python.org/pypi/nibabel
-.. _nipy development guidelines: http://nipy.sourceforge.net/devel
+.. _nipy development guidelines: http://nipy.org/devel
 .. _buildbots: http://nipy.bic.berkeley.edu/builders
 
 .. Packaging


### PR DESCRIPTION
Change canonical nipy web address - because we're set up properly on
nipy.org now.
