### PR TITLE
[Fix] sfm RuntimeWarning

### DIFF
--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -12,6 +13,7 @@ from dipy.io.image import load_nifti_data
 
 needs_sklearn = pytest.mark.skipif(not sfm.has_sklearn,
                                    reason="Requires Scikit-Learn")
+
 
 def test_design_matrix():
     data, gtab = dpd.dsi_voxels()
@@ -75,7 +77,9 @@ def test_predict():
     npt.assert_(xval.coeff_of_determination(new_pred, S[::2]) > 97)
 
     # Should be possible to predict for a single direction:
-    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
     new_pred = sffit.predict(new_gtab)
 
     # Fitting and predicting with a volume of data:
@@ -92,7 +96,9 @@ def test_predict():
     npt.assert_equal(new_pred.shape, data.shape[:-1] + bvals[::2].shape, )
 
     # Should be possible to predict for a single direction:
-    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
     new_pred = sffit.predict(new_gtab)
     npt.assert_equal(new_pred.shape, data.shape[:-1])
 
@@ -110,7 +116,9 @@ def test_predict():
     npt.assert_equal(new_pred[0, 0, 0], 0)
 
     # Should be possible to predict for a single direction:
-    new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        new_gtab = grad.gradient_table(bvals[1][None], bvecs[1][None, :])
     new_pred = sffit.predict(new_gtab)
     npt.assert_equal(new_pred.shape, data.shape[:-1])
     npt.assert_equal(new_pred[0, 0, 0], 0)
@@ -188,9 +196,9 @@ def test_exponential_iso():
         sphere = dpd.get_sphere()
         odf = sffit1.odf(sphere)
         pred = sffit1.predict(gtab)
-        npt.assert_equal(pred.shape, data[0,0,0].shape)
+        npt.assert_equal(pred.shape, data[0, 0, 0].shape)
         npt.assert_equal(odf.shape,
-                         data[0,0,0].shape[:-1] + (sphere.x.shape[0],))
+                         data[0, 0, 0].shape[:-1] + (sphere.x.shape[0],))
 
         sffit2 = sfmodel.fit(data)
         sphere = dpd.get_sphere()
@@ -219,4 +227,3 @@ def test_exponential_iso():
         sffit = sfmodel.fit(S)
         pred = sffit.predict()
         npt.assert_(xval.coeff_of_determination(pred, S) > 96)
-

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -1047,7 +1047,7 @@ def multi_shell_fiber_response(sh_order, bvals, evals, csf_md, gm_md,
     for i, bvalue in enumerate(bvals):
         gtab = GradientTable(big_sphere.vertices * bvalue)
         wm_response = single_tensor(gtab, 1., evals, evecs, snr=None)
-        response[i, 2:] = np.linalg.lstsq(B, wm_response)[0]
+        response[i, 2:] = np.linalg.lstsq(B, wm_response, rcond=-1)[0]
 
         response[i, 0] = np.exp(-bvalue * csf_md) / A
         response[i, 1] = np.exp(-bvalue * gm_md) / A


### PR DESCRIPTION
Small PR to fix some CI's warning on sfm module. I use the opportunity to fix some pep8 too.
The warnings fixed are:

```python
reconst/tests/test_mcsd.py::test_mcsd_model_delta
reconst/tests/test_mcsd.py::test_compartments
reconst/tests/test_mcsd.py::test_MultiShellDeconvModel
  /home/travis/build/dipy/dipy/venv/lib/python3.7/site-packages/dipy/sims/voxel.py:1050: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.
  To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.
    response[i, 2:] = np.linalg.lstsq(B, wm_response)[0]

reconst/tests/test_sfm.py::test_sfm
reconst/tests/test_sfm.py::test_sfm
  /home/travis/build/dipy/dipy/venv/lib/python3.7/site-packages/dipy/reconst/sfm.py:452: RuntimeWarning: invalid value encountered in true_divide
    flat_S0[..., None])
reconst/tests/test_sfm.py::test_predict
reconst/tests/test_sfm.py::test_predict
reconst/tests/test_sfm.py::test_predict
  /home/travis/build/dipy/dipy/venv/lib/python3.7/site-packages/dipy/core/gradients.py:260: UserWarning: b0_threshold (value: 50) is too low, increase your              b0_threshold. It should be higher than the lowest b0 value              (992.8797843126392).
    ({1}).".format(b0_threshold, bvals.min()))
reconst/tests/test_sfm.py::test_sfm_background
  /home/travis/build/dipy/dipy/venv/lib/python3.7/site-packages/dipy/reconst/sfm.py:452: RuntimeWarning: divide by zero encountered in true_divide
    flat_S0[..., None])
```