### PR TITLE
BF: Fix string literal comparison warning

### DIFF
--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -154,7 +154,7 @@ class QtdmriModel(Cache):
             msg += "or a float larger or equal than zero."
             msg += " Input value was %s." % laplacian_weighting
             if isinstance(laplacian_weighting, str):
-                if laplacian_weighting is not 'GCV':
+                if laplacian_weighting != 'GCV':
                     raise ValueError(msg)
             elif isinstance(laplacian_weighting, float):
                 if laplacian_weighting < 0:
@@ -172,7 +172,7 @@ class QtdmriModel(Cache):
             msg += "or a float larger or equal than zero."
             msg += " Input value was %s." % l1_weighting
             if isinstance(l1_weighting, str):
-                if l1_weighting is not 'CV':
+                if l1_weighting != 'CV':
                     raise ValueError(msg)
             elif isinstance(l1_weighting, float):
                 if l1_weighting < 0:


### PR DESCRIPTION
Fix string literal comparison warning.

Fixes
```
/home/vsts/work/1/s/venv/lib/python3.8/site-packages/dipy/reconst/qtdmri.py:157:
SyntaxWarning: "is not" with a literal. Did you mean "!="?

  if laplacian_weighting is not 'GCV':

/home/vsts/work/1/s/venv/lib/python3.8/site-packages/dipy/reconst/qtdmri.py:175:
SyntaxWarning: "is not" with a literal. Did you mean "!="?

  if l1_weighting is not 'CV'
```

raised for example in:
https://dev.azure.com/dipy/dipy/_build/results?buildId=399&view=logs&j=d9aefae6-c332-51b5-d933-a85009f5a2ac&t=10ba5eab-67e4-5f58-2aec-60b4dbb37e45&l=1926