### PR TITLE
Bundle segmentation CLI tutorial

### DIFF
--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -1,24 +1,29 @@
 .. _bundle_segmentation_flow:
 
-===============================================
+=================================================
 White Matter Bundle Segmentation with RecoBundles
-===============================================
+=================================================
 
 This tutorial explains how we can use RecoBundles [1]_ to extract
 bundles from input tractograms.
 
 
-First, we need to download a reference streamline atlas. Here, we downloaded an atlas with 
+First, we need to download a reference streamline atlas. Here, we downloaded an atlas with
 30 bundles in MNI space [2]_ from:
 
     `<https://figshare.com/articles/Atlas_of_30_Human_Brain_Bundles_in_MNI_space/12089652>`_
 
-Let's say we have an input target tractogram named ``target.trk`` and the atlas we
+For this tutorial, you can use your own tractography data or you can download a single subject
+tractogram from:
+
+    `<https://figshare.com/articles/hcp_tractogram_zip/7013003>`_
+
+Let's say we have an input target tractogram named ``streamlines.trk`` and the atlas we
 downloaded, named ``whole_brain_MNI.trk``.
 
 Visualizing the target and atlas tractograms before registration::
 
-    dipy_horizon "target.trk" "whole_brain_MNI.trk" --random_color
+    dipy_horizon "streamlines.trk" "whole_brain_MNI.trk" --random_color
 
 .. figure:: https://github.com/dipy/dipy_data/blob/master/tractograms_initial.png?raw=true
     :width: 70 %
@@ -37,11 +42,11 @@ the space of the atlas, using streamline-based linear registration (SLR) [3]_.
 
 The following workflows require two positional input arguments; ``static`` and
 ``moving`` .trk files. In our case, the ``static`` input is the atlas and the ``moving`` is
-our ``target``  tractogram.
+our ``target``  tractogram (``streamlines.trk``).
 
 Run the following workflow::
 
-    dipy_slr "whole_brain_MNI.trk" "target.trk" --force
+    dipy_slr "whole_brain_MNI.trk" "streamlines.trk" --force
 
 Per default, the SLR workflow will save a transformed tractogram as ``moved.trk``.
 
@@ -57,14 +62,14 @@ Visualizing the target and atlas tractograms after registration::
     Atlas and target tractograms after registration.
 
 -----------
-Recobundles
+RecoBundles
 -----------
 
 Create an ``out_dir`` folder (e.g., ``rb_output``), into which output will be placed::
 
     mkdir rb_output
 
-For the Recobundles workflow, we will use the 30 model bundles downloaded earlier.
+For the RecoBundles workflow, we will use the 30 model bundles downloaded earlier.
 Run the following workflow::
 
     dipy_recobundles "moved.trk" "bundles/*.trk" --force --mix_names --out_dir "rb_output"
@@ -89,20 +94,23 @@ with the model AF_L bundle used as reference in RecoBundles:
 
     Extracted Left Arcuate fasciculus (AF_L) in pink and model AF_L bundle in green color.
 
-Output of recobundles will be in native space. To get bundles in subject's
+Output of RecoBundles will be in native space. To get bundles in subject's
 original space, run following commands::
 
     mkdir org_output
 
-    dipy_labelsbundles 'target.trk' 'rb_output/*.npy' --mix_names --out_dir "org_output"
+    dipy_labelsbundles 'streamlines.trk' 'rb_output/*.npy' --mix_names --out_dir "org_output"
 
 
 
-For more information about each command line, you can go to
-`<https://github.com/dipy/dipy/blob/master/dipy/workflows/segment.py>`_
+For more information about each command line, please visit DIPY website `<https://dipy.org/>`_ .
 
 If you are using any of these commands please be sure to cite the relevant papers and
 DIPY [4]_.
+
+----------
+References
+----------
 
 .. [1] Garyfallidis et al. Recognition of white matter bundles using local and
     global streamline-based registration and clustering, Neuroimage, 2017

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -1,7 +1,7 @@
 .. _bundle_segmentation_flow:
 
 ===============================================
-White Matter Bundle Extraction with RecoBundles
+White Matter Bundle Segmentation with RecoBundles
 ===============================================
 
 This tutorial explains how we can use RecoBundles [1]_ to extract

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -24,7 +24,7 @@ Visualizing target and atlas tractograms before registration::
     :alt: alternate text
     :align: center
 
-    Atlas and target before registration.
+    Atlas and target tractograms before registration.
 
 ------------------------------------
 Streamline-Based Linear Registration
@@ -32,7 +32,7 @@ Streamline-Based Linear Registration
 
 For extracting bundles from tractogram we first need our target tractogram to
 be in common space (atlas space). We will register target tractogram to
-model atlas’ space using streamline-based linear registeration (SLR)[3]_.
+model atlas’ space using streamline-based linear registeration (SLR) [3]_.
 
 Following workflows require two positional input arguments; ``Static`` and
 ``Moving`` .trk files. ``Static`` would be the ``atlas``  and ``Moving`` would be
@@ -53,7 +53,7 @@ Visualizing target and atlas tractograms after registration::
     :alt: alternate text
     :align: center
 
-    Atlas and target after registration.
+    Atlas and target tractograms after registration.
 
 -----------
 Recobundles
@@ -100,7 +100,8 @@ original space, run following commands::
 For more information about each command line, you can go to
 `<https://github.com/dipy/dipy/blob/master/dipy/workflows/segment.py>`_
 
-If you are using any of these commands do cite the relevant papers.
+If you are using any of these commands do cite the relevant papers and
+DIPY [4]_.
 
 .. [1] Garyfallidis et al. Recognition of white matter bundles using local and
     global streamline-based registration and clustering, Neuroimage, 2017
@@ -114,7 +115,6 @@ If you are using any of these commands do cite the relevant papers.
 .. [3] Garyfallidis et al., “Robust and efficient linear registration of
     white-matter fascicles in the space of streamlines”, Neuroimage,
     117:124-140, 2015.
-
 
 .. [4] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
     S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith.

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -19,6 +19,10 @@ Visualizing target and atlas tractograms before registration::
 
     dipy_horizon "target.trk" "whole_brain_MNI.trk" --random_color
 
+.. figure:: https://github.com/dipy/dipy_data/blob/master/tractograms_initial.png?raw=true
+    :width: 70 %
+    :alt: alternate text
+    :align: center
 
 ------------------------------------
 Streamline-Based Linear Registration
@@ -42,11 +46,16 @@ Visualizing target and atlas tractograms after registration::
 
     dipy_horizon "moved.trk" "whole_brain_MNI.trk" --random_color
 
+.. figure:: https://github.com/dipy/dipy_data/blob/master/tractograms_after_registration.png?raw=true
+    :width: 70 %
+    :alt: alternate text
+    :align: center
+
 -----------
 Recobundles
 -----------
 
-Create an ``out_dir`` folder (eg: sm_plots)::
+Create an ``out_dir`` folder (eg: rb_output)::
 
     mkdir rb_output
 
@@ -56,17 +65,19 @@ Run the following workflow::
     dipy_recobundles "moved.trk" "bundles/*.trk" --force --mix_names --out_dir "rb_output"
 
 This workflow will extract 30 bundles from the tractogram.
-Plots will look like the following example:
+Example of extracted Left Arcuate fasciculus (AF_L) bundle:
 
-.. figure:: https://github.com/dipy/dipy_data/blob/master/SM_moved_UF_R__recognized.png?raw=true
+.. figure:: https://github.com/dipy/dipy_data/blob/master/AF_L_rb.png?raw=true
     :width: 70 %
     :alt: alternate text
     :align: center
 
 Output of recobundles will be in native space. To get bundles in subject's
-original space, run following command::
+original space, run following commands::
 
-     dipy_labelsbundles 'target.trk' 'rb_output/*.npy' --mix_names
+    mkdir org_output
+
+    dipy_labelsbundles 'target.trk' 'rb_output/*.npy' --mix_names --out_dir "org_output"
 
 
 
@@ -93,10 +104,3 @@ If you are using any of these commands do cite the relevant papers.
     S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith.
     "DIPY, a library for the analysis of diffusion MRI data".
     Frontiers in Neuroinformatics, 1-18, 2014.
-
-
-
-
-
-
-

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -1,0 +1,102 @@
+.. _bundle_segmentation_flow:
+
+===============================================
+White Matter Bundle Extraction with RecoBundles
+===============================================
+
+This tutorial explains how we can use RecoBundles [1]_ to extract
+bundles from input tractograms.
+
+
+First we need to download streamline atlas [2]_ with 30 bundles in MNI space from:
+
+    `<https://figshare.com/articles/Atlas_of_30_Human_Brain_Bundles_in_MNI_space/12089652>`_
+
+Let's say we have an input target tractogram named ``target.trk`` and atlas we
+download named ``whole_brain_MNI.trk``.
+
+Visualizing target and atlas tractograms before registration::
+
+    dipy_horizon "target.trk" "whole_brain_MNI.trk" --random_color
+
+
+------------------------------------
+Streamline-Based Linear Registration
+------------------------------------
+
+For extracting bundles from tractogram we first need our target tractogram to
+be in common space (atlas space). We will register target tractogram to
+model atlas’ space using streamline-based linear registeration (SLR)[3]_.
+
+Following workflows require two positional input arguments; ``Static`` and
+``Moving`` .trk files. ``Static`` would be the atlas and ``Moving`` would be
+our target tractogram.
+
+Run the following workflow::
+
+    dipy_slr "whole_brain_MNI.trk" "target.trk" --force
+
+SLR workflow will save transformed tractogram as ``moved.trk``.
+
+Visualizing target and atlas tractograms after registration::
+
+    dipy_horizon "moved.trk" "whole_brain_MNI.trk" --random_color
+
+-----------
+Recobundles
+-----------
+
+Create an ``out_dir`` folder (eg: sm_plots)::
+
+    mkdir rb_output
+
+For Recobundles workflow, we will be using 30 model bundles downloaded earlier.
+Run the following workflow::
+
+    dipy_recobundles "moved.trk" "bundles/*.trk" --force --mix_names --out_dir "rb_output"
+
+This workflow will extract 30 bundles from the tractogram.
+Plots will look like the following example:
+
+.. figure:: https://github.com/dipy/dipy_data/blob/master/SM_moved_UF_R__recognized.png?raw=true
+    :width: 70 %
+    :alt: alternate text
+    :align: center
+
+Output of recobundles will be in native space. To get bundles in subject's
+original space, run following command::
+
+     dipy_labelsbundles 'target.trk' 'rb_output/*.npy' --mix_names
+
+
+
+For more information about each command line, you can go to
+`<https://github.com/dipy/dipy/blob/master/dipy/workflows/segment.py>`_
+
+If you are using any of these commands do cite the relevant papers.
+
+.. [1] Garyfallidis et al. Recognition of white matter bundles using local and
+    global streamline-based registration and clustering, Neuroimage, 2017
+
+.. [2] Yeh F.C., Panesar S., Fernandes D., Meola A., Yoshino M.,
+    Fernandez-Miranda J.C., Vettel J.M., Verstynen T.
+    Population-averaged atlas of the macroscale human structural
+    connectome and its network topology.
+    Neuroimage, 2018.
+
+.. [3] Garyfallidis et al., “Robust and efficient linear registration of
+    white-matter fascicles in the space of streamlines”, Neuroimage,
+    117:124-140, 2015.
+
+
+.. [4] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
+    S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith.
+    "DIPY, a library for the analysis of diffusion MRI data".
+    Frontiers in Neuroinformatics, 1-18, 2014.
+
+
+
+
+
+
+

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -8,14 +8,15 @@ This tutorial explains how we can use RecoBundles [1]_ to extract
 bundles from input tractograms.
 
 
-First we need to download streamline atlas [2]_ with 30 bundles in MNI space from:
+First, we need to download a reference streamline atlas. Here, we downloaded an atlas with 
+30 bundles in MNI space [2]_ from:
 
     `<https://figshare.com/articles/Atlas_of_30_Human_Brain_Bundles_in_MNI_space/12089652>`_
 
-Let's say we have an input target tractogram named ``target.trk`` and atlas we
-download named ``whole_brain_MNI.trk``.
+Let's say we have an input target tractogram named ``target.trk`` and the atlas we
+downloaded, named ``whole_brain_MNI.trk``.
 
-Visualizing target and atlas tractograms before registration::
+Visualizing the target and atlas tractograms before registration::
 
     dipy_horizon "target.trk" "whole_brain_MNI.trk" --random_color
 
@@ -30,21 +31,21 @@ Visualizing target and atlas tractograms before registration::
 Streamline-Based Linear Registration
 ------------------------------------
 
-For extracting bundles from tractogram we first need our target tractogram to
-be in common space (atlas space). We will register target tractogram to
-model atlas’ space using streamline-based linear registeration (SLR) [3]_.
+To extract the bundles from the tractogram, we first need move our target tractogram to
+be in the same space as the atlas (MNI, in this case). We can directly register the target tractogram to
+the space of the atlas, using streamline-based linear registration (SLR) [3]_.
 
-Following workflows require two positional input arguments; ``Static`` and
-``Moving`` .trk files. ``Static`` would be the ``atlas``  and ``Moving`` would be
+The following workflows require two positional input arguments; ``static`` and
+``moving`` .trk files. In our case, the ``static`` input is the atlas and the ``moving`` is
 our ``target``  tractogram.
 
 Run the following workflow::
 
     dipy_slr "whole_brain_MNI.trk" "target.trk" --force
 
-SLR workflow will save transformed tractogram as ``moved.trk``.
+Per default, the SLR workflow will save a transformed tractogram as ``moved.trk``.
 
-Visualizing target and atlas tractograms after registration::
+Visualizing the target and atlas tractograms after registration::
 
     dipy_horizon "moved.trk" "whole_brain_MNI.trk" --random_color
 
@@ -59,17 +60,17 @@ Visualizing target and atlas tractograms after registration::
 Recobundles
 -----------
 
-Create an ``out_dir`` folder (eg: rb_output)::
+Create an ``out_dir`` folder (e.g., ``rb_output``), into which output will be placed::
 
     mkdir rb_output
 
-For Recobundles workflow, we will be using 30 model bundles downloaded earlier.
+For the Recobundles workflow, we will use the 30 model bundles downloaded earlier.
 Run the following workflow::
 
     dipy_recobundles "moved.trk" "bundles/*.trk" --force --mix_names --out_dir "rb_output"
 
 This workflow will extract 30 bundles from the tractogram.
-Example of extracted Left Arcuate fasciculus (AF_L) bundle:
+Example of extracted Left Arcuate fasciculus (AF_L) bundle (visualized with ``dipy_horizon``):
 
 .. figure:: https://github.com/dipy/dipy_data/blob/master/AF_L_rb.png?raw=true
     :width: 70 %
@@ -79,14 +80,14 @@ Example of extracted Left Arcuate fasciculus (AF_L) bundle:
     Extracted Left Arcuate fasciculus (AF_L) from input tractogram
 
 Example of extracted Left Arcuate fasciculus (AF_L) bundle visualized along
-model AF_L bundle used as reference in RecoBundles:
+with the model AF_L bundle used as reference in RecoBundles:
 
 .. figure:: https://github.com/dipy/dipy_data/blob/master/AF_L_rb_with_model.png?raw=true
     :width: 70 %
     :alt: alternate text
     :align: center
 
-    Extracted Left Arcuate fasciculus (AF_L) in Pink and model AF_L bundle in green color.
+    Extracted Left Arcuate fasciculus (AF_L) in pink and model AF_L bundle in green color.
 
 Output of recobundles will be in native space. To get bundles in subject's
 original space, run following commands::
@@ -100,7 +101,7 @@ original space, run following commands::
 For more information about each command line, you can go to
 `<https://github.com/dipy/dipy/blob/master/dipy/workflows/segment.py>`_
 
-If you are using any of these commands do cite the relevant papers and
+If you are using any of these commands please be sure to cite the relevant papers and
 DIPY [4]_.
 
 .. [1] Garyfallidis et al. Recognition of white matter bundles using local and

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -24,6 +24,8 @@ Visualizing target and atlas tractograms before registration::
     :alt: alternate text
     :align: center
 
+    Atlas and target before registration.
+
 ------------------------------------
 Streamline-Based Linear Registration
 ------------------------------------
@@ -33,8 +35,8 @@ be in common space (atlas space). We will register target tractogram to
 model atlas’ space using streamline-based linear registeration (SLR)[3]_.
 
 Following workflows require two positional input arguments; ``Static`` and
-``Moving`` .trk files. ``Static`` would be the atlas and ``Moving`` would be
-our target tractogram.
+``Moving`` .trk files. ``Static`` would be the ``atlas``  and ``Moving`` would be
+our ``target``  tractogram.
 
 Run the following workflow::
 
@@ -50,6 +52,8 @@ Visualizing target and atlas tractograms after registration::
     :width: 70 %
     :alt: alternate text
     :align: center
+
+    Atlas and target after registration.
 
 -----------
 Recobundles

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -72,6 +72,18 @@ Example of extracted Left Arcuate fasciculus (AF_L) bundle:
     :alt: alternate text
     :align: center
 
+    Extracted Left Arcuate fasciculus (AF_L) from input tractogram
+
+Example of extracted Left Arcuate fasciculus (AF_L) bundle visualized along
+model AF_L bundle used as reference in RecoBundles:
+
+.. figure:: https://github.com/dipy/dipy_data/blob/master/AF_L_rb_with_model.png?raw=true
+    :width: 70 %
+    :alt: alternate text
+    :align: center
+
+    Extracted Left Arcuate fasciculus (AF_L) in Pink and model AF_L bundle in green color.
+
 Output of recobundles will be in native space. To get bundles in subject's
 original space, run following commands::
 

--- a/doc/interfaces/index.rst
+++ b/doc/interfaces/index.rst
@@ -8,3 +8,4 @@ DIPY Workflows Interfaces
 
     basic_flow.rst
     BUAN_flow.rst
+    bundle_segmentation_flow.rst


### PR DESCRIPTION
Added bundle_segmentation_flow.rst file which explains how to extract white matter bundles from target tractogram using RecoBundles.

Figures added in the tutorial.