### PR TITLE
Gitter url update: from nipy/dipy to dipy/dipy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ that you follow the [NIPY community code of conduct](http://nipy.org/conduct.htm
 If you are looking for places that you could make a meaningful contribution,
 please contact us! We respond to queries on the [Nipy mailing
 list](https://mail.python.org/mailman/listinfo/neuroimaging), and to questions
-on our [gitter channel](https://gitter.im/nipy/dipy). A good place to get an
+on our [gitter channel](https://gitter.im/dipy/dipy). A good place to get an
 idea for things that currently need attention is the
 [issues](https://github.com/dipy/dipy/issues) page of our Github repository.
 This page collects outstanding issues that you can help address. Join the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ of the documentation for the procedures we use in developing the code.
 ### Tests and test coverage
 
 We use [pytest](https://docs.pytest.org) to write tests of the code,
-and [Azure Pipelines](https://dev.azure.com/dipy/dipy) and [Travis-CI](https://travis-ci.org/dipy/dipy)
+and [Azure Pipelines](https://dev.azure.com/dipy/dipy) and [Travis-CI](https://travis-ci.com/dipy/dipy)
 for continuous integration.
 
 If you are adding code into a module that already has a 'test' file (e.g., if

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ https://mail.python.org/mailman/listinfo/neuroimaging
 Please see the users' forum at
 https://neurostars.org/tags/dipy
 
-Please join the gitter chatroom `here <https://gitter.im/nipy/dipy>`_.
+Please join the gitter chatroom `here <https://gitter.im/dipy/dipy>`_.
 
 Code
 ====

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@
 
 |
 
-.. image:: https://travis-ci.org/dipy/dipy.svg?branch=master
-  :target: https://travis-ci.org/dipy/dipy
+.. image:: https://travis-ci.com/dipy/dipy.svg?branch=master
+  :target: https://travis-ci.com/dipy/dipy
 
 .. image:: https://dev.azure.com/dipy/dipy/_apis/build/status/dipy.dipy?branchName=master
   :target: https://dev.azure.com/dipy/dipy/_build

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -89,7 +89,7 @@
    #}
 <script>
      ((window.gitter = {}).chat = {}).options = {
-       room: 'nipy/dipy'
+       room: 'dipy/dipy'
      };
 </script>
 <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>

--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -21,7 +21,7 @@
 .. _nibabel pypi: http://pypi.python.org/pypi/nibabel
 .. _nipy development guidelines: http://nipy.org/nipy/devel/guidelines/index.html
 .. _buildbots: http://nipy.bic.berkeley.edu/builders
-.. _`dipy gitter`: https://gitter.im/nipy/dipy
+.. _`dipy gitter`: https://gitter.im/dipy/dipy
 .. _neurostars: https://neurostars.org/
 .. _h5py: https://www.h5py.org/
 .. _cvxpy: http://www.cvxpy.org/

--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -76,7 +76,7 @@
 .. _pytest: https://docs.pytest.org
 .. _`python coverage tester`: http://nedbatchelder.com/code/modules/coverage.html
 .. _cython: http://cython.org
-.. _travis-ci: https://travis-ci.org/
+.. _travis-ci: https://travis-ci.com/
 
 .. Other python projects
 .. _numpy: http://numpy.scipy.org


### PR DESCRIPTION
Links updated after Gitter migration.

**old:** https://gitter.im/nipy/dipy   -> redirect to 
**new:** https://gitter.im/dipy/dipy

fix #2144 