### PR TITLE
peaks_from_model now return peaks directions

### DIFF
--- a/dipy/reconst/odf.py
+++ b/dipy/reconst/odf.py
@@ -274,10 +274,10 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
             peak_values[idx][:n] /= pk[0]
             peak_dirs[idx] *= peak_values[idx][:, None]
 
-    gfa_array = gfa_array
-    qa_array = qa_array / global_max
-    peak_values = peak_values
-    peak_indices = peak_indices
+    #gfa_array = gfa_array
+    qa_array /= global_max
+    #peak_values = peak_values
+    #peak_indices = peak_indices
 
     # The fibernavigator only supports float32. Since this form is mainly
     # for external visualisation, we enforce float32.


### PR DESCRIPTION
This fixes #214 as well as #220. Now the function can return the peaks directions, and works with ndindex. So no need ot go outside and use the script in bin (which produces nan, strangely) with odf, now everything is done with the base function. Using ndindex is not really faster in my tests, but it enabled me to remove all the reshaping everywhere, so it's much cleaner now.
