### PR TITLE
RF: Use integer datatype for unique_rows sorting.

### DIFF
--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -612,7 +612,7 @@ def length(streamlines, affine=None):
     return map(metrics.length, streamlines)
 
 
-def unique_rows(in_array, dtype='f4'):
+def unique_rows(in_array, dtype='i4'):
     """
     This (quickly) finds the unique rows in an array
 


### PR DESCRIPTION
Does this address the following issue? 
https://github.com/nipy/dipy/issues/505
