### PR TITLE
NF - add sph_harm_basis keyword argument to sh-models and renamed basis

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -81,7 +81,7 @@ def real_sph_harm(m, n, theta, phi):
     return real_sh
 
 
-def real_sph_harm_mrtrix(sh_order, theta, phi):
+def real_sym_sh_mrtrix(sh_order, theta, phi):
     """
     Compute real spherical harmonics as in mrtrix, where the real harmonic
     $Y^m_n$ is defined to be::
@@ -124,10 +124,13 @@ def real_sph_harm_mrtrix(sh_order, theta, phi):
     return real_sh, m, n
 
 
-def real_sph_harm_fibernav(sh_order, theta, phi):
-    """
-    Compute real spherical harmonics as in fibernavigator, where the real
-    harmonic $Y^m_n$ is defined to be::
+def real_sym_sh_basis(sh_order, theta, phi):
+    """Samples a real symmetric spherical harmonic basis at point on the sphere
+
+    Samples the basis functions up to order `sh_order` at points on the sphere
+    given by `theta` and `phi`. The basis functions are defined here the same
+    way as in fibernavigator [1]_ where the real harmonic $Y^m_n$ is defined to
+    be:
 
         Imag($Y^m_n$) * sqrt(2)     if m > 0
         $Y^m_n$                     if m == 0
@@ -148,8 +151,7 @@ def real_sph_harm_fibernav(sh_order, theta, phi):
     Returns
     --------
     y_mn : real float
-        The real harmonic $Y^m_n$ sampled at `theta` and `phi` as
-        implemented in the FiberNavigator [1]_.
+        The real harmonic $Y^m_n$ sampled at `theta` and `phi`
     m : array
         The order of the harmonics.
     n : array
@@ -168,9 +170,9 @@ def real_sph_harm_fibernav(sh_order, theta, phi):
     return real_sh, m, n
 
 
-sph_harm_lookup = {None: real_sph_harm_fibernav,
-                   "mrtrix": real_sph_harm_mrtrix,
-                   "fibernav": real_sph_harm_fibernav}
+sph_harm_lookup = {None: real_sym_sh_basis,
+                   "mrtrix": real_sym_sh_mrtrix,
+                   "fibernav": real_sym_sh_basis}
 
 
 def sph_harm_ind_list(sh_order):
@@ -280,17 +282,17 @@ class SphHarmModel(OdfModel, Cache):
             If True, data will not be normalized before fitting to the model
 
         """
-        m, n = sph_harm_ind_list(sh_order)
         self._where_b0s = lazy_index(gtab.b0s_mask)
         self._where_dwi = lazy_index(~gtab.b0s_mask)
         self.assume_normed = assume_normed
         self.min_signal = min_signal
         x, y, z = gtab.gradients[self._where_dwi].T
         r, theta, phi = cart2sphere(x, y, z)
-        B = real_sph_harm(m, n, theta[:, None], phi[:, None])
+        B, m, n = real_sym_sh_basis(sh_order, theta[:, None], phi[:, None])
         L = -n * (n + 1)
         legendre0 = lpn(sh_order, 0)[0]
         F = legendre0[n]
+        self.sh_order = sh_order
         self.B = B
         self.m = m
         self.n = n
@@ -365,10 +367,21 @@ class SphHarmFit(OdfFit):
         if sampling_matrix is None:
             phi = sphere.phi.reshape((-1, 1))
             theta = sphere.theta.reshape((-1, 1))
-            sampling_matrix = real_sph_harm(self.model.m, self.model.n,
-                                            theta, phi)
+            sh_order = self.model.sh_order
+            sampling_matrix, m, n = real_sym_sh_basis(sh_order, theta, phi)
             self.model.cache_set("sampling_matrix", sphere, sampling_matrix)
         return dot(self._shm_coef, sampling_matrix.T)
+
+    @property
+    def shm_coeff(self):
+        """The spherical harmonic coefficients coefficients of the odf
+
+        Make this a property for now, if there is a usecase for modifying
+        the coefficients we can add a setter or expose the coefficients more
+        directly
+
+        """
+        return self._shm_coef
 
 
 class CsaOdfModel(SphHarmModel):

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -15,8 +15,8 @@ from dipy.sims.voxel import multi_tensor_odf
 from dipy.data import mrtrix_spherical_functions
 
 
-from dipy.reconst.shm import (real_sph_harm, real_sph_harm_mrtrix,
-                              real_sph_harm_fibernav, sph_harm_ind_list,
+from dipy.reconst.shm import (real_sph_harm, real_sym_sh_basis,
+                              real_sym_sh_mrtrix, sph_harm_ind_list,
                               OpdtModel, normalize_data, hat, lcr_matrix,
                               smooth_pinv, bootstrap_data_array,
                               bootstrap_data_voxel, ResidualBootstrapWrapper,
@@ -80,24 +80,24 @@ def test_real_sph_harm():
     assert_equal(rsh(aa, bb, cc, dd).shape, (3, 4, 5, 6))
 
 
-def test_real_sph_harm_mrtrix():
+def test_real_sym_sh_mrtrix():
     coef, expected, sphere = mrtrix_spherical_functions()
-    basis, m, n = real_sph_harm_mrtrix(8, sphere.theta, sphere.phi)
+    basis, m, n = real_sym_sh_mrtrix(8, sphere.theta, sphere.phi)
     func = np.dot(coef, basis.T)
     assert_array_almost_equal(func, expected, 4)
 
 
-def test_real_sph_harm_fibernav():
+def test_real_sym_sh_basis():
     # This test should do for now
     # The mrtrix basis should be the same as re-ordering and re-scaling the
     # fibernav basis
     new_order = [0, 5, 4, 3, 2, 1, 14, 13, 12, 11, 10, 9, 8, 7, 6]
     sphere = hemi_icosahedron.subdivide(2)
-    basis, m, n = real_sph_harm_mrtrix(4, sphere.theta, sphere.phi)
+    basis, m, n = real_sym_sh_mrtrix(4, sphere.theta, sphere.phi)
     expected = basis[:, new_order]
     expected *= np.where(m == 0, 1., np.sqrt(2))
 
-    fibernav_basis, m, n = real_sph_harm_fibernav(4, sphere.theta, sphere.phi)
+    fibernav_basis, m, n = real_sym_sh_basis(4, sphere.theta, sphere.phi)
     assert_array_almost_equal(fibernav_basis, expected)
 
 


### PR DESCRIPTION
functions to be more clear.

This is in response to https://github.com/nipy/dipy/pull/194#issuecomment-18675669, It should help ensure that there is consistent default spherical harmonic basis across dipy and make it independent of implementation.
