### PR TITLE
[Fix]  laplacian_regularization on MAPMRI + cleanup warning

### DIFF
--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -351,7 +351,9 @@ class MapmriModel(ReconstModel, Cache):
                     self.ind_mat, mu, self.S_mat, self.T_mat, self.U_mat)
             else:
                 laplacian_matrix = self.laplacian_matrix * mu[0]
-            if self.laplacian_weighting == 'GCV':
+
+            if (isinstance(self.laplacian_weighting, str) and
+                    self.laplacian_weighting.upper() == 'GCV'):
                 try:
                     lopt = generalized_crossvalidation(data, M,
                                                        laplacian_matrix)

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -73,26 +73,29 @@ def test_orthogonality_basis_functions():
     # we already know the spherical harmonics are orthonormal
     # only check j>0, l=0 basis functions
 
-    int1 = integrate.quad(lambda q:
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              1, 0, diffusivity, q) *
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              2, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
-    int2 = integrate.quad(lambda q:
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              2, 0, diffusivity, q) *
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              3, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
-    int3 = integrate.quad(lambda q:
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              3, 0, diffusivity, q) *
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              4, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
-    int4 = integrate.quad(lambda q:
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              4, 0, diffusivity, q) *
-                          mapmri.mapmri_isotropic_radial_signal_basis(
-                              5, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                category=integrate.IntegrationWarning)
+        int1 = integrate.quad(
+            lambda q: mapmri.mapmri_isotropic_radial_signal_basis(
+                1, 0, diffusivity, q) *
+            mapmri.mapmri_isotropic_radial_signal_basis(
+                2, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
+        int2 = integrate.quad(
+            lambda q: mapmri.mapmri_isotropic_radial_signal_basis(
+                2, 0, diffusivity, q) *
+            mapmri.mapmri_isotropic_radial_signal_basis(
+                3, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
+        int3 = integrate.quad(
+            lambda q: mapmri.mapmri_isotropic_radial_signal_basis(
+                3, 0, diffusivity, q) *
+            mapmri.mapmri_isotropic_radial_signal_basis(
+                4, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
+        int4 = integrate.quad(
+            lambda q: mapmri.mapmri_isotropic_radial_signal_basis(
+                4, 0, diffusivity, q) *
+            mapmri.mapmri_isotropic_radial_signal_basis(
+                5, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]
 
     # checking for first 5 basis functions if they are indeed orthogonal
     assert_almost_equal(int1, 0.)

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -69,8 +69,7 @@ def _add_rician(sig, noise1, noise2):
 
 
 def _add_rayleigh(sig, noise1, noise2):
-    """
-    Helper function to add_noise
+    r"""Helper function to add_noise.
 
     The Rayleigh distribution is $\sqrt\{Gauss_1^2 + Gauss_2^2}$.
 
@@ -217,9 +216,10 @@ def callaghan_perpendicular(q, radius):
            117.1 (1995): 94-97.
     """
     # Eq. [6] in the paper
-    E = ((2 * jn(1, 2 * np.pi * q * radius)) ** 2 /
-         (2 * np.pi * q * radius) ** 2
-         )
+    numerator = (2 * jn(1, 2 * np.pi * q * radius)) ** 2
+    denom = (2 * np.pi * q * radius) ** 2
+
+    E = np.divide(numerator, denom, out=np.zeros_like(q), where=denom != 0)
     return E
 
 


### PR DESCRIPTION
A laplacian_regularization condition was always `True` so this is a quick fix. I use the opportunity to clean some warnings for the CI's and tests. The following warning should disappear:

```python
dipy/reconst/tests/test_mapmri.py::test_orthogonality_basis_functions
  /Users/koudoro/Software/dipy/dipy/reconst/tests/test_mapmri.py:92: IntegrationWarning: The occurrence of roundoff error is detected, which prevents 
    the requested tolerance from being achieved.  The error may be 
    underestimated.
    4, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]

dipy/reconst/tests/test_mapmri.py::test_orthogonality_basis_functions
  /Users/koudoro/Software/dipy/dipy/reconst/tests/test_mapmri.py:97: IntegrationWarning: The occurrence of roundoff error is detected, which prevents 
    the requested tolerance from being achieved.  The error may be 
    underestimated.
    5, 0, diffusivity, q) * q ** 2, qmin, qmax)[0]

reconst/tests/test_mapmri.py::test_laplacian_regularization
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/dipy/reconst/mapmri.py:354: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
    if self.laplacian_weighting == 'GCV':
``` 