### PR TITLE
RF: switch travis tests to use virtualenvs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ script:
       cp ../.coveragerc .;
       COVER_ARGS="--with-coverage --cover-package dipy";
       fi
-    - $PYTHON ../tools/dipnost $COVER_ARGS `python -c "import os; import dipy; print(os.path.dirname(dipy.__file__))"`
+    - nosetests --with-doctest --verbose $COVER_ARGS dipy
 after_success:
     - if [ "${COVERAGE}" == "1" ]; then coveralls; fi


### PR DESCRIPTION
We were using a trick to get the dependencies on travis, working round their
virtualenv setup.

Now there is a usable travis wheel repository, we can use our own virtualenvs
and install all optional dependencies.

Also allows checking minimal dependencies, and Pythons 2.6 through 3.4.
