### PR TITLE
RF: update Cython dependency

### DIFF
--- a/dipy/info.py
+++ b/dipy/info.py
@@ -76,7 +76,7 @@ dipy distribution.
 # versions for dependencies
 NUMPY_MIN_VERSION='1.6'
 SCIPY_MIN_VERSION='0.9'
-CYTHON_MIN_VERSION='0.17'
+CYTHON_MIN_VERSION='0.18'
 NIBABEL_MIN_VERSION='1.0.0'
 
 # Main setup parameters


### PR DESCRIPTION
Getting compile errors for Cython 0.17; update dependency to 0.18.
