### PR TITLE
BF: Fix Cython label defined but not used warning

### DIFF
--- a/dipy/tracking/stopping_criterion.pxd
+++ b/dipy/tracking/stopping_criterion.pxd
@@ -32,9 +32,9 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
     cdef:
         double[:, :, :] include_map, exclude_map
     cpdef double get_exclude(self, double[::1] point)
-    cdef double get_exclude_c(self, double* point)
+    cdef get_exclude_c(self, double* point)
     cpdef double get_include(self, double[::1] point)
-    cdef double get_include_c(self, double* point)
+    cdef get_include_c(self, double* point)
     pass
 
 

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -145,7 +145,7 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
 
         return self.get_exclude_c(&point[0])
 
-    cdef double get_exclude_c(self, double* point):
+    cdef get_exclude_c(self, double* point):
         exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
                                                 point, self.interp_out_view)
         if exclude_err != 0:
@@ -158,7 +158,7 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
 
         return self.get_include_c(&point[0])
 
-    cdef double get_include_c(self, double* point):
+    cdef get_include_c(self, double* point):
         exclude_err = trilinear_interpolate4d_c(self.include_map[..., None],
                                                 point, self.interp_out_view)
         if exclude_err != 0:


### PR DESCRIPTION
Fix Cython label defined but not used warning.

Fixes
```
dipy/tracking/stopping_criterion.c: In function
â€˜__pyx_f_4dipy_8tracking_18stopping_criterion_27AnatomicalStoppingCriterion_get_exclude_câ€™:

2020-04-29T06:37:02.4069497Z dipy/tracking/stopping_criterion.c:5359:3: warning:
label â€˜__pyx_L1_errorâ€™ defined but not used [-Wunused-label]

   __pyx_L1_error:;

   ^

dipy/tracking/stopping_criterion.c: In function
â€˜__pyx_f_4dipy_8tracking_18stopping_criterion_27AnatomicalStoppingCriterion_get_include_câ€™:

dipy/tracking/stopping_criterion.c:5655:3: warning: label â€˜__pyx_L1_errorâ€™
defined but not used [-Wunused-label]

   __pyx_L1_error:;

   ^
```

raised for example in:
https://dev.azure.com/dipy/dipy/_build/results?buildId=373&view=logs&j=ad7c9750-8a16-5492-49ac-3815bac6d5d2&t=baa9a672-c8e1-55fc-55ff-b7fd664eb7f3&l=743