### PR TITLE
DOC: Update a few Dipy links to link to the correct repo

### DIFF
--- a/doc/devel/gitwash/git_links.txt
+++ b/doc/devel/gitwash/git_links.txt
@@ -25,7 +25,7 @@
 
 .. nipy
 .. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
+.. _`dipy github`: https://github.com/nipy/dipy
 .. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. git stuff

--- a/doc/devel/gitwash/known_projects.inc
+++ b/doc/devel/gitwash/known_projects.inc
@@ -27,7 +27,7 @@
 
 .. dipy
 .. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
+.. _`dipy github`: https://github.com/nipy/dipy
 .. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. nibabel


### PR DESCRIPTION
Some links for the main Dipy repo were pointing to Elef's repo. Updated them to point to the main nipy/dipy repo.
