### PR TITLE
Missing a blank line in examples/tracking_quick_start.py

### DIFF
--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -22,6 +22,7 @@ if __name__ == '__main__':
     """
     Then, let's load the necessary modules.
     """
+    
     import numpy as np
 
     from dipy.reconst.dti import TensorModel, fractional_anisotropy


### PR DESCRIPTION
I just noticed this break the web page generated from example. (from PR #405)
