### PR TITLE
BF + TST: Reinstated eig_from_lo_tri

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1710,6 +1710,36 @@ def quantize_evecs(evecs, odf_vertices=None):
     IN = IN.reshape(tup)
     return IN
 
+
+def eig_from_lo_tri(data):
+    """
+    Calculates tensor eigenvalues/eigenvectors from an array containing the
+    lower diagonal form of the six unique tensor elements.
+
+    Parameters
+    ----------
+    data : array_like (..., 6)
+        diffusion tensors elements stored in lower triangular order
+
+    Returns
+    -------
+    dti_params (..., 12)
+        Eigen-values and eigen-vectors of the same array.
+    """
+    data = np.asarray(data)
+    data_flat = data.reshape((-1, data.shape[-1]))
+    dti_params = np.empty((len(data_flat), 4, 3))
+
+    for ii in range(len(data_flat)):
+        tensor = from_lower_triangular(data_flat[ii])
+        eigvals, eigvecs = decompose_tensor(tensor)
+        dti_params[ii, 0] = eigvals
+        dti_params[ii, 1:] = eigvecs
+
+    dti_params.shape = data.shape[:-1] + (12,)
+    return dti_params
+
+
 common_fit_methods = {'WLS': wls_fit_tensor,
                       'LS': ols_fit_tensor,
                       'OLS': ols_fit_tensor,

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -636,3 +636,22 @@ def test_predict():
     dtif = dtim.fit(data)
     S0 = np.mean(data[...,gtab.b0s_mask], -1)
     p = dtif.predict(gtab, S0)
+
+
+def test_eig_from_lo_tri():
+    psphere = get_sphere('symmetric362')
+    bvecs = np.concatenate(([[0, 0, 0]], psphere.vertices))
+    bvals = np.zeros(len(bvecs)) + 1000
+    bvals[0] = 0
+    gtab = grad.gradient_table(bvals, bvecs)
+    mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
+    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
+               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
+    S = np.array([[single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None ),
+                 single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )]])
+
+    dm = dti.TensorModel(gtab, 'LS')
+    dmfit = dm.fit(S)
+    
+    lo_tri = lower_triangular(dmfit.quadratic_form)
+    assert_array_almost_equal(dti.eig_from_lo_tri(lo_tri), dmfit.model_params)


### PR DESCRIPTION
Maybe someone can tell me what the use-case is for this function? It used to be here as an input to the Tensor model, but that structure was changed long ago, so I am not sure what you would use this for... Anyway - it's back, by popular demand: 

http://mail.scipy.org/pipermail/nipy-devel/2014-December/010734.html
