### PR TITLE
BF: Fix Cython different sign integer comparison warning

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1075,7 +1075,7 @@ def approx_polygon_track(xyz,alpha=0.392):
     next point.
     """
     cdef :
-        int mid_index
+        size_t mid_index
         cnp.ndarray[cnp.float32_t, ndim=2] track
         float *fvec0
         float *fvec1


### PR DESCRIPTION
Fix Cython different sign integer comparison warning.

Fixes
```
dipy/tracking/localtrack.c:3505:33: warning: comparison of integers of different
signs: 'size_t' (aka 'unsigned long') and 'Py_ssize_t' (aka 'long')
[-Wsign-compare]

  for (__pyx_t_6 = 1; __pyx_t_6 < __pyx_t_5; __pyx_t_6+=1) {

                      ~~~~~~~~~ ^ ~~~~~~~~~
```

raised for example at:
https://dev.azure.com/dipy/dipy/_build/results?buildId=374&view=logs&j=eb71c31b-0e3f-5817-821a-71ddffa66479&t=c96ee7eb-f012-52fa-7392-c7ee03227595&l=705