### PR TITLE
BF: input.dtype is used per default

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -25,7 +25,7 @@ def multi_median(input, median_radius, numpass):
     input : ndarray
         Filtered input volume.
     """
-    outvol = np.zeros_like(input, dtype=input.dtype)
+    outvol = np.zeros_like(input)
     
     # Array representing the size of the median window in each dimension.
     medarr = np.ones_like(input.shape) * ((median_radius * 2) + 1)


### PR DESCRIPTION
And no dtype kwarg on some versions of numpy.

Addresses https://github.com/nipy/dipy/issues/228
