### PR TITLE
[Fix] shm.py RuntimeWarning

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -317,7 +317,7 @@ class ConstrainedSDTModel(SphHarmModel):
         qball_odf = np.dot(self.B_reg, odf_sh)
         Z = np.linalg.norm(qball_odf)
         # normalize ODF
-        odf_sh /= Z
+        odf_sh /= Z if Z else np.empty(odf_sh.shape) * np.nan
 
         shm_coeff, num_it = odf_deconv(odf_sh, self.R, self.B_reg,
                                        self.lambda_, self.tau)
@@ -655,7 +655,7 @@ def odf_deconv(odf_sh, R, B_reg, lambda_=1., tau=0.1, r2_term=False):
 
     threshold = tau * np.max(np.dot(B_reg, fodf_sh))
 
-    k = []
+    k = np.empty([])
     convergence = 50
     for num_it in range(1, convergence + 1):
         A = np.dot(B_reg, fodf_sh)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -316,12 +316,15 @@ class ConstrainedSDTModel(SphHarmModel):
         odf_sh = np.dot(self.P, s_sh)
         qball_odf = np.dot(self.B_reg, odf_sh)
         Z = np.linalg.norm(qball_odf)
-        # normalize ODF
-        odf_sh /= Z if Z else np.empty(odf_sh.shape) * np.nan
 
-        shm_coeff, num_it = odf_deconv(odf_sh, self.R, self.B_reg,
-                                       self.lambda_, self.tau)
-        # print 'SDT CSD converged after %d iterations' % num_it
+        shm_coeff, num_it = np.zeros_like(odf_sh), 0
+        if Z:
+            # normalize ODF
+            odf_sh /= Z
+            shm_coeff, num_it = odf_deconv(odf_sh, self.R, self.B_reg,
+                                           self.lambda_, self.tau)
+            # print 'SDT CSD converged after %d iterations' % num_it
+
         return SphHarmFit(self, shm_coeff, None)
 
 

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1046,9 +1046,9 @@ def calculate_max_order(n_coeffs):
     else:
         # Otherwise, the input didn't make sense:
         raise ValueError("The input to ``calculate_max_order`` was ",
-                            "%s, but that is not a valid number" % n_coeffs,
-                            "of coefficients for a spherical harmonics ",
-                            "basis set.")
+                         "%s, but that is not a valid number" % n_coeffs,
+                         "of coefficients for a spherical harmonics ",
+                         "basis set.")
 
 
 def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -427,6 +427,9 @@ def test_faster_sph_harm():
     sh2 = sph_harm_sp(m, n, theta[:, None], phi[:, None])
 
     assert_array_almost_equal(sh, sh2, 8)
+    sh = spherical_harmonics(m, n, theta[:, None], phi[:, None],
+                             use_scipy=False)
+    assert_array_almost_equal(sh, sh2, 8)
 
 
 def test_anisotropic_power():
@@ -467,6 +470,7 @@ def test_calculate_max_order():
         assert_equal(calculate_max_order(n), o)
 
     assert_raises(ValueError, calculate_max_order, 29)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fix RuntimeWarnings that appear in tutorials or continuous integration tests:

```python
direction/tests/test_pmf.py::test_boot_pmf
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/dipy/reconst/shm.py:768: RuntimeWarning: invalid value encountered in sqrt
    leverages = sqrt(1 - H.diagonal())
direction/tests/test_pmf.py::test_boot_pmf
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/dipy/reconst/csdeconv.py:550: RuntimeWarning: invalid value encountered in less
    where_fodf_small = (fodf < threshold).nonzero()[0]
direction/tests/test_pmf.py::test_boot_pmf
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/dipy/reconst/csdeconv.py:556: RuntimeWarning: invalid value encountered in less
    where_fodf_small = (fodf < threshold).nonzero()[0]
reconst/tests/test_csdeconv.py::test_odfdeconv
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/dipy/reconst/csdeconv.py:320: RuntimeWarning: invalid value encountered in true_divide
    odf_sh /= Z
```