### PR TITLE
End of line period in sft

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -110,7 +110,7 @@ class StatefulTractogram(object):
                            'must be specified separately.')
             logger.warning('To copy the state from another StatefulTractogram '
                            'you may want to use the function from_sft '
-                           '(static function of the StatefulTractogram)')
+                           '(static function of the StatefulTractogram).')
 
         if isinstance(reference, tuple) and len(reference) == 4:
             if is_reference_info_valid(*reference):
@@ -131,12 +131,12 @@ class StatefulTractogram(object):
         self._inv_affine = np.linalg.inv(self._affine)
 
         if space not in Space:
-            raise ValueError('Space MUST be from Space enum, e.g Space.VOX')
+            raise ValueError('Space MUST be from Space enum, e.g Space.VOX.')
         self._space = space
 
         if origin not in Origin:
             raise ValueError('Origin MUST be from Origin enum, '
-                             'e.g Origin.NIFTI')
+                             'e.g Origin.NIFTI.')
         self._origin = origin
         logger.debug(self)
 
@@ -352,7 +352,7 @@ class StatefulTractogram(object):
         self._tractogram._streamlines = Streamlines(streamlines)
         self.data_per_point = self.data_per_point
         self.data_per_streamline = self.data_per_streamline
-        logger.warning('Streamlines has been modified')
+        logger.warning('Streamlines has been modified.')
 
     @property
     def data_per_point(self):
@@ -371,7 +371,7 @@ class StatefulTractogram(object):
             Y_i being the number of points on streamlines #i
         """
         self._tractogram.data_per_point = data
-        logger.warning('Data_per_point has been modified')
+        logger.warning('Data_per_point has been modified.')
 
     @property
     def data_per_streamline(self):
@@ -389,7 +389,7 @@ class StatefulTractogram(object):
             X being the number of streamlines
         """
         self._tractogram.data_per_streamline = data
-        logger.warning('Data_per_streamline has been modified')
+        logger.warning('Data_per_streamline has been modified.')
 
     def get_data_per_point_keys(self):
         """ Return a list of the data_per_point attribute names """
@@ -431,7 +431,7 @@ class StatefulTractogram(object):
             self.to_rasmm()
         else:
             logger.error('Unsupported target space, please use Enum in '
-                         'dipy.io.stateful_tractogram')
+                         'dipy.io.stateful_tractogram.')
 
     def to_origin(self, target_origin):
         """ Safe function to change streamlines to a particular origin standard
@@ -442,7 +442,7 @@ class StatefulTractogram(object):
             self.to_corner()
         else:
             logger.error('Unsupported origin standard, please use Enum in '
-                         'dipy.io.stateful_tractogram')
+                         'dipy.io.stateful_tractogram.')
 
     def to_center(self):
         """ Safe function to shift streamlines so the center of voxel is
@@ -494,14 +494,14 @@ class StatefulTractogram(object):
 
         is_valid = True
         if np.any(bbox_corners < 0):
-            logger.error('Voxel space values lower than 0.0')
+            logger.error('Voxel space values lower than 0.0.')
             logger.debug(bbox_corners)
             is_valid = False
 
         if np.any(bbox_corners[:, 0] > self._dimensions[0]) or \
                 np.any(bbox_corners[:, 1] > self._dimensions[1]) or \
                 np.any(bbox_corners[:, 2] > self._dimensions[2]):
-            logger.error('Voxel space values higher than dimensions')
+            logger.error('Voxel space values higher than dimensions.')
             logger.debug(bbox_corners)
             is_valid = False
 
@@ -510,7 +510,7 @@ class StatefulTractogram(object):
 
         return is_valid
 
-    def remove_invalid_streamlines(self, epsilon=1e-6):
+    def remove_invalid_streamlines(self, epsilon=1e-3):
         """ Remove streamlines with invalid coordinates from the object.
         Will also remove the data_per_point and data_per_streamline.
         Invalid coordinates are any X,Y,Z values above the reference
@@ -580,9 +580,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logger.debug('Moved streamlines from vox to voxmm')
+                logger.debug('Moved streamlines from vox to voxmm.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _voxmm_to_vox(self):
@@ -592,9 +592,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data /= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOX
-                logger.debug('Moved streamlines from voxmm to vox')
+                logger.debug('Moved streamlines from voxmm to vox.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _vox_to_rasmm(self):
@@ -603,9 +603,9 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logger.debug('Moved streamlines from vox to rasmm')
+                logger.debug('Moved streamlines from vox to rasmm.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _rasmm_to_vox(self):
@@ -614,9 +614,9 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.apply_affine(self._inv_affine)
                 self._space = Space.VOX
-                logger.debug('Moved streamlines from rasmm to vox')
+                logger.debug('Moved streamlines from rasmm to vox.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _voxmm_to_rasmm(self):
@@ -627,9 +627,9 @@ class StatefulTractogram(object):
                     self._voxel_sizes)
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logger.debug('Moved streamlines from voxmm to rasmm')
+                logger.debug('Moved streamlines from voxmm to rasmm.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _rasmm_to_voxmm(self):
@@ -640,9 +640,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logger.debug('Moved streamlines from rasmm to voxmm')
+                logger.debug('Moved streamlines from rasmm to voxmm.')
         else:
-            logger.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function.')
             return
 
     def _shift_voxel_origin(self):
@@ -663,10 +663,10 @@ class StatefulTractogram(object):
 
         self._tractogram.streamlines._data += shift
         if self._origin == Origin.NIFTI:
-            logger.debug('Origin moved to the corner of voxel')
+            logger.debug('Origin moved to the corner of voxel.')
             self._origin = Origin.TRACKVIS
         else:
-            logger.debug('Origin moved to the center of voxel')
+            logger.debug('Origin moved to the center of voxel.')
             self._origin = Origin.NIFTI
 
 
@@ -689,7 +689,7 @@ def _is_data_per_point_valid(streamlines, data):
         Does all the streamlines and metadata attribute match
     """
     if not isinstance(data, (dict, PerArraySequenceDict)):
-        logger.error('data_per_point MUST be a dictionary')
+        logger.error('data_per_point MUST be a dictionary.')
         return False
     elif data == {}:
         return True
@@ -735,7 +735,7 @@ def _is_data_per_streamline_valid(streamlines, data):
         Does all the streamlines and metadata attribute match
     """
     if not isinstance(data, (dict, PerArrayDict)):
-        logger.error('data_per_point MUST be a dictionary')
+        logger.error('data_per_point MUST be a dictionary.')
         return False
     elif data == {}:
         return True

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -36,14 +36,14 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
 
     _, extension = os.path.splitext(filename)
     if extension not in ['.trk', '.tck', '.vtk', '.fib', '.dpy']:
-        raise TypeError('Output filename is not one of the supported format')
+        raise TypeError('Output filename is not one of the supported format.')
 
     if bbox_valid_check and not sft.is_bbox_in_vox_valid():
         raise ValueError('Bounding box is not valid in voxel space, cannot '
-                         'load a valid file if some coordinates are '
-                         'invalid. Please use the function '
-                         'remove_invalid_streamlines to discard invalid '
-                         'streamlines or set bbox_valid_check to False')
+                         'load a valid file if some coordinates are invalid.\n'
+                         'Please set bbox_valid_check to False and then use '
+                         'the function remove_invalid_streamlines to discard '
+                         'invalid streamlines.')
 
     old_space = deepcopy(sft.space)
     old_origin = deepcopy(sft.origin)
@@ -73,7 +73,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
         dpy_obj.write_tracks(sft.streamlines)
         dpy_obj.close()
 
-    logging.debug('Save %s with %s streamlines in %s seconds',
+    logging.debug('Save %s with %s streamlines in %s seconds.',
                   filename, len(sft), round(time.time() - timer, 3))
 
     sft.to_space(old_space)
@@ -116,11 +116,11 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
     """
     _, extension = os.path.splitext(filename)
     if extension not in ['.trk', '.tck', '.vtk', '.fib', '.dpy']:
-        logging.error('Output filename is not one of the supported format')
+        logging.error('Output filename is not one of the supported format.')
         return False
 
     if to_space not in Space:
-        logging.error('Space MUST be one of the 3 choices (Enum)')
+        logging.error('Space MUST be one of the 3 choices (Enum).')
         return False
 
     if reference == 'same':
@@ -134,7 +134,7 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
     if trk_header_check and extension == '.trk':
         if not is_header_compatible(filename, reference):
             logging.error('Trk file header does not match the provided '
-                          'reference')
+                          'reference.')
             return False
 
     timer = time.time()
@@ -153,7 +153,7 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         dpy_obj = Dpy(filename, mode='r')
         streamlines = list(dpy_obj.read_tracks())
         dpy_obj.close()
-    logging.debug('Load %s with %s streamlines in %s seconds',
+    logging.debug('Load %s with %s streamlines in %s seconds.',
                   filename, len(streamlines), round(time.time() - timer, 3))
 
     sft = StatefulTractogram(streamlines, reference, Space.RASMM,
@@ -166,9 +166,9 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
 
     if bbox_valid_check and not sft.is_bbox_in_vox_valid():
         raise ValueError('Bounding box is not valid in voxel space, cannot '
-                         'load a valid file if some coordinates are invalid.'
-                         'Please set bbox_valid_check to False and then use'
-                         'the function remove_invalid_streamlines to discard'
+                         'load a valid file if some coordinates are invalid.\n'
+                         'Please set bbox_valid_check to False and then use '
+                         'the function remove_invalid_streamlines to discard '
                          'invalid streamlines.')
 
     return sft


### PR DESCRIPTION
Every logging and Raise message now has a period at the end of the line. It was a mix before, which annoyed me.
One bounding box raise message also hed missing space.

After 2 months of testing "in the field" I now realized that the epsilon for the `remove_invalid_streamlines()` function is too low. At 1e-6 it does not remove enough streamlines WHEN the affine of the data has a mild rotational component and crash (often) at saving due to floating-point difference. I never have problems with 1e-3, which is what I expect after a call to `remove_invalid_streamlines()`

Any typo anyone saw in the last few months is welcome: @GuillaumeTh @ppoulin91 @AntoineTheb @fullbat