### PR TITLE
Update README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,5 +38,5 @@ License
 =======
 
 dipy is licensed under the terms of the BSD license. Some code included with
-dipy is also licensed under the BSD license.  Please the LICENSE file in the
+dipy is also licensed under the BSD license.  Please see the LICENSE file in the
 dipy distribution.


### PR DESCRIPTION
The pypi page also has the typo.

https://pypi.python.org/pypi/dipy/0.7.0
