### PR TITLE
BF - join pool before trying to delete temp directory

### DIFF
--- a/dipy/reconst/peaks.py
+++ b/dipy/reconst/peaks.py
@@ -270,6 +270,10 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         if return_odf:
             pam.odf = np.array(pam.odf)
 
+        # Make sure all worker processes have exited before leaving context
+        # manager in order to prevent temporary file deletion errors in windows
+        pool.join()
+
     # reshape the metric to the original shape
     pam.peak_dirs = np.reshape(pam.peak_dirs, shape[:-1] + [npeaks, 3])
     pam.peak_values = np.reshape(pam.peak_values, shape[:-1] + [npeaks])


### PR DESCRIPTION
I had a really weird idea about the error in https://github.com/nipy/dipy/pull/265, turns out I was way off. But this should fix the issue. It seems that Windows was trying to delete the temp directory before all the workers had fully exited.
