### PR TITLE
[Fix] update mapmri due to cvxpy 1.1

### DIFF
--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+from distutils.version import LooseVersion
 from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.base import ReconstModel, ReconstFit
 from dipy.reconst.cache import Cache
@@ -397,20 +398,27 @@ class MapmriModel(ReconstModel, Cache):
 
             data_norm = np.asarray(data / data[self.gtab.b0s_mask].mean())
             c = cvxpy.Variable(M.shape[1])
-            design_matrix = cvxpy.Constant(M)
+            if LooseVersion(cvxpy.__version__) < LooseVersion('1.1'):
+                design_matrix = cvxpy.Constant(M) * c
+            else:
+                design_matrix = cvxpy.Constant(M) @ c
             # workaround for the bug on cvxpy 1.0.15 when lopt = 0
             # See https://github.com/cvxgrp/cvxpy/issues/672
             if not lopt:
                 objective = cvxpy.Minimize(
-                    cvxpy.sum_squares(design_matrix * c - data_norm))
+                    cvxpy.sum_squares(design_matrix - data_norm))
             else:
                 objective = cvxpy.Minimize(
-                    cvxpy.sum_squares(design_matrix * c - data_norm) +
+                    cvxpy.sum_squares(design_matrix - data_norm) +
                     lopt * cvxpy.quad_form(c, laplacian_matrix)
                 )
             M0 = M[self.gtab.b0s_mask, :]
-            constraints = [(M0[0] * c) == 1,
-                           (K * c) >= -0.1]
+            if LooseVersion(cvxpy.__version__) < LooseVersion('1.1'):
+                constraints = [(M0[0] * c) == 1,
+                               (K * c) >= -0.1]
+            else:
+                constraints = [(M0[0] @ c) == 1,
+                               (K @ c) >= -0.1]
             prob = cvxpy.Problem(objective, constraints)
             try:
                 prob.solve(solver=self.cvxpy_solver)

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -122,8 +122,8 @@ class ReconstMAPMRIFlow(Workflow):
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
             if b0_threshold < bvals.min():
                 warn("b0_threshold (value: {0}) is too low, increase your "
-                     "b0_threshold. It should be higher than the first b0 value "
-                     "({1}).".format(b0_threshold, bvals.min()))
+                     "b0_threshold. It should be higher than the first b0 "
+                     "value({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals=bvals, bvecs=bvecs,
                                   small_delta=small_delta,
                                   big_delta=big_delta,

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -38,6 +38,7 @@ if have_smf:
 
 if have_matplotlib:
     import matplotlib as matplt
+    import matplotlib.pyplot as plt
 
 
 class SNRinCCFlow(Workflow):
@@ -430,29 +431,29 @@ class LinearMixedModelsFlow(Workflow):
 
         y_pos = np.arange(n)
 
-        l1, = matplt.pyplot.plot(y_pos, dotted, color='red', marker='.',
-                                 linestyle='solid', linewidth=0.6,
-                                 markersize=0.7, label="p-value < 0.01")
+        l1, = plt.plot(y_pos, dotted, color='red', marker='.',
+                       linestyle='solid', linewidth=0.6,
+                       markersize=0.7, label="p-value < 0.01")
 
-        l2, = matplt.pyplot.plot(y_pos, dotted+1, color='black', marker='.',
-                                 linestyle='solid', linewidth=0.4,
-                                 markersize=0.4, label="p-value < 0.001")
+        l2, = plt.plot(y_pos, dotted+1, color='black', marker='.',
+                       linestyle='solid', linewidth=0.4,
+                       markersize=0.4, label="p-value < 0.001")
 
-        first_legend = matplt.pyplot.legend(handles=[l1, l2],
-                                            loc='upper right')
+        first_legend = plt.legend(handles=[l1, l2],
+                                  loc='upper right')
 
-        axes = matplt.pyplot.gca()
+        axes = plt.gca()
         axes.add_artist(first_legend)
         axes.set_ylim([0, 6])
 
-        l3 = matplt.pyplot.bar(y_pos, y, color=c1, alpha=0.5,
+        l3 = plt.bar(y_pos, y, color=c1, alpha=0.5,
                                label=bundle_name)
-        matplt.pyplot.legend(handles=[l3], loc='upper left')
-        matplt.pyplot.title(title.upper())
-        matplt.pyplot.xlabel("Segment Number")
-        matplt.pyplot.ylabel("-log10(Pvalues)")
-        matplt.pyplot.savefig(plot_file)
-        matplt.pyplot.clf()
+        plt.legend(handles=[l3], loc='upper left')
+        plt.title(title.upper())
+        plt.xlabel("Segment Number")
+        plt.ylabel("-log10(Pvalues)")
+        plt.savefig(plot_file)
+        plt.clf()
 
     def run(self, h5_files, no_disks=100, out_dir=''):
         """Workflow of linear Mixed Models.
@@ -613,9 +614,9 @@ class BundleShapeAnalysis(Workflow):
             np.save(os.path.join(out_dir, bun[:-4]+".npy"), ba_matrix)
 
             cmap = matplt.cm.get_cmap('Blues')
-            matplt.pyplot.title(bun[:-4])
-            matplt.pyplot.imshow(ba_matrix, cmap=cmap)
-            matplt.pyplot.colorbar()
-            matplt.pyplot.clim(0, 1)
-            matplt.pyplot.savefig(os.path.join(out_dir, "SM_"+bun[:-4]))
-            matplt.pyplot.clf()
+            plt.title(bun[:-4])
+            plt.imshow(ba_matrix, cmap=cmap)
+            plt.colorbar()
+            plt.clim(0, 1)
+            plt.savefig(os.path.join(out_dir, "SM_"+bun[:-4]))
+            plt.clf()


### PR DESCRIPTION
This PR fixes the following errors/warnings:
```
/home/travis/build/dipy/dipy/venv/lib/python3.5/site-packages/cvxpy/expressions/expression.py:516: UserWarning: 
  This use of ``*`` has resulted in matrix multiplication.
  Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
      Use ``*`` for matrix-scalar and vector-scalar multiplication.
      Use ``@`` for matrix-matrix and matrix-vector multiplication.
      Use ``multiply`` for elementwise multiplication.
  
    warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
```

I think we just need to do a FURY release to fix the last errors and make the CI's completely happy.
