### PR TITLE
[Horizon] Update clipping range on slicer

### DIFF
--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -85,7 +85,8 @@ class Horizon(object):
                  random_colors=False, length_gt=0, length_lt=1000,
                  clusters_gt=0, clusters_lt=10000,
                  world_coords=True, interactive=True,
-                 out_png='tmp.png', recorded_events=None, return_showm=False):
+                 out_png='tmp.png', recorded_events=None, return_showm=False,
+                 bg_color=(0, 0, 0)):
         """Interactive medical visualization - Invert the Horizon!
 
 
@@ -132,6 +133,9 @@ class Horizon(object):
             Return ShowManager object. Used only at Python level. Can be used
             for extending Horizon's cababilities externally and for testing
             purposes.
+        bg_color : ndarray or list or tuple
+            Define the background color of the scene.
+            Default is black (0, 0, 0)
 
         References
         ----------
@@ -163,11 +167,13 @@ class Horizon(object):
         self.recorded_events = recorded_events
         self.show_m = None
         self.return_showm = return_showm
+        self.bg_color = bg_color
 
     def build_scene(self):
 
         self.mem = GlobalHorizon()
         scene = window.Scene()
+        scene.background(self.bg_color)
         self.add_cluster_actors(scene, self.tractograms,
                                 self.cluster_thr,
                                 enable_callbacks=False)
@@ -747,8 +753,8 @@ class Horizon(object):
 
 def horizon(tractograms=None, images=None, pams=None,
             cluster=False, cluster_thr=15.0,
-            random_colors=False, length_gt=0, length_lt=1000,
-            clusters_gt=0, clusters_lt=10000,
+            random_colors=False, bg_color=(0, 0, 0), length_gt=0,
+            length_lt=1000, clusters_gt=0, clusters_lt=10000,
             world_coords=True, interactive=True, out_png='tmp.png',
             recorded_events=None, return_showm=False):
     """Interactive medical visualization - Invert the Horizon!
@@ -759,44 +765,46 @@ def horizon(tractograms=None, images=None, pams=None,
     tractograms : sequence of StatefulTractograms
             StatefulTractograms are used for making sure that the coordinate
             systems are correct
-        images : sequence of tuples
-            Each tuple contains data and affine
-        pams : sequence of PeakAndMetrics
-            Contains peak directions and spherical harmonic coefficients
-        cluster : bool
-            Enable QuickBundlesX clustering
-        cluster_thr : float
-            Distance threshold used for clustering. Default value 15.0 for
-            small animal data you may need to use something smaller such
-            as 2.0. The threshold is in mm. For this parameter to be active
-            ``cluster`` should be enabled.
-        random_colors : bool
-            Given multiple tractograms have been included then each tractogram
-            will be shown with different color
-        length_gt : float
-            Clusters with average length greater than ``length_gt`` amount
-            in mm will be shown.
-        length_lt : float
-            Clusters with average length less than ``length_lt`` amount in mm
-            will be shown.
-        clusters_gt : int
-            Clusters with size greater than ``clusters_gt`` will be shown.
-        clusters_lt : int
-            Clusters with size less than ``clusters_lt`` will be shown.
-        world_coords : bool
-            Show data in their world coordinates (not native voxel coordinates)
-            Default True.
-        interactive : bool
-            Allow user interaction. If False then Horizon goes on stealth mode
-            and just saves pictures.
-        out_png : string
-            Filename of saved picture.
-        recorded_events : string
-            File path to replay recorded events
-        return_showm : bool
-            Return ShowManager object. Used only at Python level. Can be used
-            for extending Horizon's cababilities externally and for testing
-            purposes.
+    images : sequence of tuples
+        Each tuple contains data and affine
+    pams : sequence of PeakAndMetrics
+        Contains peak directions and spherical harmonic coefficients
+    cluster : bool
+        Enable QuickBundlesX clustering
+    cluster_thr : float
+        Distance threshold used for clustering. Default value 15.0 for
+        small animal data you may need to use something smaller such
+        as 2.0. The threshold is in mm. For this parameter to be active
+        ``cluster`` should be enabled.
+    random_colors : bool
+        Given multiple tractograms have been included then each tractogram
+        will be shown with different color
+    bg_color : ndarray or list or tuple
+        Define the background color of the scene. Default is black (0, 0, 0)
+    length_gt : float
+        Clusters with average length greater than ``length_gt`` amount
+        in mm will be shown.
+    length_lt : float
+        Clusters with average length less than ``length_lt`` amount in mm
+        will be shown.
+    clusters_gt : int
+        Clusters with size greater than ``clusters_gt`` will be shown.
+    clusters_lt : int
+        Clusters with size less than ``clusters_lt`` will be shown.
+    world_coords : bool
+        Show data in their world coordinates (not native voxel coordinates)
+        Default True.
+    interactive : bool
+        Allow user interaction. If False then Horizon goes on stealth mode
+        and just saves pictures.
+    out_png : string
+        Filename of saved picture.
+    recorded_events : string
+        File path to replay recorded events
+    return_showm : bool
+        Return ShowManager object. Used only at Python level. Can be used
+        for extending Horizon's cababilities externally and for testing
+        purposes.
 
     References
     ----------
@@ -810,7 +818,7 @@ def horizon(tractograms=None, images=None, pams=None,
                  random_colors, length_gt, length_lt,
                  clusters_gt, clusters_lt,
                  world_coords, interactive,
-                 out_png, recorded_events, return_showm)
+                 out_png, recorded_events, return_showm, bg_color=bg_color)
 
     scene = hz.build_scene()
 

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -86,7 +86,7 @@ class Horizon(object):
                  clusters_gt=0, clusters_lt=10000,
                  world_coords=True, interactive=True,
                  out_png='tmp.png', recorded_events=None, return_showm=False,
-                 bg_color=(0, 0, 0)):
+                 bg_color=(0, 0, 0), order_transparent=True):
         """Interactive medical visualization - Invert the Horizon!
 
 
@@ -136,6 +136,10 @@ class Horizon(object):
         bg_color : ndarray or list or tuple
             Define the background color of the scene.
             Default is black (0, 0, 0)
+        order_transparent : bool
+            Default True. Use depth peeling to sort transparent objects.
+            If True also enables anti-aliasing.
+
 
         References
         ----------
@@ -168,6 +172,7 @@ class Horizon(object):
         self.show_m = None
         self.return_showm = return_showm
         self.bg_color = bg_color
+        self.order_transparent = order_transparent
 
     def build_scene(self):
 
@@ -315,10 +320,11 @@ class Horizon(object):
     def build_show(self, scene):
 
         title = 'Horizon ' + horizon_version
-        self.show_m = window.ShowManager(scene, title=title,
-                                         size=(1200, 900),
-                                         order_transparent=True,
-                                         reset_camera=False)
+        self.show_m = window.ShowManager(
+            scene, title=title,
+            size=(1200, 900),
+            order_transparent=self.order_transparent,
+            reset_camera=False)
         self.show_m.initialize()
 
         if self.cluster and self.tractograms:
@@ -753,8 +759,8 @@ class Horizon(object):
 
 def horizon(tractograms=None, images=None, pams=None,
             cluster=False, cluster_thr=15.0,
-            random_colors=False, bg_color=(0, 0, 0), length_gt=0,
-            length_lt=1000, clusters_gt=0, clusters_lt=10000,
+            random_colors=False, bg_color=(0, 0, 0), order_transparent=True,
+            length_gt=0, length_lt=1000, clusters_gt=0, clusters_lt=10000,
             world_coords=True, interactive=True, out_png='tmp.png',
             recorded_events=None, return_showm=False):
     """Interactive medical visualization - Invert the Horizon!
@@ -781,6 +787,9 @@ def horizon(tractograms=None, images=None, pams=None,
         will be shown with different color
     bg_color : ndarray or list or tuple
         Define the background color of the scene. Default is black (0, 0, 0)
+    order_transparent : bool
+        Default True. Use depth peeling to sort transparent objects.
+        If True also enables anti-aliasing.
     length_gt : float
         Clusters with average length greater than ``length_gt`` amount
         in mm will be shown.
@@ -818,7 +827,8 @@ def horizon(tractograms=None, images=None, pams=None,
                  random_colors, length_gt, length_lt,
                  clusters_gt, clusters_lt,
                  world_coords, interactive,
-                 out_png, recorded_events, return_showm, bg_color=bg_color)
+                 out_png, recorded_events, return_showm, bg_color=bg_color,
+                 order_transparent=order_transparent)
 
     scene = hz.build_scene()
 

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -160,6 +160,7 @@ def slicer_panel(renderer, iren,
             mem.slicer_peaks_actor_z.display_extent(0, shape[0] - 1,
                                                     0, shape[1] - 1, z, z)
         mem.slicer_curr_z = z
+        renderer.reset_clipping_range()
 
     line_slider_x = ui.LineSlider2D(min_value=0,
                                     max_value=shape[0] - 1,
@@ -173,6 +174,7 @@ def slicer_panel(renderer, iren,
         x = int(np.round(slider.value))
         mem.slicer_curr_actor_x.display_extent(x, x, 0, shape[1] - 1, 0,
                                                shape[2] - 1)
+        renderer.reset_clipping_range()
         mem.slicer_curr_x = x
         mem.window_timer_cnt += 100
 
@@ -189,6 +191,7 @@ def slicer_panel(renderer, iren,
 
         mem.slicer_curr_actor_y.display_extent(0, shape[0] - 1, y, y,
                                                0, shape[2] - 1)
+        renderer.reset_clipping_range()
         mem.slicer_curr_y = y
 
     # TODO there is some small bug when starting the app the handles

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -98,6 +98,14 @@ def test_horizon_flow():
 
         npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
                          True)
+        npt.assert_raises(ValueError, hz_flow.run,
+                          input_files=input_files, bg_color=(0.2, 0.2))
+
+        hz_flow.run(input_files=input_files, stealth=True, bg_color=[0.5, ],
+                    out_dir=out_dir, out_stealth_png='tmp_x.png')
+        npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
+                         True)
+
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -17,8 +17,8 @@ class HorizonFlow(Workflow):
     def run(self, input_files, cluster=False, cluster_thr=15.,
             random_colors=False, length_gt=0, length_lt=1000,
             clusters_gt=0, clusters_lt=10**8, native_coords=False,
-            stealth=False, emergency_header='icbm_2009a', out_dir='',
-            out_stealth_png='tmp.png'):
+            stealth=False, emergency_header='icbm_2009a', bg_color=(0, 0, 0),
+            out_dir='', out_stealth_png='tmp.png'):
         """ Interactive medical visualization - Invert the Horizon!
 
         Interact with any number of .trk, .tck or .dpy tractograms and anatomy
@@ -54,6 +54,9 @@ class HorizonFlow(Workflow):
         emergency_header : str
             If no anatomy reference is provided an emergency header is
             provided. Current options 'icbm_2009a' and 'icbm_2009c'.
+        bg_color : variable float
+            Define the background color of the scene. Value should be
+            between [0-1]. Default is black (0, 0, 0)
         out_dir : string
             Output directory. Default current directory.
         out_stealth_png : string
@@ -142,9 +145,15 @@ class HorizonFlow(Workflow):
                     print('Peak_dirs shape')
                     print(pam.peak_dirs.shape)
 
+        if len(bg_color) == 1:
+            bg_color *= 3
+        elif len(bg_color) != 3:
+            raise ValueError('You need 3 values to set up backgound color. '
+                             'e.g --bg_color 0.5 0.5 0.5')
+
         horizon(tractograms=tractograms, images=images, pams=pams,
                 cluster=cluster, cluster_thr=cluster_thr,
-                random_colors=random_colors,
+                random_colors=random_colors, bg_color=bg_color,
                 length_gt=length_gt, length_lt=length_lt,
                 clusters_gt=clusters_gt, clusters_lt=clusters_lt,
                 world_coords=world_coords,

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -18,7 +18,7 @@ class HorizonFlow(Workflow):
             random_colors=False, length_gt=0, length_lt=1000,
             clusters_gt=0, clusters_lt=10**8, native_coords=False,
             stealth=False, emergency_header='icbm_2009a', bg_color=(0, 0, 0),
-            out_dir='', out_stealth_png='tmp.png'):
+            order_transparent=True, out_dir='', out_stealth_png='tmp.png'):
         """ Interactive medical visualization - Invert the Horizon!
 
         Interact with any number of .trk, .tck or .dpy tractograms and anatomy
@@ -27,39 +27,43 @@ class HorizonFlow(Workflow):
         Parameters
         ----------
         input_files : variable string
-        cluster : bool
+        cluster : bool, optional
             Enable QuickBundlesX clustering
-        cluster_thr : float
+        cluster_thr : float, optional
             Distance threshold used for clustering. Default value 15.0 for
             small animal brains you may need to use something smaller such
             as 2.0. The distance is in mm. For this parameter to be active
             ``cluster`` should be enabled
-        random_colors : bool
+        random_colors : bool, optional
             Given multiple tractograms have been included then each tractogram
             will be shown with different color
-        length_gt : float
+        length_gt : float, optional
             Clusters with average length greater than ``length_gt`` amount
             in mm will be shown
-        length_lt : float
+        length_lt : float, optional
             Clusters with average length less than ``length_lt`` amount in
             mm will be shown
-        clusters_gt : int
+        clusters_gt : int, optional
             Clusters with size greater than ``clusters_gt`` will be shown.
-        clusters_lt : int
+        clusters_lt : int, optional
             Clusters with size less than ``clusters_gt`` will be shown.
-        native_coords : bool
+        native_coords : bool, optional
             Show results in native coordinates
-        stealth : bool
+        stealth : bool, optional
             Do not use interactive mode just save figure.
-        emergency_header : str
+        emergency_header : str, optional
             If no anatomy reference is provided an emergency header is
             provided. Current options 'icbm_2009a' and 'icbm_2009c'.
-        bg_color : variable float
-            Define the background color of the scene. Value should be
-            between [0-1]. Default is black (0, 0, 0)
-        out_dir : string
+        bg_color : variable float, optional
+            Define the background color of the scene. Colors can be defined
+            with 1 or 3 values and should be between [0-1].
+            Default is black (e.g --bg_color 0 0 0 or --bg_color 0).
+        order_transparent : bool, optional
+            Default True. Use depth peeling to sort transparent objects.
+            If True also enables anti-aliasing.
+        out_dir : str, optional
             Output directory. Default current directory.
-        out_stealth_png : string
+        out_stealth_png : str, optional
             Filename of saved picture.
 
         References
@@ -154,6 +158,7 @@ class HorizonFlow(Workflow):
         horizon(tractograms=tractograms, images=images, pams=pams,
                 cluster=cluster, cluster_thr=cluster_thr,
                 random_colors=random_colors, bg_color=bg_color,
+                order_transparent=order_transparent,
                 length_gt=length_gt, length_lt=length_lt,
                 clusters_gt=clusters_gt, clusters_lt=clusters_lt,
                 world_coords=world_coords,

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -18,7 +18,8 @@ class HorizonFlow(Workflow):
             random_colors=False, length_gt=0, length_lt=1000,
             clusters_gt=0, clusters_lt=10**8, native_coords=False,
             stealth=False, emergency_header='icbm_2009a', bg_color=(0, 0, 0),
-            order_transparent=True, out_dir='', out_stealth_png='tmp.png'):
+            disable_order_transparency=False, out_dir='',
+            out_stealth_png='tmp.png'):
         """ Interactive medical visualization - Invert the Horizon!
 
         Interact with any number of .trk, .tck or .dpy tractograms and anatomy
@@ -58,8 +59,8 @@ class HorizonFlow(Workflow):
             Define the background color of the scene. Colors can be defined
             with 1 or 3 values and should be between [0-1].
             Default is black (e.g --bg_color 0 0 0 or --bg_color 0).
-        order_transparent : bool, optional
-            Default True. Use depth peeling to sort transparent objects.
+        disable_order_transparency : bool, optional
+            Default False. Use depth peeling to sort transparent objects.
             If True also enables anti-aliasing.
         out_dir : str, optional
             Output directory. Default current directory.
@@ -155,6 +156,7 @@ class HorizonFlow(Workflow):
             raise ValueError('You need 3 values to set up backgound color. '
                              'e.g --bg_color 0.5 0.5 0.5')
 
+        order_transparent = not disable_order_transparency
         horizon(tractograms=tractograms, images=images, pams=pams,
                 cluster=cluster, cluster_thr=cluster_thr,
                 random_colors=random_colors, bg_color=bg_color,


### PR DESCRIPTION
When the slicer goes up or down we need to update the scene clipping range because some of the slices are not immediately visible.

I use this opportunity to add 2 new optionq in Horizon: 
- `--bg_color 0.5 0.5 0.5` or `--bg_color 0.5`(change background color of the scene)
- `--disable_order_transparency`

