### PR TITLE
BF: Fix variable may be used uninitialized warning

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -303,8 +303,8 @@ def _bundle_minimum_distance_asymmetric(double [:, ::1] static,
 
         min_j = <double *> malloc(static_size * sizeof(double))
 
-        for i in range(static_size):
-            min_j[i] = inf
+        for sz_i in range(static_size):
+            min_j[sz_i] = inf
 
         for i in prange(static_size):
 

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -527,7 +527,7 @@ cdef class QuickBundles(object):
 
         nearest_cluster.id = -1
         nearest_cluster.dist = BIGGEST_DOUBLE
-
+        nearest_cluster.flip = 0
 
         for k in range(self.clusters.c_size()):
 

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -256,6 +256,7 @@ def cut_plane(tracks, ref):
         float hit[3]
         float hitMp[3]
         float *delta
+    normal[:] = [0, 0, 0]
     # List used for storage of hits.  We will fill this with lots of
     # small numpy arrays, and reuse them over the reference track point
     # loops.
@@ -638,7 +639,7 @@ cdef inline cnp.float32_t czhang(size_t t1_len,
                   min_t1t2)
     cdef:
         size_t t1_pi, t2_pi
-        cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0, dist_val
+        cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0, dist_val = 0
     for t1_pi from 0<= t1_pi < t1_len:
         mean_t1t2+=min_t1t2[t1_pi]
     mean_t1t2=mean_t1t2/t1_len

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -172,9 +172,11 @@ cdef class FBCMeasures:
             double [:, :, :] streamlines_tangent
             int [:, :] streamlines_nearestp
             double [:, :] streamline_scores
-            double [:] tangent
-            int line_id, point_id
-            int line_id2, point_id2
+            int line_id = 0
+            int point_id = 0
+            int line_id2 = 0
+            int point_id2 = 0
+            int dims
             double score
             double [:] score_mp
             int [:] xd_mp, yd_mp, zd_mp
@@ -228,9 +230,9 @@ cdef class FBCMeasures:
         # copy python streamlines into numpy array
         for line_id in range(num_fibers):
             for point_id in range(streamlines_length[line_id]):
-                for dim in range(3):
-                    streamlines[line_id, point_id, dim] = \
-                        py_streamlines[line_id][point_id][dim]
+                for dims in range(3):
+                    streamlines[line_id, point_id, dims] = \
+                        py_streamlines[line_id][point_id][dims]
         self.streamline_points = streamlines
 
         # compute tangents


### PR DESCRIPTION
Fix variable may be used uninitialized warning.

Fixes:
```
dipy/tracking/distances.c: In function
‘__pyx_f_4dipy_8tracking_9distances_czhang’:

dipy/tracking/distances.c:8842:10: warning: ‘__pyx_v_dist_val’ may be used
uninitialized in this function [-Wmaybe-uninitialized]

   return __pyx_r;

          ^
```
and
```
dipy/tracking/distances.c: In function
‘__pyx_pf_4dipy_8tracking_9distances_14cut_plane.isra.43’:

dipy/tracking/distances.c:3310:59: warning: ‘*((void *)&__pyx_v_normal+8)’ may
be used uninitialized in this function [-Wmaybe-uninitialized]

     __pyx_v_ip = (__pyx_v_ip + ((__pyx_v_vec1[__pyx_v_i]) *
(__pyx_v_vec2[__pyx_v_i])));

                                                           ^
dipy/tracking/distances.c:4696:9: note: ‘*((void *)&__pyx_v_normal+8)’ was
declared here

   float __pyx_v_normal[3];

         ^
```
and
```
dipy/tracking/fbcmeasures.c: In function
‘__pyx_f_4dipy_8tracking_11fbcmeasures_11FBCMeasures_compute._omp_fn.0’:

dipy/tracking/fbcmeasures.c:4239:7: warning: ‘__pyx_v_point_id2’ may be used
uninitialized in this function [-Wmaybe-uninitialized]

   int __pyx_v_point_id2;

       ^
dipy/tracking/fbcmeasures.c:4237:7: warning: ‘__pyx_v_point_id’ may be used
uninitialized in this function [-Wmaybe-uninitialized]

   int __pyx_v_point_id;

       ^

dipy/tracking/fbcmeasures.c:4238:7: warning: ‘__pyx_v_line_id2’ may be used
uninitialized in this function [-Wmaybe-uninitialized]

   int __pyx_v_line_id2;

       ^i
```
and
```
dipy/segment/clusteringspeed.c: In function
‘__pyx_f_4dipy_7segment_15clusteringspeed_12QuickBundles_find_nearest_cluster’:

dipy/segment/clusteringspeed.c:8204:10: warning: ‘__pyx_v_nearest_cluster.flip’
may be used uninitialized in this function [-Wmaybe-uninitialized]

   return __pyx_r;

          ^
```
and
```
dipy/align/bundlemin.c: In function
‘__pyx_pf_4dipy_5align_9bundlemin_4_bundle_minimum_distance_asymmetric._omp_fn.0’:

dipy/align/bundlemin.c:4484:29: warning: ‘__pyx_v_tmp’ may be used uninitialized
in this function [-Wmaybe-uninitialized]

                     #pragma omp for firstprivate(__pyx_v_i)
lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_tmp)

                             ^

dipy/align/bundlemin.c:4298:10: note: ‘__pyx_v_tmp’ was declared here

   double __pyx_v_tmp;

          ^
```

raised for example in:
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=675
or
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=679
or
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=780
or
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=831
or
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=902
or
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=998
