### PR TITLE
Fixed the default dipy SH basis not to be the fibernav one

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -80,6 +80,49 @@ def real_sph_harm(m, n, theta, phi):
     real_sh *= np.where(m == 0, 1., np.sqrt(2))
     return real_sh
 
+def real_sph_harm_dipy(sh_order, theta, phi):
+    """
+    Compute real spherical harmonics, where the real harmonic $Y^m_n$ is
+    defined to be:
+
+        Real($Y^m_n$) * sqrt(2) if m > 0
+        $Y^m_n$                 if m == 0
+        Imag($Y^m_n$) * sqrt(2) if m < 0
+
+    This may take scalar or array arguments. The inputs will be broadcasted
+    against each other.
+
+    Parameters
+    ----------
+    sh_order : int
+        The maximum degree or the spherical harmonic basis.
+    theta : float [0, 2*pi]
+        The azimuthal (longitudinal) coordinate.
+    phi : float [0, pi]
+        The polar (colatitudinal) coordinate.
+
+    Returns
+    --------
+    y_mn : real float
+        The real harmonic $Y^m_n$ sampled at `theta` and `phi`.
+    m : array
+        The order of the harmonics.
+    n : array
+        The degree of the harmonics.
+
+    See Also
+    --------
+    scipy.special.sph_harm
+    """
+    m, n = sph_harm_ind_list(sh_order)
+    phi = np.reshape(phi, [-1, 1])
+    theta = np.reshape(theta, [-1, 1])
+
+    sh = sph_harm(np.abs(m), n, phi, theta)
+    real_sh = np.where(m > 0, sh.imag, sh.real)
+    real_sh *= np.where(m == 0, 1., np.sqrt(2))
+    return real_sh, m, n
+
 
 def real_sph_harm_mrtrix(sh_order, theta, phi):
     """
@@ -168,7 +211,7 @@ def real_sph_harm_fibernav(sh_order, theta, phi):
     return real_sh, m, n
 
 
-sph_harm_lookup = {None: real_sph_harm_fibernav,
+sph_harm_lookup = {None: real_sph_harm_dipy,
                    "mrtrix": real_sph_harm_mrtrix,
                    "fibernav": real_sph_harm_fibernav}
 

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -15,7 +15,7 @@ from dipy.sims.voxel import multi_tensor_odf
 from dipy.data import mrtrix_spherical_functions
 
 
-from dipy.reconst.shm import (real_sph_harm, real_sph_harm_mrtrix,
+from dipy.reconst.shm import (real_sph_harm, real_sph_harm_dipy, real_sph_harm_mrtrix,
                               real_sph_harm_fibernav, sph_harm_ind_list,
                               OpdtModel, normalize_data, hat, lcr_matrix,
                               smooth_pinv, bootstrap_data_array,
@@ -79,6 +79,12 @@ def test_real_sph_harm():
     dd = np.ones((1, 1, 1, 6))
     assert_equal(rsh(aa, bb, cc, dd).shape, (3, 4, 5, 6))
 
+
+def test_real_sph_harm_dipy():
+    sphere = hemi_icosahedron.subdivide(2)
+    basis, m, n = real_sph_harm_dipy(8, sphere.theta, sphere.phi)
+    basis2 = real_sph_harm(m, n, sphere.theta[:, None], sphere.phi[:, None])
+    assert_array_equal(basis, basis2)
 
 def test_real_sph_harm_mrtrix():
     coef, expected, sphere = mrtrix_spherical_functions()
@@ -354,3 +360,4 @@ def test_sf_to_sh():
 if __name__ == "__main__":
     import nose
     nose.runmodule()
+


### PR DESCRIPTION
Maybe I have missed this in previous discussions with @MrBago and @stefanv about SH bases (dipy, mrtrix, fibernav) a while back. However, currently, the sph_harm_lookup table was pointing to the fibernav basis by default. Was this intentional? If so, that is fine and we can make it the default one.

If not intentional, I have added a real_sph_harm_dipy with the same signature as the mrtrix and fibernav one. This way, it can be used in the lookup table. 

However, it duplicates code of the real_sph_harm, which might have still been there for backwards compatibility. 

Added a test as well.
