### PR TITLE
WIP - NF - Tracking with Initial Directions and other tracking parameters

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pxd
+++ b/dipy/direction/closest_peak_direction_getter.pxd
@@ -10,7 +10,6 @@ cdef int closest_peak(np.ndarray[np.float_t, ndim=2] peak_dirs,
 cdef class BaseDirectionGetter(DirectionGetter):
 
     cdef:
-        object sphere
         dict _pf_kwargs
         PmfGen pmf_gen
         double pmf_threshold

--- a/dipy/tracking/local/direction_getter.pxd
+++ b/dipy/tracking/local/direction_getter.pxd
@@ -3,6 +3,9 @@ cimport numpy as np
 
 cdef class DirectionGetter:
 
+    cdef:
+        public object sphere
+
     cpdef np.ndarray[np.float_t, ndim=2] initial_direction(
         self, double[::1] point)
 

--- a/dipy/tracking/local/localtrack.pyx
+++ b/dipy/tracking/local/localtrack.pyx
@@ -266,7 +266,6 @@ def pft_tracker(
         Minimum white matter pve (1 - tc.include_map - tc.exclude_map) to
         reach before allowing the tractography to stop.
 
-
     Returns
     -------
     end : int

--- a/dipy/tracking/local/localtrack.pyx
+++ b/dipy/tracking/local/localtrack.pyx
@@ -376,6 +376,15 @@ cdef _pft_tracker(DirectionGetter dg,
                          particle_paths, particle_dirs, particle_weights,
                          particle_steps, particle_tissue_classes)
                 pft_trial += 1
+
+                # update the max_wm_pve visted using PFT
+                for ii in range(i):
+                    copy_point(&streamline[ii, 0], point)
+                    current_wm_pve = (1 - tc.get_include(point)
+                                      - tc.get_exclude(point))
+                    if current_wm_pve > max_wm_pve:
+                        max_wm_pve = current_wm_pve
+
                 # update the current point with the PFT results
                 copy_point(&streamline[i-1, 0], point)
                 copy_point(&directions[i-1, 0], dir)
@@ -385,12 +394,7 @@ cdef _pft_tracker(DirectionGetter dg,
                     # (ENDPOINT, OUTSIDEIMAGE) or failed to find one
                     # (INVALIDPOINT, PYERROR)
                     break
-                # update the max_wm_pve visted using PFT
-                for ii in range(i):
-                    current_wm_pve = (1 - tc.get_include(&streamline[ii, 0])
-                                      - tc.get_exclude(&streamline[ii, 0]))
-                    if current_wm_pve > max_wm_pve:
-                        max_wm_pve = current_wm_pve
+
             else:
                 # PFT was run more times than `pft_max_trials` without finding
                 # a valid stopping point. The tracking stops with INVALIDPOINT.

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -104,6 +104,15 @@ class LocalTracking(object):
             if seeds.shape[0] != initial_directions.shape[0]:
                 raise ValueError("initial_directions and seeds must have the "
                                  + "same shape[0].")
+        if (self.initial_directions is None and self.unidirectional is True and
+                self.randomize_forward_direction is False):
+                warnings.warn("Unidirectional tractography will be performed "
+                              + "without providing initial directions nor "
+                              + "randomizing extracted initial forward "
+                              + "directions. This can introduce directional "
+                              + "biases in the reconstructed streamlines. "
+                              + "See ``initial_directions`` and "
+                              + "``randomize_forward_direction`` parameters.")
         self.affine = affine
         self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
                                                 dtype=float)

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -146,8 +146,13 @@ class LocalTracking(object):
                     if d_norm > 0:
                         d = d / d_norm
                         i = self.direction_getter.sphere.find_closest(d)
-                        directions.append(
-                            self.direction_getter.sphere.vertices[i])
+                        new_d = self.direction_getter.sphere.vertices[i]
+                        if np.dot(d, new_d) < 0:
+                            #  The direction is flipped if the original
+                            #  direction is closer to the opposite direction.
+                            #  This will happen if the Sphere is an Hemisphere.
+                            new_d = new_d * -1
+                        directions.append(new_d)
                 directions = np.array(directions)
 
             directions = directions[:self.max_cross]

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -182,7 +182,6 @@ class LocalTracking(object):
             for first_step in directions:
                 stepsF = stepsB = 1
                 stepsF, tissue_class = self._tracker(s, first_step, F)
-                #print stepsF, tissue_class, first_step
                 if not (self.return_all or
                         tissue_class == TissueTypes.ENDPOINT or
                         tissue_class == TissueTypes.OUTSIDEIMAGE):
@@ -194,7 +193,6 @@ class LocalTracking(object):
                             tissue_class == TissueTypes.ENDPOINT or
                             tissue_class == TissueTypes.OUTSIDEIMAGE):
                         continue
-                    #print stepsB, tissue_class, first_step
                 if stepsB == 1:
                     streamline = F[:stepsF].copy()
                 else:

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -755,8 +755,7 @@ def test_affine_transformations():
 
 
 def test_tracking_with_initial_directions():
-    """This test that tractography play well with using initial seeding
-    directions."""
+    """This test that tractography play well with using seeding directions."""
     def allclose(x, y):
         return x.shape == y.shape and np.allclose(x, y)
 
@@ -831,8 +830,8 @@ def test_tracking_with_initial_directions():
 
     # Test inital_directions with norm != 1 and not sphere vertices
     initial_directions = np.array([[[0, 0, 0], [2, 0, 0]],
-                                   [[0.1, 0.8, 0], [0.5, 0, 0]],
-                                   [[0, 0, 0], [0.7, 0.6, 0.1]]])
+                                   [[0.1, 0.8, 0], [-0.4, 0, 0]],
+                                   [[0, 0, 0], [0.7, 0.6, -0.1]]])
     streamline_generator = LocalTracking(dg, tc, seeds, np.eye(4), 1,
                                          max_cross=2, return_all=False,
                                          initial_directions=initial_directions)
@@ -863,7 +862,6 @@ def test_tracking_with_initial_directions():
             dg, tc, seeds, np.eye(4), 1, return_all=True,
             initial_directions=initial_dir)
     streamlines = Streamlines(streamline_generator)
-    print streamlines
     npt.assert_(allclose(streamlines[0], expected[1]))
 
     npt.assert_(allclose(streamlines[1], expected[2]))

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -838,8 +838,8 @@ def test_tracking_with_initial_directions():
     streamlines = Streamlines(streamline_generator)
     npt.assert_(allclose(streamlines[0], expected[1]))
     npt.assert_(allclose(streamlines[1], expected[2]))
-    npt.assert_(allclose(streamlines[2], expected[1]))
-    npt.assert_(allclose(streamlines[2], expected[1]))
+    npt.assert_(allclose(streamlines[2], expected[1][::-1]))    
+    npt.assert_(allclose(streamlines[3], expected[1]))
 
     # Test dimension mismatch between seeds and initial_directions
     npt.assert_raises(

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -253,6 +253,19 @@ def test_probabilistic_odf_weighted_tracker():
                                            random_seed=0)).data
     npt.assert_equal(tracking_1, tracking_2)
 
+    # Test reproducibility with randomize_forward_direction
+    tracking_1 = Streamlines(LocalTracking(dg, tc, seeds, np.eye(4),
+                                           0.5,
+                                           random_seed=0,
+                                           randomize_forward_direction=True
+                                           )).data
+    tracking_2 = Streamlines(LocalTracking(dg, tc, seeds, np.eye(4),
+                                           0.5,
+                                           random_seed=0,
+                                           randomize_forward_direction=True
+                                           )).data
+    npt.assert_equal(tracking_1, tracking_2)
+
 
 def test_particle_filtering_tractography():
     """This tests that the ParticleFilteringTracking produces

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -897,6 +897,19 @@ def test_tracking_with_initial_directions():
     npt.assert_(allclose(streamlines[2], expected[2][:2][::-1]))
     npt.assert_(allclose(streamlines[3], expected[2][1:]))
 
+    # Test randomized initial forward direction
+    seeds = np.array([crossing_pos] * 30)
+    initial_directions = np.array([np.array([1, 0, 0])] * 30)[:, np.newaxis, :]
+    streamline_generator = LocalTracking(dg, tc, seeds, np.eye(4), 1,
+                                         max_cross=2, return_all=False,
+                                         unidirectional=True,
+                                         randomize_forward_direction=True,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    for sl in streamlines:
+        npt.assert_(np.allclose(sl, expected[1][2:])
+                    or np.allclose(sl, expected[1][:3][::-1]))
+
 
 if __name__ == "__main__":
     npt.run_module_suite()

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -838,7 +838,7 @@ def test_tracking_with_initial_directions():
     streamlines = Streamlines(streamline_generator)
     npt.assert_(allclose(streamlines[0], expected[1]))
     npt.assert_(allclose(streamlines[1], expected[2]))
-    npt.assert_(allclose(streamlines[2], expected[1][::-1]))    
+    npt.assert_(allclose(streamlines[2], expected[1][::-1]))
     npt.assert_(allclose(streamlines[3], expected[1]))
 
     # Test dimension mismatch between seeds and initial_directions

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -459,7 +459,6 @@ def test_particle_filtering_tractography():
                                     initial_directions=inital_directions,
                                     min_wm_pve_before_stopping=1)
     pft_streamlines = Streamlines(pft_streamlines_generator)
-    print pft_streamlines[0]
     npt.assert_(np.allclose(pft_streamlines[0], expected[1]))
 
     # Test invalid min_wm_pve_before_stopping parameters

--- a/dipy/tracking/local/tissue_classifier.pyx
+++ b/dipy/tracking/local/tissue_classifier.pyx
@@ -159,9 +159,9 @@ cdef class ConstrainedTissueClassifier(TissueClassifier):
         return self.get_include_c(&point[0])
 
     cdef double get_include_c(self, double* point):
-        exclude_err = trilinear_interpolate4d_c(self.include_map[..., None],
+        include_err = trilinear_interpolate4d_c(self.include_map[..., None],
                                                 point, self.interp_out_view)
-        if exclude_err != 0:
+        if include_err != 0:
             return 0
         return self.interp_out_view[0]
 


### PR DESCRIPTION
WIP - it needs a first review by @StongeEtienne and @jchoude. Does this will do for SET?

The aim of this PR is to add three new optional parameters to `LocalTracking`:
- `initial_directions` :  specify the initial direction for tractography to follow at the initial seed position. If `initial_directions` is `None` (default), `LocalTracking` calls `DirectionGetter.initial_direction(seed_position)` to get the initial directions (current behavior). This functions return the list of peak at the seed position. In a similar fashion, `initial_directions` contains a list of directions for every seed positions.
  - The tracking works with directions that correspond to vertices on the sphere. Thus, I had to select the vertice the closest to the input direction instead of the actual input direction. i.e. the closest sphere vertice is used as initial direction instead of the given initial directions.
- `unidirectional`: perform the tractography in a single direction from the seeding position, instead of both (default). This is especially useful in conjunction with `initial_direction`, where, for instance, those initial directions could be pointing inward from the cortical surface or outward from subcortical regions.
- `randomized_forward_direction`: Useful in conjunction with `unidirectional`, this parameter allows the tracking to start randomly either in the initial direction or in its opposite direction. If `undirectional is False`, this parameter will only reverse the points order of some streamlines.



