### PR TITLE
Fix streamlinespeed tests

### DIFF
--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -207,9 +207,9 @@ def set_number_of_points(streamlines, nb_points=3):
     >>> # Multiple streamlines
     >>> streamlines = [streamline, streamline[::2]]
     >>> modified_streamlines = set_number_of_points(streamlines, 10)
-    >>> map(len, streamlines)
+    >>> [len(s) for s in streamlines]
     [100, 50]
-    >>> map(len, modified_streamlines)
+    >>> [len(s) for s in modified_streamlines]
     [10, 10]
 
     '''


### PR DESCRIPTION
This fixes some minor mistakes in the doctests from 'streamlinespeed.pyx' that the windows buildbots were complaining about: http://nipy.bic.berkeley.edu/builders/dipy-bdist32-33/builds/25/steps/shell_10/logs/stdio. Can you please verify @MarcCote?
