### PR TITLE
BF: extend pip timeout to reduce install failures

### DIFF
--- a/tools/travis_tools.sh
+++ b/tools/travis_tools.sh
@@ -21,5 +21,5 @@ retry () {
 
 wheelhouse_pip_install() {
     # Install pip requirements via travis wheelhouse
-    retry pip install --no-index --find-links $WHEELHOUSE $@
+    retry pip install --timeout=60 --no-index --find-links $WHEELHOUSE $@
 }


### PR DESCRIPTION
pip seeming to timeout still; extend timeout.
