### PR TITLE
Slicing, adding function of StatefulTractogram

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -248,13 +248,11 @@ class StatefulTractogram(object):
             dps_equal = dps_equal and np.allclose(self.data_per_streamline[key],
                                                   other.data_per_streamline[key])
 
-        if streamlines_equal:
-            logger.warning
 
         return streamlines_equal and dpp_equal and dps_equal
 
     def __ne__(self, other):
-        """ Robust StatefulTractogram equality test (NOT) """
+        """ Robust StatefulTractogram equality test (NOT)git c """
         return not self == other
 
     def __add__(self, other_sft):

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -141,7 +141,7 @@ class StatefulTractogram(object):
         logger.debug(self)
 
     @staticmethod
-    def is_compatible_sft(sft_1, sft_2):
+    def are_compatible(sft_1, sft_2):
         """ Compatibility verification of two StatefulTractogram to ensure space,
         origin, data_per_point and data_per_streamline consistency """
 
@@ -236,7 +236,7 @@ class StatefulTractogram(object):
 
     def __eq__(self, other):
         """ Robust StatefulTractogram equality test """
-        if not self.is_compatible_sft(self, other):
+        if not self.are_compatible(self, other):
             return False
 
         streamlines_equal = np.allclose(self.streamlines.get_data(),
@@ -268,7 +268,7 @@ class StatefulTractogram(object):
 
     def __add__(self, other_sft):
         """ Addition of two sft with attributes consistency checks """
-        if not self.is_compatible_sft(self, other_sft):
+        if not self.are_compatible(self, other_sft):
             logger.debug(self)
             logger.debug(other_sft)
             raise ValueError('Inconsistent StatefulTractogram.\n'

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -241,18 +241,20 @@ class StatefulTractogram(object):
                                         other.streamlines.get_data())
         dpp_equal = True
         for key in self.data_per_point:
-            dpp_equal = dpp_equal and np.allclose(self.data_per_point[key].get_data(),
-                                                  other.data_per_point[key].get_data())
+            dpp_equal = dpp_equal and np.allclose(
+                self.data_per_point[key].get_data(),
+
+                other.data_per_point[key].get_data())
         dps_equal = True
         for key in self.data_per_streamline:
-            dps_equal = dps_equal and np.allclose(self.data_per_streamline[key],
-                                                  other.data_per_streamline[key])
-
+            dps_equal = dps_equal and np.allclose(
+                self.data_per_streamline[key],
+                other.data_per_streamline[key])
 
         return streamlines_equal and dpp_equal and dps_equal
 
     def __ne__(self, other):
-        """ Robust StatefulTractogram equality test (NOT)git c """
+        """ Robust StatefulTractogram equality test (NOT) """
         return not self == other
 
     def __add__(self, other_sft):
@@ -265,14 +267,14 @@ class StatefulTractogram(object):
                              'data_per_point and data_per_streamline keys are '
                              'the same.')
 
+        streamlines = deepcopy(self.streamlines)
+        streamlines.extend(other_sft.streamlines)
+
         data_per_point = deepcopy(self.data_per_point)
         data_per_point.extend(other_sft.data_per_point)
 
         data_per_streamline = deepcopy(self.data_per_streamline)
         data_per_streamline.extend(other_sft.data_per_streamline)
-
-        streamlines = deepcopy(self.streamlines)
-        streamlines.extend(other_sft.streamlines)
 
         return self.from_sft(streamlines, self,
                              data_per_point=data_per_point,


### PR DESCRIPTION
Thanks to new code from @MarcCote in Nibabel, interaction with StatefulTractogram are now much safer for slicing and/or adding.

Code such as this is now possible, it makes sure the spatial attributes are the same, that the sft share the same space, origin and have the same keys for data_per_*. Then it basically concatenates everything creating a new sft.
`new_sft = sft_cc[0:2000] + sft_pt[0:2000] + sft_af[0:2000]`

These operations are strict, in line with everything else in the StatefulTractogram.
For example an operation like this is not possible (inconsistent space):
```
sft_1.to_vox()
sft_2.to_rasmm()
sft_3 = sft_1 + sft_2 
```

Also important to know, to avoid side effects, like the rest of StatefulTractogram, nothing is done inplace. For example:
```
sft.to_rasmm()
sft_subset = sft[0:25]
sft.to_vox()
```
sft_subset is still in rasmm and has not be modified by the operation on sft.

Bonus:  `if sft_1 == sft_2:` now works
Implementing this made the test a lot easier. But it is a bit useless in a real-life scenario.
Everything has to be identical (header, space, origin) or all_close (streamlines coordinates, data_per_point, data_per_streamline)