### PR TITLE
Fix a memory overlap bug in multi_median (and median_otsu)

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -200,7 +200,7 @@ def median_otsu(input_volume, vol_idx=None, median_radius=4, numpass=4,
         else:
             raise ValueError("For 4D images, must provide vol_idx input")
     else:
-        b0vol = input_volume.copy()
+        b0vol = input_volume
     # Make a mask using a multiple pass median filter and histogram
     # thresholding.
     mask = multi_median(b0vol, median_radius, numpass)

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -35,8 +35,10 @@ def multi_median(input, median_radius, numpass):
     medarr = np.ones_like(input.shape) * ((median_radius * 2) + 1)
 
     # Multi pass
+    output = np.empty_like(input)
     for i in range(0, numpass):
-        median_filter(input, medarr, output=input)
+        median_filter(input, medarr, output=output)
+        input, output = output, input
     return input
 
 

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -34,6 +34,10 @@ def multi_median(input, median_radius, numpass):
     # Array representing the size of the median window in each dimension.
     medarr = np.ones_like(input.shape) * ((median_radius * 2) + 1)
 
+    if numpass > 1:
+        # ensure the input array is not modified
+        input = input.copy()
+
     # Multi pass
     output = np.empty_like(input)
     for i in range(0, numpass):

--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -37,13 +37,14 @@ def test_mask():
     assert_equal(final, initial)
 
     # Test multi_median.
-    median_test = np.arange(25).reshape(5, 5)
-    median_control = median_test.copy()
+    img = np.arange(25).reshape(5, 5)
+    img_copy = img.copy()
     medianradius = 2
-    median_test = multi_median(median_test, medianradius, 3)
+    median_test = multi_median(img, medianradius, 3)
+    assert_equal(img, img_copy)
 
-    medarr = np.ones_like(median_control.shape) * ((medianradius * 2) + 1)
-    median_control = median_filter(median_control, medarr)
+    medarr = np.ones_like(img.shape) * ((medianradius * 2) + 1)
+    median_control = median_filter(img, medarr)
     median_control = median_filter(median_control, medarr)
     median_control = median_filter(median_control, medarr)
     assert_equal(median_test, median_control)

--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -39,13 +39,13 @@ def test_mask():
     # Test multi_median.
     median_test = np.arange(25).reshape(5, 5)
     median_control = median_test.copy()
-    medianradius = 3
+    medianradius = 2
     median_test = multi_median(median_test, medianradius, 3)
 
     medarr = np.ones_like(median_control.shape) * ((medianradius * 2) + 1)
-    median_filter(median_control, medarr, output=median_control)
-    median_filter(median_control, medarr, output=median_control)
-    median_filter(median_control, medarr, output=median_control)
+    median_control = median_filter(median_control, medarr)
+    median_control = median_filter(median_control, medarr)
+    median_control = median_filter(median_control, medarr)
     assert_equal(median_test, median_control)
 
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -8,6 +8,15 @@ renamed or are deprecated (not recommended) during different release circles.
 DIPY 1.2.0 changes
 ------------------
 
+**Segmentation**
+
+In prior releases, for users with SciPy < 1.5, a memory overlap bug occurs in
+``multi_median``, causing an overly smooth output. This has now been fixed,
+regardless of the user's installed SciPy version. Users of this function via
+``median_otsu`` thresholding should check the output of their image processing
+pipelines after the 1.2.0 release to make sure thresholding is still operating
+as expected (if not, try readjusting the ``median_radius`` parameter).
+
 **Tracking**
 
 The ``dipy.reconst.peak_direction_getter.EuDXDirectionGetter`` has


### PR DESCRIPTION
This PR works around a bug in SciPy. input/output arrays cannot overlap in memory during calls to `scipy.ndimage.median` (see scipy/scipy#9553).

The issue will be fixed upstream by scipy/scipy#11986 (See the figure in the first comment there, which illustrates the severity of the issue!)

The solution proposed here works with current SciPy and should be kept even once the SciPy minimum version is updated, as it avoids repeatedly creating a new temporary array within `scipy.ndimage.median` in each iteration.

I have plotted the smoothed volumes from the following small script pre and post-PR below:
```Python
import numpy as np
from dipy.data import get_fnames
from dipy.io.image import load_nifti
from dipy.segment.mask import multi_median

hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')

stanford_b0, stanford_b0_affine = load_nifti(hardi_fname)
stanford_b0 = np.squeeze(stanford_b0)[..., 0]

filtered = multi_median(stanford_b0, median_radius=4, numpass=1)
```

**Current Master (erroneous, overly smooth)**
![01_current_master_1iter](https://user-images.githubusercontent.com/6528957/80793041-01b74580-8b64-11ea-9b79-1660b4ee7f40.png)


**With this PR (looks as expected)**
![02_fixed_1iter](https://user-images.githubusercontent.com/6528957/80793052-08de5380-8b64-11ea-8bf7-ca601b6de59f.png)

**One other issue to consider:** Does the change here imply that the default values for `median_radius` and `numpass` should be adjusted? I am not sure if they were initially set empirically, relying on the faulty filtering, or if the values come from the literature. I checked back to SciPy 1.1 and it still had the same bug, but I didn't go back to much older versions..
