### PR TITLE
Fix peak extraction default value of relative_peak_threshold

### DIFF
--- a/bin/dipy_peak_extraction
+++ b/bin/dipy_peak_extraction
@@ -11,7 +11,7 @@ from dipy.core.sphere import Sphere
 
 
 def peak_extraction(odfs_file, sphere_vertices_file, out_file, relative_peak_threshold=.25,
-                    peak_normalize=1, min_separation_angle=45, max_peak_number=5):
+                    peak_normalize=1, min_separation_angle=45., max_peak_number=5):
 
     in_nifti = nib.load(odfs_file)
     refaff = in_nifti.get_affine()
@@ -51,24 +51,30 @@ def buildArgsParser():
     p.add_argument(action='store', dest='spherical_functions_file',
                    help='Input nifti file representing the orientation '
                         'distribution function.')
+
     p.add_argument(action='store', dest='sphere_vertices_file',
                    help="""Sphere vertices in a text file (Nx3)
     x1 x2 x3
      ...
     xN yN zN""")
-    p.add_argument(action='store', dest='out_file',
+
+    p.add_argument(action='store', dest='out_file', type=str,
                    help='Output nifti file with the peak directions.')
-    p.add_argument('-t', '--peak_threshold', action='store',
+
+    p.add_argument('-t', '--peak_threshold', action='store',type=float,
                    dest='peak_thresh', metavar='float', required=False,
-                   default=0.5, help='Relative peak threshold (default 0.5)')
+                   default=0.25, help='Relative peak threshold (default 0.25)')
+
     p.add_argument('-n', '--peak_normalize', action='store', dest='peak_norm',
-                   metavar='int', required=False, default=1,
+                   type=int, metavar='int', required=False, default=1,
                    help='Normalize peaks according to spherical function '
                         'value (default 1)')
-    p.add_argument('-a', '--angle', action='store', dest='angle',
+
+    p.add_argument('-a', '--angle', action='store', dest='angle', type=float,
                    metavar='float', required=False, default=45.0,
                    help='Minimum separation angle (default 45 degrees)')
-    p.add_argument('-m', '--max_peak_number', action='store',
+
+    p.add_argument('-m', '--max_peak_number', action='store', type=int,
                    dest='max_peak_num', metavar='int', required=False,
                    default=5,
                    help='Maximum number of peaks found (default 5 peaks)')


### PR DESCRIPTION
As discussed, this fixes #231 by changing the default value for relative_peak_threshold in the dipy_peak_extraction script.

I also added some type to the parser since only some values should be passed by the command line.
