### PR TITLE
Add full SH basis

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1031,8 +1031,10 @@ def sf_to_sh(sf, sphere, sh_order=4, basis_type=None, smooth=0.0):
         ``None`` for the default DIPY basis,
         ``tournier07`` for the symmetric Tournier 2007 [2]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
-        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd orders, and
-        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd orders
+        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd and\
+                            even order terms, and
+        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd and\
+                              even order terms
         (``None`` defaults to ``descoteaux07``).
     smooth : float, optional
         Lambda-regularization in the SH fit (default 0.0).
@@ -1086,8 +1088,10 @@ def sh_to_sf(sh, sphere, sh_order=4, basis_type=None):
         ``None`` for the default DIPY basis,
         ``tournier07`` for the symmetric Tournier 2007 [2]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
-        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd orders, and
-        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd orders
+        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd and\
+                            even order terms, and
+        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd and\
+                              even order terms
         (``None`` defaults to ``descoteaux07``).
 
     Returns
@@ -1137,8 +1141,10 @@ def sh_to_sf_matrix(sphere, sh_order=4, basis_type=None, return_inv=True,
         ``None`` for the default DIPY basis,
         ``tournier07`` for the symmetric Tournier 2007 [2]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
-        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd orders, and
-        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd orders
+        ``tournier07_full`` for Tournier 2007 [2]_ basis with odd and\
+                            even order terms, and
+        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd and\
+                              even order terms
         (``None`` defaults to ``descoteaux07``).
     return_inv : bool
         If True then the inverse of the matrix is also returned

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1032,7 +1032,7 @@ def sf_to_sh(sf, sphere, sh_order=4, basis_type=None, smooth=0.0):
         ``tournier07`` for the symmetric Tournier 2007 [2]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
         ``tournier07_full`` for Tournier 2007 [2]_ basis with odd orders, and
-        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with orders
+        ``descoteaux07_full`` for Descoteaux 2007 [1]_ basis with odd orders
         (``None`` defaults to ``descoteaux07``).
     smooth : float, optional
         Lambda-regularization in the SH fit (default 0.0).

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -1,12 +1,11 @@
 """
 ==========================================================
-Spherical function approximation using spherical harmonics
+Signal Reconstruction Using Spherical Harmonics
 ==========================================================
 
-This example shows how you can use spherical harmonics function to reconstruct
-any spherical function using DIPY_. Before we can reconstruct a signal, we need
-to generate one. To do so, we will use the sphere created in
-:ref:`example_gradients_spheres`.
+This example shows how you can use a spherical harmonics (SH) function to
+reconstruct any spherical function using DIPY_. In order to generate a
+signal, we will use the sphere created in :ref:`example_gradients_spheres`.
 """
 
 import numpy as np
@@ -14,9 +13,9 @@ from gradients_spheres import sph
 
 """
 We now need to create our initial signal. To do so, we will use our sphere's
-vertices as the points on which our spherical function (SF) is sampled. We will
+vertices as the sampled points of our spherical function (SF). We will
 use ``multi_tensor_odf`` to simulate an ODF. For more information on how to use
-DIPY_ to simulate a signal and a ODF, see :ref:`example_simulate_multi_tensor`.
+DIPY_ to simulate a signal and ODF, see :ref:`example_simulate_multi_tensor`.
 """
 
 from dipy.sims.voxel import multi_tensor_odf
@@ -48,14 +47,14 @@ if interactive:
 .. figure:: symm_signal.png
    :align: center
 
-   Illustration of the simulated signal on a sphere of 64 points
+   Illustration of the simulated signal sampled on a sphere of 64 points
    per hemisphere
 
-We can now express this signal in term of spherical harmonics (SH) coefficients
-using ``sf_to_sh``. This function converts a spherical function (SF) on the
-sphere in a series of SH coefficients. For more information on SH, see
-:ref:`sh_basis`. For this example, we will use the ``descoteaux07`` basis up to
-maximum order 8.
+We can now express this signal as a series of SH coefficients using
+``sf_to_sh``. This function converts a series of SF coefficients in a series of
+SH coefficients. For more information on SH basis, see :ref:`sh-basis`. For
+this example, we will use the ``descoteaux07`` basis up to a maximum SH order
+of 8.
 """
 
 from dipy.reconst.shm import sf_to_sh
@@ -68,12 +67,10 @@ sh_order = 8
 sh_coeffs = sf_to_sh(odf, sph, sh_order, sh_basis)
 
 """
-``sh_coeffs`` is an array containing the SH coefficients defining our initial
-ODF. We can use it as input of ``sh_to_sf`` to reconstruct our original signal.
-From the SH coefficients, it is possible to project our SF on a sphere of
-higher resolution than our original signal. We will now reproject our signal
-expressed in terms of SH coefficients on a high resolution sphere using
-``sh_to_sf``.
+``sh_coeffs`` is an array containing the SH coefficients multiplying the SH
+functions of the chosen basis. We can use it as input of ``sh_to_sf`` to
+reconstruct our original signal. We will now reproject our signal on a high
+resolution sphere using ``sh_to_sf``.
 """
 
 from dipy.data import get_sphere
@@ -96,7 +93,8 @@ if interactive:
 .. figure:: symm_reconst.png
    :align: center
 
-   Reconstruction of a symmetric simulated signal on a high resolution sphere
+   Reconstruction of a symmetric signal on a high resolution sphere using a
+   symmetric basis
 
 While a symmetric SH basis works well for reconstructing symmetric SF, it fails
 to do so on asymmetric signals. We will now create such a signal by using a
@@ -124,7 +122,7 @@ if interactive:
 .. figure:: asym_signal.png
    :align: center
 
-   Illustration of an asymmetric simulated signal on a sphere of 64
+   Illustration of an asymmetric signal sampled on a sphere of 64
    points per hemisphere
 
 Let's try to reconstruct this SF using a symmetric SH basis.

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -1,0 +1,183 @@
+"""
+==========================================================
+Spherical function approximation using spherical harmonics
+==========================================================
+
+This example shows how you can use spherical harmonics function to reconstruct
+any spherical function using DIPY_. Before we can reconstruct a signal, we need
+to generate one. To do so, we will use the sphere created in
+:ref:`example_gradients_spheres`.
+"""
+
+import numpy as np
+from gradients_spheres import sph
+
+"""
+We now need to create our initial signal. To do so, we will use our sphere's
+vertices as the points on which our spherical function (SF) is sampled. We will
+use ``multi_tensor_odf`` to simulate an ODF. For more information on how to use
+DIPY_ to simulate a signal and a ODF, see :ref:`example_simulate_multi_tensor`.
+"""
+
+from dipy.sims.voxel import multi_tensor_odf
+
+mevals = np.array([[0.0015, 0.00015, 0.00015],
+                   [0.0015, 0.00015, 0.00015]])
+angles = [(0, 0), (60, 0)]
+odf = multi_tensor_odf(sph.vertices, mevals, angles, [50, 50])
+
+
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
+ren.SetBackground(1, 1, 1)
+
+odf_actor = actor.odf_slicer(odf[None, None, None, :], sphere=sph)
+odf_actor.RotateX(90)
+ren.add(odf_actor)
+
+print('Saving illustration as symm_signal.png')
+window.record(ren, out_path='symm_signal.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
+"""
+.. figure:: symm_signal.png
+   :align: center
+
+   Illustration of the simulated signal on a sphere of 64 points
+   per hemisphere
+
+We can now express this signal in term of spherical harmonics (SH) coefficients
+using ``sf_to_sh``. This function converts a spherical function (SF) on the
+sphere in a series of SH coefficients. For more information on SH, see
+:ref:`sh_basis`. For this example, we will use the ``descoteaux07`` basis up to
+maximum order 8.
+"""
+
+from dipy.reconst.shm import sf_to_sh
+
+# Change this value to try out other bases
+sh_basis = 'descoteaux07'
+# Change this value to try other maximum orders
+sh_order = 8
+
+sh_coeffs = sf_to_sh(odf, sph, sh_order, sh_basis)
+
+"""
+``sh_coeffs`` is an array containing the SH coefficients defining our initial
+ODF. We can use it as input of ``sh_to_sf`` to reconstruct our original signal.
+From the SH coefficients, it is possible to project our SF on a sphere of
+higher resolution than our original signal. We will now reproject our signal
+expressed in terms of SH coefficients on a high resolution sphere using
+``sh_to_sf``.
+"""
+
+from dipy.data import get_sphere
+from dipy.reconst.shm import sh_to_sf
+
+high_res_sph = get_sphere('symmetric724').subdivide(2)
+reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis)
+
+window.rm_all(ren)
+odf_actor = actor.odf_slicer(reconst[None, None, None, :], sphere=high_res_sph)
+odf_actor.RotateX(90)
+ren.add(odf_actor)
+
+print('Saving output as symm_reconst.png')
+window.record(ren, out_path='symm_reconst.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
+"""
+.. figure:: symm_reconst.png
+   :align: center
+
+   Reconstruction of a symmetric simulated signal on a high resolution sphere
+
+While a symmetric SH basis works well for reconstructing symmetric SF, it fails
+to do so on asymmetric signals. We will now create such a signal by using a
+different ODF for each hemisphere of our sphere.
+"""
+
+mevals = np.array([[0.0015, 0.0003, 0.0003]])
+angles = [(0, 0)]
+odf2 = multi_tensor_odf(sph.vertices, mevals, angles, [100])
+
+n_pts_hemisphere = int(sph.vertices.shape[0] / 2)
+asym_odf = np.append(odf[:n_pts_hemisphere], odf2[n_pts_hemisphere:])
+
+window.rm_all(ren)
+odf_actor = actor.odf_slicer(asym_odf[None, None, None, :], sphere=sph)
+odf_actor.RotateX(90)
+ren.add(odf_actor)
+
+print('Saving output as asym_signal.png')
+window.record(ren, out_path='asym_signal.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
+"""
+.. figure:: asym_signal.png
+   :align: center
+
+   Illustration of an asymmetric simulated signal on a sphere of 64
+   points per hemisphere
+
+Let's try to reconstruct this SF using a symmetric SH basis.
+"""
+
+sh_coeffs = sf_to_sh(asym_odf, sph, sh_order, sh_basis)
+reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis)
+
+window.rm_all(ren)
+odf_actor = actor.odf_slicer(reconst[None, None, None, :], sphere=high_res_sph)
+odf_actor.RotateX(90)
+ren.add(odf_actor)
+
+print('Saving output as asym_reconst.png')
+window.record(ren, out_path='asym_reconst.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
+"""
+.. figure:: asym_reconst.png
+   :align: center
+
+   Reconstruction of an asymmetric signal using a symmetric SH basis
+
+As we can see, a symmetric basis fails to properly represent asymmetric SF.
+Fortunately, DIPY_ also implements full SH bases, which can deal with symmetric
+as well as asymmetric signals. For this tutorial, we will demonstrate it using
+the ``descoteaux07_full`` SH basis.
+"""
+
+# Change this value to try out other bases
+sh_basis = 'descoteaux07_full'
+
+sh_coeffs = sf_to_sh(asym_odf, sph, sh_order, sh_basis)
+reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis)
+
+window.rm_all(ren)
+odf_actor = actor.odf_slicer(reconst[None, None, None, :], sphere=high_res_sph)
+odf_actor.RotateX(90)
+ren.add(odf_actor)
+
+print('Saving output as asym_reconst_full.png')
+window.record(ren, out_path='asym_reconst_full.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
+"""
+.. figure:: asym_reconst_full.png
+    :align: center
+
+    Reconstruction of an asymmetric signal using a full SH basis
+
+As we can see, a full SH basis properly reconstruct asymmetric signal.
+
+.. include:: ../links_names.inc
+"""

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -18,6 +18,7 @@
  reconst_mapmri.py
  reconst_mcsd.py
  reconst_qtdmri.py
+ reconst_sh.py
  reconst_shore.py
  reconst_shore_metrics.py
  kfold_xval.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -143,6 +143,11 @@ Statistical evaluation
 
 - :ref:`example_kfold_xval`
 
+Spherical harmonics reconstruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :ref:`example_reconst_sh`
+
 ----------------------
 Contextual enhancement
 ----------------------

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -143,8 +143,8 @@ Statistical evaluation
 
 - :ref:`example_kfold_xval`
 
-Spherical harmonics reconstruction
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Intra-Voxel Signal Reconstruction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reconst_sh`
 

--- a/doc/theory/sh_basis.rst
+++ b/doc/theory/sh_basis.rst
@@ -65,9 +65,15 @@ literature for the computation of the ODF. DIPY implements two of these in the
 In both cases, $\Re$ denotes the real part of the spherical harmonic basis, and
 $\Im$ denotes the imaginary part.
 
-In practice, a maximum even order $k$ is chosen such that $k \leq l$. The
-choice of an even order is motivated by the symmetry of the diffusion process
-around the origin.
+In practice, a maximum even order $k$ is chosen such that $k \leq l$. By only
+taking into account even order SH functions, the above bases can be used to
+reconstruct symmetric spherical functions. The choice of an even order is
+motivated by the symmetry of the diffusion process around the origin.
+
+Both bases are also available as full SH bases, where odd order SH functions are
+also taken into account when reconstructing a spherical function. These full
+bases can successfully reconstruct asymmetric signals as well as symmetric
+signals.
 
 Descoteaux *et al.* [1]_ use the Q-Ball Imaging (QBI) formalization to recover
 the ODF, while Tournier *et al.* [2]_ use the Spherical Deconvolution (SD)


### PR DESCRIPTION
Add bases `descoteaux07_full `and `tournier07_full` as available SH basis in `dipy/reconst/shm.py`. These bases add odd order spherical harmonics to the symmetric basis and can approximate symmetric and asymmetric spherical functions. New functions are `real_full_sh_mrtrix` (tournier07_full), `real_full_sh_basis` (descoteaux07_full) and `sph_harm_full_ind_list` (used to construct index list of orders and degrees of the complete SH basis).