### PR TITLE
BF: ensure `btens` attribute of `GradientTable` is initialised

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -139,7 +139,7 @@ class GradientTable(object):
                                  + "strings, or an array of exact b-tensors. "
                                  + "String options: 'LTE', 'PTE', 'STE', 'CTE'")
         else:
-            self.btens = btens
+            self.btens = None
 
     @auto_attr
     def bvals(self):

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -138,6 +138,8 @@ class GradientTable(object):
                                  + "Please provide a string, an array of "
                                  + "strings, or an array of exact b-tensors. "
                                  + "String options: 'LTE', 'PTE', 'STE', 'CTE'")
+        else:
+            self.btens = btens
 
     @auto_attr
     def bvals(self):

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -91,9 +91,9 @@ def test_GradientTable_btensor_calculation():
                           [3, 4, 0],
                           [5, 0, 12]], 'float')
 
-    # Check that no btens are created unless specified
+    # Check that when btens attribute not specified it takes the value of None
     gt = GradientTable(gradients)
-    npt.assert_equal(hasattr(gt, 'btens'), False)
+    npt.assert_equal(gt.btens, None)
 
     # Check that btens are correctly created if specified
     gt = GradientTable(gradients, btens='LTE')


### PR DESCRIPTION
Create an instance of the [GradientTable](https://github.com/dipy/dipy/blob/85738ae82223aae9af9893220665f1203ea3dd8a/dipy/core/gradients.py#L17) class without specifying the `btens` attribute:

    >>> gt = GradientTable(gradients)

Where `gradients` is a gradient table without specifying b-tensors (e.g. see [here](https://github.com/dipy/dipy/blob/85738ae82223aae9af9893220665f1203ea3dd8a/dipy/core/tests/test_gradients.py#L87)).
Query the `btens` attribute on that instance:

    >>> print(gt.btens)
    AttributeError: 'GradientTable' object has no attribute 'btens'

This error being triggered does seem to be the expected behaviour, as judging by [dipy/core/tests/test_gradients.py](https://github.com/dipy/dipy/blob/master/dipy/core/tests/test_gradients.py), specifically [this](https://github.com/dipy/dipy/blob/85738ae82223aae9af9893220665f1203ea3dd8a/dipy/core/tests/test_gradients.py#L96) line.

However, this behaviour is not consistent with other [GradientTable](https://github.com/dipy/dipy/blob/85738ae82223aae9af9893220665f1203ea3dd8a/dipy/core/gradients.py#L17) attributes. For example, making a similar query for `big_delta` does return its default value:

    >>> print(gt.big_delta)
    None

This pull requests aims to implement this behaviour. I also updated the corresponding test function accordingly.