### PR TITLE
[FIX] check seeds dtype

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -81,8 +81,8 @@ class LocalTracking(object):
         if maxlen < 1:
             raise ValueError("maxlen must be greater than 0.")
         if not isinstance(seeds, Iterable):
-            raise ValueError("seeds should be a list of 3D points. Please"
-                             " create a (N,3) ndarray")
+            raise ValueError("seeds should be (N,3) array.")
+
         self.affine = affine
         self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
                                                 dtype=float)

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -1,4 +1,5 @@
 import random
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -79,6 +80,9 @@ class LocalTracking(object):
             raise ValueError("step_size must be greater than 0.")
         if maxlen < 1:
             raise ValueError("maxlen must be greater than 0.")
+        if not isinstance(seeds, Iterable):
+            raise ValueError("seeds should be a list of 3D points. Please"
+                             " create a (N,3) ndarray")
         self.affine = affine
         self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
                                                 dtype=float)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -765,6 +765,11 @@ def test_affine_transformations():
     bad_affine[0, 1] = 1.
     npt.assert_raises(ValueError, LocalTracking, dg, sc, seeds, bad_affine, 1.)
 
+    # TST - bad seeds
+    bad_seeds = 1000
+    npt.assert_raises(ValueError, LocalTracking, dg, sc, bad_seeds,
+                      np.eye(4), 1.)
+
     # TST - identity
     a0 = np.eye(4)
     # TST - affines with positive/negative offsets


### PR DESCRIPTION
A small PR to fix #2034. I just check the `seed` type to avoid an error later with a much more complex message.  