### PR TITLE
Minor Typos and imports in the beginning

### DIFF
--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -10,7 +10,7 @@ lengths or overall shape.
 A streamline in DIPY_ is represented as a numpy array of size
 :math:`(N \times 3)` where each row of the array represents a 3D point of the
 streamline. A set of streamlines is represented with a list of
-numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where 'M' is the
+numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where $M$ is the
 number of streamlines in the set.
 """
 

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -8,9 +8,9 @@ also how to compress the streamlines without considerably reducing their
 lengths or overall shape.
 
 A streamline in DIPY_ is represented as a numpy array of size
-:math:`(N \times 3)` where each row of the array represent a 3D point of the
+:math:`(N \times 3)` where each row of the array represents a 3D point of the
 streamline. A set of streamlines is represented with a list of
-numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where $M$ is the
+numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where 'M' is the
 number of streamlines in the set.
 """
 
@@ -18,7 +18,8 @@ import numpy as np
 from dipy.tracking.distances import approx_polygon_track
 from dipy.tracking.streamline import set_number_of_points
 from dipy.tracking.utils import length
-
+import matplotlib.pyplot as plt
+from dipy.viz import window, actor
 
 """
 Let's first create a simple simulation of a bundle of streamlines using
@@ -55,8 +56,6 @@ Below we show the histogram of the lengths of the streamlines.
 """
 
 lengths = list(length(bundle))
-
-import matplotlib.pyplot as plt
 
 fig_hist, ax = plt.subplots(1)
 ax.hist(lengths, color='burlywood')
@@ -112,8 +111,6 @@ Both, ``set_number_of_points`` and ``approx_polygon_track`` can be thought as
 methods for lossy compression of streamlines.
 """
 
-from dipy.viz import window, actor
-
 # Enables/disables interactive visualization
 interactive = False
 
@@ -150,14 +147,13 @@ becomes obvious that we have managed to reduce in a great amount the size of the
 initial dataset.
 """
 
-import matplotlib.pyplot as plt
-
 fig_hist, ax = plt.subplots(1)
 ax.hist(n_pts, color='r', histtype='step', label='initial')
 ax.hist(n_pts_ds, color='g', histtype='step', label='set_number_of_points (12)')
 ax.hist(n_pts_ds2, color='b', histtype='step', label='approx_polygon_track (0.25)')
 ax.set_xlabel('Number of points')
 ax.set_ylabel('Count')
+
 # plt.show()
 plt.legend()
 plt.savefig('n_pts_histogram.png')
@@ -181,6 +177,7 @@ ax.plot(lengths_downsampled, color='g', label='set_number_of_points (12)')
 ax.plot(lengths_downsampled2, color='b', label='approx_polygon_track (0.25)')
 ax.set_xlabel('Streamline ID')
 ax.set_ylabel('Length')
+
 # plt.show()
 plt.legend()
 plt.savefig('lengths_plots.png')


### PR DESCRIPTION
Based on proposition https://github.com/dipy/dipy/pull/2093 to import all required modules in the top to avoid callbacks in the middle of example and makes it look more systematic. 