### PR TITLE
Add the mode param for border management.

### DIFF
--- a/dipy/align/aniso2iso.py
+++ b/dipy/align/aniso2iso.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.ndimage import affine_transform
 
 
-def resample(data, affine, zooms, new_zooms, order=1, mode='constant'):
+def resample(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
     """Resample data from anisotropic to isotropic voxel size
 
     Parameters
@@ -24,6 +24,9 @@ def resample(data, affine, zooms, new_zooms, order=1, mode='constant'):
     mode : string ('constant', 'nearest', 'reflect' or 'wrap')
         Points outside the boundaries of the input are filled according
         to the given mode.
+    cval : float
+        Value used for points outside the boundaries of the input if
+        mode='constant'.
 
     Returns
     -------
@@ -67,14 +70,14 @@ def resample(data, affine, zooms, new_zooms, order=1, mode='constant'):
     if data.ndim == 3:
         data2 = affine_transform(input=data, matrix=R, offset=np.zeros(3,),
                                  output_shape=tuple(new_shape),
-                                 order=order, mode=mode)
+                                 order=order, mode=mode, cval=cval)
     if data.ndim == 4:
         data2l=[] 
         for i in range(data.shape[-1]):
-            tmp=affine_transform(input=data[..., i], matrix=R,
-                                 offset=np.zeros(3,),
-                                 output_shape=tuple(new_shape),
-                                 order=order, mode=mode)
+            tmp = affine_transform(input=data[..., i], matrix=R,
+                                   offset=np.zeros(3,),
+                                   output_shape=tuple(new_shape),
+                                   order=order, mode=mode, cval=cval)
             data2l.append(tmp)        
         data2 = np.zeros(tmp.shape+(data.shape[-1],), data.dtype)
         for i in range(data.shape[-1]):


### PR DESCRIPTION
I added the possibility to specify the mode parameter to scipy's affine_transform to have more control over border management. 

The only real code change is the addition of the mode param to the resample method and the passing of this mode to the two affine_transform calls. All the other changes are some pep8ifications while I was there.
