### PR TITLE
ENH: function to calculate size/shape parameters of b-tensors and vice-versa

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -757,7 +757,7 @@ def _btens_to_params_2d(btens_2d, ztol):
     Returns
     -------
     bval: float
-        b-value
+        b-value (trace)
     bdelta: float
         normalized tensor anisotropy
     bdelta: float
@@ -779,7 +779,7 @@ def _btens_to_params_2d(btens_2d, ztol):
 
     evals = np.real(np.linalg.eig(btens_2d)[0])
     bval = np.sum(evals)
-    bval_is_zero = bval <= ztol
+    bval_is_zero = np.abs(bval) <= ztol
 
     if bval_is_zero:
         bval = 0
@@ -806,8 +806,8 @@ def _btens_to_params_2d(btens_2d, ztol):
 
         b_eta = yyxx_diff/(2*lambda_iso*bdelta+np.spacing(1))
 
-        if np.abs(bval) <= ztol:
-            bval = 0
+        if np.abs(b_eta) <= b_eta:
+            b_eta = 0
 
     return float(bval), float(bdelta), float(b_eta)
 
@@ -824,7 +824,7 @@ def btens_to_params(btens, ztol=1e-10):
     Returns
     -------
     bval: numpy.ndarray
-        b-value(s)
+        b-value(s) (trace(s))
     bdelta: numpy.ndarray
         normalized tensor anisotropy(s)
     b_eta: numpy.ndarray

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -932,9 +932,6 @@ def params_to_btens(bval, bdelta, b_eta):
     if not (b_eta >= 0 and b_eta <= 1):
         raise ValueError("`b_eta` must be >= 0 and <= 1")
 
-    # if bdelta == 0 and b_eta != 0:
-    #     raise ValueError("`b_eta` must be 0 if `bdelta` is 0")
-
     m1 = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 2]])
     m2 = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 0]])
     btens = bval/3*(np.eye(3)+bdelta*(m1+b_eta*m2))

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -880,3 +880,38 @@ def btens_m2p(btens, ztol=1e-10):
     b_eta = b_eta.round(decimals=6)
 
     return bval, bdelta, b_eta
+
+def btens_p2m(bval, bdelta, b_eta):
+    """Compute b-tensor matrix from trace, anisotropy and assymetry parameters
+
+    Parameters
+    ----------
+    bval: float
+        b-value
+    bdelta: float
+        normalized tensor anisotropy
+    bdelta: float
+        tensor assymetry
+
+    Returns
+    -------
+    (3, 3) numpy.ndarray
+        output b-tensor
+
+    Notes
+    -----
+    Implements eq. 7.11. p. 231 in [1].
+
+    References
+    ----------
+    .. [1] D. Topgaard, NMR methods for studying microscopic diffusion
+    anisotropy, in: R. Valiullin (Ed.), Diffusion NMR of Confined Systems: Fluid
+    Transport in Porous Solids and Heterogeneous Materials, Royal Society of
+    Chemistry, Cambridge, UK, 2016.
+
+    """
+    m1 = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 2]])
+    m2 = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 0]])
+    btens = bval/3*(np.eye(3)+bdelta*(m1+b_eta*m2))
+
+    return btens

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -739,6 +739,7 @@ def check_multi_b(gtab, n_bvals, non_zero=True, bmag=None):
     else:
         return True
 
+
 def _btens_to_params_2d(btens_2d, ztol):
     """Compute trace, anisotropy and assymetry parameters from a single b-tensor
 
@@ -811,6 +812,7 @@ def _btens_to_params_2d(btens_2d, ztol):
 
     return float(bval), float(bdelta), float(b_eta)
 
+
 def btens_to_params(btens, ztol=1e-10):
     r"""Compute trace, anisotropy and assymetry parameters from b-tensors
 
@@ -881,6 +883,7 @@ def btens_to_params(btens, ztol=1e-10):
 
     return bval, bdelta, b_eta
 
+
 def params_to_btens(bval, bdelta, b_eta):
     """Compute b-tensor from trace, anisotropy and assymetry parameters
 
@@ -913,9 +916,9 @@ def params_to_btens(bval, bdelta, b_eta):
 
     # Check input times are OK
     expected_input_types = (float, int)
-    input_types_all_ok = isinstance(bval, expected_input_types) and \
-                         isinstance(bdelta, expected_input_types) and \
-                         isinstance(b_eta, expected_input_types)
+    input_types_all_ok = (isinstance(bval, expected_input_types) and
+                          isinstance(bdelta, expected_input_types) and
+                          isinstance(b_eta, expected_input_types))
 
     if not input_types_all_ok:
         s = [x.__name__ for x in expected_input_types]

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -739,11 +739,11 @@ def check_multi_b(gtab, n_bvals, non_zero=True, bmag=None):
     else:
         return True
 
-def _btens_m2p_2d(btens_2d, ztol):
+def _btens_to_params_2d(btens_2d, ztol):
     """Compute trace, anisotropy and assymetry parameters from a single b-tensor
 
     Auxiliary function where calculation of `bval`, bdelta` and `b_eta` from a
-    (3,3) b-tensor takes place. The main function `btens_m2p` then wraps
+    (3,3) b-tensor takes place. The main function `btens_to_params` then wraps
     around this to enable support of input (N, 3, 3) arrays, where N = number of
     b-tensors
 
@@ -808,7 +808,7 @@ def _btens_m2p_2d(btens_2d, ztol):
 
     return float(bval), float(bdelta), float(b_eta)
 
-def btens_m2p(btens, ztol=1e-10):
+def btens_to_params(btens, ztol=1e-10):
     r"""Compute trace, anisotropy and assymetry parameters from b-tensors
 
     Parameters
@@ -835,7 +835,7 @@ def btens_m2p(btens, ztol=1e-10):
     Examples
     --------
     >>> lte = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
-    >>> bval, bdelta, b_eta = btens_m2p(lte)
+    >>> bval, bdelta, b_eta = btens_to_params(lte)
     >>> print("bval={}; bdelta={}; b_eta={}".format(bdelta, bval, b_eta))
     bval=[1.]; bdelta=[1.]; b_eta=[0.]
 
@@ -871,7 +871,7 @@ def btens_m2p(btens, ztol=1e-10):
     # Loop over b-tensor(s)
     for i in range(btens.shape[0]):
         i_btens = btens[i, :, :]
-        i_bval, i_bdelta, i_b_eta = _btens_m2p_2d(i_btens, ztol)
+        i_bval, i_bdelta, i_b_eta = _btens_to_params_2d(i_btens, ztol)
         bval[i] = i_bval
         bdelta[i] = i_bdelta
         b_eta[i] = i_b_eta
@@ -881,7 +881,7 @@ def btens_m2p(btens, ztol=1e-10):
 
     return bval, bdelta, b_eta
 
-def btens_p2m(bval, bdelta, b_eta):
+def params_to_btens(bval, bdelta, b_eta):
     """Compute b-tensor matrix from trace, anisotropy and assymetry parameters
 
     Parameters

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -739,7 +739,7 @@ def check_multi_b(gtab, n_bvals, non_zero=True, bmag=None):
     else:
         return True
 
-def _btens_m2p(btens_2d, ztol):
+def _btens_m2p_2d(btens_2d, ztol):
     """Compute trace, anisotropy and assymetry parameters from a single b-tensor
 
     Auxiliary function where calculation of `bval`, bdelta` and `b_eta` from a
@@ -871,7 +871,7 @@ def btens_m2p(btens, ztol=1e-10):
     # Loop over b-tensor(s)
     for i in range(btens.shape[0]):
         i_btens = btens[i, :, :]
-        i_bval, i_bdelta, i_b_eta = _btens_m2p(i_btens, ztol)
+        i_bval, i_bdelta, i_b_eta = _btens_m2p_2d(i_btens, ztol)
         bval[i] = i_bval
         bdelta[i] = i_bdelta
         b_eta[i] = i_b_eta

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -890,7 +890,7 @@ def btens_p2m(bval, bdelta, b_eta):
         b-value
     bdelta: float
         normalized tensor anisotropy
-    bdelta: float
+    b_eta: float
         tensor assymetry
 
     Returns

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -842,7 +842,7 @@ def btens_to_params(btens, ztol=1e-10):
     >>> lte = np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
     >>> bval, bdelta, b_eta = btens_to_params(lte)
     >>> print("bval={}; bdelta={}; b_eta={}".format(bdelta, bval, b_eta))
-    bval=[1.]; bdelta=[1.]; b_eta=[0.]
+    bval=[ 1.]; bdelta=[ 1.]; b_eta=[ 0.]
 
     """
     # Bad input checks

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -535,7 +535,6 @@ def test_btens_to_params():
 
     base_tensors = [linear_tensor, planar_tensor,
                     spherical_tensor, cigar_tensor]
-    n_base_tensors = len(base_tensors)
 
     # ---------------------------------
     # Test function on baseline tensors

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -11,7 +11,7 @@ from dipy.core.gradients import (gradient_table, GradientTable,
                                  WATER_GYROMAGNETIC_RATIO,
                                  reorient_bvecs, generate_bvecs,
                                  check_multi_b, round_bvals, unique_bvals,
-                                 btensor_to_bdelta)
+                                 params_to_btens, btens_to_params)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.geometry import vec2vec_rotmat
 
@@ -503,21 +503,21 @@ def test_check_multi_b():
     gtab = gradient_table(bvals, bvecs)
     npt.assert_(check_multi_b(gtab, 2, non_zero=False))
 
-
-def test_btensor_to_bdelta():
+def test_btens_to_params():
     """
-    Checks if bdeltas and bvals are as expected for 4 b-tensor shapes
+    Checks if bvals, bdeltas and b_etas are as expected for 4 b-tensor shapes
     (LTE, PTE, STE, CTE) as well as scaled and rotated versions of them
 
-    This function intrinsically tests the function `_btensor_to_bdelta_2d` as
-    `_btensor_to_bdelta_2d` is only meant to be called by `btensor_to_bdelta`
+    This function intrinsically tests the function `_btens_to_params_2d` as
+    `_btens_to_params_2d` is only meant to be called by `btens_to_params`
 
     """
     n_rotations = 30
     n_scales = 3
 
-    expected_bdeltas = np.array([1, -0.5, 0, 0.5])
     expected_bvals = np.array([1, 1, 1, 1])
+    expected_bdeltas = np.array([1, -0.5, 0, 0.5])
+    expected_b_etas = np.array([0, 0, 0, 0])
 
     # Baseline tensors to test
     linear_tensor = np.array([[1, 0, 0],
@@ -541,19 +541,14 @@ def test_btensor_to_bdelta():
     # Test function on baseline tensors
     # ---------------------------------
 
-    # Pre-allocate
-    bdeltas = np.empty(n_base_tensors)
-    bvals = np.empty(n_base_tensors)
-
     # Loop through each tensor type and check results
     for i, tensor in enumerate(base_tensors):
-        i_bdelta, i_bval = btensor_to_bdelta(tensor)
+        i_bval, i_bdelta, i_b_eta = btens_to_params(tensor)
 
-        bdeltas[i] = i_bdelta
-        bvals[i] = i_bval
+        npt.assert_array_almost_equal(i_bval, expected_bvals[i])
+        npt.assert_array_almost_equal(i_bdelta, expected_bdeltas[i])
+        npt.assert_array_almost_equal(i_b_eta, expected_b_etas[i])
 
-    npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
-    npt.assert_array_almost_equal(bvals, expected_bvals)
 
     # Test function on a 3D input
     base_tensors_array = np.empty((4, 3, 3))
@@ -562,10 +557,11 @@ def test_btensor_to_bdelta():
     base_tensors_array[2, :, :] = spherical_tensor
     base_tensors_array[3, :, :] = cigar_tensor
 
-    bdeltas, bvals = btensor_to_bdelta(base_tensors_array)
+    bvals, bdeltas, b_etas = btens_to_params(base_tensors_array)
 
-    npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
     npt.assert_array_almost_equal(bvals, expected_bvals)
+    npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
+    npt.assert_array_almost_equal(b_etas, expected_b_etas)
 
     # -----------------------------------------------------
     # Test function after rotating+scaling baseline tensors
@@ -587,36 +583,82 @@ def test_btensor_to_bdelta():
             u_i = u[rot_idx, :]
             R_i = vec2vec_rotmat(np.array([1, 0, 0]), u_i)
 
-            # Pre-allocate
-            bdeltas = np.empty(n_base_tensors)
-            bvals = np.empty(n_base_tensors)
-
             # Rotate each of the baseline test tensors and check results
             for i, tensor in enumerate(base_tensors):
 
                 tensor_rot_i = np.matmul(np.matmul(R_i, tensor), R_i.T)
-                i_bdelta, i_bval = btensor_to_bdelta(tensor_rot_i*scale)
+                i_bval, i_bdelta, i_b_eta = btens_to_params(tensor_rot_i*scale)
 
-                bdeltas[i] = i_bdelta
-                bvals[i] = i_bval
-
-            npt.assert_array_almost_equal(bdeltas, expected_bdeltas)
-            npt.assert_array_almost_equal(bvals, ebs)
+                npt.assert_array_almost_equal(i_bval, ebs[i])
+                npt.assert_array_almost_equal(i_bdelta, expected_bdeltas[i])
+                npt.assert_array_almost_equal(i_b_eta, expected_b_etas[i])
 
     # Input can't be string
-    npt.assert_raises(ValueError, btensor_to_bdelta, 'LTE')
+    npt.assert_raises(ValueError, btens_to_params, 'LTE')
 
     # Input can't be list of strings
-    npt.assert_raises(ValueError, btensor_to_bdelta, ['LTE', 'LTE'])
+    npt.assert_raises(ValueError, btens_to_params, ['LTE', 'LTE'])
 
     # Input can't be 1D nor 4D
-    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((3,)))
-    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((3, 3, 3, 3)))
+    npt.assert_raises(ValueError, btens_to_params, np.zeros((3,)))
+    npt.assert_raises(ValueError, btens_to_params, np.zeros((3, 3, 3, 3)))
 
     # Input shape must be (3, 3) OR (N, 3, 3)
-    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((4, 4)))
-    npt.assert_raises(ValueError, btensor_to_bdelta, np.zeros((2, 2, 2)))
+    npt.assert_raises(ValueError, btens_to_params, np.zeros((4, 4)))
+    npt.assert_raises(ValueError, btens_to_params, np.zeros((2, 2, 2)))
 
+def test_params_to_btens():
+    """
+    Checks if `params_to_btens` generates the expected b-tensors from provided
+    `bvals`, `bdeltas`, `b_etas`.
+
+    """
+    # Test parameters that should generate "baseline" b-tensors
+    bvals = [1, 1, 1, 1]
+    bdeltas = [0, -0.5, 0.5, 1]
+    b_etas = [0, 0, 0, 0]
+
+    expected_btens = []
+    expected_btens.append(np.eye(3) / 3)
+    expected_btens.append(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 0]]) / 2)
+    expected_btens.append(np.array([[0.5, 0, 0], [0, 0.5, 0], [0, 0, 2]]) / 3)
+    expected_btens.append(np.array([[0, 0, 0], [0, 0, 0], [0, 0, 1]]))
+
+    for i, (bval, bdelta, b_eta) in enumerate(zip(bvals, bdeltas, b_etas)):
+        btens = params_to_btens(bval, bdelta, b_eta)
+        npt.assert_array_almost_equal(btens, expected_btens[i])
+
+    # Additional tests
+    bvals = [1.7, 0.4, 2.3]
+    bdeltas = [0.6, -0.2, 0]
+    b_etas = [0.3, 0.8, 0.7]
+
+    expected_btens = []
+    expected_btens.append(np.array([[0.12466667, 0, 0],
+                                    [0, 0.32866667, 0],
+                                    [0, 0, 1.24666667]]))
+    expected_btens.append(np.array([[0.18133333, 0, 0],
+                                    [0, 0.13866667, 0],
+                                    [0, 0, 0.08]]))
+    expected_btens.append(np.array([[0.76666667, 0, 0],
+                                    [0, 0.76666667, 0],
+                                    [0, 0, 0.76666667]]))
+
+    for i, (bval, bdelta, b_eta) in enumerate(zip(bvals, bdeltas, b_etas)):
+        btens = params_to_btens(bval, bdelta, b_eta)
+        npt.assert_array_almost_equal(btens, expected_btens[i])
+
+    # Tests to trigger value errors
+    # 1: wrong input type
+    # 2: bval out of valid range
+    # 3: bdelta out of valid range
+    # 4: b_eta out of valid range
+    bvals = [np.array([1]), -1, 1, 1]
+    bdeltas = [0, 0, -1, 1]
+    b_etas = [0, 0, 0, -1]
+
+    for i, (bval, bdelta, b_eta) in enumerate(zip(bvals, bdeltas, b_etas)):
+        npt.assert_raises(ValueError, params_to_btens, bval, bdelta, b_eta)
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -503,6 +503,7 @@ def test_check_multi_b():
     gtab = gradient_table(bvals, bvecs)
     npt.assert_(check_multi_b(gtab, 2, non_zero=False))
 
+
 def test_btens_to_params():
     """
     Checks if bvals, bdeltas and b_etas are as expected for 4 b-tensor shapes
@@ -605,6 +606,7 @@ def test_btens_to_params():
     # Input shape must be (3, 3) OR (N, 3, 3)
     npt.assert_raises(ValueError, btens_to_params, np.zeros((4, 4)))
     npt.assert_raises(ValueError, btens_to_params, np.zeros((2, 2, 2)))
+
 
 def test_params_to_btens():
     """


### PR DESCRIPTION
This PR refactors and enhances the function previously known as `btensor_to_bdelta` which I implemented in a previous PR (#2125). This function, which I renamed to `btens_to_params` now also outputs other b-tensor parameters: the trace (b-value) and the assymetry. In continuation with my previous PR (#2125), this further simplifies a future implementation of microstructure models using data acquired with b-tensors of arbitrary shapes.

This PR further includes a utility function `params_to_btens` which does the reverse of the above, that is, computes a b-tensor from its "parameters" trace, normalized anisotropy and assymetry.

New/updated tests provided for everything. Thanks @kerkelae for useful discussions 😉. 