### PR TITLE
Parallelize the first part of 3d affine registration using local function

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -440,7 +440,7 @@ class AffineMap(object):
 
 class MutualInformationMetric(object):
 
-    def __init__(self, nbins=32, sampling_proportion=None):
+    def __init__(self, nbins=32, sampling_proportion=None, num_threads=None):
         r""" Initializes an instance of the Mutual Information metric
 
         This class implements the methods required by Optimizer to drive the
@@ -460,6 +460,9 @@ class MutualInformationMetric(object):
             then sparse sampling is used, where `sampling_proportion`
             specifies the proportion of voxels to be used. The default is
             None.
+        num_threads : int
+            Number of threads. If None (default) then all available threads
+            will be used.
 
         Notes
         -----
@@ -475,6 +478,7 @@ class MutualInformationMetric(object):
         self.sampling_proportion = sampling_proportion
         self.metric_val = None
         self.metric_grad = None
+        self.num_threads = num_threads
 
     def setup(self, transform, static, moving, static_grid2world=None,
               moving_grid2world=None, starting_affine=None):
@@ -653,7 +657,7 @@ class MutualInformationMetric(object):
                                             self.moving_world2grid,
                                             self.moving_spacing,
                                             self.static.shape,
-                                            grid_to_world)
+                                            grid_to_world, self.num_threads)
                 # The Jacobian must be evaluated at the pre-aligned points
                 H.update_gradient_dense(
                     params,
@@ -669,7 +673,7 @@ class MutualInformationMetric(object):
                 mgrad, inside = vf.sparse_gradient(self.moving,
                                                    self.moving_world2grid,
                                                    self.moving_spacing,
-                                                   pts)
+                                                   pts, self.num_threads)
                 # The Jacobian must be evaluated at the pre-aligned points
                 pts = self.samples_prealigned[..., :self.dim]
                 H.update_gradient_sparse(params, self.transform, static_values,


### PR DESCRIPTION
Parallelize _gradient_3d() & _sparse_gradient_3d() in vector_fields.pyx using local function.

You can profile this affine example [sl_aff_reg_3d.py](https://github.com/RicciWoo/registration/blob/master/sl_aff_reg_3d.py) to test the overall performance (multiple calls).
> python -m cProfile -o sl_aff_par_grad_fun.prof sl_aff_reg_3d.py

For testing the performance of each call: use the other repository with timer [aff-par-grad-fun-tim](https://github.com/RicciWoo/dipy/tree/aff-par-grad-fun-tim).

You can run this python code [sl_test_grad_3d.py](https://github.com/RicciWoo/registration/blob/master/sl_test_grad_3d.py) to time a single call to _gradient_3d(). This code is for running on a headless cluster, to run on local computer, please remove the virtual frame buffer "xvfbwrapper".
> python sl_test_grad_3d.py
