### PR TITLE
Handle cpu count exception

### DIFF
--- a/dipy/reconst/odf.py
+++ b/dipy/reconst/odf.py
@@ -176,8 +176,8 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
                                     relative_peak_threshold,
                                     min_separation_angle, mask, return_odf,
                                     return_sh, gfa_thr, normalize_peaks,
-                                    sh_order, sh_basis_type, ravel_peaks,
-                                    npeaks, parallel=False)
+                                    sh_order, sh_basis_type, npeaks,
+                                    parallel=False)
 
     shape = list(data.shape)
     n_shm_coeff = (sh_order + 2) * (sh_order + 1) / 2


### PR DESCRIPTION
There was an issue on macosx. mp.cpu_count() can raise a NotImplementedError. If this happens, a warning is raised, and peaks_from_model (..., parallel=False) is return instead.

http://nipy.bic.berkeley.edu/builders/dipy-py2.6-osx-10.5-intel/builds/245/steps/shell_5/logs/stdio
