### PR TITLE
RF - Make peaks_from_model part of dipy.direction

### DIFF
--- a/dipy/direction/__init__.py
+++ b/dipy/direction/__init__.py
@@ -1,1 +1,2 @@
 from .probabilistic_direction_getter import ProbabilisticDirectionGetter
+from dipy.reconst.peaks import *

--- a/dipy/tracking/tests/test_localtrack.py
+++ b/dipy/tracking/tests/test_localtrack.py
@@ -2,7 +2,8 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.tracking.local.tissue_classifier import ThresholdTissueClassifier
-from dipy.reconst.peaks import default_sphere, peaks_from_model
+from dipy.data import default_sphere
+from dipy.direction import peaks_from_model
 
 def test_ThresholdTissueClassifier():
     a = np.random.random((3, 5, 7))

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -50,7 +50,8 @@ image.
 """
 
 from dipy.reconst.shm import CsaOdfModel
-from dipy.reconst.peaks import peaks_from_model, default_sphere
+from dipy.data import default_sphere
+from dipy.direction import peaks_from_model
 
 csa_model = CsaOdfModel(gtab, sh_order=6)
 csa_peaks = peaks_from_model(csa_model, data, default_sphere,

--- a/doc/examples/probabilistic_fiber_tracking.py
+++ b/doc/examples/probabilistic_fiber_tracking.py
@@ -96,7 +96,7 @@ this basis to represent the data internally. However we can fit the ODF of any
 model to the spherical harmonic basis using the ``peaks_from_model`` function.
 """
 
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 
 peaks = peaks_from_model(csd_model, data, default_sphere, .5, 25,
                          mask=white_matter, return_sh=True, parallel=True)

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -13,7 +13,7 @@ import numpy as np
 import nibabel as nib
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi, get_sphere
 from dipy.reconst.shm import CsaOdfModel, normalize_data
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 
 """
 Download and read the data for this tutorial.

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -12,7 +12,7 @@ Import modules, fetch and read data, and compute the mask.
 import time
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi, get_sphere
 from dipy.reconst.shm import CsaOdfModel
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 from dipy.segment.mask import median_otsu
 
 fetch_stanford_hardi()

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -148,7 +148,7 @@ In Dipy we also provide tools for finding the peak directions (maxima) of the
 ODFs. For this purpose we strongly recommend using ``peaks_from_model``.
 """
 
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 
 csd_peaks = peaks_from_model(model=csd_model,
                              data=data_small,

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -54,7 +54,7 @@ duration of execution with or without parallelism.
 """
 
 import time
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 
 start_time = time.time()
 csd_peaks_parallel = peaks_from_model(model=csd_model,

--- a/doc/examples/reconst_gqi.py
+++ b/doc/examples/reconst_gqi.py
@@ -13,7 +13,7 @@ First import the necessary modules:
 import numpy as np
 from dipy.data import fetch_taiwan_ntu_dsi, read_taiwan_ntu_dsi, get_sphere
 from dipy.reconst.gqi import GeneralizedQSamplingModel
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 
 """
 Download and read the data for this tutorial.

--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -24,7 +24,7 @@ import numpy as np
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
-from dipy.reconst.peaks import peaks_from_model
+from dipy.direction import peaks_from_model
 from dipy.tracking.eudx import EuDX
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi, get_sphere
 from dipy.segment.mask import median_otsu


### PR DESCRIPTION
@Garyfallidis and I discussed moving `peaks_from_model` into `dipy.direction`. This PR allows updates all the example to import the this function from the new module, but doesn't actually move the module in order to maintain backwards compatibility.
