### PR TITLE
NF: Complete masking implementation in affine registration with MI

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -933,6 +933,12 @@ class AffineRegistration(object):
         n = transform.get_number_of_parameters()
         self.nparams = n
 
+        static_masked, moving_masked = static, moving
+        if static_mask:
+            static_masked = static*static_mask
+        if moving_mask:
+            moving_masked = moving*moving_mask
+
         if params0 is None:
             params0 = self.transform.get_identity_parameters()
         self.params0 = params0
@@ -940,9 +946,9 @@ class AffineRegistration(object):
             self.starting_affine = np.eye(self.dim + 1)
         elif isinstance(starting_affine, str):
             if starting_affine == 'mass':
-                affine_map = transform_centers_of_mass(static,
+                affine_map = transform_centers_of_mass(static_masked,
                                                        static_grid2world,
-                                                       moving,
+                                                       moving_masked,
                                                        moving_grid2world)
                 self.starting_affine = affine_map.affine
             elif starting_affine == 'voxel-origin':
@@ -968,10 +974,10 @@ class AffineRegistration(object):
         moving_direction, moving_spacing = \
             get_direction_and_spacings(moving_grid2world, self.dim)
 
-        static = ((static.astype(np.float64) - static.min()) /
-                  (static.max() - static.min()))
-        moving = ((moving.astype(np.float64) - moving.min()) /
-                  (moving.max() - moving.min()))
+        static = ((static.astype(np.float64) - static_masked.min()) /
+                  (static_masked.max() - static_masked.min()))
+        moving = ((moving.astype(np.float64) - moving_masked.min()) /
+                  (moving_masked.max() - moving_masked.min()))
 
         # Build the scale space of the input images
         if self.use_isotropic:

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -985,42 +985,20 @@ class AffineRegistration(object):
                                                  self.sigmas,
                                                  moving_grid2world,
                                                  moving_spacing, False)
-            if not moving_mask is None:
-                self.moving_mask_ss = IsotropicScaleSpace(
-                    moving_mask, self.factors,
-                    [0]*len(self.factors),
-                    moving_grid2world,
-                    moving_spacing, False)
 
             self.static_ss = IsotropicScaleSpace(static, self.factors,
                                                  self.sigmas,
                                                  static_grid2world,
                                                  static_spacing, False)
-            if not static_mask is None:
-                self.static_mask_ss = IsotropicScaleSpace(
-                    static_mask, self.factors,
-                    [0]*len(self.factors),
-                    static_grid2world,
-                    static_spacing, False)
 
         else:
             self.moving_ss = ScaleSpace(moving, self.levels, moving_grid2world,
                                         moving_spacing, self.ss_sigma_factor,
                                         False)
-            if not moving_mask is None:
-                self.moving_mask_ss = ScaleSpace(
-                    moving_mask, self.levels, moving_grid2world,
-                    moving_spacing, 1,
-                    False)
 
             self.static_ss = ScaleSpace(static, self.levels, static_grid2world,
                                         static_spacing, self.ss_sigma_factor,
                                         False)
-            if not static_mask is None:
-                self.static_ss = ScaleSpace(
-                    static_mask, self.levels, static_grid2world,
-                    static_spacing, 1,
-                    False)
 
     def optimize(self, static, moving, transform, params0,
                  static_grid2world=None, moving_grid2world=None,
@@ -1115,20 +1093,17 @@ class AffineRegistration(object):
             current_static = current_affine_map.transform(smooth_static)
             current_static_mask = None
             if not static_mask is None:
-                current_static_mask = self.static_mask_ss.get_image(level) > 0
+                current_static_mask = current_affine_map.transform(static_mask) > 0
 
             # The moving image is full resolution
             current_moving_grid2world = original_moving_grid2world
 
             current_moving = self.moving_ss.get_image(level)
-            current_moving_mask = None
-            if not moving_mask is None:
-                current_moving_mask = self.moving_mask_ss.get_image(level) > 0
             # Prepare the metric for iterations at this resolution
             self.metric.setup(transform, current_static, current_moving,
                               current_static_grid2world,
                               current_moving_grid2world, self.starting_affine,
-                              current_static_mask, current_moving_mask)
+                              current_static_mask, moving_mask)
 
             # Optimize this level
             if self.options is None:

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -934,9 +934,9 @@ class AffineRegistration(object):
         self.nparams = n
 
         static_masked, moving_masked = static, moving
-        if static_mask:
+        if not static_mask is None:
             static_masked = static*static_mask
-        if moving_mask:
+        if not moving_mask is None:
             moving_masked = moving*moving_mask
 
         if params0 is None:
@@ -985,7 +985,7 @@ class AffineRegistration(object):
                                                  self.sigmas,
                                                  moving_grid2world,
                                                  moving_spacing, False)
-            if moving_mask:
+            if not moving_mask is None:
                 self.moving_mask_ss = IsotropicScaleSpace(
                     moving_mask, self.factors,
                     [0]*len(self.factors),
@@ -996,7 +996,7 @@ class AffineRegistration(object):
                                                  self.sigmas,
                                                  static_grid2world,
                                                  static_spacing, False)
-            if static_mask:
+            if not static_mask is None:
                 self.static_mask_ss = IsotropicScaleSpace(
                     static_mask, self.factors,
                     [0]*len(self.factors),
@@ -1007,7 +1007,7 @@ class AffineRegistration(object):
             self.moving_ss = ScaleSpace(moving, self.levels, moving_grid2world,
                                         moving_spacing, self.ss_sigma_factor,
                                         False)
-            if moving_mask:
+            if not moving_mask is None:
                 self.moving_mask_ss = ScaleSpace(
                     moving_mask, self.levels, moving_grid2world,
                     moving_spacing, 1,
@@ -1016,7 +1016,7 @@ class AffineRegistration(object):
             self.static_ss = ScaleSpace(static, self.levels, static_grid2world,
                                         static_spacing, self.ss_sigma_factor,
                                         False)
-            if static_mask:
+            if not static_mask is None:
                 self.static_ss = ScaleSpace(
                     static_mask, self.levels, static_grid2world,
                     static_spacing, 1,
@@ -1114,7 +1114,7 @@ class AffineRegistration(object):
                                            original_static_grid2world)
             current_static = current_affine_map.transform(smooth_static)
             current_static_mask = None
-            if static_mask:
+            if not static_mask is None:
                 current_static_mask = self.static_mask_ss.get_image(level) > 0
 
             # The moving image is full resolution
@@ -1122,7 +1122,7 @@ class AffineRegistration(object):
 
             current_moving = self.moving_ss.get_image(level)
             current_moving_mask = None
-            if moving_mask:
+            if not moving_mask is None:
                 current_moving_mask = self.moving_mask_ss.get_image(level) > 0
             # Prepare the metric for iterations at this resolution
             self.metric.setup(transform, current_static, current_moving,


### PR DESCRIPTION
I noticed that the ParzenJointHistogram can use binary mask, so I changed the mutual-info and registration code to be able to use it, as masking can sometime improve the registration.

For the moment, there is no testing nor updated doc, nor pep8 (will do if there is interest in merging).

Comments and advices are welcomed. 

Thanks.