### PR TITLE
WIP: coordinate mapping with DiffeomorphicMap

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -258,22 +258,83 @@ class DiffeomorphicMap(object):
         self.backward = np.zeros(tuple(self.disp_shape) + (self.dim,),
                                  dtype=floating)
 
-    def _get_warping_function(self, interpolation):
+    def _get_warping_function(self, interpolation, warp_coordinates=False):
         r"""Appropriate warping function for the given interpolation type
 
         Returns the right warping function from vector_fields that must be
         called for the specified data dimension and interpolation type
+
+        Parameters
+        ----------
+        interpolation : string, either 'linear' or 'nearest'
+            specifies the type of interpolation used for image warping. It
+            does not have any effect if `warp_coordinates` is True, in which
+            case no interpolation is intended to be performed.
+        warp_coordinates : Boolean,
+            if False, then returns the right image warping function for this
+            DiffeomorphicMap dimension and the specified `interpolation`. If
+            True, then returns the right coordinate warping function.
         """
         if self.dim == 2:
+            if warp_coordinates:
+                return vfu.warp_coordinates_2d
             if interpolation == 'linear':
                 return vfu.warp_2d
             else:
                 return vfu.warp_2d_nn
         else:
+            if warp_coordinates:
+                return vfu.warp_coordinates_3d
             if interpolation == 'linear':
                 return vfu.warp_3d
             else:
                 return vfu.warp_3d_nn
+
+    def _warp_coordinates_forward(self, points, coord2world=None,
+                                  world2coord=None):
+        r"""Warps the list of points in the forward direction
+
+        Applies this diffeomorphic map to the list of points given by `points`.
+        We assume that the points' coordinates are mapped to world coordinates
+        by applying the `coord2world` affine transform. The warped coordinates
+        are given in world coordinates unless `world2coord` affine transform
+        is specified, in which case the warped points will be transformed
+        to the corresponding coordinate system.
+
+        Parameters
+        ----------
+        points :
+        coord2world :
+        world2coord :
+        """
+        warp_f = self._get_warping_function(None, warp_coordinates=True)
+        coord2prealigned = mult_aff(self.prealign, coord2world)
+        out = warp_f(points, self.forward, coord2prealigned, world2coord,
+                     self.disp_world2grid)
+        return out
+
+    def _warp_coordinates_backward(self, points, coord2world=None,
+                                   world2coord=None):
+        r"""Warps the list of points in the backward direction
+
+        Applies this diffeomorphic map to the list of points given by `points`.
+        We assume that the points' coordinates are mapped to world coordinates
+        by applying the `coord2world` affine transform. The warped coordinates
+        are given in world coordinates unless `world2coord` affine transform
+        is specified, in which case the warped points will be transformed
+        to the corresponding coordinate system.
+
+        Parameters
+        ----------
+        points :
+        coord2world :
+        world2coord :
+        """
+        warp_f = self._get_warping_function(None, warp_coordinates=True)
+        world2invprealigned = mult_aff(world2coord, self.prealign_inv)
+        out = warp_f(points, self.backward, coord2world, world2invprealigned,
+                     self.disp_world2grid)
+        return out
 
     def _warp_forward(self, image, interpolation='linear',
                       image_world2grid=None, out_shape=None,
@@ -588,6 +649,26 @@ class DiffeomorphicMap(object):
                                          image_world2grid, out_shape,
                                          out_grid2world)
         return np.asarray(warped)
+
+    def transform_points(self, points, coord2world=None,
+                         world2coord=None):
+        if self.is_inverse:
+            out = self._warp_coordinates_backward(points, coord2world,
+                                                  world2coord)
+        else:
+            out = self._warp_coordinates_forward(points, coord2world,
+                                                 world2coord)
+        return out
+
+    def transform_points_inverse(self, points, coord2world=None,
+                                 world2coord=None):
+        if self.is_inverse:
+            out = self._warp_coordinates_forward(points, coord2world,
+                                                 world2coord)
+        else:
+            out = self._warp_coordinates_backward(points, coord2world,
+                                                  world2coord)
+        return out
 
     def inverse(self):
         r"""Inverse of this DiffeomorphicMap instance

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -959,3 +959,107 @@ def test_em_2d_demons():
     reduced = 1.0 - final_energy / starting_energy
 
     assert(reduced > 0.9)
+
+
+def test_coordinate_mapping():
+    r"""Test coordinate mapping with DiffeomorphicMap
+
+    1. Create a random displacement field and a small affine transform to map
+       grid to world coordinates.
+    2. Create a DiffeomorphicMap with the previously created field and affine
+       transform.
+    3. Create a random input image.
+    4. Select a few non-boundary voxels from the domain grid.
+    5. Warp the input image with the DiffeomorphicMap and interpolate the
+       **warped image** at the selected locations. The result is the
+       `expected` array.
+    6. Map only the selected points using the DiffeomorphicMap and
+       interpolate the **input image** at the warped points. The result is the
+       `actual` array, which should be almost equal to the `expected` array.
+    """
+    np.random.seed(1741332)
+    for dim in range(2, 4):
+        npoints = 100
+        points = np.empty((npoints, dim), dtype=np.float64)
+        if dim == 2:
+            domain_shape = (10, 10)
+            codomain_shape = (15, 15)
+            nr = domain_shape[0]
+            nc = domain_shape[1]
+            s = 1.1
+            t = 0.25
+            trans = np.array([[1, 0, -t*nr],
+                              [0, 1, -t*nc],
+                              [0, 0, 1]])
+            trans_inv = np.linalg.inv(trans)
+            scale = np.array([[1*s, 0, 0],
+                              [0, 1*s, 0],
+                              [0, 0, 1]])
+            gt_affine = trans_inv.dot(scale.dot(trans))
+            n = codomain_shape[0] * codomain_shape[1]
+            moving_image = np.random.randint(0, 10, n).reshape(codomain_shape)
+            moving_image = moving_image.astype(np.float64)
+            # Select a few grid coordinates not at the boundary of the domain
+            points[:, 0] = np.random.randint(1, nr-1, npoints)
+            points[:, 1] = np.random.randint(1, nc-1, npoints)
+            random_df = vfu.create_random_displacement_2d
+            interpolate_f = vfu.interpolate_scalar_2d
+        else:
+            domain_shape = (10, 10, 10)
+            codomain_shape = (15, 15, 15)
+            nr = domain_shape[0]
+            nc = domain_shape[1]
+            ns = domain_shape[2]
+            s = 1.1
+            t = 0.25
+            trans = np.array([[1, 0, 0, -t*ns],
+                              [0, 1, 0, -t*nr],
+                              [0, 0, 1, -t*nc],
+                              [0, 0, 0, 1]])
+            trans_inv = np.linalg.inv(trans)
+            scale = np.array([[1*s, 0, 0, 0],
+                              [0, 1*s, 0, 0],
+                              [0, 0, 1*s, 0],
+                              [0, 0, 0, 1]])
+            gt_affine = trans_inv.dot(scale.dot(trans))
+            n = codomain_shape[0] * codomain_shape[1] * codomain_shape[2]
+            moving_image = np.random.randint(0, 10, n).reshape(codomain_shape)
+            moving_image = moving_image.astype(np.float64)
+            # Select a few grid coordinates not at the boundary of the domain
+            points[:, 0] = np.random.randint(1, nr-1, npoints)
+            points[:, 1] = np.random.randint(1, nc-1, npoints)
+            points[:, 2] = np.random.randint(1, ns-1, npoints)
+            random_df = vfu.create_random_displacement_3d
+            interpolate_f = vfu.interpolate_scalar_3d
+
+        #create the random displacement field
+        domain_grid2world = gt_affine
+        codomain_grid2world = gt_affine
+        disp, assign = random_df(np.array(domain_shape, dtype=np.int32),
+                                 domain_grid2world,
+                                 np.array(codomain_shape, dtype=np.int32),
+                                 codomain_grid2world)
+        disp = disp.astype(floating)
+        # Create a DiffeomorphicMap instance
+        diff_map = imwarp.DiffeomorphicMap(dim, domain_shape,
+                                           domain_grid2world, domain_shape,
+                                           domain_grid2world, codomain_shape,
+                                           codomain_grid2world, None)
+        diff_map.forward = disp
+
+        # Here, expected is obtained after two interpolation steps, therefore
+        # we need to increase the tolerance when comparing against the result
+        # using only one interpolation step (we set decimal=5 below)
+        warped = diff_map.transform(moving_image, 'linear')
+        expected, inside = interpolate_f(warped, points)
+
+        # Now map the points with the implementation under test
+        # Specify how to map the given array to world coordinates
+        in2world = diff_map.domain_grid2world
+        # Request mapping back from world to grid coordinates
+        world2out = diff_map.domain_world2grid
+        # Execute warping
+        wpoints = diff_map.transform_points(points, in2world, world2out)
+        # Interpolate at warped points and verify it's equal to direct warping
+        actual, inside = interpolate_f(moving_image, wpoints)
+        assert_array_almost_equal(actual, expected, decimal=5)

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -465,7 +465,7 @@ def interpolate_scalar_3d(floating[:, :, :] image, locations):
         cnp.npy_intp i, n = locations.shape[0]
         floating[:] out = np.zeros(shape=(n,), dtype=ftype)
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
-        double[:,:] _locations = np.array(locations, dtype=np.float64)
+        double[:, :] _locations = np.array(locations, dtype=np.float64)
     with nogil:
         for i in range(n):
             inside[i] = _interpolate_scalar_3d[floating](image,
@@ -646,7 +646,7 @@ cdef inline int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
         out[1] = 0
         out[2] = 0
         return 0
-    #---top-left
+    # ---top-left
     kk = <int>floor(dkk)
     ii = <int>floor(dii)
     jj = <int>floor(djj)
@@ -1874,11 +1874,11 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
         cnp.npy_intp n = points.shape[0]
         cnp.npy_intp i
         double x, y, z, wx, wy, wz, gx, gy, gz
-        double[:,:] out = np.zeros(shape=(n, 3), dtype=np.float64)
-        double[:,:] _points = np.array(points, dtype=np.float64)
-        double[:,:] in2grid
+        double[:, :] out = np.zeros(shape=(n, 3), dtype=np.float64)
+        double[:, :] _points = np.array(points, dtype=np.float64)
+        double[:, :] in2grid
         int inside
-        floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+        floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
         in2grid = field_world2grid
@@ -1914,7 +1914,7 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
                 gz = z
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, tmp)
+            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, &tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -1950,11 +1950,11 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
         cnp.npy_intp n = points.shape[0]
         cnp.npy_intp i
         double x, y, wx, wy, gx, gy
-        double[:,:] out = np.zeros(shape=(n, 2), dtype=np.float64)
-        double[:,:] _points = np.array(points, dtype=np.float64)
-        double[:,:] in2grid
+        double[:, :] out = np.zeros(shape=(n, 2), dtype=np.float64)
+        double[:, :] _points = np.array(points, dtype=np.float64)
+        double[:, :] in2grid
         int inside
-        floating[:] tmp = np.zeros(shape=(2,), dtype = np.asarray(d1).dtype)
+        floating[:] tmp = np.zeros(shape=(2,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
         in2grid = field_world2grid
@@ -1984,7 +1984,7 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
                 gy = y
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_2d[floating](d1, gx, gy, tmp)
+            inside = _interpolate_vector_2d[floating](d1, gx, gy, &tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -2077,7 +2077,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
 
     cdef floating[:, :, :] warped = np.zeros(shape=(nslices, nrows, ncols),
                                              dtype=np.asarray(volume).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+    cdef floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
 
     with nogil:
 
@@ -2127,7 +2127,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
 
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                                                               dii, djj,
-                                                              &warped[k,i,j])
+                                                              &warped[k, i, j])
     return np.asarray(warped)
 
 
@@ -2193,7 +2193,7 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
                         dii = i
                         djj = j
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
-                        dii, djj, &out[k,i,j])
+                        dii, djj, &out[k, i, j])
     return np.asarray(out)
 
 
@@ -2322,8 +2322,8 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
                         dii = di + i
                         djj = dj + j
 
-                    inside = _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
-                                                       &warped[k,i,j])
+                    inside = _interpolate_scalar_nn_3d[number](volume,
+                                        dkk, dii, djj, &warped[k, i, j])
     return np.asarray(warped)
 
 
@@ -2388,7 +2388,7 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
                         dii = i
                         djj = j
                     _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
-                                                      &out[k,i,j])
+                                                      &out[k, i, j])
     return np.asarray(out)
 
 
@@ -2835,11 +2835,11 @@ def create_random_displacement_2d(int[:] from_shape,
     Creates a random 2D displacement field mapping points of an input discrete
     domain (with dimensions given by from_shape) to points of an output
     discrete domain (with shape given by to_shape). The affine matrices
-    bringing discrete coordinates to physical space are given by from_grid2world
-    (for the displacement field discretization) and to_grid2world (for the target
-    discretization). Since this function is intended to be used for testing,
-    voxels in the input domain will never be assigned to boundary voxels on the
-    output domain.
+    bringing discrete coordinates to physical space are given by
+    from_grid2world (for the displacement field discretization) and
+    to_grid2world (for the target discretization). Since this function is
+    intended to be used for testing, voxels in the input domain will never be
+    assigned to boundary voxels on the output domain.
 
     Parameters
     ----------
@@ -2863,7 +2863,7 @@ def create_random_displacement_2d(int[:] from_shape,
         cnp.npy_intp i, j, ri, rj
         double di, dj, dii, djj
         int[:, :, :] int_field = np.empty(tuple(from_shape) + (2,),
-                                            dtype=np.int32)
+                                          dtype=np.int32)
         double[:, :, :] output = np.zeros(tuple(from_shape) + (2,),
                                           dtype=np.float64)
         cnp.npy_intp dom_size = from_shape[0]*from_shape[1]
@@ -2908,18 +2908,20 @@ def create_random_displacement_2d(int[:] from_shape,
     return np.asarray(output), np.asarray(int_field)
 
 
-def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2world,
-                                  int[:] to_shape, double[:, :] to_grid2world):
+def create_random_displacement_3d(int[:] from_shape,
+                                  double[:, :] from_grid2world,
+                                  int[:] to_shape,
+                                  double[:, :] to_grid2world):
     r"""Creates a random 3D displacement 'exactly' mapping points of two grids
 
     Creates a random 3D displacement field mapping points of an input discrete
     domain (with dimensions given by from_shape) to points of an output
     discrete domain (with shape given by to_shape). The affine matrices
-    bringing discrete coordinates to physical space are given by from_grid2world
-    (for the displacement field discretization) and to_grid2world (for the target
-    discretization). Since this function is intended to be used for testing,
-    voxels in the input domain will never be assigned to boundary voxels on the
-    output domain.
+    bringing discrete coordinates to physical space are given by
+    from_grid2world (for the displacement field discretization) and
+    to_grid2world (for the target discretization). Since this function is
+    intended to be used for testing, voxels in the input domain will never be
+    assigned to boundary voxels on the output domain.
 
     Parameters
     ----------
@@ -2943,7 +2945,7 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
         cnp.npy_intp i, j, k, ri, rj, rk
         double di, dj, dk, dii, djj, dkk
         int[:, :, :, :] int_field = np.empty(tuple(from_shape) + (3,),
-                                               dtype=np.int32)
+                                             dtype=np.int32)
         double[:, :, :, :] output = np.zeros(tuple(from_shape) + (3,),
                                              dtype=np.float64)
         cnp.npy_intp dom_size = from_shape[0]*from_shape[1]*from_shape[2]
@@ -2985,8 +2987,8 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
                     dii = ri
                     djj = rj
 
-                # the displacement vector at (i,j) must be the target point minus
-                # the original point, both in physical space
+                # the displacement vector at (i,j) must be the target point
+                # minus the original point, both in physical space
 
                 output[k, i, j, 0] = dkk - dk
                 output[k, i, j, 1] = dii - di
@@ -3272,12 +3274,13 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                                                    img_world2grid)
                         # Interpolate img at q
                         in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
+                                                q[1], q[2], &out[k, i, j, p])
                         if in_flag == 0:
                             out[k, i, j, p] = 0
                             inside[k, i, j] = 0
                             continue
-                        out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
+                        out[k, i, j, p] = ((out[k, i, j, p] - tmp) /
+                                           img_spacing[p])
                         dx[p] = x[p]
 
 
@@ -3341,7 +3344,7 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                                            img_world2grid)
                 # Interpolate img at q
                 in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1],
-                    q[2], &out[i, p])
+                                                           q[2], &out[i, p])
                 if in_flag == 0:
                     out[i, p] = 0
                     inside[i] = 0
@@ -3356,8 +3359,8 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                 q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
                                            img_world2grid)
                 # Interpolate img at q
-                in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1], q[2],
-                                                 &out[i, p])
+                in_flag = _interpolate_scalar_3d[floating](img,
+                                                q[0], q[1], q[2], &out[i, p])
                 if in_flag == 0:
                     out[i, p] = 0
                     inside[i] = 0
@@ -3428,7 +3431,7 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
                     in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
+                                                    q[1], &out[i, j, p])
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0
@@ -3440,7 +3443,7 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
                     in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
+                                                    q[1], &out[i, j, p])
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -1857,6 +1857,149 @@ def downsample_displacement_field_2d(floating[:, :, :] field):
     return np.asarray(down)
 
 
+def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
+                        double[:, :] in2world,
+                        double[:, :] world2out,
+                        double[:, :] field_world2grid):
+    r"""
+    Parameters
+    ----------
+    points : array, shape (n, 3)
+    d1 : array, shape (S, R, C, 3)
+    in2world : array, shape (4, 4)
+    world2out : array, shape (4, 4)
+    field_world2grid : array, shape (4, 4)
+    """
+    cdef:
+        cnp.npy_intp n = points.shape[0]
+        cnp.npy_intp i
+        double x, y, z, wx, wy, wz, gx, gy, gz
+        double[:,:] out = np.zeros(shape=(n, 3), dtype=np.float64)
+        double[:,:] _points = np.array(points, dtype=np.float64)
+        double[:,:] in2grid
+        int inside
+        floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+    # in2grid maps points to displacement's grid
+    if in2world is None:  # then points are already in world coordinates
+        in2grid = field_world2grid
+    elif field_world2grid is None:  # then the grid is in world coordinates
+        in2grid = in2world
+    else:
+        in2grid = np.dot(field_world2grid, in2world)
+
+    with nogil:
+        for i in range(n):
+            x = _points[i, 0]
+            y = _points[i, 1]
+            z = _points[i, 2]
+
+            # Map points to world coordinates
+            if in2world is not None:
+                wx = _apply_affine_3d_x0(x, y, z, 1, in2world)
+                wy = _apply_affine_3d_x1(x, y, z, 1, in2world)
+                wz = _apply_affine_3d_x2(x, y, z, 1, in2world)
+            else:
+                wx = x
+                wy = y
+                wz = z
+
+            # Map points to deformation field's grid
+            if in2grid is not None:
+                gx = _apply_affine_3d_x0(x, y, z, 1, in2grid)
+                gy = _apply_affine_3d_x1(x, y, z, 1, in2grid)
+                gz = _apply_affine_3d_x2(x, y, z, 1, in2grid)
+            else:
+                gx = x
+                gy = y
+                gz = z
+
+            # Interpolate deformation field at (gx, gy, gz)
+            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, tmp)
+
+            # Warp input point
+            wx += tmp[0]
+            wy += tmp[1]
+            wz += tmp[2]
+
+            # Map warped point to requested out coordinates
+            if world2out is not None:
+                out[i, 0] = _apply_affine_3d_x0(wx, wy, wz, 1, world2out)
+                out[i, 1] = _apply_affine_3d_x1(wx, wy, wz, 1, world2out)
+                out[i, 2] = _apply_affine_3d_x2(wx, wy, wz, 1, world2out)
+            else:
+                out[i, 0] = wx
+                out[i, 1] = wy
+                out[i, 2] = wz
+    return np.asarray(out)
+
+
+def warp_coordinates_2d(points,  floating[:, :, :] d1,
+                        double[:, :] in2world,
+                        double[:, :] world2out,
+                        double[:, :] field_world2grid):
+    r"""
+    Parameters
+    ----------
+    points : array, shape (n, 2)
+    d1 : array, shape (S, R, C, 2)
+    in2world : array, shape (3, 3)
+    world2out : array, shape (3, 3)
+    field_world2grid : array, shape (3, 3)
+    """
+    cdef:
+        cnp.npy_intp n = points.shape[0]
+        cnp.npy_intp i
+        double x, y, wx, wy, gx, gy
+        double[:,:] out = np.zeros(shape=(n, 2), dtype=np.float64)
+        double[:,:] _points = np.array(points, dtype=np.float64)
+        double[:,:] in2grid
+        int inside
+        floating[:] tmp = np.zeros(shape=(2,), dtype = np.asarray(d1).dtype)
+    # in2grid maps points to displacement's grid
+    if in2world is None:  # then points are already in world coordinates
+        in2grid = field_world2grid
+    elif field_world2grid is None:  # then the grid is in world coordinates
+        in2grid = in2world
+    else:
+        in2grid = np.dot(field_world2grid, in2world)
+    with nogil:
+        for i in range(n):
+            x = _points[i, 0]
+            y = _points[i, 1]
+
+            # Map points to world coordinates
+            if in2world is not None:
+                wx = _apply_affine_2d_x0(x, y, 1, in2world)
+                wy = _apply_affine_2d_x1(x, y, 1, in2world)
+            else:
+                wx = x
+                wy = y
+
+            # Map points to deformation field's grid
+            if in2grid is not None:
+                gx = _apply_affine_2d_x0(x, y, 1, in2grid)
+                gy = _apply_affine_2d_x1(x, y, 1, in2grid)
+            else:
+                gx = x
+                gy = y
+
+            # Interpolate deformation field at (gx, gy, gz)
+            inside = _interpolate_vector_2d[floating](d1, gx, gy, tmp)
+
+            # Warp input point
+            wx += tmp[0]
+            wy += tmp[1]
+
+            # Map warped point to requested out coordinates
+            if world2out is not None:
+                out[i, 0] = _apply_affine_2d_x0(wx, wy, 1, world2out)
+                out[i, 1] = _apply_affine_2d_x1(wx, wy, 1, world2out)
+            else:
+                out[i, 0] = wx
+                out[i, 1] = wy
+    return np.asarray(out)
+
+
 def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
             double[:, :] affine_idx_in=None,
             double[:, :] affine_idx_out=None,


### PR DESCRIPTION
Exposes two new methods from DiffeomorphicMap to warp points. This may be used, for example, to transform streamlines after registering two images.
