### PR TITLE
Parallelize affine registration

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -440,7 +440,7 @@ class AffineMap(object):
 
 class MutualInformationMetric(object):
 
-    def __init__(self, nbins=32, sampling_proportion=None):
+    def __init__(self, nbins=32, sampling_proportion=None, num_threads=None):
         r""" Initializes an instance of the Mutual Information metric
 
         This class implements the methods required by Optimizer to drive the
@@ -460,6 +460,9 @@ class MutualInformationMetric(object):
             then sparse sampling is used, where `sampling_proportion`
             specifies the proportion of voxels to be used. The default is
             None.
+        num_threads : int
+            Number of threads. If None (default) then all available threads
+            will be used
 
         Notes
         -----
@@ -475,6 +478,7 @@ class MutualInformationMetric(object):
         self.sampling_proportion = sampling_proportion
         self.metric_val = None
         self.metric_grad = None
+        self.num_threads = num_threads
 
     def setup(self, transform, static, moving, static_grid2world=None,
               moving_grid2world=None, starting_affine=None):
@@ -653,7 +657,7 @@ class MutualInformationMetric(object):
                                             self.moving_world2grid,
                                             self.moving_spacing,
                                             self.static.shape,
-                                            grid_to_world)
+                                            grid_to_world, self.num_threads)
                 # The Jacobian must be evaluated at the pre-aligned points
                 H.update_gradient_dense(
                     params,

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -884,9 +884,10 @@ cdef void _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
         cnp.npy_intp offset, valid_points
         int constant_jacobian = 0
         cnp.npy_intp k, i, j, r, c
-        double rn, cn, *prod, x[2]
+        double rn, cn, *prod
         double val, spline_arg, norm_factor
         double[:, :] J = np.empty(shape=(2, n), dtype=np.float64)
+        double[:] x = np.empty(shape=(2,), dtype=np.float64)
 
     prod = <double *>malloc(sizeof(double) * n)
     if prod == NULL:
@@ -999,9 +1000,10 @@ cdef void _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
         cnp.npy_intp offset, valid_points
         int constant_jacobian = 0
         cnp.npy_intp l, k, i, j, r, c
-        double rn, cn, *prod, x[3]
+        double rn, cn, *prod
         double val, spline_arg, norm_factor
         double[:, :] J = np.empty(shape=(3, n), dtype=np.float64)
+        double[:] x = np.empty(shape=(3,), dtype=np.float64)
 
     prod = <double *>malloc(sizeof(double) * n)
     if prod == NULL:

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -3063,9 +3063,9 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
     return np.asarray(s)
 
 
-def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
-                 double[:] img_spacing, double[:, :] out_grid2world,
-                 floating[:, :, :, :] out, int[:, :, :] inside):
+cdef void _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
+                       double[:] img_spacing, double[:, :] out_grid2world,
+                       floating[:, :, :, :] out, int[:, :, :] inside) nogil:
     r""" Gradient of a 3D image in physical space coordinates
 
     Each grid cell (i, j, k) in the sampling grid (determined by
@@ -3105,65 +3105,61 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
         int nrows = out.shape[1]
         int ncols = out.shape[2]
         int i, j, k, in_flag
-        double tmp
-        double[:] x = np.empty(shape=(3,), dtype=np.float64)
-        double[:] dx = np.empty(shape=(3,), dtype=np.float64)
-        double[:] h = np.empty(shape=(3,), dtype=np.float64)
-        double[:] q = np.empty(shape=(3,), dtype=np.float64)
-    with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        h[2] = 0.5 * img_spacing[2]
-        for k in range(nslices):
-            for i in range(nrows):
-                for j in range(ncols):
-                    inside[k, i, j] = 1
-                    # Compute coordinates of index (k, i, j) in physical space
-                    x[0] = _apply_affine_3d_x0(k, i, j, 1, out_grid2world)
-                    x[1] = _apply_affine_3d_x1(k, i, j, 1, out_grid2world)
-                    x[2] = _apply_affine_3d_x2(k, i, j, 1, out_grid2world)
-                    dx[:] = x[:]
-                    for p in range(3):
-                        # Compute coordinates of point dx on img's grid
-                        dx[p] = x[p] - h[p]
-                        q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
-                        if in_flag == 0:
-                            out[k, i, j, p] = 0
-                            inside[k, i, j] = 0
-                            continue
-                        tmp = out[k, i, j, p]
-                        # Compute coordinates of point dx on img's grid
-                        dx[p] = x[p] + h[p]
-                        q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
-                        if in_flag == 0:
-                            out[k, i, j, p] = 0
-                            inside[k, i, j] = 0
-                            continue
-                        out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
-                        dx[p] = x[p]
+        double tmp, x[3], dx[3], h[3], q[3]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    h[2] = 0.5 * img_spacing[2]
+    for k in range(nslices):
+        for i in range(nrows):
+            for j in range(ncols):
+                inside[k, i, j] = 1
+                # Compute coordinates of index (k, i, j) in physical space
+                x[0] = _apply_affine_3d_x0(k, i, j, 1, out_grid2world)
+                x[1] = _apply_affine_3d_x1(k, i, j, 1, out_grid2world)
+                x[2] = _apply_affine_3d_x2(k, i, j, 1, out_grid2world)
+                dx[:] = x[:]
+                for p in range(3):
+                    # Compute coordinates of point dx on img's grid
+                    dx[p] = x[p] - h[p]
+                    q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    # Interpolate img at q
+                    in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                        q[1], q[2], &out[k, i, j, p])
+                    if in_flag == 0:
+                        out[k, i, j, p] = 0
+                        inside[k, i, j] = 0
+                        continue
+                    tmp = out[k, i, j, p]
+                    # Compute coordinates of point dx on img's grid
+                    dx[p] = x[p] + h[p]
+                    q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                               img_world2grid)
+                    # Interpolate img at q
+                    in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                        q[1], q[2], &out[k, i, j, p])
+                    if in_flag == 0:
+                        out[k, i, j, p] = 0
+                        inside[k, i, j] = 0
+                        continue
+                    out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
+                    dx[p] = x[p]
 
 
-def _sparse_gradient_3d(floating[:, :, :] img,
-                        double[:, :] img_world2grid,
-                        double[:] img_spacing,
-                        double[:, :] sample_points,
-                        floating[:, :] out, int[:] inside):
+cdef void _sparse_gradient_3d(floating[:, :, :] img,
+                              double[:, :] img_world2grid,
+                              double[:] img_spacing,
+                              double[:, :] sample_points,
+                              floating[:, :] out, int[:] inside) nogil:
     r""" Gradient of a 3D image evaluated at a set of points in physical space
 
     For each row (x_i, y_i, z_i) in sample_points, the image is interpolated at
@@ -3195,58 +3191,55 @@ def _sparse_gradient_3d(floating[:, :, :] img,
     cdef:
         int n = sample_points.shape[0]
         int i, in_flag
-        double tmp
-        double[:] dx = np.empty(shape=(3,), dtype=np.float64)
-        double[:] h = np.empty(shape=(3,), dtype=np.float64)
-        double[:] q = np.empty(shape=(3,), dtype=np.float64)
-    with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        h[2] = 0.5 * img_spacing[2]
-        for i in range(n):
-            inside[i] = 1
-            dx[0] = sample_points[i, 0]
-            dx[1] = sample_points[i, 1]
-            dx[2] = sample_points[i, 2]
-            for p in range(3):
-                # Compute coordinates of point dx on img's grid
-                dx[p] = sample_points[i, p] - h[p]
-                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                # Interpolate img at q
-                in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1],
-                    q[2], &out[i, p])
-                if in_flag == 0:
-                    out[i, p] = 0
-                    inside[i] = 0
-                    continue
-                tmp = out[i, p]
-                # Compute coordinates of point dx on img's grid
-                dx[p] = sample_points[i, p] + h[p]
-                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                           img_world2grid)
-                # Interpolate img at q
-                in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1], q[2],
-                                                 &out[i, p])
-                if in_flag == 0:
-                    out[i, p] = 0
-                    inside[i] = 0
-                    continue
-                out[i, p] = (out[i, p] - tmp) / img_spacing[p]
-                dx[p] = sample_points[i, p]
+        double tmp, dx[3], h[3], q[3]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    h[2] = 0.5 * img_spacing[2]
+    for i in range(n):
+        inside[i] = 1
+        dx[0] = sample_points[i, 0]
+        dx[1] = sample_points[i, 1]
+        dx[2] = sample_points[i, 2]
+        for p in range(3):
+            # Compute coordinates of point dx on img's grid
+            dx[p] = sample_points[i, p] - h[p]
+            q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1],
+                q[2], &out[i, p])
+            if in_flag == 0:
+                out[i, p] = 0
+                inside[i] = 0
+                continue
+            tmp = out[i, p]
+            # Compute coordinates of point dx on img's grid
+            dx[p] = sample_points[i, p] + h[p]
+            q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                       img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1], q[2],
+                                             &out[i, p])
+            if in_flag == 0:
+                out[i, p] = 0
+                inside[i] = 0
+                continue
+            out[i, p] = (out[i, p] - tmp) / img_spacing[p]
+            dx[p] = sample_points[i, p]
 
 
-def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
-                 double[:] img_spacing, double[:, :] out_grid2world,
-                 floating[:, :, :] out, int[:, :] inside):
+cdef void _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
+                       double[:] img_spacing, double[:, :] out_grid2world,
+                       floating[:, :, :] out, int[:, :] inside) nogil:
     r""" Gradient of a 2D image in physical space coordinates
 
     Each grid cell (i, j) in the sampling grid (determined by
@@ -3284,53 +3277,49 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
         int nrows = out.shape[0]
         int ncols = out.shape[1]
         int i, j, k, in_flag
-        double tmp
-        double[:] x = np.empty(shape=(2,), dtype=np.float64)
-        double[:] dx = np.empty(shape=(2,), dtype=np.float64)
-        double[:] h = np.empty(shape=(2,), dtype=np.float64)
-        double[:] q = np.empty(shape=(2,), dtype=np.float64)
-    with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        for i in range(nrows):
-            for j in range(ncols):
-                inside[i, j] = 1
-                # Compute coordinates of index (i, j) in physical space
-                x[0] = _apply_affine_2d_x0(i, j, 1, out_grid2world)
-                x[1] = _apply_affine_2d_x1(i, j, 1, out_grid2world)
-                dx[:] = x[:]
-                for p in range(2):
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] - h[p]
-                    q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                    q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
-                    if in_flag == 0:
-                        out[i, j, p] = 0
-                        inside[i, j] = 0
-                        continue
-                    tmp = out[i, j, p]
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] + h[p]
-                    q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                    q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
-                    if in_flag == 0:
-                        out[i, j, p] = 0
-                        inside[i, j] = 0
-                        continue
-                    out[i, j, p] = (out[i, j, p] - tmp) / img_spacing[p]
-                    dx[p] = x[p]
+        double tmp, x[2], dx[2], h[2], q[2]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    for i in range(nrows):
+        for j in range(ncols):
+            inside[i, j] = 1
+            # Compute coordinates of index (i, j) in physical space
+            x[0] = _apply_affine_2d_x0(i, j, 1, out_grid2world)
+            x[1] = _apply_affine_2d_x1(i, j, 1, out_grid2world)
+            dx[:] = x[:]
+            for p in range(2):
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] - h[p]
+                q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+                q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_2d[floating](img, q[0],
+                    q[1], &out[i, j, p])
+                if in_flag == 0:
+                    out[i, j, p] = 0
+                    inside[i, j] = 0
+                    continue
+                tmp = out[i, j, p]
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] + h[p]
+                q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+                q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_2d[floating](img, q[0],
+                    q[1], &out[i, j, p])
+                if in_flag == 0:
+                    out[i, j, p] = 0
+                    inside[i, j] = 0
+                    continue
+                out[i, j, p] = (out[i, j, p] - tmp) / img_spacing[p]
+                dx[p] = x[p]
 
 
-def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
-                        double[:] img_spacing,
-                        double[:, :] sample_points,
-                        floating[:, :] out, int[:] inside):
+cdef void _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
+                              double[:] img_spacing,
+                              double[:, :] sample_points,
+                              floating[:, :] out, int[:] inside) nogil:
     r""" Gradient of a 2D image evaluated at a set of points in physical space
 
     For each row (x_i, y_i) in sample_points, the image is interpolated at
@@ -3364,43 +3353,40 @@ def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
     cdef:
         int n = sample_points.shape[0]
         int i, in_flag
-        double tmp
-        double[:] dx = np.empty(shape=(2,), dtype=np.float64)
-        double[:] h = np.empty(shape=(2,), dtype=np.float64)
-        double[:] q = np.empty(shape=(2,), dtype=np.float64)
-    with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        for i in range(n):
-            inside[i] = 1
-            dx[0] = sample_points[i, 0]
-            dx[1] = sample_points[i, 1]
-            for p in range(2):
-                # Compute coordinates of point dx on img's grid
-                dx[p] = sample_points[i, p] - h[p]
-                q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                # Interpolate img at q
-                in_flag = _interpolate_scalar_2d[floating](img, q[0], q[1],
-                                                           &out[i, p])
-                if in_flag == 0:
-                    out[i, p] = 0
-                    inside[i] = 0
-                    continue
-                tmp = out[i, p]
-                # Compute coordinates of point dx on img's grid
-                dx[p] = sample_points[i, p] + h[p]
-                q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                # Interpolate img at q
-                in_flag = _interpolate_scalar_2d[floating](img, q[0], q[1],
-                                                           &out[i, p])
-                if in_flag == 0:
-                    out[i, p] = 0
-                    inside[i] = 0
-                    continue
-                out[i, p] = (out[i, p] - tmp) / img_spacing[p]
-                dx[p] = sample_points[i, p]
+        double tmp, dx[2], h[2], q[2]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    for i in range(n):
+        inside[i] = 1
+        dx[0] = sample_points[i, 0]
+        dx[1] = sample_points[i, 1]
+        for p in range(2):
+            # Compute coordinates of point dx on img's grid
+            dx[p] = sample_points[i, p] - h[p]
+            q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+            q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_2d[floating](img, q[0], q[1],
+                                                       &out[i, p])
+            if in_flag == 0:
+                out[i, p] = 0
+                inside[i] = 0
+                continue
+            tmp = out[i, p]
+            # Compute coordinates of point dx on img's grid
+            dx[p] = sample_points[i, p] + h[p]
+            q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+            q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_2d[floating](img, q[0], q[1],
+                                                       &out[i, p])
+            if in_flag == 0:
+                out[i, p] = 0
+                inside[i] = 0
+                continue
+            out[i, p] = (out[i, p] - tmp) / img_spacing[p]
+            dx[p] = sample_points[i, p]
 
 
 def gradient(img, img_world2grid, img_spacing, out_shape,
@@ -3437,20 +3423,33 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
     ftype = img.dtype.type
     out = np.empty(tuple(out_shape)+(dim,), dtype=ftype)
     inside = np.empty(tuple(out_shape), dtype=np.int32)
-    # Select joint density gradient 2D or 3D
-    if dim == 2:
-        jd_grad = _gradient_2d
-    elif dim == 3:
-        jd_grad = _gradient_3d
-    else:
-        raise ValueError('Undefined gradient for image dimension %d' % (dim,))
     if img_world2grid.dtype != np.float64:
         img_world2grid = img_world2grid.astype(np.float64)
     if img_spacing.dtype != np.float64:
         img_spacing = img_spacing.astype(np.float64)
     if out_grid2world.dtype != np.float64:
         out_grid2world = out_grid2world.astype(np.float64)
-    jd_grad(img, img_world2grid, img_spacing, out_grid2world, out, inside)
+    # Select joint density gradient 2D or 3D
+    if dim == 2:
+        if img.dtype == np.float32:
+            _gradient_2d[cython.float](img, img_world2grid, img_spacing,
+                                       out_grid2world, out, inside)
+        elif img.dtype == np.float64:
+            _gradient_2d[cython.double](img, img_world2grid, img_spacing,
+                                        out_grid2world, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
+    elif dim == 3:
+        if img.dtype == np.float32:
+            _gradient_3d[cython.float](img, img_world2grid, img_spacing,
+                                       out_grid2world, out, inside)
+        elif img.dtype == np.float64:
+            _gradient_3d[cython.double](img, img_world2grid, img_spacing,
+                                        out_grid2world, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
+    else:
+        raise ValueError('Undefined gradient for image dimension %d' % (dim,))
     return np.asarray(out), np.asarray(inside)
 
 
@@ -3485,14 +3484,29 @@ def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
     n = sample_points.shape[0]
     out = np.empty(shape=(n, dim), dtype=ftype)
     inside = np.empty(shape=(n,), dtype=np.int32)
-    # Select joint density gradient 2D or 3D
-    if dim == 2:
-        jd_grad = _sparse_gradient_2d
-    else:
-        jd_grad = _sparse_gradient_3d
     if img_world2grid.dtype != np.float64:
         img_world2grid = img_world2grid.astype(np.float64)
     if img_spacing.dtype != np.float64:
         img_spacing = img_spacing.astype(np.float64)
-    jd_grad(img, img_world2grid, img_spacing, sample_points, out, inside)
+    # Select joint density gradient 2D or 3D
+    if dim == 2:
+        if img.dtype == np.float32:
+            _sparse_gradient_2d[cython.float](img, img_world2grid, img_spacing,
+                                              sample_points, out, inside)
+        elif img.dtype == np.float64:
+            _sparse_gradient_2d[cython.double](img, img_world2grid, img_spacing,
+                                               sample_points, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
+    elif dim == 3:
+        if img.dtype == np.float32:
+            _sparse_gradient_3d[cython.float](img, img_world2grid, img_spacing,
+                                              sample_points, out, inside)
+        elif img.dtype == np.float64:
+            _sparse_gradient_3d[cython.double](img, img_world2grid, img_spacing,
+                                               sample_points, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
+    else:
+        raise ValueError('Undefined gradient for image dimension %d' % (dim,))
     return np.asarray(out), np.asarray(inside)


### PR DESCRIPTION
Parallelize affine registration using prange and local function:
1. cythonized \_gradient_* in vector_fields.pyx;
2. typed and made nogil on \_compute_pdfs_* in parzenhist.pyx;
3. parallelized \_gradient_3d using prange and local function.

To specify number of threads: give num_threads to MutualInformationMetric
> metric = MutualInformationMetric(nbins, sampling_prop, num_threads=4)