### PR TITLE
BF: SFM prediction with mask

### DIFF
--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -53,7 +53,11 @@ def _to_fit_iso(data, gtab, mask=None):
     if mask is None:
         mask = np.ones(data.shape[:-1], dtype=bool)
     # Turn it into a 2D thing:
-    data = data[mask]
+    if len(mask.shape) > 0:
+        data = data[mask]
+    else:
+        # This handles the corner case of fitting a single voxel:
+        data = data.reshape((-1, data.shape[0]))
     data_no_b0 = data[:, ~gtab.b0s_mask]
     nzb0 = data_no_b0 > 0
     nzb0_idx = np.where(nzb0)

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -207,11 +207,16 @@ class ExponentialIsotropicFit(IsotropicFit):
         """
         if gtab is None:
             gtab = self.model.gtab
-
-        return np.exp(-gtab.bvals[~gtab.b0s_mask] *
+        if len(self.params.shape) == 0:
+            pred = np.exp(-gtab.bvals[~gtab.b0s_mask] *
+                      (np.zeros(np.sum(~gtab.b0s_mask)) +
+                       self.params[..., np.newaxis]))
+        else:
+            pred = np.exp(-gtab.bvals[~gtab.b0s_mask] *
                       (np.zeros((self.params.shape[0],
                        np.sum(~gtab.b0s_mask))) +
                        self.params[..., np.newaxis]))
+        return pred
 
 
 def sfm_design_matrix(gtab, sphere, response, mode='signal'):

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -163,7 +163,7 @@ class ExponentialIsotropicModel(IsotropicModel):
     Representing the isotropic signal as a fit to an exponential decay function
     with b-values
     """
-    def fit(self, data):
+    def fit(self, data, mask=None):
         """
         Parameters
         ----------
@@ -173,7 +173,7 @@ class ExponentialIsotropicModel(IsotropicModel):
         -------
         ExponentialIsotropicFit class instance.
         """
-        to_fit = _to_fit_iso(data, self.gtab)
+        to_fit = _to_fit_iso(data, self.gtab, mask=mask)
         # Fitting to the log-transformed relative data is much faster:
         nz_idx = to_fit > 0
         to_fit[nz_idx] = np.log(to_fit[nz_idx])

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -180,6 +180,12 @@ class ExponentialIsotropicModel(IsotropicModel):
         to_fit[~nz_idx] = -np.inf
         p = nanmean(to_fit / self.gtab.bvals[~self.gtab.b0s_mask], -1)
         params = -p
+        if mask is None:
+            params = np.reshape(params, data.shape[:-1])
+        else:
+            out_params = np.zeros(data.shape[:-1])
+            out_params[mask] = params
+            params = out_params
         return ExponentialIsotropicFit(self, params)
 
 
@@ -201,6 +207,7 @@ class ExponentialIsotropicFit(IsotropicFit):
         """
         if gtab is None:
             gtab = self.model.gtab
+
         return np.exp(-gtab.bvals[~gtab.b0s_mask] *
                       (np.zeros((self.params.shape[0],
                        np.sum(~gtab.b0s_mask))) +

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -79,7 +79,6 @@ def test_predict():
     new_pred = sffit.predict(new_gtab)
 
     # Fitting and predicting with a volume of data:
-
     fdata, fbval, fbvec = dpd.get_fnames('small_25')
     gtab = grad.gradient_table(fbval, fbvec)
     data = load_nifti_data(fdata)
@@ -187,8 +186,26 @@ def test_exponential_iso():
 
         sffit1 = sfmodel.fit(data[0, 0, 0])
         sphere = dpd.get_sphere()
-        sffit1.odf(sphere)
-        sffit1.predict(gtab)
+        odf = sffit1.odf(sphere)
+        pred = sffit1.predict(gtab)
+        npt.assert_equal(pred.shape, data.shape)
+        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
+
+        sffit2 = sfmodel.fit(data)
+        sphere = dpd.get_sphere()
+        odf = sffit2.odf(sphere)
+        pred = sffit2.predict(gtab)
+        npt.assert_equal(pred.shape, data.shape)
+        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
+
+        mask = np.zeros(data.shape[:3])
+        mask[2:5, 2:5, :] = 1
+        sffit3 = sfmodel.fit(data, mask=mask)
+        sphere = dpd.get_sphere()
+        odf = sffit3.odf(sphere)
+        pred = sffit3.predict(gtab)
+        npt.assert_equal(pred.shape, data.shape)
+        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
 
         SNR = 1000
         S0 = 100
@@ -200,3 +217,4 @@ def test_exponential_iso():
         sffit = sfmodel.fit(S)
         pred = sffit.predict()
         npt.assert_(xval.coeff_of_determination(pred, S) > 96)
+

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -188,15 +188,17 @@ def test_exponential_iso():
         sphere = dpd.get_sphere()
         odf = sffit1.odf(sphere)
         pred = sffit1.predict(gtab)
-        npt.assert_equal(pred.shape, data.shape)
-        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
+        npt.assert_equal(pred.shape, data[0,0,0].shape)
+        npt.assert_equal(odf.shape,
+                         data[0,0,0].shape[:-1] + (sphere.x.shape[0],))
 
         sffit2 = sfmodel.fit(data)
         sphere = dpd.get_sphere()
         odf = sffit2.odf(sphere)
         pred = sffit2.predict(gtab)
         npt.assert_equal(pred.shape, data.shape)
-        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
+        npt.assert_equal(odf.shape,
+                         data.shape[:-1] + (sphere.x.shape[0],))
 
         mask = np.zeros(data.shape[:3])
         mask[2:5, 2:5, :] = 1
@@ -205,7 +207,7 @@ def test_exponential_iso():
         odf = sffit3.odf(sphere)
         pred = sffit3.predict(gtab)
         npt.assert_equal(pred.shape, data.shape)
-        npt.assert_equal(odf.shape, data.shape[:-1] + sphere.x.shape[0],)
+        npt.assert_equal(odf.shape, data.shape[:-1] + (sphere.x.shape[0],))
 
         SNR = 1000
         S0 = 100

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -74,6 +74,48 @@ def test_predict():
     new_pred = sffit.predict(new_gtab)
     npt.assert_(xval.coeff_of_determination(new_pred, S[::2]) > 97)
 
+    # Should be possible to predict for a single direction:
+    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    new_pred = sffit.predict(new_gtab)
+
+    # Fitting and predicting with a volume of data:
+
+    fdata, fbval, fbvec = dpd.get_fnames('small_25')
+    gtab = grad.gradient_table(fbval, fbvec)
+    data = load_nifti_data(fdata)
+    sfmodel = sfm.SparseFascicleModel(gtab, response=[0.0015, 0.0003, 0.0003])
+    sffit = sfmodel.fit(data)
+    pred = sffit.predict()
+
+    # Should be possible to predict using a different gtab:
+    new_gtab = grad.gradient_table(bvals[::2], bvecs[::2])
+    new_pred = sffit.predict(new_gtab)
+    npt.assert_equal(new_pred.shape, data.shape[:-1] + bvals[::2].shape, )
+
+    # Should be possible to predict for a single direction:
+    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    new_pred = sffit.predict(new_gtab)
+    npt.assert_equal(new_pred.shape, data.shape[:-1])
+
+    # Fitting and predicting with masked data:
+    mask = np.zeros(data.shape[:3])
+    mask[2:5, 2:5, :] = 1
+    sffit = sfmodel.fit(data, mask=mask)
+    pred = sffit.predict()
+    npt.assert_equal(pred.shape, data.shape)
+
+    # Should be possible to predict using a different gtab:
+    new_gtab = grad.gradient_table(bvals[::2], bvecs[::2])
+    new_pred = sffit.predict(new_gtab)
+    npt.assert_equal(new_pred.shape, data.shape[:-1] + bvals[::2].shape,)
+    npt.assert_equal(new_pred[0, 0, 0], 0)
+
+    # Should be possible to predict for a single direction:
+    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    new_pred = sffit.predict(new_gtab)
+    npt.assert_equal(new_pred.shape, data.shape[:-1])
+    npt.assert_equal(new_pred[0, 0, 0], 0)
+
 
 def test_sfm_background():
     fdata, fbvals, fbvecs = dpd.get_fnames()


### PR DESCRIPTION
This fixes a bug in the way that SFM does signal prediction when fit with a mask. This is something I just stumbled upon earlier today while I was working with @dPys on https://github.com/nipreps/dmriprep/pull/62. This should fix the issues we were seeing there.