### PR TITLE
add small and big delta

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -232,7 +232,7 @@ def gradient_table(bvals, bvecs=None, big_delta=None, small_delta=None,
         bvecs = np.asarray(bvecs)
         if (bvecs.shape[1] > bvecs.shape[0])  and bvecs.shape[0]>1:
             bvecs = bvecs.T
-    return gradient_table_from_bvals_bvecs(bvals, bvecs, big_delta=None,
-                                           small_delta=None,
+    return gradient_table_from_bvals_bvecs(bvals, bvecs, big_delta=big_delta,
+                                           small_delta=small_delta,
                                            b0_threshold=b0_threshold,
                                            atol=1e-2)


### PR DESCRIPTION
This is a very small pull request, I found that even if gradients.py had as parameters small_delta and big_delta it didn't save them. So even if you had set the deltas using:

gtab = gradient_table(bvals, bvecs,big_delta=0.0577, small_delta=0.0454)

when you type:

gtab.big_delta

the output was always None.
This PR fix this bug.
