### PR TITLE
ENH: function to calculate anisotropy of b-tensors

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -766,15 +766,10 @@ def btensor_to_bdelta(btens):
 
     Examples
     --------
-    >>> a = np.array([ 0.033333,  0.016667, -0.016667])
-    >>> b = np.array([ 0.016667,  0.033333,  0.016667])
-    >>> c = np.array([-0.016667,  0.016667,  0.033333])
-    >>> btens = np.vstack((a,b,c))
-    >>> bdelta, bval = btensor_params(btens)
-    >>> print(bdelta)
-    >>> print(bval)
-    [-0.500015]
-    [0.099999]
+    >>> lte = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+    >>> bdelta, bval = btensor_to_bdelta(lte)
+    >>> print(f"bdelta={bdelta[0]}; bval={bval[0]}")
+    bdelta=1.0; bval=1.0
 
     """
     def _btensor_to_bdelta_2d(btens_2d):

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -737,6 +737,7 @@ def check_multi_b(gtab, n_bvals, non_zero=True, bmag=None):
     else:
         return True
 
+
 def btensor_to_bdelta(btens):
     r"""Compute anisotropy of b-tensor(s)
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -769,7 +769,7 @@ def btensor_to_bdelta(btens):
     --------
     >>> lte = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
     >>> bdelta, bval = btensor_to_bdelta(lte)
-    >>> print(f"bdelta={bdelta[0]}; bval={bval[0]}")
+    >>> print("bdelta={}; bval={}".format(bdelta[0], bval[0]))
     bdelta=1.0; bval=1.0
 
     """
@@ -810,9 +810,9 @@ def btensor_to_bdelta(btens):
         return bdelta, bval
 
     # Bad input checks
-    value_error_msg = (f"`btens` must be a 2D or 3D numpy array, respectively"
-                       f" with (3, 3) or (N, 3, 3) shape, where N corresponds"
-                       f" to the number of b-tensors")
+    value_error_msg = "`btens` must be a 2D or 3D numpy array, respectively" \
+                      " with (3, 3) or (N, 3, 3) shape, where N corresponds" \
+                      " to the number of b-tensors"
     if not isinstance(btens, np.ndarray):
         raise ValueError(value_error_msg)
 

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -506,14 +506,17 @@ def test_check_multi_b():
 
 def test_btensor_to_bdelta():
     """
-    Checks if b_deltas and bvals are as expected for 4 b-tensor shapes
+    Checks if bdeltas and bvals are as expected for 4 b-tensor shapes
     (LTE, PTE, STE, CTE) as well as scaled and rotated versions of them
+
+    This function intrinsically tests the function `_btensor_to_bdelta_2d` as
+    `_btensor_to_bdelta_2d` is only meant to be called by `btensor_to_bdelta`
 
     """
     n_rotations = 30
     n_scales = 3
 
-    expected_b_deltas = np.array([1, -0.5, 0, 0.5])
+    expected_bdeltas = np.array([1, -0.5, 0, 0.5])
     expected_bvals = np.array([1, 1, 1, 1])
 
     # Baseline tensors to test
@@ -549,7 +552,7 @@ def test_btensor_to_bdelta():
         bdeltas[i] = i_bdelta
         bvals[i] = i_bval
 
-    npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+    npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
     npt.assert_array_almost_equal(bvals, expected_bvals)
 
     # Test function on a 3D input
@@ -561,7 +564,7 @@ def test_btensor_to_bdelta():
 
     bdeltas, bvals = btensor_to_bdelta(base_tensors_array)
 
-    npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+    npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
     npt.assert_array_almost_equal(bvals, expected_bvals)
 
     # -----------------------------------------------------
@@ -597,7 +600,7 @@ def test_btensor_to_bdelta():
                 bdeltas[i] = i_bdelta
                 bvals[i] = i_bval
 
-            npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+            npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
             npt.assert_array_almost_equal(bvals, ebs)
 
     # Input can't be string

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -516,8 +516,8 @@ def test_btensor_to_bdelta():
     n_rotations = 30
     n_scales = 3
 
-    expected_bvals = np.array([1, 1, 1, 1])
     expected_b_deltas = np.array([1, -0.5, 0, 0.5])
+    expected_bvals = np.array([1, 1, 1, 1])
 
     # Baseline tensors to test
     linear_tensor = np.array([[1, 0, 0],
@@ -550,8 +550,8 @@ def test_btensor_to_bdelta():
     # ---------------------------------
 
     # Pre-allocate
-    bvals = np.empty(n_base_tensors)
     bdeltas = np.empty(n_base_tensors)
+    bvals = np.empty(n_base_tensors)
 
     # Loop through each tensor type and check results
     for i, tensor in enumerate(base_tensors):
@@ -563,7 +563,17 @@ def test_btensor_to_bdelta():
     npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
     npt.assert_array_almost_equal(bvals, expected_bvals)
 
-    a = 1
+    # Test function on a 3D input
+    base_tensors_array = np.empty((4, 3, 3))
+    base_tensors_array[0, :, :] = linear_tensor
+    base_tensors_array[1, :, :] = planar_tensor
+    base_tensors_array[2, :, :] = spherical_tensor
+    base_tensors_array[3, :, :] = cigar_tensor
+
+    bdeltas, bvals = btensor_to_bdelta(base_tensors_array)
+
+    npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+    npt.assert_array_almost_equal(bvals, expected_bvals)
 
     # -----------------------------------------------------
     # Test function after rotating+scaling baseline tensors
@@ -590,8 +600,8 @@ def test_btensor_to_bdelta():
             R_i = vec2vec_rotmat(np.array([1, 0, 0]), u_i)
 
             # Pre-allocate
-            bvals = np.empty(n_base_tensors)
             bdeltas = np.empty(n_base_tensors)
+            bvals = np.empty(n_base_tensors)
 
             # Rotate each of the baseline test tensors and check results
             for i, tensor in enumerate(base_tensors):
@@ -605,8 +615,8 @@ def test_btensor_to_bdelta():
             print(f"---------- Rot #{rot_idx} ----------")
             print_calc_vs_exp(bdeltas, expected_b_deltas, bvals, ebs)
 
-            npt.assert_array_almost_equal(bvals, ebs)
             npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+            npt.assert_array_almost_equal(bvals, ebs)
 
     # Input can't be string
     npt.assert_raises(ValueError, btensor_to_bdelta, 'LTE')

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -563,6 +563,8 @@ def test_btensor_to_bdelta():
     npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
     npt.assert_array_almost_equal(bvals, expected_bvals)
 
+    a = 1
+
     # -----------------------------------------------------
     # Test function after rotating+scaling baseline tensors
     # -----------------------------------------------------
@@ -605,6 +607,20 @@ def test_btensor_to_bdelta():
 
             npt.assert_array_almost_equal(bvals, ebs)
             npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
+
+    # Input can't be string
+    npt.assert_raises(ValueError, btensor_to_bdelta, 'LTE')
+
+    # Input can't be list of strings
+    npt.assert_raises(ValueError, btensor_to_bdelta, ['LTE', 'LTE'])
+
+    # Input can't be 1D nor 4D
+    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((3,)))
+    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((3, 3, 3, 3)))
+
+    # Input shape must be (3, 3) OR (N, 3, 3)
+    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((4,4)))
+    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((2, 2, 2)))
 
 
 if __name__ == "__main__":

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -509,9 +509,6 @@ def test_btensor_to_bdelta():
     Checks if b_deltas and bvals are as expected for 4 b-tensor shapes
     (LTE, PTE, STE, CTE) as well as scaled and rotated versions of them
 
-    The number of times the btensor_to_bdelta() function is called by this
-    testing function is 4+(n_rotations*(n_scales+1))
-
     """
     n_rotations = 30
     n_scales = 3
@@ -535,15 +532,6 @@ def test_btensor_to_bdelta():
 
     base_tensors = [linear_tensor, planar_tensor, spherical_tensor, cigar_tensor]
     n_base_tensors = len(base_tensors)
-
-    def print_calc_vs_exp(bdeltas, expected_b_deltas, bvals, expected_bvals):
-        """temporary helper function: print calculated vs expected
-
-        """
-        print(f"bdeltas (calc) = {bdeltas}")
-        print(f"bdeltas (exp)  = {expected_b_deltas}")
-        print(f"bvals (calc) = {bvals}")
-        print(f"bvals (exp)  = {expected_bvals}")
 
     # ---------------------------------
     # Test function on baseline tensors
@@ -585,10 +573,6 @@ def test_btensor_to_bdelta():
 
         ebs = expected_bvals*scale
 
-        print(f"##############################")
-        print(f"        Scale = {scale}       ")
-        print(f"##############################")
-
         # Generate `n_rotations` random 3-element vectors of norm 1
         v = np.random.random((n_rotations, 3))-0.5
         u = np.apply_along_axis(lambda w: w/np.linalg.norm(w), axis=1, arr=v)
@@ -611,9 +595,6 @@ def test_btensor_to_bdelta():
 
                 bdeltas[i] = i_bdelta
                 bvals[i] = i_bval
-
-            print(f"---------- Rot #{rot_idx} ----------")
-            print_calc_vs_exp(bdeltas, expected_b_deltas, bvals, ebs)
 
             npt.assert_array_almost_equal(bdeltas, expected_b_deltas)
             npt.assert_array_almost_equal(bvals, ebs)

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -530,7 +530,8 @@ def test_btensor_to_bdelta():
                              [0, .5, 0],
                              [0, 0, .5]]) / 3
 
-    base_tensors = [linear_tensor, planar_tensor, spherical_tensor, cigar_tensor]
+    base_tensors = [linear_tensor, planar_tensor,
+                    spherical_tensor, cigar_tensor]
     n_base_tensors = len(base_tensors)
 
     # ---------------------------------
@@ -610,7 +611,7 @@ def test_btensor_to_bdelta():
     npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((3, 3, 3, 3)))
 
     # Input shape must be (3, 3) OR (N, 3, 3)
-    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((4,4)))
+    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((4, 4)))
     npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((2, 2, 2)))
 
 


### PR DESCRIPTION
This PR provides a function (`btensor_to_bdelta`) to calculate the normalized anisotropy of b-tensors.

The idea was to implement this so that the new `btens` attribute from the `GradientTable` class could be directly fed to `btensor_to_bdelta` to get the tensor anisotropy for each measurement. I believe this will be useful for future implementations of microstructure models that rely on datasets acquired with multiple b-tensor shapes (e.g. [ref1](https://linkinghub.elsevier.com/retrieve/pii/S1053-8119(16)30345-7), [ref2](https://linkinghub.elsevier.com/retrieve/pii/S1053-8119(16)00148-8)).

I placed this function in _dipy/core/gradients.py_ as I think it is general enough that it might be useful in the implementation of different models (e.g. to help sort data before powder-averaging and/or actual model fitting).

I also provide what I hope are extensive tests but please do let me know if these can be improved (as well as anything else of course).

Thanks!
