### PR TITLE
BF: Fix Cython signed vs. unsigned integer comparison warning

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -671,7 +671,7 @@ cdef inline void min_distances(size_t t1_len,
         cnp.float32_t *t2_pt
         cnp.float32_t d0, d1, d2
         cnp.float32_t delta2
-        int t1_pi, t2_pi
+        size_t t1_pi, t2_pi
     for t2_pi from 0<= t2_pi < t2_len:
         min_t2t1[t2_pi] = inf
     for t1_pi from 0<= t1_pi < t1_len:
@@ -1075,7 +1075,7 @@ def approx_polygon_track(xyz,alpha=0.392):
     next point.
     """
     cdef :
-        int mid_index
+        size_t mid_index
         cnp.ndarray[cnp.float32_t, ndim=2] track
         float *fvec0
         float *fvec1


### PR DESCRIPTION
Fix Cython signed vs. unsigned integer comparison warning.

Fixes:
```
dipy/tracking/distances.c: In function
â€˜__pyx_f_4dipy_8tracking_9distances_min_distancesâ€™:

dipy/tracking/distances.c:8874:41: warning:
comparison between signed and unsigned integer expressions [-Wsign-compare]

for (__pyx_v_t2_pi = 0; __pyx_v_t2_pi <
__pyx_t_1; __pyx_v_t2_pi++) {
                                         ^
```
and
```
dipy/tracking/distances.c:11524:38: warning: comparison between signed and
unsigned integer expressions [-Wsign-compare]
__pyx_t_12 = ((__pyx_v_mid_index < (__pyx_v_t_len - 1)) != 0);
                                 ^
```

raised for example in:
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=652
and
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=671