### PR TITLE
BF: more problems with path quoting in windows

### DIFF
--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -18,7 +18,9 @@ if "%line1:~0,2%" == "#!" (goto :goodstart)
 echo First line of %pyscript% does not start with "#!"
 exit /b 1
 :goodstart
-set py_exe="%line1:~2%"
+set py_exe=%line1:~2%
+REM quote exe in case of spaces in path name
+set py_exe="%py_exe%"
 call %py_exe% %pyscript% %*
 """
 


### PR DESCRIPTION
For some reason, windows was losing the closing double quote for the python
path, making a confusing mess executing the scripts.

Try again with a longer way.
