### PR TITLE
BUAN bundle highlight option in horizon

### DIFF
--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -80,8 +80,8 @@ HELP_MESSAGE = """
 
 class Horizon(object):
 
-    def __init__(self, tractograms=None, images=None, pams=None, np_files=None,
-                 cluster=False, cluster_thr=15.0,
+    def __init__(self, tractograms=None, images=None, pams=None,
+                 npy_files=None, cluster=False, cluster_thr=15.0,
                  random_colors=False, length_gt=0, length_lt=1000,
                  clusters_gt=0, clusters_lt=10000,
                  world_coords=True, interactive=True,
@@ -100,7 +100,7 @@ class Horizon(object):
             Each tuple contains data and affine
         pams : sequence of PeakAndMetrics
             Contains peak directions and spherical harmonic coefficients
-        np_files : sequence of arrays
+        npy_files : sequence of arrays
             Contains numpy array with pvalues along the length of bundles
             extracted from BUAN framework.
         cluster : bool
@@ -774,7 +774,7 @@ class Horizon(object):
                           reset_camera=False)
 
 
-def horizon(tractograms=None, images=None, pams=None, np_files=None,
+def horizon(tractograms=None, images=None, pams=None, npy_files=None,
             cluster=False, cluster_thr=15.0,
             random_colors=False, bg_color=(0, 0, 0), order_transparent=True,
             length_gt=0, length_lt=1000, clusters_gt=0, clusters_lt=10000,
@@ -792,7 +792,7 @@ def horizon(tractograms=None, images=None, pams=None, np_files=None,
         Each tuple contains data and affine
     pams : sequence of PeakAndMetrics
         Contains peak directions and spherical harmonic coefficients
-    np_files : sequence of arrays
+    npy_files : sequence of arrays
         Contains numpy array with pvalues along the length of bundles
         extracted from BUAN framework.
     cluster : bool
@@ -847,7 +847,7 @@ def horizon(tractograms=None, images=None, pams=None, np_files=None,
         adaptive visualization, Proceedings of: International Society of
         Magnetic Resonance in Medicine (ISMRM), Montreal, Canada, 2019.
     """
-    hz = Horizon(tractograms, images, pams, np_files, cluster, cluster_thr,
+    hz = Horizon(tractograms, images, pams, npy_files, cluster, cluster_thr,
                  random_colors, length_gt, length_lt,
                  clusters_gt, clusters_lt,
                  world_coords, interactive,

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -83,7 +83,7 @@ class Horizon(object):
 
 
     def __init__(self, tractograms=None, images=None, pams=None,
-                 npy_files=None, cluster=False, cluster_thr=15.0,
+                 cluster=False, cluster_thr=15.0,
                  random_colors=False, length_gt=0, length_lt=1000,
                  clusters_gt=0, clusters_lt=10000,
                  world_coords=True, interactive=True,
@@ -102,10 +102,6 @@ class Horizon(object):
             Each tuple contains data and affine
         pams : sequence of PeakAndMetrics
             Contains peak directions and spherical harmonic coefficients
-        npy_files : sequence of arrays
-
-            Contains numpy array with pvalues along the length of bundles
-            extracted from BUAN framework.
         cluster : bool
             Enable QuickBundlesX clustering
         cluster_thr : float
@@ -778,7 +774,7 @@ class Horizon(object):
 
 
 
-def horizon(tractograms=None, images=None, pams=None, npy_files=None,
+def horizon(tractograms=None, images=None, pams=None,
             cluster=False, cluster_thr=15.0,
             random_colors=False, bg_color=(0, 0, 0), order_transparent=True,
             length_gt=0, length_lt=1000, clusters_gt=0, clusters_lt=10000,
@@ -796,9 +792,6 @@ def horizon(tractograms=None, images=None, pams=None, npy_files=None,
         Each tuple contains data and affine
     pams : sequence of PeakAndMetrics
         Contains peak directions and spherical harmonic coefficients
-    npy_files : sequence of arrays
-        Contains numpy array with pvalues along the length of bundles
-        extracted from BUAN framework.
     cluster : bool
         Enable QuickBundlesX clustering
     cluster_thr : float
@@ -852,7 +845,7 @@ def horizon(tractograms=None, images=None, pams=None, npy_files=None,
         Magnetic Resonance in Medicine (ISMRM), Montreal, Canada, 2019.
     """
 
-    hz = Horizon(tractograms, images, pams, npy_files, cluster, cluster_thr,
+    hz = Horizon(tractograms, images, pams, cluster, cluster_thr,
                  random_colors, length_gt, length_lt,
                  clusters_gt, clusters_lt,
                  world_coords, interactive,

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -142,8 +142,8 @@ class Horizon(object):
         order_transparent : bool
             Default True. Use depth peeling to sort transparent objects.
             If True also enables anti-aliasing.
-        buan : bool
-            Enables BUAN framework visualization.
+        buan : bool, optional
+            Enables BUAN framework visualization. Default is False.
         buan_colors : list, optional
             List of colors for bundles.
 
@@ -291,11 +291,9 @@ class Horizon(object):
                     apply_shader(self, centroid_actor)
 
             else:
-                if self.buan:
-                    streamline_actor = actor.line(streamlines,
-                                                  self.buan_colors[color_ind])
-                else:
-                    streamline_actor = actor.line(streamlines, colors=colors)
+
+                s_colors = self.buan_colors[color_ind] if self.buan else colors
+                streamline_actor = actor.line(streamlines, colors=s_colors)
 
                 streamline_actor.GetProperty().SetEdgeVisibility(1)
                 streamline_actor.GetProperty().SetRenderLinesAsTubes(1)
@@ -823,8 +821,8 @@ def horizon(tractograms=None, images=None, pams=None,
     interactive : bool
         Allow user interaction. If False then Horizon goes on stealth mode
         and just saves pictures.
-    buan : bool
-        Enables BUAN framework visualization.
+    buan : bool, optional
+        Enables BUAN framework visualization. Default is False.
     buan_colors : list, optional
         List of colors for bundles.
     out_png : string

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -67,6 +67,13 @@ def test_horizon_flow():
             clusters_lt=np.inf, clusters_gt=0,
             world_coords=True, interactive=False)
 
+    buan_colors = np.ones(streamlines.get_data().shape)
+
+    print(buan_colors)
+    horizon(tractograms, buan=True, buan_colors=buan_colors,
+            world_coords=True, interactive=False)
+
+
     data = 255 * np.random.rand(197, 233, 189)
 
     images = [(data, affine)]
@@ -80,12 +87,16 @@ def test_horizon_flow():
 
         fimg = os.path.join(out_dir, 'test.nii.gz')
         ftrk = os.path.join(out_dir, 'test.trk')
+        fnpy = os.path.join(out_dir, 'test.npy')
 
         save_nifti(fimg, data, affine)
         dimensions = data.shape
         nii_header = create_nifti_header(affine, dimensions, vox_size)
         sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
         save_tractogram(sft, ftrk, bbox_valid_check=False)
+
+        pvalues = np.random.uniform(low=0, high=1, size=(10,))
+        np.save(fnpy, pvalues)
 
         input_files = [ftrk, fimg]
 
@@ -105,6 +116,17 @@ def test_horizon_flow():
                     out_dir=out_dir, out_stealth_png='tmp_x.png')
         npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
                          True)
+
+        input_files = [ftrk, fnpy]
+
+        npt.assert_equal(len(input_files), 2)
+
+        hz_flow.run(input_files=input_files, stealth=True, bg_color=[0.5, ],
+                    buan=True, buan_thr=0.5, buan_highlight=(1,1,0),
+                    out_dir=out_dir, out_stealth_png='tmp_x.png')
+        npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
+                         True)
+
 
 
 

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -121,7 +121,7 @@ def test_horizon_flow():
         npt.assert_equal(len(input_files), 2)
 
         hz_flow.run(input_files=input_files, stealth=True, bg_color=[0.5, ],
-                    buan=True, buan_thr=0.5, buan_highlight=(1,1,0),
+                    buan=True, buan_thr=0.5, buan_highlight=(1, 1, 0),
                     out_dir=out_dir, out_stealth_png='tmp_x.png')
         npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
                          True)

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -69,7 +69,6 @@ def test_horizon_flow():
 
     buan_colors = np.ones(streamlines.get_data().shape)
 
-    print(buan_colors)
     horizon(tractograms, buan=True, buan_colors=buan_colors,
             world_coords=True, interactive=False)
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -88,6 +88,7 @@ class HorizonFlow(Workflow):
         numpy_files = []
         interactive = not stealth
         world_coords = not native_coords
+        bundle_colors = None
 
         mni_2009a = {}
         mni_2009a['affine'] = np.array([[1., 0., 0., -98.],

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -7,9 +7,14 @@ from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import create_nifti_header
 from dipy.stats.analysis import assignment_map
-from fury.colormap import line_colors
-from fury.utils import numpy_to_vtk_colors
 from vtk.util import numpy_support
+from dipy.utils.optpkg import optional_package
+
+fury, has_fury, setup_module = optional_package('fury')
+
+if has_fury:
+    from fury.colormap import line_colors
+from fury.utils import numpy_to_vtk_colors
 
 class HorizonFlow(Workflow):
 
@@ -196,7 +201,7 @@ class HorizonFlow(Workflow):
                 vtk_colors = numpy_to_vtk_colors(255 * cols_arr[colors_mapper])
                 colors = numpy_support.vtk_to_numpy(vtk_colors)
                 colors = (colors - np.min(colors))/np.ptp(colors)
-                print(colors)
+
                 for i in range(n):
 
                     if pvalues[i] < buan_thr:

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -196,9 +196,9 @@ class HorizonFlow(Workflow):
 
         order_transparent = not disable_order_transparency
         horizon(tractograms=tractograms, images=images, pams=pams,
-                np_files=numpy_files, cluster=cluster, cluster_thr=cluster_thr,
-                random_colors=random_colors, bg_color=bg_color,
-                order_transparent=order_transparent,
+                npy_files=numpy_files, cluster=cluster,
+                cluster_thr=cluster_thr, random_colors=random_colors,
+                bg_color=bg_color, order_transparent=order_transparent,
                 length_gt=length_gt, length_lt=length_lt,
                 clusters_gt=clusters_gt, clusters_lt=clusters_lt,
                 world_coords=world_coords,

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -27,7 +27,7 @@ class HorizonFlow(Workflow):
             clusters_gt=0, clusters_lt=10**8, native_coords=False,
             stealth=False, emergency_header='icbm_2009a', bg_color=(0, 0, 0),
             disable_order_transparency=False, buan=False, buan_thr=0.5,
-            buan_highlight=(1,0,0), out_dir='', out_stealth_png='tmp.png'):
+            buan_highlight=(1, 0, 0), out_dir='', out_stealth_png='tmp.png'):
         """ Interactive medical visualization - Invert the Horizon!
 
         Interact with any number of .trk, .tck or .dpy tractograms and anatomy
@@ -204,7 +204,7 @@ class HorizonFlow(Workflow):
                 for i in range(n):
 
                     if pvalues[i] < buan_thr:
-                        colors[ind==i] = buan_highlight
+                        colors[ind == i] = buan_highlight
 
                 bundle_colors.append(colors)
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -184,7 +184,8 @@ class HorizonFlow(Workflow):
                     if pvalues[ind[i]] < buan_thr:
                         colors.append([0, 1, 0])
                     else:
-                        colors.append([1, 0, 0])
+                        #colors.append([1, 0, 0])
+                        colors.append([None])
 
                 bundle_colors.append(colors)
 
@@ -196,15 +197,9 @@ class HorizonFlow(Workflow):
 
         order_transparent = not disable_order_transparency
         horizon(tractograms=tractograms, images=images, pams=pams,
-<<<<<<< HEAD
                 npy_files=numpy_files, cluster=cluster,
                 cluster_thr=cluster_thr, random_colors=random_colors,
                 bg_color=bg_color, order_transparent=order_transparent,
-=======
-                np_files=numpy_files, cluster=cluster, cluster_thr=cluster_thr,
-                random_colors=random_colors, bg_color=bg_color,
-                order_transparent=order_transparent,
->>>>>>> 9771d2a2b4c0e9f44655e623486566ce653b798c
                 length_gt=length_gt, length_lt=length_lt,
                 clusters_gt=clusters_gt, clusters_lt=clusters_lt,
                 world_coords=world_coords,

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -7,14 +7,17 @@ from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import create_nifti_header
 from dipy.stats.analysis import assignment_map
-from vtk.util import numpy_support
 from dipy.utils.optpkg import optional_package
 
 fury, has_fury, setup_module = optional_package('fury')
+vtk, has_vtk, _ = optional_package('vtk')
 
 if has_fury:
     from fury.colormap import line_colors
     from fury.utils import numpy_to_vtk_colors
+
+if has_vtk:
+    from vtk.util import numpy_support
 
 class HorizonFlow(Workflow):
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -212,9 +212,9 @@ class HorizonFlow(Workflow):
 
         order_transparent = not disable_order_transparency
         horizon(tractograms=tractograms, images=images, pams=pams,
-                npy_files=numpy_files, cluster=cluster,
-                cluster_thr=cluster_thr, random_colors=random_colors,
-                bg_color=bg_color, order_transparent=order_transparent,
+                cluster=cluster, cluster_thr=cluster_thr,
+                random_colors=random_colors, bg_color=bg_color,
+                order_transparent=order_transparent,
                 length_gt=length_gt, length_lt=length_lt,
                 clusters_gt=clusters_gt, clusters_lt=clusters_lt,
                 world_coords=world_coords,

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -181,13 +181,11 @@ class HorizonFlow(Workflow):
                 for i in range(len(ind)):
 
                     if pvalues[ind[i]] < buan_thr:
-                        colors.append([0,1,0])
+                        colors.append([0, 1, 0])
                     else:
-                        colors.append([1,0,0])
+                        colors.append([1, 0, 0])
 
                 bundle_colors.append(colors)
-
-
 
         if len(bg_color) == 1:
             bg_color *= 3

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -7,7 +7,7 @@ from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import create_nifti_header
 from dipy.stats.analysis import assignment_map
-
+from fury.colormap import distinguishable_colormap
 
 class HorizonFlow(Workflow):
 
@@ -66,8 +66,8 @@ class HorizonFlow(Workflow):
         buan : bool
             Enables BUAN framework visualization.
         buan_thr : float, optional
-            Default 2. Uses the threshold value to highlight segments on the
-            bundle which have pvalues higher than this threshold.
+            Default 0.5. Uses the threshold value to highlight segments on the
+            bundle which have pvalues less than this threshold.
         out_dir : str, optional
             Output directory. Default current directory.
         out_stealth_png : str, optional
@@ -169,6 +169,7 @@ class HorizonFlow(Workflow):
 
         if buan:
             bundle_colors = []
+
             for i in range(len(numpy_files)):
 
                 n = len(numpy_files[i])
@@ -178,14 +179,11 @@ class HorizonFlow(Workflow):
                 indx = assignment_map(bundle, bundle, n)
                 ind = np.array(indx)
 
-                colors = []
-                for i in range(len(ind)):
+                colors = np.ones((len(ind),3))
+                for i in range(n):
 
-                    if pvalues[ind[i]] < buan_thr:
-                        colors.append([0, 1, 0])
-                    else:
-                        #colors.append([1, 0, 0])
-                        colors.append([None])
+                    if pvalues[i] < buan_thr:
+                        colors[ind==i]=[1,0,0]
 
                 bundle_colors.append(colors)
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -14,7 +14,7 @@ fury, has_fury, setup_module = optional_package('fury')
 
 if has_fury:
     from fury.colormap import line_colors
-from fury.utils import numpy_to_vtk_colors
+    from fury.utils import numpy_to_vtk_colors
 
 class HorizonFlow(Workflow):
 
@@ -70,8 +70,8 @@ class HorizonFlow(Workflow):
         disable_order_transparency : bool, optional
             Default False. Use depth peeling to sort transparent objects.
             If True also enables anti-aliasing.
-        buan : bool
-            Enables BUAN framework visualization.
+        buan : bool, optional
+            Enables BUAN framework visualization. Default is False.
         buan_thr : float, optional
             Default 0.5. Uses the threshold value to highlight segments on the
             bundle which have pvalues less than this threshold.
@@ -195,7 +195,6 @@ class HorizonFlow(Workflow):
                 points_per_line = [len(bundle[i]) for i in lines_range]
                 points_per_line = np.array(points_per_line, np.intp)
 
-
                 cols_arr = line_colors(bundle)
                 colors_mapper = np.repeat(lines_range, points_per_line, axis=0)
                 vtk_colors = numpy_to_vtk_colors(255 * cols_arr[colors_mapper])
@@ -205,7 +204,7 @@ class HorizonFlow(Workflow):
                 for i in range(n):
 
                     if pvalues[i] < buan_thr:
-                        colors[ind==i]=buan_highlight
+                        colors[ind==i] = buan_highlight
 
                 bundle_colors.append(colors)
 


### PR DESCRIPTION
Added functionality in `dipy_horizon` to show highlighted areas/segments on a bundle where pvalues (negative log of pvalues) are greater than a certain threshold (threshold is a parameter).

Usage:

`dipy_horizon IFOF_L.trk IFOF_L_fa_pvalues_log.npy --buan --buan_thr 2`

`buan_thr 2` for `-log(pvalues)` is equal to `0.01` pvalues.


Resulting visualization looks something like this:

<img width="597" alt="Screen Shot 2020-06-10 at 10 34 19 PM" src="https://user-images.githubusercontent.com/26060471/84338791-01e72f80-ab6b-11ea-9a9d-cd6d32d40e9a.png">


Where, red color indicates -log(pvalues) greater than a buan threshold of 2.

We can also provide `pvalues` instead of `-log(pvalues)`.

`dipy_horizon IFOF_L.trk IFOF_L_fa_pvalues.npy --buan --buan_thr 0.01`

Results will be the same but with inverted colors. 
<img width="864" alt="Screen Shot 2020-06-10 at 10 33 47 PM" src="https://user-images.githubusercontent.com/26060471/84338705-c2b8de80-ab6a-11ea-9cb5-34c8cbd987f7.png">
Now, green is the highlighted area.
