### PR TITLE
RF: Rename tensor statistics to remove "tensor_" from them.

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -229,7 +229,7 @@ def color_fa(fa, evecs):
 
 
 # The following are used to calculate the tensor mode:
-def tensor_determinant(q_form):
+def determinant(q_form):
     """
     The determinant of a tensor, given in quadratic form
 
@@ -325,7 +325,7 @@ def deviatoric(q_form):
     return A_squiggle
 
 
-def tensor_norm(q_form):
+def norm(q_form):
     r"""
     Calculate the Frobenius norm of a tensor quadratic form
 
@@ -355,7 +355,7 @@ def tensor_norm(q_form):
     return np.sqrt(np.sum(np.sum(np.abs(q_form ** 2), -1), -1))
 
 
-def tensor_mode(q_form):
+def mode(q_form):
     r"""
     Mode (MO) of a diffusion tensor [1]_.
 
@@ -392,13 +392,13 @@ def tensor_mode(q_form):
     """
 
     A_squiggle = deviatoric(q_form)
-    A_s_norm = tensor_norm(A_squiggle)
+    A_s_norm = norm(A_squiggle)
     # Add two dims for the (3,3), so that it can broadcast on A_squiggle:
     A_s_norm = A_s_norm.reshape(A_s_norm.shape + (1, 1))
-    return  3 * np.sqrt(6) * tensor_determinant((A_squiggle / A_s_norm))
+    return  3 * np.sqrt(6) * determinant((A_squiggle / A_s_norm))
 
 
-def tensor_linearity(evals, axis=-1):
+def linearity(evals, axis=-1):
     r"""
     The linearity of the tensor [1]_
 
@@ -433,7 +433,7 @@ def tensor_linearity(evals, axis=-1):
     return (ev1 - ev2) / evals.sum(0)
 
 
-def tensor_planarity(evals, axis=-1):
+def planarity(evals, axis=-1):
     r"""
     The planarity of the tensor [1]_
 
@@ -468,7 +468,7 @@ def tensor_planarity(evals, axis=-1):
     return (2 * (ev2 - ev3) / evals.sum(0))
 
 
-def tensor_sphericity(evals, axis=-1):
+def sphericity(evals, axis=-1):
     r"""
     The sphericity of the tensor [1]_
 
@@ -644,7 +644,7 @@ class TensorFit(object):
         Tensor mode calculated from cached eigenvalues.
 
         """
-        return tensor_mode(self.quadratic_form)
+        return mode(self.quadratic_form)
 
     @auto_attr
     def md(self):
@@ -755,7 +755,7 @@ class TensorFit(object):
             analysis" in Proc. 5th Annual ISMRM, 1997.
 
         """
-        return tensor_planarity(self.evals)
+        return planarity(self.evals)
 
 
     @auto_attr
@@ -781,7 +781,7 @@ class TensorFit(object):
             analysis" in Proc. 5th Annual ISMRM, 1997.
 
         """
-        return tensor_linearity(self.evals)
+        return linearity(self.evals)
 
 
     @auto_attr
@@ -807,7 +807,7 @@ class TensorFit(object):
             analysis" in Proc. 5th Annual ISMRM, 1997.
 
         """
-        return tensor_sphericity(self.evals)
+        return sphericity(self.evals)
 
 
     def odf(self, sphere):
@@ -1084,7 +1084,7 @@ def lower_triangular(tensor, b0=None):
         return D
 
 
-def tensor_eig_from_lo_tri(data):
+def eig_from_lo_tri(data):
     """Calculates parameters for creating a Tensor instance
 
     Calculates tensor parameters from the six unique tensor elements. This

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -13,8 +13,7 @@ from dipy.reconst.dti import (axial_diffusivity, color_fa,
                               fractional_anisotropy, from_lower_triangular,
                               lower_triangular, mean_diffusivity,
                               radial_diffusivity, TensorModel, trace,
-                              tensor_linearity, tensor_planarity,
-                              tensor_sphericity)
+                              linearity, planarity, sphericity)
 
 from dipy.io.bvectxt import read_bvec_file
 from dipy.data import get_data, dsi_voxels, get_sphere
@@ -29,8 +28,8 @@ def test_tensor_algebra():
     Test that the computation of tensor determinant and norm is correct
     """
     test_arr = np.random.rand(10, 3, 3)
-    t_det = dti.tensor_determinant(test_arr)
-    t_norm = dti.tensor_norm(test_arr)
+    t_det = dti.determinant(test_arr)
+    t_norm = dti.norm(test_arr)
     for i, x in enumerate(test_arr):
         assert_almost_equal(np.linalg.det(x), t_det[i])
         assert_almost_equal(np.linalg.norm(x), t_norm[i])
@@ -152,17 +151,17 @@ def test_diffusivities():
     Trace = trace(dmfit.evals)
     rd = radial_diffusivity(dmfit.evals)
     ad = axial_diffusivity(dmfit.evals)
-    linearity = tensor_linearity(dmfit.evals)
-    planarity = tensor_planarity(dmfit.evals)
-    sphericity = tensor_sphericity(dmfit.evals)
+    lin = linearity(dmfit.evals)
+    plan = planarity(dmfit.evals)
+    spher = sphericity(dmfit.evals)
     
     assert_almost_equal(md, (0.0015 + 0.0003 + 0.0001) / 3)
     assert_almost_equal(Trace, (0.0015 + 0.0003 + 0.0001))
     assert_almost_equal(ad, 0.0015)
     assert_almost_equal(rd, (0.0003 + 0.0001) / 2)
-    assert_almost_equal(linearity, (0.0015 - 0.0003)/Trace)
-    assert_almost_equal(planarity, 2 * (0.0003 - 0.0001)/Trace)
-    assert_almost_equal(sphericity, (3 * 0.0001)/Trace)
+    assert_almost_equal(lin, (0.0015 - 0.0003)/Trace)
+    assert_almost_equal(plan, 2 * (0.0003 - 0.0001)/Trace)
+    assert_almost_equal(spher, (3 * 0.0001)/Trace)
 
 
 def test_color_fa():
@@ -269,9 +268,9 @@ def test_WLS_and_LS_fit():
     assert_array_almost_equal(tensor_est.quadratic_form, tensor)
     assert_almost_equal(tensor_est.md, md)
     assert_array_almost_equal(tensor_est.lower_triangular(b0), D)
-    assert_array_almost_equal(tensor_est.linearity, tensor_linearity(evals))
-    assert_array_almost_equal(tensor_est.planarity, tensor_planarity(evals))
-    assert_array_almost_equal(tensor_est.sphericity, tensor_sphericity(evals))
+    assert_array_almost_equal(tensor_est.linearity, linearity(evals))
+    assert_array_almost_equal(tensor_est.planarity, planarity(evals))
+    assert_array_almost_equal(tensor_est.sphericity, sphericity(evals))
 
 
 


### PR DESCRIPTION
They are all in the dti module after all.
