### PR TITLE
BF: fix import statement for get_cmap

### DIFF
--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -36,7 +36,7 @@ cm, have_matplotlib, _ = optional_package('matplotlib.cm')
 if have_matplotlib:
     get_cmap = cm.get_cmap
 else:
-    import dipy.data.get_cmap as get_cmap
+    from dipy.data import get_cmap
 
 # a track buffer used only with picking tracks
 track_buffer = []


### PR DESCRIPTION
I think you can't do `import module.attribute as attribute`, and you have to
do something like `from module import attribute`.
