### PR TITLE
Track from mesh

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/kristianeschenburg/anaconda3/bin/python3"
+}

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -480,8 +480,8 @@ def seeds_from_mesh(vertices, faces, n_samples=None, affine=None):
             # Generate seeds from triangle and compute nearest vertex
             face_seeds, nearest = sample_triangle(coords, face, n_samples)
 
-            lo = c*n_samples
-            hi = (c+1)*n_samples
+            lo = c * n_samples
+            hi = (c + 1) * n_samples
 
             seeds[lo:hi, :] = face_seeds
             assignment[lo:hi] = nearest
@@ -529,13 +529,12 @@ def sample_triangle(vertices, face, n_samples=None):
     if n_samples is None:
         return vertices
     # Otherwise, check n_samples type and value
-    else:
-        if not isinstance(n_samples, int):
-            raise TypeError('n_samples must be of type int')
-        if n_samples < 0:
-            raise ValueError('n_samples must be greater than 0')
+    if not isinstance(n_samples, int):
+        raise TypeError('n_samples must be of type int.')
+    if n_samples < 0:
+        raise ValueError('n_samples must be greater than 0.')
 
-    v1,v2,v3 = vertices[0:3,:]
+    v1, v2, v3 = vertices[0:3,:]
 
     r = np.random.uniform(0, 1, n_samples*2)
     r = np.tile(r, [3,1]).T
@@ -544,15 +543,15 @@ def sample_triangle(vertices, face, n_samples=None):
     r2 = r[n_samples:, :]
 
     # generate barycentric average of vertex coordinates
-    samples = (1-np.sqrt(r1))*v1 + np.sqrt(r1)*(1-r2)*v2 + \
-        np.sqrt(r1)*r2*v3
+    samples = (1 - np.sqrt(r1)) * v1 + np.sqrt(r1) * (1-r2) * v2 + \
+        np.sqrt(r1) * r2 * v3
     
     # Compute distance to each vertex in triangle
     # and assign seeds to nearest vertex
     distance = cdist(vertices, samples)
     nearest = np.asarray(face)[np.argmin(distance, axis=0)]
 
-    return [samples, nearest]
+    return samples, nearest
 
 
 def random_seeds_from_mask(mask, seeds_count=1, seed_count_per_voxel=True,

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -435,7 +435,7 @@ def seeds_from_mesh(vertices, faces, n_samples=None, affine=None):
     -------
     seeds : 2d float array
         3d coordinates of seeds sampled from each triangle in a mesh
-    assignment : 2d int array
+    assignment : 1d int array
         closest vertex in original mesh to each seed
 
     Examples
@@ -466,7 +466,7 @@ def seeds_from_mesh(vertices, faces, n_samples=None, affine=None):
     else:
 
         if isinstance(faces, np.ndarray):
-            faces = faces.T.tolist()
+            faces = faces.tolist()
 
         S = len(faces)*n_samples
 
@@ -519,6 +519,10 @@ def sample_triangle(vertices, face, n_samples=None):
         when ``n_samples`` not of type int
     ValueError
         when ``n_samples`` less than 0
+
+    Examples
+    -------
+    See ``seed_from_mesh`` for examples of usage.
     """
 
     # If n_samples not provided, return original vertex coordinates


### PR DESCRIPTION
Added two methods to dipy/tracking/utils.py:

``seeds_from_mesh``: generates seed points randomly sampled from a surface mesh.  Parameterized by vertex coordinates, list of triangles in mesh, number of samples to generate per face, and an affine transformation.  The affine transformation brings the generated seed points into the tracking space using the inverse of the diffusion image affine transformation.  Assumes that the mesh is already aligned to some standard space, and that the diffusion image affine matrix brings the diffusion image to this standard space. 

``sample_triangle``: samples points from a single mesh triangle, defined by 3 vertex coordinates.

I've included a description of each method, with the types of accepted parameters, return values, exceptions raised, as well as examples, though I still need to write tests.

A while back, @MrBago had suggested (https://mail.python.org/pipermail/neuroimaging/2016-August/001128.html) also projecting vertices a few **mm** into the white matter -- I'm hoping to add a method to do this as well.  Ideally, this could be extended to track *between* surfaces, though there are a few issues that would need to be resolved, including:
1. stopping criteria for tracking (streamline / face intersection)
2. how to update counts for source/target points upon streamline intersection

Any thoughts, critiques, comments, and ideas are much appreciated!