### PR TITLE
BF: Fix Cython function  override warning

### DIFF
--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -41,7 +41,8 @@ cdef class EuDXDirectionGetter(DirectionGetter):
 
         self.initialized = True
 
-    def initial_direction(self, double[::1] point):
+    cpdef np.ndarray[np.float_t, ndim=2] initial_direction(self,
+                                                           double[::1] point):
         """The best starting directions for fiber tracking from point
 
         All the valid peaks in the voxel closest to point are returned as


### PR DESCRIPTION
Fix Cython function override warning.

A `cpdef` function can be only overriden by a `cpdef` function in a derived
class that is an extension type (`cdef class`).

Fixes:
```
warning: dipy/reconst/eudx_direction_getter.pyx:44:4: Overriding cdef method
with def method.
```

raised for example in
https://dev.azure.com/dipy/dipy/_build/results?buildId=343&view=logs&j=d9aefae6-c332-51b5-d933-a85009f5a2ac&t=10ba5eab-67e4-5f58-2aec-60b4dbb37e45&l=1950

or
https://travis-ci.org/github/dipy/dipy/jobs/679159532
(warning in raw log: https://api.travis-ci.org/v3/job/679159532/log.txt)