### PR TITLE
MAINT: Up Numpy version to 1.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     - python: 3.5
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
+        - DEPENDS="cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.5.0 nose"
     # To test minimum dependencies for Python 3.7:
     - python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     - python: 3.5
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.29 numpy==1.9.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
+        - DEPENDS="cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
     # To test minimum dependencies for Python 3.7:
     - python: 3.7
       dist: xenial

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
         python.version: '3.7'
       Python35-64bit + MIN_DEPS:
         python.version: '3.5'
-        DEPENDS: "cython==0.29 numpy==1.9.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
+        DEPENDS: "cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
       Python37-64bit + MIN_DEPS:
         python.version: '3.7'
         DEPENDS: "cython==0.29 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
         python.version: '3.7'
       Python35-64bit + MIN_DEPS:
         python.version: '3.5'
-        DEPENDS: "cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.4.0 nose"
+        DEPENDS: "cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.5.0 nose"
       Python37-64bit + MIN_DEPS:
         python.version: '3.7'
         DEPENDS: "cython==0.29 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0"

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -78,10 +78,10 @@ MIT licenses.
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
 CYTHON_MIN_VERSION = '0.29'
-NUMPY_MIN_VERSION = '1.9.0'
+NUMPY_MIN_VERSION = '1.12.0'
 SCIPY_MIN_VERSION = '1.0'
 NIBABEL_MIN_VERSION = '3.0.0'
-H5PY_MIN_VERSION = '2.4.0'
+H5PY_MIN_VERSION = '2.5.0'
 PACKAGING_MIN_VERSION = '19.0'
 
 # Main setup parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Check against .travis.yml file and dipy/info.py
 cython>=0.29
-numpy>=1.9.0
+numpy>=1.12.0
 scipy>=1.0
 nibabel>=3.0.0
-h5py>=2.4.0
+h5py>=2.5.0
 packaging>=19.0


### PR DESCRIPTION
This should help with this: https://github.com/dipy/dipy/pull/2033#issuecomment-587558735. It seems that nibabel has upped their minimal requirement for 3.0
 and we can follow along.