### PR TITLE
_streamlines_in_mask bounds check

### DIFF
--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -314,7 +314,7 @@ def _target(target_f, streamlines, voxel_both_true, voxel_one_true,
     assert_true(exclude[0] is streamlines[1])
 
 
-@pytest.mark.parametrize("streamline, no_matched", [
+@pytest.mark.parametrize("streamline, expected_matched", [
     (np.array([[-10, 0, 0], [0, 0, 0]]), 0),
     (np.array([[-10, 0, 0], [1, -10, 0]]), 0),
     (np.array([[0, 0, 0], [10, 10, 10]]), 0),
@@ -323,13 +323,13 @@ def _target(target_f, streamlines, voxel_both_true, voxel_one_true,
     (np.array([[-10, 0, 0], [10, 0, 0]]), 1),
     (np.array([[1, -10, 0], [1, 10, 0]]), 1),
 ])
-def test_target_line_based_out_of_bounds(streamline, no_matched):
+def test_target_line_based_out_of_bounds(streamline, expected_matched):
     # Ensures https://github.com/dipy/dipy/issues/2182 doesn't happen
     # and that target_line_based works with out of bounds points
     mask = np.zeros((2, 1, 1), dtype=np.uint8)
     mask[1, 0, 0] = 1
     matched = list(target_line_based([streamline], np.eye(4), mask))
-    assert len(matched) == no_matched
+    assert len(matched) == expected_matched
 
 
 def test_near_roi():

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -1,4 +1,3 @@
-import pytest
 import warnings
 
 import numpy as np
@@ -314,20 +313,21 @@ def _target(target_f, streamlines, voxel_both_true, voxel_one_true,
     assert_true(exclude[0] is streamlines[1])
 
 
-@pytest.mark.parametrize("streamline, expected_matched", [
-    (np.array([[-10, 0, 0], [0, 0, 0]]), 0),
-    (np.array([[-10, 0, 0], [1, -10, 0]]), 0),
-    (np.array([[0, 0, 0], [10, 10, 10]]), 0),
-    (np.array([[-2, -0.6, -0.6], [2, -0.6, -0.6]]), 0),
-    (np.array([[-10000, 0, 0], [0, 0, 0]]), 0),
-    (np.array([[-10, 0, 0], [10, 0, 0]]), 1),
-    (np.array([[1, -10, 0], [1, 10, 0]]), 1),
-])
-def test_target_line_based_out_of_bounds(streamline, expected_matched):
-    mask = np.zeros((2, 1, 1), dtype=np.uint8)
-    mask[1, 0, 0] = 1
-    matched = list(target_line_based([streamline], np.eye(4), mask))
-    assert len(matched) == expected_matched
+def test_target_line_based_out_of_bounds():
+    test_cases = [
+        (np.array([[-10, 0, 0], [0, 0, 0]]), 0),
+        (np.array([[-10, 0, 0], [1, -10, 0]]), 0),
+        (np.array([[0, 0, 0], [10, 10, 10]]), 0),
+        (np.array([[-2, -0.6, -0.6], [2, -0.6, -0.6]]), 0),
+        (np.array([[-10000, 0, 0], [0, 0, 0]]), 0),
+        (np.array([[-10, 0, 0], [10, 0, 0]]), 1),
+        (np.array([[1, -10, 0], [1, 10, 0]]), 1),
+    ]
+    for streamline, expected_matched in test_cases:
+        mask = np.zeros((2, 1, 1), dtype=np.uint8)
+        mask[1, 0, 0] = 1
+        matched = list(target_line_based([streamline], np.eye(4), mask))
+        assert len(matched) == expected_matched
 
 
 def test_near_roi():

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import warnings
 
 import numpy as np
@@ -311,6 +312,24 @@ def _target(target_f, streamlines, voxel_both_true, voxel_one_true,
     assert_true(include[0] is streamlines[0])
     npt.assert_equal(len(exclude), 1)
     assert_true(exclude[0] is streamlines[1])
+
+
+@pytest.mark.parametrize("streamline, no_matched", [
+    (np.array([[-10, 0, 0], [0, 0, 0]]), 0),
+    (np.array([[-10, 0, 0], [1, -10, 0]]), 0),
+    (np.array([[0, 0, 0], [10, 10, 10]]), 0),
+    (np.array([[-2, -0.6, -0.6], [2, -0.6, -0.6]]), 0),
+    (np.array([[-10000, 0, 0], [0, 0, 0]]), 0),
+    (np.array([[-10, 0, 0], [10, 0, 0]]), 1),
+    (np.array([[1, -10, 0], [1, 10, 0]]), 1),
+])
+def test_target_line_based_out_of_bounds(streamline, no_matched):
+    # Ensures https://github.com/dipy/dipy/issues/2182 doesn't happen
+    # and that target_line_based works with out of bounds points
+    mask = np.zeros((2, 1, 1), dtype=np.uint8)
+    mask[1, 0, 0] = 1
+    matched = list(target_line_based([streamline], np.eye(4), mask))
+    assert len(matched) == no_matched
 
 
 def test_near_roi():

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -324,8 +324,6 @@ def _target(target_f, streamlines, voxel_both_true, voxel_one_true,
     (np.array([[1, -10, 0], [1, 10, 0]]), 1),
 ])
 def test_target_line_based_out_of_bounds(streamline, expected_matched):
-    # Ensures https://github.com/dipy/dipy/issues/2182 doesn't happen
-    # and that target_line_based works with out of bounds points
     mask = np.zeros((2, 1, 1), dtype=np.uint8)
     mask[1, 0, 0] = 1
     matched = list(target_line_based([streamline], np.eye(4), mask))

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -295,9 +295,9 @@ cdef cnp.npy_intp _streamline_in_mask(
             # Find the coordinates of voxel containing current point, to
             # tag it in the map
             half_ratio = 0.5 * length_ratio
-            x = <cnp.npy_intp>(current_pt[0] + half_ratio * direction[0])
-            y = <cnp.npy_intp>(current_pt[1] + half_ratio * direction[1])
-            z = <cnp.npy_intp>(current_pt[2] + half_ratio * direction[2])
+            x = <cnp.npy_intp>floor(current_pt[0] + half_ratio * direction[0])
+            y = <cnp.npy_intp>floor(current_pt[1] + half_ratio * direction[1])
+            z = <cnp.npy_intp>floor(current_pt[2] + half_ratio * direction[2])
             if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
                 if mask[x, y, z]:
                     return 1
@@ -314,9 +314,9 @@ cdef cnp.npy_intp _streamline_in_mask(
             c_get_closest_edge(current_pt, direction, current_edge)
 
     # Check last point
-    x = <cnp.npy_intp>next_pt[0]
-    y = <cnp.npy_intp>next_pt[1]
-    z = <cnp.npy_intp>next_pt[2]
+    x = <cnp.npy_intp>floor(next_pt[0])
+    y = <cnp.npy_intp>floor(next_pt[1])
+    z = <cnp.npy_intp>floor(next_pt[2])
     if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
         if mask[x, y, z]:
             return 1

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -298,8 +298,9 @@ cdef cnp.npy_intp _streamline_in_mask(
             x = <cnp.npy_intp>(current_pt[0] + half_ratio * direction[0])
             y = <cnp.npy_intp>(current_pt[1] + half_ratio * direction[1])
             z = <cnp.npy_intp>(current_pt[2] + half_ratio * direction[2])
-            if mask[x, y, z]:
-                return 1
+            if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
+                if mask[x, y, z]:
+                    return 1
 
             # current_pt is moved to the closest edge
             for dim_idx in range(3):
@@ -316,7 +317,9 @@ cdef cnp.npy_intp _streamline_in_mask(
     x = <cnp.npy_intp>next_pt[0]
     y = <cnp.npy_intp>next_pt[1]
     z = <cnp.npy_intp>next_pt[2]
-    return mask[x, y, z]
+    if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
+        if mask[x, y, z]:
+            return 1
 
 
 @cython.boundscheck(False)

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -320,6 +320,7 @@ cdef cnp.npy_intp _streamline_in_mask(
     if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
         if mask[x, y, z]:
             return 1
+    return 0
 
 
 @cython.boundscheck(False)

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -298,7 +298,7 @@ cdef cnp.npy_intp _streamline_in_mask(
             x = <cnp.npy_intp>floor(current_pt[0] + half_ratio * direction[0])
             y = <cnp.npy_intp>floor(current_pt[1] + half_ratio * direction[1])
             z = <cnp.npy_intp>floor(current_pt[2] + half_ratio * direction[2])
-            if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
+            if 0 <= x < mask.shape[0] and 0 <= y < mask.shape[1] and 0 <= z < mask.shape[2]:
                 if mask[x, y, z]:
                     return 1
 
@@ -317,7 +317,7 @@ cdef cnp.npy_intp _streamline_in_mask(
     x = <cnp.npy_intp>floor(next_pt[0])
     y = <cnp.npy_intp>floor(next_pt[1])
     z = <cnp.npy_intp>floor(next_pt[2])
-    if x >= 0 and y >= 0 and z >= 0 and x < mask.shape[0] and y < mask.shape[1] and z < mask.shape[2]:
+    if 0 <= x < mask.shape[0] and 0 <= y < mask.shape[1] and 0 <= z < mask.shape[2]:
         if mask[x, y, z]:
             return 1
     return 0


### PR DESCRIPTION
Closes https://github.com/dipy/dipy/issues/2182

Adds bound checking in _streamlines_in_mask when accessing the mask array.

I also changed it to explicitly return 1 or 0  for the final point to avoid returning unwanted values given in the mask array
