### PR TITLE
[Fix] some warning on stats module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ __config__.py
 dipy/.idea/
 .idea
 .vscode
+.pytest_cache/*

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -140,8 +140,8 @@ def assignment_map(target_bundle, model_bundle, no_disks):
     clusters = qb.cluster(mbundle_streamlines)
     centroids = Streamlines(clusters.centroids)
 
-    _, indx = cKDTree(centroids.data, 1,
-                      copy_data=True).query(target_bundle.data, k=1)
+    _, indx = cKDTree(centroids.get_data(), 1,
+                      copy_data=True).query(target_bundle.get_data(), k=1)
 
     return indx
 

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -534,7 +534,7 @@ def intersect_sphere(xyz, center, radius):
 
 
 def inside_sphere(xyz, center, radius):
-    """ If any point of the track is inside a sphere of a specified
+    r""" If any point of the track is inside a sphere of a specified
     center and radius return True otherwise False.  Mathematicaly this
     can be simply described by $|x-c|\le r$ where $x$ a point $c$ the
     center of the sphere and $r$ the radius of the sphere.
@@ -566,7 +566,7 @@ def inside_sphere(xyz, center, radius):
 
 
 def inside_sphere_points(xyz, center, radius):
-    """ If a track intersects with a sphere of a specified center and
+    r""" If a track intersects with a sphere of a specified center and
     radius return the points that are inside the sphere otherwise False.
     Mathematicaly this can be simply described by $|x-c| \le r$ where $x$
     a point $c$ the center of the sphere and $r$ the radius of the

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -121,7 +121,7 @@ class SNRinCCFlow(Workflow):
 
             if not np.count_nonzero(mask_cc_part.astype(np.uint8)):
                 logging.warning("Empty mask: corpus callosum not found."
-                                " Updated your data or your threshold")
+                                " Update your data or your threshold")
 
             save_nifti(cc_mask_path, mask_cc_part.astype(np.uint8), affine)
             logging.info('CC mask saved as {0}'.format(cc_mask_path))

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -119,10 +119,17 @@ class SNRinCCFlow(Workflow):
                                                  bbox_threshold,
                                                  return_cfa=True)
 
+            if not np.count_nonzero(mask_cc_part.astype(np.uint8)):
+                logging.warning("Empty mask: corpus callosum not found."
+                                " Updated your data or your threshold")
+
             save_nifti(cc_mask_path, mask_cc_part.astype(np.uint8), affine)
             logging.info('CC mask saved as {0}'.format(cc_mask_path))
 
-            mean_signal = np.mean(data[mask_cc_part], axis=0)
+            masked_data = data[mask_cc_part]
+            mean_signal = 0
+            if masked_data.size:
+                mean_signal = np.mean(masked_data, axis=0)
             mask_noise = binary_dilation(mask, iterations=10)
             mask_noise[..., :mask_noise.shape[-1]//2] = 1
             mask_noise = ~mask_noise
@@ -130,7 +137,10 @@ class SNRinCCFlow(Workflow):
             save_nifti(mask_noise_path, mask_noise.astype(np.uint8), affine)
             logging.info('Mask noise saved as {0}'.format(mask_noise_path))
 
-            noise_std = np.std(data[mask_noise, :])
+            noise_std = 0
+            if np.count_nonzero(mask_noise.astype(np.uint8)):
+                noise_std = np.std(data[mask_noise, :])
+
             logging.info('Noise standard deviation sigma= ' + str(noise_std))
 
             idx = np.sum(gtab.bvecs, axis=-1) == 0
@@ -146,14 +156,14 @@ class SNRinCCFlow(Workflow):
             SNR_directions = []
             for direction in ['b0', axis_X, axis_Y, axis_Z]:
                 if direction == 'b0':
-                    SNR = mean_signal[0]/noise_std
+                    SNR = mean_signal[0]/noise_std if noise_std else 0
                     logging.info("SNR for the b=0 image is :" + str(SNR))
                 else:
                     logging.info("SNR for direction " + str(direction) +
                                  " " + str(gtab.bvecs[direction]) + "is :" +
                                  str(SNR))
                     SNR_directions.append(direction)
-                    SNR = mean_signal[direction]/noise_std
+                    SNR = mean_signal[direction]/noise_std if noise_std else 0
                 SNR_output.append(SNR)
 
             data = []

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -26,6 +26,7 @@ matplt, have_matplotlib, _ = optional_package("matplotlib")
 
 def test_stats():
     with TemporaryDirectory() as out_dir:
+
         data_path, bval_path, bvec_path = get_fnames('small_101D')
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
@@ -34,8 +35,8 @@ def test_stats():
 
         snr_flow = SNRinCCFlow(force=True)
         args = [data_path, bval_path, bvec_path, mask_path]
-
         snr_flow.run(*args, out_dir=out_dir)
+
         assert_true(os.path.exists(os.path.join(out_dir, 'product.json')))
         assert_true(os.stat(os.path.join(
             out_dir, 'product.json')).st_size != 0)
@@ -122,7 +123,8 @@ def test_buan_bundle_profiles():
 
 @pytest.mark.skipif(not have_pandas or not have_statsmodels or not have_tables
                     or not have_matplotlib,
-                    reason='Requires Pandas, StatsModels, PyTables, and matplotlib')
+                    reason='Requires Pandas, StatsModels, PyTables, and '
+                           'matplotlib')
 def test_bundle_analysis_tractometry_flow():
 
     with TemporaryDirectory() as dirpath:
@@ -189,7 +191,8 @@ def test_bundle_analysis_tractometry_flow():
 
 @pytest.mark.skipif(not have_pandas or not have_statsmodels or not have_tables
                     or not have_matplotlib,
-                    reason='Requires Pandas, StatsModels, PyTables, and matplotlib')
+                    reason='Requires Pandas, StatsModels, PyTables, and '
+                           'matplotlib')
 def test_linear_mixed_models_flow():
 
     with TemporaryDirectory() as dirpath:
@@ -256,7 +259,8 @@ def test_linear_mixed_models_flow():
 
 @pytest.mark.skipif(not have_pandas or not have_statsmodels or not have_tables
                     or not have_matplotlib,
-                    reason='Requires Pandas, StatsModels, PyTables, and matplotlib')
+                    reason='Requires Pandas, StatsModels, PyTables, and '
+                           'matplotlib')
 def test_bundle_shape_analysis_flow():
 
     with TemporaryDirectory() as dirpath:
@@ -316,4 +320,5 @@ def test_bundle_shape_analysis_flow():
 
 
 if __name__ == '__main__':
-    npt.run_module_suite()
+    # npt.run_module_suite()
+    test_bundle_shape_analysis_flow()

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -320,5 +320,4 @@ def test_bundle_shape_analysis_flow():
 
 
 if __name__ == '__main__':
-    # npt.run_module_suite()
-    test_bundle_shape_analysis_flow()
+    npt.run_module_suite()


### PR DESCRIPTION
The goal of this PR is to fix some warning on the stats module

```python
workflows/tests/test_stats.py::test_stats
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/numpy/core/fromnumeric.py:3334: RuntimeWarning: Mean of empty slice.
    return _methods._mean(a, axis=axis, dtype=dtype,
workflows/tests/test_stats.py::test_stats
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/numpy/core/_methods.py:153: RuntimeWarning: invalid value encountered in true_divide
    ret = um.true_divide(
workflows/tests/test_stats.py::test_stats
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/numpy/core/_methods.py:216: RuntimeWarning: Degrees of freedom <= 0 for slice
    ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
workflows/tests/test_stats.py::test_stats
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/numpy/core/_methods.py:185: RuntimeWarning: invalid value encountered in true_divide
    arrmean = um.true_divide(
workflows/tests/test_stats.py::test_stats
  /home/travis/build/dipy/dipy/venv/lib/python3.8/site-packages/numpy/core/_methods.py:209: RuntimeWarning: invalid value encountered in double_scalars
    ret = ret.dtype.type(ret / rcount)
```