### PR TITLE
Cluster threshold parameter in dipy_buan_shapes workflow

### DIFF
--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -79,7 +79,7 @@ def bundle_adjacency(dtracks0, dtracks1, threshold):
     return res
 
 
-def ba_analysis(recognized_bundle, expert_bundle, nb_pts=20, threshold=5.):
+def ba_analysis(recognized_bundle, expert_bundle, nb_pts=20, threshold=6.):
     """ Calculates bundle adjacency score between two given bundles
 
     Parameters
@@ -91,7 +91,7 @@ def ba_analysis(recognized_bundle, expert_bundle, nb_pts=20, threshold=5.):
         from inout tractogram
     nb_pts : integer (default 20)
         Discretizing streamlines to have nb_pts number of points
-    threshold : float (default 5)
+    threshold : float (default 6)
         Threshold used for in computing bundle adjacency. Threshold controls
         how much strictness user wants while calculating bundle adjacency
         between two bundles. Smaller threshold means bundles should be strictly
@@ -123,7 +123,7 @@ def cluster_bundle(bundle, clust_thr, rng, nb_pts=20, select_randomly=500000):
     bundle : Streamlines
         White matter tract
     clust_thr : float
-        clustering threshold used in quickbundles
+        clustering threshold used in quickbundlesX
     rng : RandomState
     nb_pts: integer (default 20)
         Discretizing streamlines to have nb_points number of points
@@ -151,7 +151,8 @@ def cluster_bundle(bundle, clust_thr, rng, nb_pts=20, select_randomly=500000):
     return centroids
 
 
-def bundle_shape_similarity(bundle1, bundle2, rng, threshold=5):
+def bundle_shape_similarity(bundle1, bundle2, rng, clust_thr=[5, 3, 1.5],
+                            threshold=6):
     """ Calculates bundle shape similarity between two given bundles using
     bundle adjacency (BA) metric
 
@@ -162,7 +163,9 @@ def bundle_shape_similarity(bundle1, bundle2, rng, threshold=5):
     bundle2 : Streamlines
         White matter tract from another subject (eg: AF_L)
     rng : RandomState
-    threshold : float (default 5)
+    clust_thr : float (default [5, 3, 1.5])
+        list of clustering thresholds used in quickbundlesX
+    threshold : float (default 6)
         Threshold used for in computing bundle adjacency. Threshold controls
         how much strictness user wants while calculating shape similarity
         between two bundles. Smaller threshold means bundles should be strictly
@@ -183,9 +186,9 @@ def bundle_shape_similarity(bundle1, bundle2, rng, threshold=5):
     if len(bundle1) == 0 or len(bundle2) == 0:
         return 0
 
-    bundle1_centroids = cluster_bundle(bundle1, clust_thr=[1.25],
+    bundle1_centroids = cluster_bundle(bundle1, clust_thr=clust_thr,
                                        rng=rng)
-    bundle2_centroids = cluster_bundle(bundle2, clust_thr=[1.25],
+    bundle2_centroids = cluster_bundle(bundle2, clust_thr=clust_thr,
                                        rng=rng)
     bundle1_centroids = Streamlines(bundle1_centroids)
     bundle2_centroids = Streamlines(bundle2_centroids)

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -163,7 +163,7 @@ def bundle_shape_similarity(bundle1, bundle2, rng, clust_thr=[5, 3, 1.5],
     bundle2 : Streamlines
         White matter tract from another subject (eg: AF_L)
     rng : RandomState
-    clust_thr : float (default [5, 3, 1.5])
+    clust_thr : list of float (default [5, 3, 1.5])
         list of clustering thresholds used in quickbundlesX
     threshold : float (default 6)
         Threshold used for in computing bundle adjacency. Threshold controls

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -514,7 +514,7 @@ class BundleShapeAnalysis(Workflow):
     def get_short_name(cls):
         return 'BS'
 
-    def run(self, subject_folder, threshold=6, clust_thr=[5, 3, 1.5],
+    def run(self, subject_folder, clust_thr="[5,3,1.5]", threshold=6,
             out_dir=''):
         """Workflow of bundle analytics.
 
@@ -528,11 +528,12 @@ class BundleShapeAnalysis(Workflow):
             Path to the input subject folder. This path may contain
             wildcards to process multiple inputs at once.
 
+        clust_thr : string (default [5,3,1.5]), optional
+            list of bundle clustering thresholds used in quickbundlesX
+
         threshold : float (default 6), optional
             Bundle shape similarity threshold.
 
-        clust_thr : float (default [5, 3, 1.5])
-            list of bundle clustering thresholds used in quickbundlesX
 
         out_dir : string, optional
             Output directory (default input file directory)
@@ -547,6 +548,11 @@ class BundleShapeAnalysis(Workflow):
 
         """
         rng = np.random.RandomState()
+
+        clust_thr = list(map(float, clust_thr.strip('[]').split(',')))
+        #clust_thr=[5,3,1.5]
+        print(clust_thr)
+
         all_subjects = []
         if os.path.isdir(subject_folder):
             groups = os.listdir(subject_folder)

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -514,7 +514,7 @@ class BundleShapeAnalysis(Workflow):
     def get_short_name(cls):
         return 'BS'
 
-    def run(self, subject_folder, clust_thr="[5,3,1.5]", threshold=6,
+    def run(self, subject_folder, clust_thr=[5, 3, 1.5], threshold=6,
             out_dir=''):
         """Workflow of bundle analytics.
 
@@ -528,12 +528,11 @@ class BundleShapeAnalysis(Workflow):
             Path to the input subject folder. This path may contain
             wildcards to process multiple inputs at once.
 
-        clust_thr : string (default [5,3,1.5]), optional
+        clust_thr : variable float (default [5,3,1.5]), optional
             list of bundle clustering thresholds used in quickbundlesX
 
         threshold : float (default 6), optional
             Bundle shape similarity threshold.
-
 
         out_dir : string, optional
             Output directory (default input file directory)
@@ -548,8 +547,6 @@ class BundleShapeAnalysis(Workflow):
 
         """
         rng = np.random.RandomState()
-
-        clust_thr = list(map(float, clust_thr.strip('[]').split(',')))
 
         all_subjects = []
         if os.path.isdir(subject_folder):

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -550,8 +550,6 @@ class BundleShapeAnalysis(Workflow):
         rng = np.random.RandomState()
 
         clust_thr = list(map(float, clust_thr.strip('[]').split(',')))
-        #clust_thr=[5,3,1.5]
-        print(clust_thr)
 
         all_subjects = []
         if os.path.isdir(subject_folder):
@@ -611,5 +609,6 @@ class BundleShapeAnalysis(Workflow):
             matplt.pyplot.title(bun[:-4])
             matplt.pyplot.imshow(ba_matrix, cmap=cmap)
             matplt.pyplot.colorbar()
+            matplt.pyplot.clim(0, 1)
             matplt.pyplot.savefig(os.path.join(out_dir, "SM_"+bun[:-4]))
             matplt.pyplot.clf()

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -514,7 +514,8 @@ class BundleShapeAnalysis(Workflow):
     def get_short_name(cls):
         return 'BS'
 
-    def run(self, subject_folder, threshold=6, out_dir=''):
+    def run(self, subject_folder, threshold=6, clust_thr=[5, 3, 1.5],
+            out_dir=''):
         """Workflow of bundle analytics.
 
         Applies bundle shape similarity analysis on bundles of subjects and
@@ -529,6 +530,9 @@ class BundleShapeAnalysis(Workflow):
 
         threshold : float (default 6), optional
             Bundle shape similarity threshold.
+
+        clust_thr : float (default [5, 3, 1.5])
+            list of bundle clustering thresholds used in quickbundlesX
 
         out_dir : string, optional
             Output directory (default input file directory)
@@ -588,7 +592,7 @@ class BundleShapeAnalysis(Workflow):
                                               bbox_valid_check=False).streamlines
 
                     ba_value = bundle_shape_similarity(bundle1, bundle2, rng,
-                                                       threshold)
+                                                       clust_thr, threshold)
 
                     ba_matrix[i][j] = ba_value
 

--- a/doc/interfaces/buan_flow.rst
+++ b/doc/interfaces/buan_flow.rst
@@ -91,16 +91,18 @@ Run the following workflow::
 
     dipy_buan_shapes subjects_small/ --out_dir "sm_plots"
 
-This workflow will generate 30 bundles shape similarity plots.
+This workflow will generate 30 bundles shape similarity plots. Shape similarity
+score ranges between 0-1, where 1 being highest similarity and 0 being lowest.
 Plots will look like the following example:
 
-.. figure:: https://github.com/dipy/dipy_data/blob/master/SM_moved_ML_L__recognized.png?raw=true
+.. figure:: https://github.com/dipy/dipy_data/blob/master/SM_moved_UF_R__recognized.png?raw=true
     :width: 70 %
     :alt: alternate text
     :align: center
 
-    Result plot for left medial lemniscus (ML_L) for 10 subjects.
-    First 5 subjects belong to the healthy control group and last 5 subjects belong to patient group
+    Result plot for right uncinate fasciculus (UF_R) for 10 subjects.
+    First 5 subjects belong to the healthy control group and last 5 subjects belong to patient group.
+    In the diagonal, we have shape similarity score of 1 as it is calculated between a bundle and itself.
 
 --------------------------------------
 Reproducing results on larger dataset:

--- a/doc/interfaces/buan_flow.rst
+++ b/doc/interfaces/buan_flow.rst
@@ -89,7 +89,7 @@ Create an ``out_dir`` folder (eg: sm_plots)::
 
 Run the following workflow::
 
-    dipy_buan_shapes subjects/ --out_dir "sm_plots"
+    dipy_buan_shapes subjects_small/ --out_dir "sm_plots"
 
 This workflow will generate 30 bundles shape similarity plots.
 Plots will look like the following example:


### PR DESCRIPTION
Added cluster threshold (clust_thr) as an optional argument in dipy_buan_shapes workflow. 
Updated default clust_thr values as well.

This small update makes the workflow faster.