### PR TITLE
BF: Fix Cython floating point absolute value warning

### DIFF
--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -15,7 +15,7 @@ from dipy.utils.fast_numpy cimport cumsum, where_to_insert, copy_point
 cdef extern from "dpy_math.h" nogil:
     int dpy_signbit(double x)
     double dpy_rint(double x)
-    double abs(double)
+    double fabs(double)
 
 
 @cython.cdivision(True)
@@ -27,7 +27,7 @@ cdef inline double stepsize(double point, double increment) nogil:
     if dist == 0:
         # Point is on an edge, return step size to next edge.  This is most
         # likely to come up if overstep is set to 0.
-        return 1. / abs(increment)
+        return 1. / fabs(increment)
     else:
         return dist / increment
 


### PR DESCRIPTION
Fix Cython floating point absolute value warning:
```
dipy/tracking/localtrack.c:2846:21: warning: using integer absolute value
function 'abs' when argument is of floating point type [-Wabsolute-value]

     __pyx_r = (1. / abs(__pyx_v_increment));

                     ^

 dipy/tracking/localtrack.c:2846:21: note: use function 'fabs' instead

     __pyx_r = (1. / abs(__pyx_v_increment));

                     ^~~

                    fabs
```

raised for example in
https://dev.azure.com/dipy/dipy/_build/results?buildId=374&view=logs&j=eb71c31b-0e3f-5817-821a-71ddffa66479&t=c96ee7eb-f012-52fa-7392-c7ee03227595&l=698