### PR TITLE
BF: Fix NumPy warning when creating arrays from ragged sequences

### DIFF
--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -185,7 +185,8 @@ def test_mask():
     Test whether setting incorrect mask raises and error
     """
     mask_correct = data_multi[..., 0] > 0.2
-    mask_not_correct = np.array([[False, True, False], [True, False]])
+    mask_not_correct = np.array([[False, True, False], [True, False]],
+                                dtype=np.bool)
 
     ivim_fit = ivim_model_trr.fit(data_multi, mask_correct)
     est_signal = ivim_fit.predict(gtab, S0=1.)


### PR DESCRIPTION
Fix NumPy warning when creating arrays from ragged sequences in IVIM
reconstruction test.

Fixes
```
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences
(which is a list-or-tuple of lists-or-tuples-or ndarrays with different
lengths or shapes) is deprecated. If you meant to do this, you must specify
'dtype=object' when creating the ndarray
```

triggered in
https://travis-ci.org/github/dipy/dipy/jobs/676101427#L5495

Rationale:
https://numpy.org/neps/nep-0034-infer-dtype-is-object.html