### PR TITLE
[Fix] decrease tolerance on forecast

### DIFF
--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -480,8 +480,8 @@ def lb_forecast(sh_order):
     diag_lb = np.zeros(n_c)
     counter = 0
     for l in range(0, sh_order + 1, 2):
-        for _ in range(-l, l + 1):
-            diag_lb[counter] = (l * (l + 1)) ** 2
-            counter += 1
+        stop = 2 * l + 1 + counter
+        diag_lb[counter:stop] = (l * (l + 1)) ** 2
+        counter = stop
 
     return np.diag(diag_lb)


### PR DESCRIPTION
The aim of this PR is to fix #1654 by decreasing the solver tolerance. At the moment, the current tolerance is 0.001, which I think is too high for getting any quality solutions.
* Advantage: The solution is more reliable and stable, and hopefully it will fix the negative variables that violate our positivity constraints
* Drawback: We have a tiny loss of speed. 

As you can see [here](https://github.com/cvxgrp/cvxpy/issues/591), cvxpy (and osqp) improved its solver. In fact, some unnecessary extra variables were introduced during the problem resolution. Below, the previous version verbose result: 
```
with cvxpy v1.0.9
-----------------------------------------------------------------
           OSQP v0.4.1  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2018
-----------------------------------------------------------------
problem:  variables n = 249, constraints m = 272
          nnz(P) + nnz(A) = 7247
settings: linear system solver = qdldl,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 25),
          scaling: on, scaled_termination: off
          warm start: on, polish: on

iter   objective    pri res    dua res    rho        time
   1   0.0000e+00   1.00e+00   1.11e+04   1.00e-01   1.61e-03s
 175   1.4997e-01   2.58e-04   9.77e-04   5.50e-01   7.11e-03s

status:               solved
solution polish:      unsuccessful
number of iterations: 175
optimal objective:    0.1500
run time:             7.85e-03s
optimal rho estimate: 1.53e-01
```

here, you can see that `variables n = 249`  is really strange because our input matrix, in this test, has a shape of (193, 28). It will make more sense to have 221 variables. This is what we get with the new `cvxpy` release as you can see below. 
````
with cvxpy v1.0.10
-----------------------------------------------------------------
           OSQP v0.4.1  -  Operator Splitting QP Solver
              (c) Bartolomeo Stellato,  Goran Banjac
        University of Oxford  -  Stanford University 2018
-----------------------------------------------------------------
problem:  variables n = 221, constraints m = 244
          nnz(P) + nnz(A) = 7191
settings: linear system solver = qdldl,
          eps_abs = 1.0e-03, eps_rel = 1.0e-03,
          eps_prim_inf = 1.0e-04, eps_dual_inf = 1.0e-04,
          rho = 1.00e-01 (adaptive),
          sigma = 1.00e-06, alpha = 1.60, max_iter = 4000
          check_termination: on (interval 25),
          scaling: on, scaled_termination: off
          warm start: on, polish: on

iter   objective    pri res    dua res    rho        time
   1   0.0000e+00   1.00e+00   1.11e+04   1.00e-01   1.27e-03s
 200   1.3808e-01   4.50e-03   2.42e-05   1.00e-01   6.75e-03s
 250   1.4711e-01   1.49e-03   9.48e-04   5.71e-01   8.38e-03s

status:               solved
solution polish:      unsuccessful
number of iterations: 250
optimal objective:    0.1471
run time:             9.35e-03s
optimal rho estimate: 3.20e-01
````

To me, this indicates that the 2 versions of cvxpy are solving a different problem.  Fixing the tolerance issue may be a good starting point for our test to stop failing.  Does it make sense  @maurozucchelli  @arokem @Garyfallidis ?
