### PR TITLE
Improve performance of tissue classification

### DIFF
--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -239,48 +239,6 @@ class ConstantObservationModel(object):
         return mu_upd, var_upd
 
 
-    def update_param_new(self, image, P_L_Y, mu, cnp.npy_intp nclasses):
-        r""" Updates the means and the variances in each iteration for all
-        the labels. This is for equations 25 and 26 of the Zhang et al. paper
-
-        Parameters
-        -----------
-        image : ndarray
-            3D structural gray-scale image
-        P_L_Y : ndarray
-            4D probability map of the label given the input image
-            computed by the expectation maximization (EM) algorithm
-        mu : ndarray
-            1 x nclasses, current estimate of the mean of each tissue
-            class.
-        nclasses : int
-            number of tissue classes
-
-        Returns
-        --------
-
-        mu_upd : ndarray
-            1 x nclasses, updated mean of each tissue class
-        var_upd : ndarray
-            1 x nclasses, updated variance of each tissue class
-        """
-        cdef int l
-        mu_upd = np.zeros(nclasses, dtype=np.float64)
-        var_upd = np.zeros(nclasses, dtype=np.float64)
-        mu_num = np.zeros(image.shape + (nclasses,), dtype=np.float64)
-        var_num = np.zeros(image.shape + (nclasses,), dtype=np.float64)
-
-        for l in range(nclasses):
-            mu_num[..., l] = P_L_Y[..., l] * image
-            var_num[..., l] = mu_num[..., l] * image
-
-            mu_upd[l] = np.sum(mu_num[..., l]) / np.sum(P_L_Y[..., l])
-            var_upd[l] = (np.sum(var_num[..., l]) / np.sum(P_L_Y[..., l]) -
-                          mu_upd[l] ** 2)
-
-        return mu_upd, var_upd
-
-
 cdef void _initialize_param_uniform(double[:, :, :] image, double[:] mu,
                                     double[:] sigma) nogil:
     r""" Initializes the means and standard deviations uniformly

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -44,18 +44,18 @@ class ConstantObservationModel(object):
 
         Parameters
         ----------
-        image : array,
-                3D structural image
-        nclasses : int,
-                number of desired classes
+        image : array
+            3D structural image
+        nclasses : int
+            number of desired classes
 
         Returns
         -------
-        mu : array,
-                1 x nclasses, mean for each class
-        sigma : array,
-                1 x nclasses, standard deviation for each class.
-                Set up to 1.0 for all classes.
+        mu : array
+            1 x nclasses, mean for each class
+        sigma : array
+            1 x nclasses, standard deviation for each class.
+            Set up to 1.0 for all classes.
         """
         cdef:
             double[:] mu = np.empty((nclasses,), dtype=np.float64)
@@ -71,18 +71,18 @@ class ConstantObservationModel(object):
 
         Parameters
         ----------
-        input_image : ndarray,
-                 3D structural image
-        seg_image : ndarray,
-                 3D segmented image
-        nclass : int,
-                 number of classes (3 in most cases)
+        input_image : ndarray
+            3D structural image
+        seg_image : ndarray
+            3D segmented image
+        nclass : int
+            number of classes (3 in most cases)
 
         Returns
         -------
-        mu, std: ndarrays,
-                 1 x nclasses dimension
-                 Mean and standard deviation for each class
+        mu, std : ndarrays
+            1 x nclasses dimension
+            Mean and standard deviation for each class
 
         """
         cdef:
@@ -135,19 +135,19 @@ class ConstantObservationModel(object):
 
         Parameters
         ----------
-        image : ndarray,
-                3D gray scale structural image
-        mu : ndarray,
-                mean of each class
-        sigmasq : ndarray,
-                variance of each class
+        image : ndarray
+            3D gray scale structural image
+        mu : ndarray
+            mean of each class
+        sigmasq : ndarray
+            variance of each class
         nclasses : int
-                number of classes
+            number of classes
 
         Returns
         -------
-        nloglike : ndarray,
-                4D negloglikelihood for each class in each volume
+        nloglike : ndarray
+            4D negloglikelihood for each class in each volume
         """
         cdef int l
         nloglike = np.zeros(image.shape + (nclasses,), dtype=np.float64)
@@ -163,23 +163,23 @@ class ConstantObservationModel(object):
 
         Parameters
         -----------
-        img : ndarray,
+        img : ndarray
             3D structural gray-scale image
-        nclasses : int,
+        nclasses : int
             number of tissue classes
-        mu : ndarray,
+        mu : ndarray
             1 x nclasses, current estimate of the mean of each tissue class
-        sigmasq : ndarray,
+        sigmasq : ndarray
             1 x nclasses, current estimate of the variance of each
             tissue class
-        P_L_N : ndarray,
+        P_L_N : ndarray
             4D probability map of the label given the neighborhood.
 
         Previously computed by function prob_neighborhood
 
         Returns
         --------
-        P_L_Y : ndarray,
+        P_L_Y : ndarray
             4D probability of the label given the input image
         """
         cdef int l
@@ -205,22 +205,22 @@ class ConstantObservationModel(object):
 
         Parameters
         -----------
-        image : ndarray,
-                3D structural gray-scale image
-        P_L_Y : ndarray,
-                4D probability map of the label given the input image
-                computed by the expectation maximization (EM) algorithm
-        mu : ndarray,
-                1 x nclasses, current estimate of the mean of each tissue
-                class.
-        nclasses : int,
-                number of tissue classes
+        image : ndarray
+            3D structural gray-scale image
+        P_L_Y : ndarray
+            4D probability map of the label given the input image
+            computed by the expectation maximization (EM) algorithm
+        mu : ndarray
+            1 x nclasses, current estimate of the mean of each tissue
+            class.
+        nclasses : int
+            number of tissue classes
 
         Returns
         --------
-        mu_upd : ndarray,
+        mu_upd : ndarray
                 1 x nclasses, updated mean of each tissue class
-        var_upd : ndarray,
+        var_upd : ndarray
                 1 x nclasses, updated variance of each tissue class
         """
         cdef int l
@@ -245,24 +245,24 @@ class ConstantObservationModel(object):
 
         Parameters
         -----------
-        image : ndarray,
-                3D structural gray-scale image
-        P_L_Y : ndarray,
-                4D probability map of the label given the input image
-                computed by the expectation maximization (EM) algorithm
-        mu : ndarray,
-                1 x nclasses, current estimate of the mean of each tissue
-                class.
-        nclasses : int,
-                number of tissue classes
+        image : ndarray
+            3D structural gray-scale image
+        P_L_Y : ndarray
+            4D probability map of the label given the input image
+            computed by the expectation maximization (EM) algorithm
+        mu : ndarray
+            1 x nclasses, current estimate of the mean of each tissue
+            class.
+        nclasses : int
+            number of tissue classes
 
         Returns
         --------
 
-        mu_upd : ndarray,
-                1 x nclasses, updated mean of each tissue class
-        var_upd : ndarray,
-                1 x nclasses, updated variance of each tissue class
+        mu_upd : ndarray
+            1 x nclasses, updated mean of each tissue class
+        var_upd : ndarray
+            1 x nclasses, updated variance of each tissue class
         """
         cdef int l
         mu_upd = np.zeros(nclasses, dtype=np.float64)
@@ -281,7 +281,7 @@ class ConstantObservationModel(object):
         return mu_upd, var_upd
 
 
-cdef void _initialize_param_uniform(double[:,:,:] image, double[:] mu,
+cdef void _initialize_param_uniform(double[:, :, :] image, double[:] mu,
                                     double[:] sigma) nogil:
     r""" Initializes the means and standard deviations uniformly
 
@@ -290,16 +290,18 @@ cdef void _initialize_param_uniform(double[:,:,:] image, double[:] mu,
 
     Parameters
     ----------
-    image : array,
-            3D structural gray-scale image
-    mu : buffer array for the mean of each tissue class
-    sigma : buffer array for the variance of each tissue class
+    image : array
+        3D structural gray-scale image
+    mu : array
+        buffer array for the mean of each tissue class
+    sigma : array
+        buffer array for the variance of each tissue class
 
     Returns
     -------
-    mu : array,
+    mu : array
         1 x nclasses, mean of each class
-    sigma : array,
+    sigma : array
         1 x nclasses, standard deviation of each class
     """
     cdef:
@@ -310,15 +312,15 @@ cdef void _initialize_param_uniform(double[:,:,:] image, double[:] mu,
         int i
         double min_val
         double max_val
-    min_val = image[0,0,0]
-    max_val = image[0,0,0]
+    min_val = image[0, 0, 0]
+    max_val = image[0, 0, 0]
     for x in range(nx):
         for y in range(ny):
             for z in range(nz):
-                if image[x,y,z] < min_val:
-                    min_val = image[x,y,z]
-                if image[x,y,z] > max_val:
-                    max_val = image[x,y,z]
+                if image[x, y, z] < min_val:
+                    min_val = image[x, y, z]
+                if image[x, y, z] > max_val:
+                    max_val = image[x, y, z]
     for i in range(nclasses):
         sigma[i] = 1.0
         mu[i] = min_val + i * (max_val - min_val)/nclasses
@@ -335,20 +337,20 @@ cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
 
     Parameters
     ----------
-    image : array,
-            3D structural gray-scale image
-    mu : array,
-            mean of each class
-    sigmasq : array,
-            variance of each class
-    classid : int,
-            class identifier
+    image : array
+        3D structural gray-scale image
+    mu : array
+        mean of each class
+    sigmasq : array
+        variance of each class
+    classid : int
+        class identifier
     neglogl : buffer for the neg-loglikelihood
 
     Returns
     -------
-    neglogl : array,
-            neg-loglikelihood for the class (l = classid)
+    neglogl : array
+        neg-loglikelihood for the class (l = classid)
     """
     cdef:
         cnp.npy_intp nx = image.shape[0]
@@ -386,28 +388,28 @@ cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
 
     Parameters
     -----------
-    image : array,
-            3D structural gray-scale image
+    image : array
+        3D structural gray-scale image
     gaussian : array
-            3D buffer for the gaussian distribution that is multiplied by
-            P_L_N to make P_L_Y
-    mu : array,
-            current estimate of the mean of each tissue class
-    sigmasq : array,
-            current estimate of the variance of each tissue
-            class
-    classid : int,
-            tissue class identifier
-    P_L_N : array,
-            4D probability map of the label given the neighborhood.
-            Previously computed by function prob_neighborhood
+        3D buffer for the gaussian distribution that is multiplied by
+        P_L_N to make P_L_Y
+    mu : array
+        current estimate of the mean of each tissue class
+    sigmasq : array
+        current estimate of the variance of each tissue
+        class
+    classid : int
+        tissue class identifier
+    P_L_N : array
+        4D probability map of the label given the neighborhood.
+        Previously computed by function prob_neighborhood
     P_L_Y : array
-            4D buffer to hold P(L|Y)
+        4D buffer to hold P(L|Y)
 
     Returns
     --------
-    P_L_Y : array,
-            4D probability of the label given the input image P(L|Y)
+    P_L_Y : array
+        4D probability of the label given the input image P(L|Y)
     """
     cdef:
         cnp.npy_intp nx = image.shape[0]
@@ -451,14 +453,14 @@ class IteratedConditionalModes(object):
 
         Parameters
         ----------
-        nloglike : ndarray,
-                4D shape, nloglike[x,y,z,k] is the likelihhood of class k
-                for voxel (x, y, z)
+        nloglike : ndarray
+            4D shape, nloglike[x, y, z, k] is the likelihhood of class k
+            for voxel (x, y, z)
 
         Returns
         --------
-        seg : ndarray,
-                3D initial segmentation
+        seg : ndarray
+            3D initial segmentation
         """
         seg = np.zeros(nloglike.shape[:3]).astype(np.int16)
 
@@ -476,22 +478,22 @@ class IteratedConditionalModes(object):
 
         Parameters
         ----------
-        nloglike : ndarray,
-                4D shape, nloglike[x,y,z,k] is the negative log likelihood
-                of class k at voxel (x,y,z)
-        beta : float,
-                positive scalar, it is the parameter of the Potts/Ising
-                model. Determines the smoothness of the output segmentation.
-        seg : ndarray,
-                3D initial segmentation. This segmentation will change by one
-                iteration of the ICM algorithm
+        nloglike : ndarray
+            4D shape, nloglike[x, y, z, k] is the negative log likelihood
+            of class k at voxel (x, y, z)
+        beta : float
+            positive scalar, it is the parameter of the Potts/Ising
+            model. Determines the smoothness of the output segmentation.
+        seg : ndarray
+            3D initial segmentation. This segmentation will change by one
+            iteration of the ICM algorithm
 
         Returns
         -------
-        new_seg : ndarray,
-                3D final segmentation
-        energy : ndarray,
-                3D final energy
+        new_seg : ndarray
+            3D final segmentation
+        energy : ndarray
+            3D final energy
         """
         energy = np.zeros(nloglike.shape[:3]).astype(np.float64)
 
@@ -510,18 +512,18 @@ class IteratedConditionalModes(object):
 
         Parameters
         -----------
-        seg : ndarray,
+        seg : ndarray
             3D tissue segmentation derived from the ICM model
-        beta : float,
+        beta : float
             scalar that determines the importance of the neighborhood and
             the spatial smoothness of the segmentation.
             Usually between 0 to 0.5
-        nclasses : int,
+        nclasses : int
             number of tissue classes
 
         Returns
         --------
-        PLN : ndarray,
+        PLN : ndarray
             4D probability map of the label given the neighborhood of the
             voxel.
         """
@@ -560,7 +562,8 @@ cdef void _initialize_maximum_likelihood(double[:,:,:,:] nloglike,
     Parameters
     ----------
     nloglike : array
-        4D nloglike[x,y,z,k] is the likelihhood of class k for voxel (x,y,z)
+        4D nloglike[x, y, z, k] is the likelihhood of class k for voxel
+        (x, y, z)
     seg : array
         3D buffer for the initial segmentation
 
@@ -600,27 +603,27 @@ cdef void _icm_ising(double[:,:,:,:] nloglike, double beta,
 
     Parameters
     ----------
-    nloglike : array,
-            4D nloglike[x,y,z,k] is the negative log likelihood of class k
-            at voxel (x,y,z)
-    beta : float,
-            positive scalar, it is the parameter of the Potts/Ising model.
-            Determines the smoothness of the output segmentation
-    seg : array,
-            3D initial segmentation.
-            This segmentation will change by one iteration of the ICM algorithm
-    energy : array,
-            3D buffer for the energy
-    new_seg : array,
-            3D buffer for the final segmentation
+    nloglike : array
+        4D nloglike[x, y, z, k] is the negative log likelihood of class k
+        at voxel (x, y, z)
+    beta : float
+        positive scalar, it is the parameter of the Potts/Ising model.
+        Determines the smoothness of the output segmentation
+    seg : array
+        3D initial segmentation.
+        This segmentation will change by one iteration of the ICM algorithm
+    energy : array
+        3D buffer for the energy
+    new_seg : array
+        3D buffer for the final segmentation
 
     Returns
     -------
-    energy : array,
-            3D map of the energy for every voxel
-    new_seg : array,
-            3D new final segmentation (there is a new one after each
-            iteration).
+    energy : array
+        3D map of the energy for every voxel
+    new_seg : array
+        3D new final segmentation (there is a new one after each
+        iteration).
     """
     cdef:
         cnp.npy_intp nneigh = 6
@@ -678,22 +681,23 @@ cdef void _prob_class_given_neighb(cnp.npy_short[:, :, :] seg, double beta,
 
     Parameters
     -----------
-    image : array,
-            3D structural gray-scale image
-    seg : array,
-            3D tissue segmentation derived from the ICM model
-    beta : float,
-            scalar that determines the importance of the neighborhood and the
-            spatial smoothness of the segmentation. Usually between 0 to 0.5
-    classid : int,
-            tissue class identifier
-    P_L_N : buffer array for P(L|N)
+    image : array
+        3D structural gray-scale image
+    seg : array
+        3D tissue segmentation derived from the ICM model
+    beta : float
+        scalar that determines the importance of the neighborhood and the
+        spatial smoothness of the segmentation. Usually between 0 to 0.5
+    classid : int
+        tissue class identifier
+    P_L_N : array
+        buffer array for P(L|N)
 
     Returns
     --------
-    P_L_N : array,
-            3D map of the probability of the label (l) given the neighborhood
-            of the voxel P(L|N)
+    P_L_N : array
+        3D map of the probability of the label (l) given the neighborhood
+        of the voxel P(L|N)
     """
     cdef:
         cnp.npy_intp nx = seg.shape[0]


### PR DESCRIPTION
This PR improves the performance of tissue classification by modifying the Cython code in the `seg_stats` method of `ConstantObservationModel` to avoid high overhead. There should be no change in behavior with this PR.

This initial call to `seg_stats` in the `classify` method of `TissueClassifierHMRF` for the example data in `doc/demo/tissue_classification.py` takes > 60 seconds on my system prior to this PR and ~60 ms afterwards. So, the setup prior to iteration is now nearly instantaneous. The iterated conditional modes loop itself still takes the same time as before (~2 minutes), giving an overall speedup of around 30% for the demo.

I would recommend reviewing the first commit in isolation as it has all of the important changes.
The remaining commits are just minor maintenance/style fixes.
