### PR TITLE
Add optional installs for different settings.

### DIFF
--- a/dipy/info.py
+++ b/dipy/info.py
@@ -108,3 +108,23 @@ REQUIRES            = ["numpy (>=%s)" % NUMPY_MIN_VERSION,
                        "nibabel (>=%s)" % NIBABEL_MIN_VERSION,
                        "h5py (>=%s)" % H5PY_MIN_VERSION,
                        "packaging (>=%s)" % PACKAGING_MIN_VERSION]
+EXTRAS_REQUIRE = {
+    "doc": [
+        "fury>=0.6",
+        "sphinx",
+    ],
+    "viz": [
+        "fury>=0.6"
+    ],
+    "ml": [
+        "scikit_learn",
+        "pandas",
+        "statsmodels"
+        "tables",
+        "tensorflow"
+    ]
+
+}
+
+EXTRAS_REQUIRE["all"] = list(set([a[i] for a in list(EXTRAS_REQUIRE.values())
+                                  for i in range(len(a))]))

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -109,12 +109,30 @@ REQUIRES            = ["numpy (>=%s)" % NUMPY_MIN_VERSION,
                        "h5py (>=%s)" % H5PY_MIN_VERSION,
                        "packaging (>=%s)" % PACKAGING_MIN_VERSION]
 EXTRAS_REQUIRE = {
+    "test":[
+        "pytest",
+        "coverage",
+        "coveralls",
+        "codecov"
+    ]
     "doc": [
-        "fury>=0.6",
-        "sphinx",
+        "cython",
+        "numpy",
+        "scipy",
+        "nibabel>=3.0.0",
+        "h5py",
+        "cvxpy",
+        "pandas",
+        "tables",
+        "matplotlib",
+        "fury>=0.6"
+        "scikit-learn",
+        "scikit-image",
+        "statsmodels",
     ],
     "viz": [
-        "fury>=0.6"
+        "fury>=0.6",
+        "matplotlib"
     ],
     "ml": [
         "scikit_learn",

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -109,12 +109,12 @@ REQUIRES            = ["numpy (>=%s)" % NUMPY_MIN_VERSION,
                        "h5py (>=%s)" % H5PY_MIN_VERSION,
                        "packaging (>=%s)" % PACKAGING_MIN_VERSION]
 EXTRAS_REQUIRE = {
-    "test":[
+    "test": [
         "pytest",
         "coverage",
         "coveralls",
-        "codecov"
-    ]
+        "codecov",
+    ],
     "doc": [
         "cython",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,8 @@ if using_setuptools:
     extra_setuptools_args = dict(
         tests_require=['pytest'],
         zip_safe=False,
-        extras_require=dict(
-            doc=['Sphinx>=1.0'],
-            test=['pytest']),
-        python_requires=">= 3.5")
+        extras_require=info.EXTRAS_REQUIRE,
+        )
 
 # Define extensions
 EXTS = []
@@ -181,7 +179,6 @@ def main(**extra_args):
           platforms=info.PLATFORMS,
           version=info.VERSION,
           requires=info.REQUIRES,
-          extras_require=info.EXTRAS_REQUIRE,
           provides=info.PROVIDES,
           packages=['dipy',
                     'dipy.tests',

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ def main(**extra_args):
           platforms=info.PLATFORMS,
           version=info.VERSION,
           requires=info.REQUIRES,
+          extras_require=info.EXTRAS_REQUIRE,
           provides=info.PROVIDES,
           packages=['dipy',
                     'dipy.tests',


### PR DESCRIPTION
Follow up on https://github.com/dipy/dipy/pull/2204#issuecomment-675530197 iin #2204:

This would entail that installing with:

`pip install dipy[all]`

would now include all the optional dependencies specified in this dict. 

Question: what else do we need to include in this dict (if anything)?