### PR TITLE
BF: Fix sequence stacking warning in LiFE tracking

### DIFF
--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -363,7 +363,7 @@ class FiberModel(ReconstModel):
                                      unique_idx=vox_coords)
         # How many fibers in each voxel (this will determine how many
         # components are in the matrix):
-        n_unique_f = len(np.hstack(v2f.values()))
+        n_unique_f = len(np.hstack(list(v2f.values())))
         # Preallocate these, which will be used to generate the sparse
         # matrix:
         f_matrix_sig = np.zeros(n_unique_f * n_bvecs, dtype=np.float)


### PR DESCRIPTION
Fix sequence stacking warning in LiFE tracking

Fixes:
```
FutureWarning: arrays to stack must be passed as a "sequence" type such as list
or tuple. Support for non-sequence iterables such as generators is deprecated as
of NumPy 1.16 and will raise an error in the future.
```

raised for example in
https://dev.azure.com/dipy/46625eaf-7255-4a2c-9e92-befcdbdca2a8/_apis/build/builds/293/logs/262