### PR TITLE
BF: fix writing history to file in Python 3

### DIFF
--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -183,9 +183,8 @@ class Optimizer(object):
                 self.tmp_files.append(fname)
 
                 def history_of_x(kx):
-                    f = open(fname, 'a')
-                    np.savetxt(f, kx)
-                    f.close()
+                    with open(fname, 'ab') as f:
+                        np.savetxt(f, kx)
 
                 res = minimize(fun, x0, args, method, jac, hess, hessp, bounds,
                                constraints, tol, callback=history_of_x,


### PR DESCRIPTION
Need to open file in binary mode to save text, strangely.

See:
http://nipy.bic.berkeley.edu/builders/dipy-py3.3/builds/227/steps/shell_8/logs/stdio
for error.
