### PR TITLE
Report on coverage for old scipy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     # To test minimum dependencies
     - python: 2.7
       env:
+        - COVERAGE=1
         - DEPENDS="cython==0.18 numpy==1.6.0 scipy==0.9.0 nibabel==1.2.0"
 before_install:
     - virtualenv venv


### PR DESCRIPTION
This might be the thing. That machine tests for the minimal versions of our dependency - meaning scipy==0.9. If we have a coverage report here as well, we can check for both minimal dependencies and typical dependencies. Together - these should give full coverage on `dipy.core.optimize`
