### PR TITLE
Replace manual sform values with get_best_affine

### DIFF
--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -32,7 +32,7 @@ def trk_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_vox_space():
@@ -40,7 +40,7 @@ def tck_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -51,7 +51,7 @@ def fib_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_vox_space():
@@ -59,7 +59,7 @@ def dpy_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def trk_equal_in_rasmm_space():
@@ -67,7 +67,7 @@ def trk_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_rasmm_space():
@@ -75,7 +75,7 @@ def tck_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -86,7 +86,7 @@ def fib_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_rasmm_space():
@@ -94,7 +94,7 @@ def dpy_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def trk_equal_in_voxmm_space():
@@ -102,7 +102,7 @@ def trk_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_voxmm_space():
@@ -110,7 +110,7 @@ def tck_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -121,7 +121,7 @@ def fib_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_voxmm_space():
@@ -129,7 +129,7 @@ def dpy_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def switch_voxel_sizes_from_rasmm():
@@ -143,11 +143,11 @@ def switch_voxel_sizes_from_rasmm():
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
-                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
     sft_switch.to_voxmm()
     assert_allclose(tmp_points_voxmm,
-                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def switch_voxel_sizes_from_voxmm():
@@ -161,11 +161,11 @@ def switch_voxel_sizes_from_voxmm():
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
-                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
     sft_switch.to_voxmm()
     assert_allclose(tmp_points_voxmm,
-                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def to_rasmm_equivalence():
@@ -176,8 +176,8 @@ def to_rasmm_equivalence():
 
     sft_1.to_rasmm()
     sft_2.to_space(Space.RASMM)
-    assert_allclose(sft_1.streamlines._data,
-                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines.get_data(),
+                    sft_2.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def to_voxmm_equivalence():
@@ -188,8 +188,8 @@ def to_voxmm_equivalence():
 
     sft_1.to_voxmm()
     sft_2.to_space(Space.VOXMM)
-    assert_allclose(sft_1.streamlines._data,
-                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines.get_data(),
+                    sft_2.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def to_vox_equivalence():
@@ -200,8 +200,8 @@ def to_vox_equivalence():
 
     sft_1.to_vox()
     sft_2.to_space(Space.VOX)
-    assert_allclose(sft_1.streamlines._data,
-                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines.get_data(),
+                    sft_2.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def to_corner_equivalence():
@@ -212,8 +212,8 @@ def to_corner_equivalence():
 
     sft_1.to_corner()
     sft_2.to_origin(Origin.TRACKVIS)
-    assert_allclose(sft_1.streamlines.data,
-                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines.get_data(),
+                    sft_2.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def to_center_equivalence():
@@ -224,8 +224,8 @@ def to_center_equivalence():
 
     sft_1.to_center()
     sft_2.to_origin(Origin.NIFTI)
-    assert_allclose(sft_1.streamlines.data,
-                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines.get_data(),
+                    sft_2.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def trk_iterative_saving_loading():
@@ -239,7 +239,7 @@ def trk_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.trk', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines._data,
+                            sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.trk')
 
@@ -255,7 +255,7 @@ def tck_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.tck', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines._data,
+                            sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.tck')
 
@@ -274,7 +274,7 @@ def fib_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.fib', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines._data,
+                            sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.fib')
 
@@ -290,7 +290,7 @@ def dpy_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.dpy', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines._data,
+                            sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.dpy')
 
@@ -303,7 +303,7 @@ def iterative_to_vox_transformation():
         sft.to_vox()
         sft.to_rasmm()
         assert_allclose(tmp_points_rasmm,
-                        sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                        sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def iterative_to_voxmm_transformation():
@@ -314,7 +314,7 @@ def iterative_to_voxmm_transformation():
         sft.to_voxmm()
         sft.to_rasmm()
         assert_allclose(tmp_points_rasmm,
-                        sft.streamlines._data, atol=1e-3, rtol=1e-6)
+                        sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def empty_space_change():
@@ -322,20 +322,20 @@ def empty_space_change():
     sft.to_vox()
     sft.to_voxmm()
     sft.to_rasmm()
-    assert_array_equal([], sft.streamlines._data)
+    assert_array_equal([], sft.streamlines.get_data())
 
 
 def empty_shift_change():
     sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
     sft.to_corner()
     sft.to_center()
-    assert_array_equal([], sft.streamlines._data)
+    assert_array_equal([], sft.streamlines.get_data())
 
 
 def empty_remove_invalid():
     sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
     sft.remove_invalid_streamlines()
-    assert_array_equal([], sft.streamlines._data)
+    assert_array_equal([], sft.streamlines.get_data())
 
 
 def shift_corner_from_rasmm():

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -162,7 +162,6 @@ def io_tractogram(extension):
         nii_header = create_nifti_header(in_affine, in_dimensions,
                                          in_voxel_sizes)
         sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
-        print(nii_header.get_best_affine())
         save_tractogram(sft, fname, bbox_valid_check=False)
 
         if extension == 'trk':

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -162,7 +162,7 @@ def io_tractogram(extension):
         nii_header = create_nifti_header(in_affine, in_dimensions,
                                          in_voxel_sizes)
         sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
-
+        print(nii_header.get_best_affine())
         save_tractogram(sft, fname, bbox_valid_check=False)
 
         if extension == 'trk':

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -1,8 +1,7 @@
 import os
 
 from dipy.data import fetch_gold_standard_io
-from dipy.io.utils import (create_nifti_header,
-                           decfa, decfa_to_float,
+from dipy.io.utils import (decfa, decfa_to_float,
                            get_reference_info,
                            is_reference_info_valid)
 from nibabel import Nifti1Image
@@ -110,15 +109,6 @@ def test_reference_info_validity():
             msg='RAS should be a valid voxel order')
 
 
-def reference_info_zero_affine():
-    header = create_nifti_header(np.zeros((4, 4)), [10, 10, 10], [1, 1, 1])
-    try:
-        get_reference_info(header)
-        return True
-    except ValueError:
-        return False
-
-
 def test_reference_info_identical():
     tuple_1 = get_reference_info(filepath_dix['gs.trk'])
     tuple_2 = get_reference_info(filepath_dix['gs.nii'])
@@ -129,8 +119,3 @@ def test_reference_info_identical():
     assert_array_equal(dimensions_1, dimensions_2)
     assert_allclose(voxel_sizes_1, voxel_sizes_2)
     assert voxel_order_1 == voxel_order_2
-
-
-def test_all_zeros_affine():
-    assert_(not reference_info_zero_affine(),
-            msg='An all zeros affine should not be valid')

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -1,7 +1,8 @@
 import os
 
 from dipy.data import fetch_gold_standard_io
-from dipy.io.utils import (decfa, decfa_to_float,
+from dipy.io.utils import (create_nifti_header,
+                           decfa, decfa_to_float,
                            get_reference_info,
                            is_reference_info_valid)
 from nibabel import Nifti1Image
@@ -109,6 +110,15 @@ def test_reference_info_validity():
             msg='RAS should be a valid voxel order')
 
 
+def reference_info_zero_affine():
+    header = create_nifti_header(np.zeros((4, 4)), [10, 10, 10], [1, 1, 1])
+    try:
+        get_reference_info(header)
+        return True
+    except ValueError:
+        return False
+
+
 def test_reference_info_identical():
     tuple_1 = get_reference_info(filepath_dix['gs.trk'])
     tuple_2 = get_reference_info(filepath_dix['gs.nii'])
@@ -119,3 +129,8 @@ def test_reference_info_identical():
     assert_array_equal(dimensions_1, dimensions_2)
     assert_allclose(voxel_sizes_1, voxel_sizes_2)
     assert voxel_order_1 == voxel_order_2
+
+
+def test_all_zeros_affine():
+    assert_(not reference_info_zero_affine(),
+            msg='An all zeros affine should not be valid')

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -267,7 +267,6 @@ def get_reference_info(reference):
         is_sft = True
 
     if is_nifti:
-        affine = np.eye(4).astype(np.float32)
         affine = header.get_best_affine()
         dimensions = header['dim'][1:4]
         voxel_sizes = header['pixdim'][1:4]

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -355,9 +355,7 @@ def create_tractogram_header(tractogram_type, affine, dimensions, voxel_sizes,
 def create_nifti_header(affine, dimensions, voxel_sizes):
     """ Write a standard nifti header from spatial attribute """
     new_header = nib.Nifti1Header()
-    new_header['srow_x'] = affine[0, 0:4]
-    new_header['srow_y'] = affine[1, 0:4]
-    new_header['srow_z'] = affine[2, 0:4]
+    new_header.set_sform(affine)
     new_header['dim'][1:4] = dimensions
     new_header['pixdim'][1:4] = voxel_sizes
 

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -268,9 +268,7 @@ def get_reference_info(reference):
 
     if is_nifti:
         affine = np.eye(4).astype(np.float32)
-        affine[0, 0:4] = header['srow_x']
-        affine[1, 0:4] = header['srow_y']
-        affine[2, 0:4] = header['srow_z']
+        affine = header.get_best_affine()
         dimensions = header['dim'][1:4]
         voxel_sizes = header['pixdim'][1:4]
 


### PR DESCRIPTION
A simple switch to a much more robust Nibabel `get_best_affine()`

Manual getting the sform was often giving full zeros affine when they came from ITK/MITK/ANTs