### PR TITLE
Readme.rst and info.py update about the license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,6 @@ Dipy is licensed under the terms of the BSD license.
 Please see the LICENSE file in the dipy distribution.
 
 Dipy uses other libraries also licensed under the BSD or the
-MIT licenses with the only exception of the SHORE module which
-optionally uses the cvxopt library and cvxopt is licensed
+MIT licenses, with the only exception of the SHORE module which
+optionally uses the cvxopt library. Cvxopt is licensed
 under the GPL license.

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -72,8 +72,8 @@ Dipy is licensed under the terms of the BSD license.
 Please see the LICENSE file in the dipy distribution.
 
 Dipy uses other libraries also licensed under the BSD or the
-MIT licenses with the only exception of the SHORE module which
-optionally uses the cvxopt library and cvxopt is licensed
+MIT licenses, with the only exception of the SHORE module which
+optionally uses the cvxopt library. Cvxopt is licensed
 under the GPL license.
 """
 


### PR DESCRIPTION
Here you are. This should resolve the license problem. Let's try to focus on more productive issues from now on hopefully get rid of cvxopt soon.
