### PR TITLE
Make single and multi tensor simulations compatible with btensors

### DIFF
--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -313,6 +313,28 @@ def test_DKI_crossing_fibers_simulations():
                               decimal=5)
 
 
+def test_single_tensor_btens():
+    """ Testing single tensor simulations when a btensor is given
+    """
+    gtab_lte = gradient_table(gtab.bvals, gtab.bvecs, btens='LTE')
+    gtab_ste = gradient_table(gtab.bvals, gtab.bvecs, btens='STE')
+
+    # Check if Signals producted with LTE btensor gives same results as
+    # previous simulations not specifying b-tensor
+    evecs = np.eye(3)
+    evals = np.array([1.4, .35, .35]) * 10 ** (-3)
+    S_ref = single_tensor(gtab, 100, evals, evecs, snr=None)
+    S_btens = single_tensor(gtab_lte, 100, evals, evecs, snr=None)
+    assert_array_almost_equal(S_ref, S_btens)
+
+    # Check if Signals producted with STE btensor gives signals that matches
+    # the signal decay for mean diffusivity
+    md = np.sum(evals)/3
+    S_ref = 100 * np.exp(-gtab.bvals * md)
+    S_btens = single_tensor(gtab_ste, 100, evals, evecs, snr=None)
+    assert_array_almost_equal(S_ref, S_btens)
+
+
 if __name__ == "__main__":
 
     test_multi_tensor()

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -335,6 +335,29 @@ def test_single_tensor_btens():
     assert_array_almost_equal(S_ref, S_btens)
 
 
+def test_multi_tensor_btens():
+    """ Testing multi tensor simulations when a btensor is given
+    """
+    mevals = np.array(([0.003, 0.0002, 0.0002],
+                       [0.0015, 0.0003, 0.0003]))
+    e0 = np.array([np.sqrt(2) / 2., np.sqrt(2) / 2., 0])
+    e1 = np.array([0, np.sqrt(2) / 2., np.sqrt(2) / 2.])
+    mevecs = [all_tensor_evecs(e0), all_tensor_evecs(e1)]
+
+    gtab_ste = gradient_table(gtab.bvals, gtab.bvecs, btens='STE')
+
+    s1 = single_tensor(gtab_ste, 100, mevals[0], mevecs[0], snr=None)
+    s2 = single_tensor(gtab_ste, 100, mevals[1], mevecs[1], snr=None)
+
+    Ssingle = 0.5*s1 + 0.5*s2
+
+    S, _ = multi_tensor(gtab_ste, mevals, S0=100,
+                        angles=[(90, 45), (45, 90)],
+                        fractions=[50, 50], snr=None)
+
+    assert_array_almost_equal(S, Ssingle)
+
+
 if __name__ == "__main__":
 
     test_multi_tensor()

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -361,8 +361,12 @@ def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
     S = np.zeros(len(gradients))
     D = dot(dot(R, np.diag(evals)), R.T)
 
-    for (i, g) in enumerate(gradients):
-        S[i] = S0 * np.exp(-gtab.bvals[i] * dot(dot(g.T, D), g))
+    if gtab.btens is None:
+        for (i, g) in enumerate(gradients):
+            S[i] = S0 * np.exp(-gtab.bvals[i] * dot(dot(g.T, D), g))
+    else:
+        for (i, b) in enumerate(gtab.btens):
+            S[i] = S0 * np.exp(- np.sum(b * D))
 
     S = add_noise(S, snr, S0)
 

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -314,12 +314,14 @@ def cylinders_and_ball_soderman(gtab, tau, radii=[5e-3, 5e-3], D=0.7e-3,
 
 
 def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
-    """ Simulated Q-space signal with a single tensor.
+    """ Simulate diffusion-weighted signals with a single tensor.
 
     Parameters
     -----------
     gtab : GradientTable
-        Measurement directions.
+        Table with information of b-values and gradient directions g.
+        Note that if gtab has a btens attribute, simulations will be performed
+        according to the given b-tensor B information.
     S0 : double,
         Strength of signal in the presence of no diffusion gradient (also
         called the ``b=0`` value).
@@ -336,7 +338,9 @@ def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
     Returns
     --------
     S : (N,) ndarray
-        Simulated signal: ``S(q, tau) = S_0 e^(-b g^T R D R.T g)``.
+        Simulated signal:
+            ``S(b, g) = S_0 e^(-b g^T R D R.T g)``, if gtab.tens=None
+            ``S(B) = S_0 e^(-B:D)``, if gtab.tens information is given
 
     References
     ----------
@@ -380,6 +384,9 @@ def multi_tensor(gtab, mevals, S0=1., angles=[(0, 0), (90, 0)],
     Parameters
     -----------
     gtab : GradientTable
+        Table with information of b-values and gradient directions.
+        Note that if gtab has a btens attribute, simulations will be performed
+        according to the given b-tensor information.
     mevals : array (K, 3)
         each tensor's eigenvalues in each row
     S0 : float


### PR DESCRIPTION
In this PR, I am adapting the single and multi tensor simulations to run with the gradiant_table btensor when this is not None. 

This PR will be usefull to carry on with the implemenation of techniques based on advanced diffusion sequences - in particular for code testing. 