### PR TITLE
WIP: Integer indices

### DIFF
--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -612,7 +612,8 @@ class RecoBundles(object):
         pruned_indices = [rtransf_cluster_map[i].indices
                           for i in np.where(mins != np.inf)[0]]
         pruned_indices = list(chain(*pruned_indices))
-        pruned_streamlines = transf_streamlines[np.array(pruned_indices)]
+        pruned_streamlines = transf_streamlines[
+                                  np.array(pruned_indices).astype(int)]
 
         initial_indices = list(chain(*neighb_indices))
         final_indices = [initial_indices[i] for i in pruned_indices]

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -312,7 +312,7 @@ class LabelsBundlesFlow(Workflow):
             logging.info(sf)
             streamlines, header = load_trk(sf)
             logging.info(lb)
-            location = np.load(lb)
+            location = np.load(lb).astype(int)
             logging.info('Saving output files ...')
             save_trk(out_bundle, streamlines[location], np.eye(4))
             logging.info(out_bundle)


### PR DESCRIPTION
I ran into these two indexing operations that otherwise throw errors of this kind: 

```
Traceback (most recent call last):
  File "/Users/arokem/.virtualenvs/dipy/bin/dipy_labelsbundles", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/arokem/source/dipy/bin/dipy_labelsbundles", line 9, in <module>
    run_flow(LabelsBundlesFlow())
  File "/Users/arokem/source/dipy/dipy/workflows/flow_runner.py", line 87, in run_flow
    return flow.run(**args)
  File "/Users/arokem/source/dipy/dipy/workflows/segment.py", line 317, in run
    save_trk(out_bundle, streamlines[location], np.eye(4))
  File "/Users/arokem/.virtualenvs/dipy/lib/python3.7/site-packages/nibabel/streamlines/array_sequence.py", line 315, in __getitem__
    seq._offsets = self._offsets[off_idx]
```

I have a couple of questions (I guess for @Garyfallidis?): The first is whether these fixes make sense to you? Do we need to use a rounding operation instead of the cast to integer in `bundles.py`? For the workflow indexing error, can we prevent this by saving the npy files as integer dtype? Any reason not to do that? The other is how we would go about testing for these errors. These cases don't seem to be covered right now.