### PR TITLE
BF: set integer type for crossplatform compilation

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -222,7 +222,8 @@ def add_padding_reflection(double [:, :, ::1] arr, padding):
 def correspond_indices(dim_size, padding):
     return np.ascontiguousarray(np.hstack((np.arange(1, padding + 1)[::-1],
                                 np.arange(dim_size),
-                                np.arange(dim_size - padding - 1, dim_size - 1)[::-1])))
+                                np.arange(dim_size - padding - 1, dim_size - 1)[::-1])),
+                                dtype=np.intp)
 
 
 def remove_padding(arr, padding):


### PR DESCRIPTION
Found cnp.npy_intp not long error when tried to run nosetests in Win 7 64 bit and fixed it here.
