### PR TITLE
NF: generate config.pxi file with Cython DEF vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ else: # We have nibabel
     # up pyx and c files.
     build_ext = cyproc_exts(EXTS, CYTHON_MIN_VERSION, 'pyx-stamps')
     # Add openmp flags if they work
-    extbuilder = add_flag_checking(build_ext, ['-fopenmp'])
+    extbuilder = add_flag_checking(build_ext, [('-fopenmp', 'HAVE_OPENMP')])
 
 # Installer that checks for install-time dependencies
 class installer(install.install):


### PR DESCRIPTION
Eleftherios needs to do conditional compiling depending on whether openmp is
present or not.

Following the recipe in
http://stackoverflow.com/questions/3826458/cython-conditional-compile-based-on-external-value
-- build a `config.pxi` file containing DEF variables that can be used in
extension code.  For example, with the code here, a Cython extension could
include the following:

```
include "config.pxi"

IF HAVE_OPENMP:
   cimport openmp
```
