### PR TITLE
Skipping tests for different versions of Scipy for optimize.py

### DIFF
--- a/dipy/core/tests/test_optimize.py
+++ b/dipy/core/tests/test_optimize.py
@@ -52,24 +52,13 @@ def test_optimize_new_scipy():
                     options={'maxcor': 10, 'ftol': 1e-7,
                              'gtol': 1e-5, 'eps': 1e-8},
                     evolution=True)
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
 
     assert_equal(opt.evolution.shape, (opt.nit, 4))
-
-    print(opt.evolution)
 
     opt = Optimizer(fun=func2, x0=np.array([1., 1., 1., 5.]),
                     method='Powell',
                     options={'xtol': 1e-6, 'ftol': 1e-6, 'maxiter': 1e6},
                     evolution=True)
-
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
-    print(opt.message)
-    print(opt.evolution)
 
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]))
 
@@ -85,18 +74,10 @@ def test_optimize_old_scipy():
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0]))
     assert_almost_equal(opt.fopt, 0)
 
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
-
     opt = Optimizer(fun=func2, x0=np.array([1., 1., 1., 5.]),
                     method='Powell',
                     options={'xtol': 1e-6, 'ftol': 1e-6, 'maxiter': 1e6},
                     evolution=True)
-
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
 
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]))
 
@@ -107,20 +88,12 @@ def test_optimize_old_scipy():
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0]))
     assert_almost_equal(opt.fopt, 0)
 
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
-
     opt = Optimizer(fun=func, x0=np.array([1., 1., 1.]),
                     method='L-BFGS-B',
                     options=None)
 
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0]))
     assert_almost_equal(opt.fopt, 0)
-
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
 
     opt = Optimizer(fun=func2, x0=np.array([1., 1., 1., 5.]),
                     method='L-BFGS-B',
@@ -129,18 +102,10 @@ def test_optimize_old_scipy():
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]), 4)
     assert_almost_equal(opt.fopt, 0)
 
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
-
     opt = Optimizer(fun=func2, x0=np.array([1., 1., 1., 5.]),
                     method='Powell',
                     options={'maxiter': 1e6},
                     evolution=True)
-
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
 
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]))
 
@@ -148,10 +113,6 @@ def test_optimize_old_scipy():
                     method='Powell',
                     options={'maxiter': 1e6},
                     evolution=True)
-
-    print(opt.nit)
-    print(opt.fopt)
-    print(opt.nfev)
 
     assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]))
 


### PR DESCRIPTION
I am using the skipping test mechanism to make the tests on optimize to be a bit more readable. 
Nothing much in this PR. Mostly a change in style.
