### PR TITLE
Peak from model issue #253

### DIFF
--- a/dipy/reconst/peaks.py
+++ b/dipy/reconst/peaks.py
@@ -140,11 +140,11 @@ class PeaksAndMetrics(object):
 def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
                                min_separation_angle, mask, return_odf,
                                return_sh, gfa_thr, normalize_peaks,
-                               sh_order, sh_basis_type, npeaks, B, invB, nbr_process):
+                               sh_order, sh_basis_type, npeaks, B, invB, nbr_processes):
 
-    if nbr_process is None:
+    if nbr_processes is None:
         try:
-            nbr_process = cpu_count()
+            nbr_processes = cpu_count()
         except NotImplementedError:
             warn("Cannot determine number of cpus. \
                  returns peaks_from_model(..., paralle=False).")
@@ -160,7 +160,7 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
 
     data = np.reshape(data, (-1, shape[-1]))
     n = data.shape[0]
-    nbr_chunks = nbr_process ** 2
+    nbr_chunks = nbr_processes ** 2
     chunk_size = int(np.ceil(n / nbr_chunks))
     indices = zip(np.arange(0, n, chunk_size),
                   np.arange(0, n, chunk_size) + chunk_size)
@@ -177,7 +177,7 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         else:
             mask_file_name = None
 
-        pool = Pool(nbr_process)
+        pool = Pool(nbr_processes)
 
         pam_res = pool.map(_peaks_from_model_parallel_sub,
                            zip(repeat((data_file_name, mask_file_name)),
@@ -311,14 +311,14 @@ def _peaks_from_model_parallel_sub(args):
                             min_separation_angle, mask, return_odf,
                             return_sh, gfa_thr, normalize_peaks,
                             sh_order, sh_basis_type, npeaks, B, invB,
-                            parallel=False, nbr_process=None)
+                            parallel=False, nbr_processes=None)
 
 
 def peaks_from_model(model, data, sphere, relative_peak_threshold,
                      min_separation_angle, mask=None, return_odf=False,
                      return_sh=True, gfa_thr=0, normalize_peaks=False,
                      sh_order=8, sh_basis_type=None, npeaks=5, B=None, invB=None,
-                     parallel=False, nbr_process=None):
+                     parallel=False, nbr_processes=None):
     """Fits the model to data and computes peaks and metrics
 
     Parameters
@@ -363,8 +363,8 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
     parallel: bool
         If True, use multiprocessing to compute peaks and metric
         (default False).
-    nbr_process: int
-        If `parallel == True`, the number of subprocess to use
+    nbr_processes: int
+        If `parallel == True`, the number of subprocesses to use
         (default multiprocessing.cpu_count()).
 
     Returns
@@ -392,7 +392,7 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
                                           npeaks,
                                           B,
                                           invB,
-                                          nbr_process)
+                                          nbr_processes)
 
     shape = data.shape[:-1]
     if mask is None:
@@ -539,4 +539,3 @@ def reshape_peaks_for_visualization(peaks):
         peaks = peaks.peak_dirs
 
     return peaks.reshape(np.append(peaks.shape[:-2], -1)).astype('float32')
-('float32')

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -70,10 +70,10 @@ csapeaks_parallel = peaks_from_model(model=csamodel,
                                      normalize_peaks=True,
                                      npeaks=5,
                                      parallel=True,
-                                     nbr_process=2)  # default multiprocessing.cpu_count()
+                                     nbr_processes=2)  # default multiprocessing.cpu_count()
 
 time_parallel = time.time() - start_time
-print("peaks_from_model using 2 process ran in : " +
+print("peaks_from_model using 2 processes ran in : " +
       str(time_parallel) + " seconds")
 """
 peaks_from_model using 2 process ran in  : 114.333221912 seconds, using 2 process
@@ -90,7 +90,7 @@ csapeaks = peaks_from_model(model=csamodel,
                             normalize_peaks=True,
                             npeaks=5,
                             parallel=False,
-                            nbr_process=None)
+                            nbr_processes=None)
 
 time_single = time.time() - start_time
 print("peaks_from_model ran in : " + str(time_single) + " seconds")

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -117,14 +117,14 @@ csd_peaks_parallel = peaks_from_model(model=csd_model,
                                       normalize_peaks=True,
                                       npeaks=5,
                                       parallel=True,
-                                      nbr_process=None)  # default multiprocessing.cpu_count()
+                                      nbr_processes=None)  # default multiprocessing.cpu_count()
 
 time_parallel = time.time() - start_time
 print("peaks_from_model using " + str(multiprocessing.cpu_count())
       + " process ran in :" + str(time_parallel) + " seconds")
 
 """
-peaks_from_model using 8 process ran in :114.425682068 seconds
+peaks_from_model using 8 processes ran in :114.425682068 seconds
 """
 
 start_time = time.time()
@@ -139,7 +139,7 @@ csd_peaks = peaks_from_model(model=csd_model,
                              normalize_peaks=True,
                              npeaks=5,
                              parallel=False,
-                             nbr_process=None)
+                             nbr_processes=None)
 
 time_single = time.time() - start_time
 print("peaks_from_model ran in :" + str(time_single) + " seconds")


### PR DESCRIPTION
This PR should fix issue https://github.com/nipy/dipy/issues/253.

The problem is in the call to np.linalg.pinv, we didn't figure out why this happens on the buildbot. Nevertheless, this should fix the problem since pinv is no more called in the peaks_from_model_parallel. We added 2 optional parameters (B, invB) to peak_from_model, and give it pre-computed to the parallel function.

additionnaly,
- if B is already computed before calling peak_from_model, no need to recompute it
- if not, B is only computed once in the parallel version, instead of once per process
