### PR TITLE
TST: Reduce sensitivity on these tests.

### DIFF
--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -169,8 +169,8 @@ def test_stream_rigid():
     moved2 = transform_streamlines(moving, srm.matrix)
     moved3 = srm.transform(moving)
 
-    assert_array_equal(moved[0], moved2[0])
-    assert_array_equal(moved2[0], moved3[0])
+    assert_array_almost_equal(moved[0], moved2[0], decimal=4)
+    assert_array_almost_equal(moved2[0], moved3[0], decimal=4)
 
 
 def test_min_vs_min_fast_precision():


### PR DESCRIPTION
This level of accuracy is not handled well on all platforms:

http://nipy.bic.berkeley.edu/builders/dipy-bdist32-27/builds/168/steps/shell_8/logs/stdio

http://nipy.bic.berkeley.edu/builders/dipy-py2.7-win32/builds/147/steps/shell_6/logs/stdio
