### PR TITLE
Multidimensional gradient table

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -69,20 +69,24 @@ class GradientTable(object):
         self.big_delta = big_delta
         self.small_delta = small_delta
         self.b0_threshold = b0_threshold
+        if btens is not None:
+            linear_tensor = np.array([[1, 0, 0],
+                                      [0, 0, 0],
+                                      [0, 0, 0]])
+            planar_tensor = np.array([[1, 0, 0],
+                                      [0, 1, 0],
+                                      [0, 0, 0]]) / 2
+            spherical_tensor = np.array([[1, 0, 0],
+                                         [0, 1, 0],
+                                         [0, 0, 1]]) / 3
         if isinstance(btens, str):
             b_tensors = np.zeros((len(self.bvals), 3, 3))
             if btens == 'LTE':
-                b_tensor = np.array([[1, 0, 0],
-                                     [0, 0, 0],
-                                     [0, 0, 0]])
+                b_tensor = linear_tensor
             elif btens == 'PTE':
-                b_tensor = np.array([[0, 0, 0],
-                                     [0, 1, 0],
-                                     [0, 0, 1]]) / 2
+                b_tensor = planar_tensor
             elif btens == 'STE':
-                b_tensor = np.array([[1, 0, 0],
-                                     [0, 1, 0],
-                                     [0, 0, 1]]) / 3
+                b_tensor = spherical_tensor
             else:
                 raise ValueError("%s is an invalid value for btens. "%btens
                                  + "Please provide one of the following: "
@@ -105,22 +109,13 @@ class GradientTable(object):
             for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
                 R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
                 if btens[i] == 'LTE':
-                    b_tensor = np.array([[1, 0, 0],
-                                         [0, 0, 0],
-                                         [0, 0, 0]])
-                    b_tensors[i] = (np.matmul(np.matmul(R, b_tensor), R.T)
+                    b_tensors[i] = (np.matmul(np.matmul(R, linear_tensor), R.T)
                                     * bval)
                 elif btens[i] == 'PTE':
-                    b_tensor = np.array([[0, 0, 0],
-                                         [0, 1, 0],
-                                         [0, 0, 1]]) / 2
-                    b_tensors[i] = (np.matmul(np.matmul(R, b_tensor), R.T)
+                    b_tensors[i] = (np.matmul(np.matmul(R, planar_tensor), R.T)
                                     * bval)
                 elif btens[i] == 'STE':
-                    b_tensor = np.array([[1, 0, 0],
-                                         [0, 1, 0],
-                                         [0, 0, 1]]) / 3
-                    b_tensors[i] = b_tensor * bval
+                    b_tensors[i] = spherical_tensor * bval
                 else:
                     raise ValueError(
                             "%s is an invalid value in btens array. "%btens[i]
@@ -210,8 +205,8 @@ def gradient_table_from_bvals_bvecs(bvals, bvecs, b0_threshold=50, atol=1e-2,
            with the corresponding gradient direction and the planar tensor's
            normal is aligned with the corresponding gradient direction.
            Magnitude is scaled to match the b-value.
-        3. an arry of shape (N,3,3) specifying the b-tensor of each volume
-           exactly. N corresponds to the number volumes in data No rotation of
+        3. an array of shape (N,3,3) specifying the b-tensor of each volume
+           exactly. N corresponds to the number volumes in data. No rotation of
            scaling is performed.
 
     Other Parameters
@@ -483,7 +478,7 @@ def gradient_table(bvals, bvecs=None, big_delta=None, small_delta=None,
            normal is aligned with the corresponding gradient direction.
            Magnitude is scaled to match the b-value.
         3. an arry of shape (N,3,3) specifying the b-tensor of each volume
-           exactly. N corresponds to the number volumes in data No rotation of
+           exactly. N corresponds to the number volumes in data No rotation or
            scaling is performed.
 
     Returns

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -97,11 +97,11 @@ class GradientTable(object):
             self.btens = b_tensors
         elif (isinstance(btens, np.ndarray) and (btens.shape ==
                 (gradients.shape[0],) or (btens.shape ==
-                (gradients.shape[0],1)) or (btens.shape == (1,
+                (gradients.shape[0], 1)) or (btens.shape == (1,
                 gradients.shape[0])))):
             b_tensors = np.zeros((len(self.bvals), 3, 3))
-            if (btens.shape == (1,gradients.shape[0],1)):
-                btens = btens.reshape((gradients.shape[0],1))
+            if btens.shape == (1,gradients.shape[0], 1):
+                btens = btens.reshape((gradients.shape[0], 1))
             for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
                 R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
                 if btens[i] == 'LTE':
@@ -451,7 +451,7 @@ def gradient_table(bvals, bvecs=None, big_delta=None, small_delta=None,
 
     atol : float
         All b-vectors need to be unit vectors up to a tolerance.
-        
+
     btens : can be any of two options
 
         1. a string specifying the shape of the encoding tensor shape for all

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -100,7 +100,7 @@ class GradientTable(object):
                 (gradients.shape[0], 1)) or (btens.shape == (1,
                 gradients.shape[0])))):
             b_tensors = np.zeros((len(self.bvals), 3, 3))
-            if btens.shape == (1,gradients.shape[0], 1):
+            if btens.shape == (1, gradients.shape[0]):
                 btens = btens.reshape((gradients.shape[0], 1))
             for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
                 R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
@@ -164,7 +164,7 @@ class GradientTable(object):
         denom = self.bvals + (self.bvals == 0)
         denom = denom.reshape((-1, 1))
         return self.gradients / denom
-    
+
     @property
     def info(self):
         logger.info('B-values shape (%d,)' % self.bvals.shape)

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -126,6 +126,9 @@ class GradientTable(object):
                             "%s is an invalid value in btens array. "%btens[i]
                             + "Array element options: 'LTE', 'PTE', 'STE'.")
             self.btens = b_tensors
+        elif (isinstance(btens, np.ndarray) and btens.shape ==
+                (gradients.shape[0], 3, 3)):
+            self.btens = btens
         elif btens is not None:
             raise ValueError("%s is an invalid value for btens. "%btens
                              + "Please provide a string or an array of "
@@ -191,15 +194,25 @@ def gradient_table_from_bvals_bvecs(bvals, bvecs, b0_threshold=50, atol=1e-2,
     atol : float
         Each vector in `bvecs` must be a unit vectors up to a tolerance of
         `atol`.
-    btens : can be any of two options
-        1. a string specifying the shape of the encoding tensor shape for all
-           volumes in data. Options: 'LTE', 'PTE', 'STE' corresponding to
-           linear, planar, and spherical tensor encoding. (default 'LTE')
+    btens : can be any of three options
+        1. a string specifying the shape of the encoding tensor for all volumes
+           in data. Options: 'LTE', 'PTE', 'STE' corresponding to linear,
+           planar, and spherical tensor encoding. Tensors are rotated so that
+           the linear tensor is aligned with the corresponding gradient
+           direction and the planar tensor's normal is aligned with the
+           corresponding gradient direction. Magnitude is scaled to match the
+           b-value.
         2. an array of strings of shape (N,), (N, 1), or (1, N) specifying
            encoding tensor shape for each volume separately. N corresponds to
            the number volumes in data. Options for elements in array: 'LTE',
            'PTE', 'STE' corresponding to linear, planar, and spherical tensor
-           encoding.
+           encoding. Tensors are rotated so that the linear tensor is aligned
+           with the corresponding gradient direction and the planar tensor's
+           normal is aligned with the corresponding gradient direction.
+           Magnitude is scaled to match the b-value.
+        3. an arry of shape (N,3,3) specifying the b-tensor of each volume
+           exactly. N corresponds to the number volumes in data No rotation of
+           scaling is performed.
 
     Other Parameters
     ----------------
@@ -452,16 +465,26 @@ def gradient_table(bvals, bvecs=None, big_delta=None, small_delta=None,
     atol : float
         All b-vectors need to be unit vectors up to a tolerance.
 
-    btens : can be any of two options
+    btens : can be any of three options
 
-        1. a string specifying the shape of the encoding tensor shape for all
-           volumes in data. Options: 'LTE', 'PTE', 'STE' corresponding to
-           linear, planar, and spherical tensor encoding. (default 'LTE')
+        1. a string specifying the shape of the encoding tensor for all volumes
+           in data. Options: 'LTE', 'PTE', 'STE' corresponding to linear,
+           planar, and spherical tensor encoding. Tensors are rotated so that
+           the linear tensor is aligned with the corresponding gradient
+           direction and the planar tensor's normal is aligned with the
+           corresponding gradient direction. Magnitude is scaled to match the
+           b-value.
         2. an array of strings of shape (N,), (N, 1), or (1, N) specifying
            encoding tensor shape for each volume separately. N corresponds to
            the number volumes in data. Options for elements in array: 'LTE',
            'PTE', 'STE' corresponding to linear, planar, and spherical tensor
-           encoding.
+           encoding. Tensors are rotated so that the linear tensor is aligned
+           with the corresponding gradient direction and the planar tensor's
+           normal is aligned with the corresponding gradient direction.
+           Magnitude is scaled to match the b-value.
+        3. an arry of shape (N,3,3) specifying the b-tensor of each volume
+           exactly. N corresponds to the number volumes in data No rotation of
+           scaling is performed.
 
     Returns
     -------

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -79,56 +79,56 @@ class GradientTable(object):
             spherical_tensor = np.array([[1, 0, 0],
                                          [0, 1, 0],
                                          [0, 0, 1]]) / 3
-        if isinstance(btens, str):
-            b_tensors = np.zeros((len(self.bvals), 3, 3))
-            if btens == 'LTE':
-                b_tensor = linear_tensor
-            elif btens == 'PTE':
-                b_tensor = planar_tensor
-            elif btens == 'STE':
-                b_tensor = spherical_tensor
+            if isinstance(btens, str):
+                b_tensors = np.zeros((len(self.bvals), 3, 3))
+                if btens == 'LTE':
+                    b_tensor = linear_tensor
+                elif btens == 'PTE':
+                    b_tensor = planar_tensor
+                elif btens == 'STE':
+                    b_tensor = spherical_tensor
+                else:
+                    raise ValueError("%s is an invalid value for btens. "%btens
+                                     + "Please provide one of the following: "
+                                     + "'LTE', 'PTE', 'STE.'")
+                for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
+                    if btens == 'STE':
+                        b_tensors[i] = b_tensor * bval
+                    else:
+                        R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
+                        b_tensors[i] = (np.matmul(np.matmul(R, b_tensor), R.T)
+                                        * bval)
+                self.btens = b_tensors
+            elif (isinstance(btens, np.ndarray) and (btens.shape ==
+                    (gradients.shape[0],) or (btens.shape ==
+                    (gradients.shape[0], 1)) or (btens.shape == (1,
+                    gradients.shape[0])))):
+                b_tensors = np.zeros((len(self.bvals), 3, 3))
+                if btens.shape == (1, gradients.shape[0]):
+                    btens = btens.reshape((gradients.shape[0], 1))
+                for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
+                    R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
+                    if btens[i] == 'LTE':
+                        b_tensors[i] = (np.matmul(np.matmul(R, linear_tensor),
+                                        R.T) * bval)
+                    elif btens[i] == 'PTE':
+                        b_tensors[i] = (np.matmul(np.matmul(R, planar_tensor),
+                                        R.T) * bval)
+                    elif btens[i] == 'STE':
+                        b_tensors[i] = spherical_tensor * bval
+                    else:
+                        raise ValueError(
+                                "%s is an invalid value in btens. "%btens[i]
+                                + "Array element options: 'LTE', 'PTE', 'STE'.")
+                self.btens = b_tensors
+            elif (isinstance(btens, np.ndarray) and btens.shape ==
+                    (gradients.shape[0], 3, 3)):
+                self.btens = btens
             else:
                 raise ValueError("%s is an invalid value for btens. "%btens
-                                 + "Please provide one of the following: "
-                                 + "'LTE', 'PTE', 'STE.'")
-            for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
-                if btens == 'STE':
-                    b_tensors[i] = b_tensor * bval
-                else:
-                    R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
-                    b_tensors[i] = (np.matmul(np.matmul(R, b_tensor), R.T)
-                                    * bval)
-            self.btens = b_tensors
-        elif (isinstance(btens, np.ndarray) and (btens.shape ==
-                (gradients.shape[0],) or (btens.shape ==
-                (gradients.shape[0], 1)) or (btens.shape == (1,
-                gradients.shape[0])))):
-            b_tensors = np.zeros((len(self.bvals), 3, 3))
-            if btens.shape == (1, gradients.shape[0]):
-                btens = btens.reshape((gradients.shape[0], 1))
-            for i, (bvec, bval) in enumerate(zip(self.bvecs, self.bvals)):
-                R = vec2vec_rotmat(np.array([1, 0, 0]), bvec)
-                if btens[i] == 'LTE':
-                    b_tensors[i] = (np.matmul(np.matmul(R, linear_tensor), R.T)
-                                    * bval)
-                elif btens[i] == 'PTE':
-                    b_tensors[i] = (np.matmul(np.matmul(R, planar_tensor), R.T)
-                                    * bval)
-                elif btens[i] == 'STE':
-                    b_tensors[i] = spherical_tensor * bval
-                else:
-                    raise ValueError(
-                            "%s is an invalid value in btens array. "%btens[i]
-                            + "Array element options: 'LTE', 'PTE', 'STE'.")
-            self.btens = b_tensors
-        elif (isinstance(btens, np.ndarray) and btens.shape ==
-                (gradients.shape[0], 3, 3)):
-            self.btens = btens
-        elif btens is not None:
-            raise ValueError("%s is an invalid value for btens. "%btens
-                             + "Please provide a string or an array of "
-                             + "strings with the same size as the number of "
-                             + "volumes. String options: 'LTE', 'PTE', 'STE'.")
+                                 + "Please provide a string, an array of "
+                                 + "strings, or an array of exact b-tensors. "
+                                 + "String options: 'LTE', 'PTE', 'STE'.")
 
     @auto_attr
     def bvals(self):

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -142,9 +142,17 @@ def test_GradientTable_btensor_calculation():
                 dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), bvec)
                 npt.assert_almost_equal(np.abs(dot_prod), 1)
 
+    # Check btens input option 3
+    btens = np.array([np.eye(3, 3) for i in range(6)])
+    gt = GradientTable(gradients, btens=btens)
+    npt.assert_equal(btens, gt.btens)
+    npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
+
     # Check invalid input
     npt.assert_raises(ValueError, GradientTable, gradients=gradients,
                       btens='PPP')
+    npt.assert_raises(ValueError, GradientTable, gradients=gradients,
+                      btens=np.array([np.eye(3, 3) for i in range(10)]))
     npt.assert_raises(ValueError, GradientTable, gradients=gradients,
                       btens=np.zeros((10, 10)))
 

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -122,7 +122,8 @@ def test_GradientTable_btensor_calculation():
             if btens == 'LTE':
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), bvec)
+                    dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]),
+                                      bvec)
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 2

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -90,22 +90,25 @@ def test_GradientTable_btensor_calculation():
                           [0, 0, 1],
                           [3, 4, 0],
                           [5, 0, 12]], 'float')
-    gt = GradientTable(gradients)
-
-    # Check that the number of b tensors is correct
-    npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
-
-    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
-                                               gt.btens)):
-        
-        # Check that the b tensor magnitude is correct
-        npt.assert_almost_equal(bval, np.trace(bten))
-        
-        # Check that the b tensor orientation is correct
-        if bval != 0:
-            evals, evecs = np.linalg.eig(bten)
-            dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
-            npt.assert_almost_equal(np.abs(dot_prod), 1)
+    
+    for btens in ['LTE', 'PTE', 'STE']:
+        gt = GradientTable(gradients, btens=btens)
+    
+        # Check that the number of b tensors is correct
+        npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
+    
+        for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
+                                                   gt.btens)):
+            
+            # Check that the b tensor magnitude is correct
+            npt.assert_almost_equal(bval, np.trace(bten))
+            
+            # Check that the b tensor orientation is correct
+            if btens == 'LTE':
+                if bval != 0:
+                    evals, evecs = np.linalg.eig(bten)
+                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
+                    npt.assert_almost_equal(np.abs(dot_prod), 1)
 
 
 def test_gradient_table_from_qvals_bvecs():

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -81,6 +81,33 @@ def test_GradientTable():
         assert len(w) == 1
 
 
+def test_GradientTable_btensor_calculation():
+    
+    # Generate a gradient table without specifying b-tensors
+    gradients = np.array([[0, 0, 0],
+                          [1, 0, 0],
+                          [0, 1, 0],
+                          [0, 0, 1],
+                          [3, 4, 0],
+                          [5, 0, 12]], 'float')
+    gt = GradientTable(gradients)
+
+    # Check that the number of b tensors is correct
+    npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
+
+    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
+                                               gt.btens)):
+        
+        # Check that the b tensor magnitude is correct
+        npt.assert_almost_equal(bval, np.trace(bten))
+        
+        # Check that the b tensor orientation is correct
+        if bval != 0:
+            evals, evecs = np.linalg.eig(bten)
+            dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
+            npt.assert_almost_equal(np.abs(dot_prod), 1)
+
+
 def test_gradient_table_from_qvals_bvecs():
     qvals = 30. * np.ones(7)
     big_delta = .03  # pulse separation of 30ms

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -82,7 +82,7 @@ def test_GradientTable():
 
 
 def test_GradientTable_btensor_calculation():
-    
+
     # Generate a gradient table without specifying b-tensors
     gradients = np.array([[0, 0, 0],
                           [1, 0, 0],
@@ -90,33 +90,39 @@ def test_GradientTable_btensor_calculation():
                           [0, 0, 1],
                           [3, 4, 0],
                           [5, 0, 12]], 'float')
+
+    # Check that no btens are created unless specified
     gt = GradientTable(gradients)
-    
+    npt.assert_equal(hasattr(gt, 'btens'), False)
+
+    # Check that btens are correctly created if specified
+    gt = GradientTable(gradients, btens='LTE')
+
     # Check that the number of b tensors is correct
     npt.assert_equal(gt.btens.shape[0], gt.bvals.shape[0])
-    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, gt.btens)):        
+    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, gt.btens)):
         # Check that the b tensor magnitude is correct
-        npt.assert_almost_equal(np.trace(bten), bval)        
+        npt.assert_almost_equal(np.trace(bten), bval)
         # Check that the b tensor orientation is correct
         if bval != 0:
             evals, evecs = np.linalg.eig(bten)
             dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
             npt.assert_almost_equal(np.abs(dot_prod), 1)
-    
+
     # Check btens input option 1
     for btens in ['LTE', 'PTE', 'STE']:
         gt = GradientTable(gradients, btens=btens)
         # Check that the number of b tensors is correct
         npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
         for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs,
-                                                   gt.btens)):        
+                                                   gt.btens)):
             # Check that the b tensor magnitude is correct
-            npt.assert_almost_equal(np.trace(bten), bval)        
+            npt.assert_almost_equal(np.trace(bten), bval)
             # Check that the b tensor orientation is correct
             if btens == 'LTE':
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), 
+                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]),
                                       gt.bvecs[i])
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
 
@@ -125,22 +131,22 @@ def test_GradientTable_btensor_calculation():
     gt = GradientTable(gradients, btens=btens)
     # Check that the number of b tensors is correct
     npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
-    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
-                                               gt.btens)):        
+    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs,
+                                               gt.btens)):
         # Check that the b tensor magnitude is correct
-        npt.assert_almost_equal(np.trace(bten), bval)        
+        npt.assert_almost_equal(np.trace(bten), bval)
         # Check that the b tensor orientation is correct
         if btens[i] == 'LTE':
             if bval != 0:
                 evals, evecs = np.linalg.eig(bten)
-                dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), 
+                dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]),
                                   gt.bvecs[i])
                 npt.assert_almost_equal(np.abs(dot_prod), 1)
-                
-    # Check invalide
-    npt.assert_raises(ValueError, GradientTable, gradients=gradients, 
+
+    # Check invalid input
+    npt.assert_raises(ValueError, GradientTable, gradients=gradients,
                       btens='PPP')
-    npt.assert_raises(ValueError, GradientTable, gradients=gradients, 
+    npt.assert_raises(ValueError, GradientTable, gradients=gradients,
                       btens=np.zeros((10,10)))
 
 

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -110,7 +110,7 @@ def test_GradientTable_btensor_calculation():
             npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 1
-    for btens in ['LTE', 'PTE', 'STE']:
+    for btens in ['LTE', 'PTE', 'STE', 'CTE']:
         gt = GradientTable(gradients, btens=btens)
         # Check that the number of b tensors is correct
         npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
@@ -119,15 +119,19 @@ def test_GradientTable_btensor_calculation():
             # Check that the b tensor magnitude is correct
             npt.assert_almost_equal(np.trace(bten), bval)
             # Check that the b tensor orientation is correct
-            if btens == 'LTE':
+            if btens == ('LTE' or 'CTE'):
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]),
-                                      bvec)
+                    dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), bvec)
+                    npt.assert_almost_equal(np.abs(dot_prod), 1)
+            elif btens == 'PTE':
+                if bval != 0:
+                    evals, evecs = np.linalg.eig(bten)
+                    dot_prod = np.dot(np.real(evecs[:, np.argmin(evals)]), bvec)
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 2
-    btens = np.array(['LTE', 'PTE', 'STE', 'PTE', 'LTE', 'PTE'])
+    btens = np.array(['LTE', 'PTE', 'STE', 'CTE', 'LTE', 'PTE'])
     gt = GradientTable(gradients, btens=btens)
     # Check that the number of b tensors is correct
     npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
@@ -136,10 +140,15 @@ def test_GradientTable_btensor_calculation():
         # Check that the b tensor magnitude is correct
         npt.assert_almost_equal(np.trace(bten), bval)
         # Check that the b tensor orientation is correct
-        if btens[i] == 'LTE':
+        if btens[i] == ('LTE' or 'CTE'):
             if bval != 0:
                 evals, evecs = np.linalg.eig(bten)
                 dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), bvec)
+                npt.assert_almost_equal(np.abs(dot_prod), 1)
+        elif btens[i] == 'PTE':
+            if bval != 0:
+                evals, evecs = np.linalg.eig(bten)
+                dot_prod = np.dot(np.real(evecs[:, np.argmin(evals)]), bvec)
                 npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 3

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -100,13 +100,13 @@ def test_GradientTable_btensor_calculation():
 
     # Check that the number of b tensors is correct
     npt.assert_equal(gt.btens.shape[0], gt.bvals.shape[0])
-    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, gt.btens)):
+    for i, (bval, bten) in enumerate(zip(gt.bvals, gt.btens)):
         # Check that the b tensor magnitude is correct
         npt.assert_almost_equal(np.trace(bten), bval)
         # Check that the b tensor orientation is correct
         if bval != 0:
             evals, evecs = np.linalg.eig(bten)
-            dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
+            dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), gt.bvecs[i])
             npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 1
@@ -122,8 +122,7 @@ def test_GradientTable_btensor_calculation():
             if btens == 'LTE':
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]),
-                                      gt.bvecs[i])
+                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), bvec)
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 2
@@ -139,15 +138,14 @@ def test_GradientTable_btensor_calculation():
         if btens[i] == 'LTE':
             if bval != 0:
                 evals, evecs = np.linalg.eig(bten)
-                dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]),
-                                  gt.bvecs[i])
+                dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), bvec)
                 npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check invalid input
     npt.assert_raises(ValueError, GradientTable, gradients=gradients,
                       btens='PPP')
     npt.assert_raises(ValueError, GradientTable, gradients=gradients,
-                      btens=np.zeros((10,10)))
+                      btens=np.zeros((10, 10)))
 
 
 def test_gradient_table_from_qvals_bvecs():

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -90,25 +90,58 @@ def test_GradientTable_btensor_calculation():
                           [0, 0, 1],
                           [3, 4, 0],
                           [5, 0, 12]], 'float')
+    gt = GradientTable(gradients)
     
+    # Check that the number of b tensors is correct
+    npt.assert_equal(gt.btens.shape[0], gt.bvals.shape[0])
+    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, gt.btens)):        
+        # Check that the b tensor magnitude is correct
+        npt.assert_almost_equal(np.trace(bten), bval)        
+        # Check that the b tensor orientation is correct
+        if bval != 0:
+            evals, evecs = np.linalg.eig(bten)
+            dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
+            npt.assert_almost_equal(np.abs(dot_prod), 1)
+    
+    # Check btens input option 1
     for btens in ['LTE', 'PTE', 'STE']:
         gt = GradientTable(gradients, btens=btens)
-    
         # Check that the number of b tensors is correct
         npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
-    
-        for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
-                                                   gt.btens)):
-            
+        for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs,
+                                                   gt.btens)):        
             # Check that the b tensor magnitude is correct
-            npt.assert_almost_equal(bval, np.trace(bten))
-            
+            npt.assert_almost_equal(np.trace(bten), bval)        
             # Check that the b tensor orientation is correct
             if btens == 'LTE':
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), gt.bvecs[i])
+                    dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), 
+                                      gt.bvecs[i])
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
+
+    # Check btens input option 2
+    btens = np.array(['LTE', 'PTE', 'STE', 'PTE', 'LTE', 'PTE'])
+    gt = GradientTable(gradients, btens=btens)
+    # Check that the number of b tensors is correct
+    npt.assert_equal(gt.bvals.shape[0], gt.btens.shape[0])
+    for i, (bval, bvec, bten) in enumerate(zip(gt.bvals, gt.bvecs, 
+                                               gt.btens)):        
+        # Check that the b tensor magnitude is correct
+        npt.assert_almost_equal(np.trace(bten), bval)        
+        # Check that the b tensor orientation is correct
+        if btens[i] == 'LTE':
+            if bval != 0:
+                evals, evecs = np.linalg.eig(bten)
+                dot_prod = np.dot(np.real(evecs[:,np.argmax(evals)]), 
+                                  gt.bvecs[i])
+                npt.assert_almost_equal(np.abs(dot_prod), 1)
+                
+    # Check invalide
+    npt.assert_raises(ValueError, GradientTable, gradients=gradients, 
+                      btens='PPP')
+    npt.assert_raises(ValueError, GradientTable, gradients=gradients, 
+                      btens=np.zeros((10,10)))
 
 
 def test_gradient_table_from_qvals_bvecs():


### PR DESCRIPTION
I suggest extending the GradientTable class to contain information about b-tensor shapes.

This preliminary code calculates the b-tensors for each acquisition and saves the information as an attribute of the GradientTable. The user can explicitly define the used tensor shapes as linear, planar, or spherical. Next step is to add support for arbitrary tensor shapes in the form of a 3 x 3 matrix or an array of such matrices. If the user does not specify the tensor shape, the code assumes the acquisition to have been performed using linear tensors (traditional single diffusion encoding), so the gradient_table function and GradientTable class can be used as before.

Before finishing the implementation, I would like to ask you for your opinion on the organization of the proposed code.

After this is implemented, the next steps can be implementing multidimensional simulations (Topgaard. "Multidimensional diffusion MRI". https://doi.org/10.1016/j.jmr.2016.12.007) and simple methods for estimating microscopic diffusion anisotropy from data acquired with multidimensional diffusion encoding (Yang, et al. "Double diffusion encoding MRI for the clinic."  https://doi.org/10.1002/mrm.27043, Nery, et al. "In vivo demonstration of microscopic anisotropy in the human kidney using multidimensional diffusion MRI." https://doi.org/10.1002/mrm.27869).