### PR TITLE
RF - update csdeconv to use SphHarmFit class to reduce code duplication.

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -4,10 +4,8 @@ import numpy as np
 from dipy.reconst.odf import OdfModel, OdfFit
 from dipy.reconst.cache import Cache
 from dipy.reconst.multi_voxel import multi_voxel_model
-from dipy.reconst.shm import (sph_harm_ind_list,
-                              real_sph_harm,
-                              sph_harm_lookup,
-                              lazy_index)
+from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm,
+                              sph_harm_lookup, lazy_index, SphHarmFit)
 from dipy.data import get_sphere
 from dipy.core.geometry import cart2sphere
 from dipy.core.ndindex import ndindex
@@ -115,25 +113,7 @@ class ConstrainedSphericalDeconvModel(OdfModel, Cache):
     def fit(self, data):
         s_sh = np.linalg.lstsq(self.B_dwi, data[self._where_dwi])[0]
         shm_coeff, num_it = csdeconv(s_sh, self.sh_order, self.R, self.B_reg, self.lambda_, self.tau)
-        return ConstrainedSphericalDeconvFit(self, shm_coeff)
-
-
-class ConstrainedSphericalDeconvFit(OdfFit):
-
-    def __init__(self, model, fodf_sh):
-        self.shm_coeff = fodf_sh
-        self.model = model
-
-    def odf(self, sphere):
-
-        sampling_matrix = self.model.cache_get("sampling_matrix", sphere)
-        if sampling_matrix is None:
-            phi = sphere.phi[:, np.newaxis] #sphere.phi.reshape((-1, 1))
-            theta = sphere.theta.reshape((-1, 1))
-            sampling_matrix = real_sph_harm(self.model.m, self.model.n, theta, phi)
-            self.model.cache_set("sampling_matrix", sphere, sampling_matrix)
-
-        return np.dot(self.shm_coeff, sampling_matrix.T)
+        return SphHarmFit(self, shm_coeff, None)
 
 
 @multi_voxel_model
@@ -219,26 +199,7 @@ class ConstrainedSDTModel(OdfModel, Cache):
         odf_sh /= Z
         shm_coeff, num_it = odf_deconv(odf_sh, self.sh_order, self.R, self.B_reg, self.lambda_, self.tau)
         # print 'SDT CSD converged after %d iterations' % num_it
-
-        return ConstrainedSDTFit(self, shm_coeff)
-
-
-class ConstrainedSDTFit(OdfFit):
-
-    def __init__(self, model, fodf_sh):
-        self.shm_coeff = fodf_sh
-        self.model = model
-
-    def odf(self, sphere):
-
-        sampling_matrix = self.model.cache_get("sampling_matrix", sphere)
-        if sampling_matrix is None:
-            phi = sphere.phi[:, np.newaxis] #sphere.phi.reshape((-1, 1))
-            theta = sphere.theta.reshape((-1, 1))
-            sampling_matrix = real_sph_harm(self.model.m, self.model.n, theta, phi)
-            self.model.cache_set("sampling_matrix", sphere, sampling_matrix)
-
-        return np.dot(self.shm_coeff, sampling_matrix.T)
+        return SphHarmFit(self, shm_coeff, None)
 
 
 def estimate_response(gtab, evals, S0):


### PR DESCRIPTION
Hey guys, I think we can reduce code duplication by using the SphHarmFit here, also this should help with implementing new features on the fit object.
