### PR TITLE
BF: Use equality check instead of identity check

### DIFF
--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -224,25 +224,25 @@ def plot_2d_diffeomorphic_map(mapping, delta=10, fname=None,
         # By default, direct_grid_shape is the codomain grid
         if direct_grid_shape is None:
             direct_grid_shape = mapping.codomain_shape
-        if direct_grid2world is -1:
+        if direct_grid2world == -1:
             direct_grid2world = mapping.codomain_grid2world
 
         # By default, the inverse grid is the domain grid
         if inverse_grid_shape is None:
             inverse_grid_shape = mapping.domain_shape
-        if inverse_grid2world is -1:
+        if inverse_grid2world == -1:
             inverse_grid2world = mapping.domain_grid2world
     else:
         # Now by default, direct_grid_shape is the mapping's input grid
         if direct_grid_shape is None:
             direct_grid_shape = mapping.domain_shape
-        if direct_grid2world is -1:
+        if direct_grid2world == -1:
             direct_grid2world = mapping.domain_grid2world
 
         # By default, the output grid is the mapping's domain grid
         if inverse_grid_shape is None:
             inverse_grid_shape = mapping.codomain_shape
-        if inverse_grid2world is -1:
+        if inverse_grid2world == -1:
             inverse_grid2world = mapping.codomain_grid2world
 
     # The world-to-image (image = drawn lattice on the output grid)
@@ -386,19 +386,19 @@ def overlay_slices(L, R, slice_index=None, slice_type=1, ltitle='Left',
 
     # Create the color image to draw the overlapped slices into, and extract
     # the slices (note the transpositions)
-    if slice_type is 0:
+    if slice_type == 0:
         if slice_index is None:
             slice_index = sh[0] // 2
         colorImage = np.zeros(shape=(sh[2], sh[1], 3), dtype=np.uint8)
         ll = np.asarray(L[slice_index, :, :]).astype(np.uint8).T
         rr = np.asarray(R[slice_index, :, :]).astype(np.uint8).T
-    elif slice_type is 1:
+    elif slice_type == 1:
         if slice_index is None:
             slice_index = sh[1] // 2
         colorImage = np.zeros(shape=(sh[2], sh[0], 3), dtype=np.uint8)
         ll = np.asarray(L[:, slice_index, :]).astype(np.uint8).T
         rr = np.asarray(R[:, slice_index, :]).astype(np.uint8).T
-    elif slice_type is 2:
+    elif slice_type == 2:
         if slice_index is None:
             slice_index = sh[2] // 2
         colorImage = np.zeros(shape=(sh[1], sh[0], 3), dtype=np.uint8)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -9,7 +9,7 @@ def get_args_default(func):
     if sys.version_info[0] >= 3:
         sig_object = inspect.signature(func)
         params = sig_object.parameters.values()
-        names = [param.name for param in params if param.name is not 'self']
+        names = [param.name for param in params if param.name != 'self']
         defaults = [param.default for param in params
                     if param.default is not inspect._empty]
     else:


### PR DESCRIPTION
Use equality check instead of identity check.

Fixes for example
```
/home/vsts/work/1/s/venv/lib/python3.8/site-packages/dipy/viz/regtools.py:227:
SyntaxWarning: "is" with a literal. Did you mean "=="?
if direct_grid2world is -1:
```

Reported for example in
https://dev.azure.com/dipy/46625eaf-7255-4a2c-9e92-befcdbdca2a8/_apis/build/builds/310/logs/267