### PR TITLE
BF: Fix `distutils` Python version requirement option warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ if using_setuptools:
         zip_safe=False,
         extras_require=dict(
             doc=['Sphinx>=1.0'],
-            test=['pytest']))
+            test=['pytest']),
+        python_requires=">= 3.5")
 
 # Define extensions
 EXTS = []
@@ -221,7 +222,6 @@ def main(**extra_args):
                     'dipy.nn.tests'],
 
           ext_modules=EXTS,
-          python_requires=">= 3.5",
           # The package_data spec has no effect for me (on python 2.6) -- even
           # changing to data_files doesn't get this stuff included in the
           # source distribution -- not sure if it has something to do with the


### PR DESCRIPTION
Fix `distutils` Python version requirement option warning.

Fixes
```
/opt/python/3.7.1/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown
distribution option: 'python_requires'

  warnings.warn(msg)
```

raised for example in
https://dev.azure.com/dipy/dipy/_build/results?buildId=343&view=logs&j=d9aefae6-c332-51b5-d933-a85009f5a2ac&t=10ba5eab-67e4-5f58-2aec-60b4dbb37e45&l=1948

or
https://travis-ci.org/github/dipy/dipy/jobs/679159532
(warning in raw log: https://api.travis-ci.org/v3/job/679159532/log.txt)