### PR TITLE
NF: Update definitions of SH bases and documentation

### DIFF
--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -556,11 +556,18 @@ def test_peaksFromModelParallel():
                                               return_odf=True,
                                               return_sh=True, parallel=True,
                                               nbr_processes=-2)
-            assert_(len(w) == 2)
-            assert_(issubclass(w[0].category, UserWarning))
+
+            # Both previous calls to peaks_from_model raise a
+            # PendingDeprecationWarning when sh_to_sf_basis is called, then a
+            # UserWarning when _peaks_from_model_parallel is called with an
+            # invalid number of processes, and finally another
+            # PendingDeprecationWarning when peaks_from_model is called a
+            # second time with parallel=False
+            assert_(len(w) == 6)
             assert_(issubclass(w[1].category, UserWarning))
-            assert_("Invalid number of processes " in str(w[0].message))
+            assert_(issubclass(w[4].category, UserWarning))
             assert_("Invalid number of processes " in str(w[1].message))
+            assert_("Invalid number of processes " in str(w[4].message))
 
             for pam in [pam_multi, pam_multi_inv1, pam_multi_inv2]:
                 assert_equal(pam.gfa.dtype, pam_single.gfa.dtype)

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -73,9 +73,12 @@ def test_boot_pmf():
         warnings.simplefilter("always", category=UserWarning)
         csd_model = ConstrainedSphericalDeconvModel(gtab, response,
                                                     sh_order=6)
-        npt.assert_(len(w) == 1)
+        # Tests that the first catched warning comes from
+        # the CSD model  constructor
         npt.assert_(issubclass(w[0].category, UserWarning))
         npt.assert_("Number of parameters required " in str(w[0].message))
+        # Tests that additionnal warnings are raised for outdated SH basis
+        npt.assert_(len(w) > 1)
 
     boot_pmf_gen_sh4 = BootPmfGen(data, model=csd_model, sphere=hsph_updated,
                                   sh_order=4)

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1141,7 +1141,7 @@ def sh_to_sf(sh, sphere, sh_order=4, basis_type=None,
         Default: False
     use_legacy_definition: bool, optional
         True to use a legacy basis definition for backward compatibility
-        with previous tournier07 and descoteaux07 implementations. 
+        with previous tournier07 and descoteaux07 implementations.
         Default: False
 
     Returns

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -280,7 +280,7 @@ def real_sh_tournier_from_index(m, n, theta, phi, legacy=True):
            framework for medical image processing and visualisation.
            NeuroImage. 2019 Nov 15;202:116-137.
     """
-    # In the case where m < 0, Tournier basis consider |m|
+    # In the m < 0 case, Tournier basis considers |m|
     sh = spherical_harmonics(np.abs(m), n, phi, theta)
     real_sh = np.where(m < 0, sh.imag, sh.real)
 

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -695,7 +695,6 @@ def _gfa_sh(coef, sh0_index=0):
         The coefficients, using a normalized sh basis, that represent each odf.
     sh0_index : int, optional
         The index of the coefficient associated with the 0th order sh harmonic.
-        Default: 0
 
     Returns
     -------
@@ -881,7 +880,6 @@ class SphHarmFit(OdfFit):
 
         S0 : float array
            The mean non-diffusion-weighted signal in each voxel.
-           Default: 1.0 in all voxels
         """
         if not hasattr(self.model, 'predict'):
             msg = "This model does not have prediction implemented yet"
@@ -1363,12 +1361,11 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
         A ndarray where the last dimension is the
         SH coefficients estimates for that voxel.
     norm_factor: float, optional
-        The value to normalize the ap values. Default is 10^-5.
+        The value to normalize the ap values.
     power : int, optional
-        The degree to which power maps are calculated. Default: 2.
+        The degree to which power maps are calculated.
     non_negative: bool, optional
         Whether to rectify the resulting map to be non-negative.
-        Default: True.
 
     Returns
     -------
@@ -1531,7 +1528,7 @@ def convert_sh_to_legacy(sh_coeffs, sh_basis, full_basis=False):
         ``descoteaux07`` for the Descoteaux 2007 [1]_ basis.
     full_basis: bool, optional
         True if the input SH basis includes both even and odd
-        order SH functions. Default: False
+        order SH functions.
 
     Returns
     -------

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -115,12 +115,12 @@ def sh_to_rh(r_sh, m, n):
     return r_rh
 
 
-def gen_dirac(m, n, theta, phi):
+def gen_dirac(m, n, theta, phi, legacy=True):
     """ Generate Dirac delta function orientated in (theta, phi) on the sphere
 
     The spherical harmonics (SH) representation of this Dirac is returned as
-    coefficients to spherical harmonic functions produced by
-    `shm.real_sph_harm`.
+    coefficients to spherical harmonic functions produced from ``descoteaux07``
+    basis.
 
     Parameters
     ----------
@@ -137,7 +137,7 @@ def gen_dirac(m, n, theta, phi):
 
     See Also
     --------
-    shm.real_sph_harm, shm.real_sym_sh_basis
+    shm.real_sh_descoteaux_from_index, shm.real_sh_descoteaux
 
     Returns
     -------
@@ -146,7 +146,7 @@ def gen_dirac(m, n, theta, phi):
         `(m + 2) * (m + 1) / 2`.
 
     """
-    return real_sph_harm(m, n, theta, phi)
+    return real_sh_descoteaux_from_index(m, n, theta, phi, legacy=legacy)
 
 
 def spherical_harmonics(m, n, theta, phi, use_scipy=True):
@@ -202,7 +202,7 @@ def spherical_harmonics(m, n, theta, phi, use_scipy=True):
 @deprecate_with_version('dipy.reconst.shm.real_sph_harm is deprecated, '
                         'Please use '
                         'dipy.reconst.shm.real_sh_descoteaux_from_index '
-                        'instead')
+                        'instead', since='1.3', until='2.0')
 def real_sph_harm(m, n, theta, phi):
     """ Compute real spherical harmonics.
 
@@ -238,7 +238,7 @@ def real_sph_harm(m, n, theta, phi):
     return real_sh_descoteaux_from_index(m, n, theta, phi, legacy=True)
 
 
-def real_sh_tournier_from_index(m, n, theta, phi, legacy=False):
+def real_sh_tournier_from_index(m, n, theta, phi, legacy=True):
     """ Compute real spherical harmonics as initially defined in Tournier
     2007 [1]_ then updated in MRtrix3 [2]_, where the real harmonic $Y^m_n$
     is defined to be:
@@ -295,7 +295,7 @@ def real_sh_tournier_from_index(m, n, theta, phi, legacy=False):
     return real_sh
 
 
-def real_sh_descoteaux_from_index(m, n, theta, phi, legacy=False):
+def real_sh_descoteaux_from_index(m, n, theta, phi, legacy=True):
     """ Compute real spherical harmonics as in Descoteaux et al. 2007 [1]_,
     where the real harmonic $Y^m_n$ is defined to be:
 
@@ -350,7 +350,7 @@ def real_sh_descoteaux_from_index(m, n, theta, phi, legacy=False):
 
 def real_sh_tournier(sh_order, theta, phi,
                      full_basis=False,
-                     legacy=False):
+                     legacy=True):
     """ Compute real spherical harmonics as initially defined in Tournier
     2007 [1]_ then updated in MRtrix3 [2]_, where the real harmonic $Y^m_n$
     is defined to be:
@@ -409,7 +409,7 @@ def real_sh_tournier(sh_order, theta, phi,
 
 def real_sh_descoteaux(sh_order, theta, phi,
                        full_basis=False,
-                       legacy=False):
+                       legacy=True):
     """ Compute real spherical harmonics as in Descoteaux et al. 2007 [1]_,
     where the real harmonic $Y^m_n$ is defined to be:
 
@@ -463,7 +463,8 @@ def real_sh_descoteaux(sh_order, theta, phi,
 
 
 @deprecate_with_version('dipy.reconst.shm.real_sym_sh_mrtix is deprecated, '
-                        'Please use dipy.reconst.shm.real_sh_tournier instead')
+                        'Please use dipy.reconst.shm.real_sh_tournier instead',
+                        since='1.3', until='2.0')
 def real_sym_sh_mrtrix(sh_order, theta, phi):
     """
     Compute real symmetric spherical harmonics as in Tournier 2007 [2]_, where
@@ -513,7 +514,7 @@ def real_sym_sh_mrtrix(sh_order, theta, phi):
 
 @deprecate_with_version('dipy.reconst.shm.real_sym_sh_basis is deprecated, '
                         'Please use dipy.reconst.shm.real_sh_descoteaux '
-                        'instead')
+                        'instead', since='1.3', until='2.0')
 def real_sym_sh_basis(sh_order, theta, phi):
     """Samples a real symmetric spherical harmonic basis at point on the sphere
 
@@ -1104,7 +1105,7 @@ class ResidualBootstrapWrapper(object):
 
 
 def sf_to_sh(sf, sphere, sh_order=4, basis_type=None, full_basis=False,
-             legacy=False, smooth=0.0):
+             legacy=True, smooth=0.0):
     """Spherical function to spherical harmonics (SH).
 
     Parameters
@@ -1168,7 +1169,7 @@ def sf_to_sh(sf, sphere, sh_order=4, basis_type=None, full_basis=False,
 
 
 def sh_to_sf(sh, sphere, sh_order=4, basis_type=None,
-             full_basis=False, legacy=False):
+             full_basis=False, legacy=True):
     """Spherical harmonics (SH) to spherical function (SF).
 
     Parameters
@@ -1228,7 +1229,7 @@ def sh_to_sf(sh, sphere, sh_order=4, basis_type=None,
 
 
 def sh_to_sf_matrix(sphere, sh_order=4, basis_type=None, full_basis=False,
-                    legacy=False, return_inv=True, smooth=0):
+                    legacy=True, return_inv=True, smooth=0):
     """ Matrix that transforms Spherical harmonics (SH) to spherical
     function (SF).
 

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -198,6 +198,7 @@ def spherical_harmonics(m, n, theta, phi, use_scipy=True):
     val = val * np.exp(1j * m * theta)
     return val
 
+
 @deprecate_with_version('dipy.reconst.shm.real_sph_harm is deprecated, '
                         'Please use '
                         'dipy.reconst.shm.real_sh_descoteaux_from_index '

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -165,8 +165,8 @@ def spherical_harmonics(m, n, theta, phi, use_scipy=True):
         The azimuthal (longitudinal) coordinate.
     phi : float [0, pi]
         The polar (colatitudinal) coordinate.
-    use_scipy : bool
-        if True, use scipy implementation. default(True)
+    use_scipy : bool, optional
+        if True, use scipy implementation. Default: True
 
     Returns
     -------
@@ -254,11 +254,11 @@ def real_sh_tournier(sh_order, theta, phi,
         The polar (colatitudinal) coordinate.
     phi : float [0, 2*pi]
         The azimuthal (longitudinal) coordinate.
-    is_full_basis: bool
+    is_full_basis: bool, optional
         If true, returns a basis including odd order SH functions as well as
         even order SH functions. Otherwise returns only even order SH
-        functions. default(False)
-    is_legacy: bool
+        functions. Default: False
+    is_legacy: bool, optional
         If true, uses MRtrix 0.2 SH basis definition, where the sqrt(2) factor
         is omitted. Else, uses MRtrix 3 definition presented above.
 
@@ -327,14 +327,14 @@ def real_sh_descoteaux(sh_order, theta, phi,
         The polar (colatitudinal) coordinate.
     phi : float [0, 2*pi]
         The azimuthal (longitudinal) coordinate.
-    is_full_basis: bool
+    is_full_basis: bool, optional
         If true, returns a basis including odd order SH functions as well as
         even order SH functions. Otherwise returns only even order SH
-        functions. default(False)
-    is_legacy: bool
+        functions. Default: False
+    is_legacy: bool, optional
         If true, uses DIPY's legacy descoteaux07 implementation (where |m|
         for m < 0). Else, implements the basis as defined in Descoteaux et al.
-        2007. default(False)
+        2007. Default: False
 
     Returns
     -------
@@ -566,7 +566,8 @@ def order_from_ncoef(ncoef, is_full_basis=False):
     ncoef: int
         number of coefficients
     is_full_basis: bool, optional
-        True when coefficients are for a full SH basis
+        True when coefficients are for a full SH basis.
+        Default: False
 
     Returns
     -------
@@ -641,8 +642,9 @@ def _gfa_sh(coef, sh0_index=0):
     ----------
     coef : array
         The coefficients, using a normalized sh basis, that represent each odf.
-    sh0_index : int
+    sh0_index : int, optional
         The index of the coefficient associated with the 0th order sh harmonic.
+        Default: 0
 
     Returns
     -------
@@ -1065,21 +1067,21 @@ def sf_to_sh(sf, sphere, sh_order=4, basis_type=None, use_full_basis=False,
         Maximum SH order in the SH fit.  For `sh_order`, there will be
         ``(sh_order + 1) * (sh_order + 2) / 2`` SH coefficients for a symmetric
         basis and ``(sh_order + 1) * (sh_order + 1)`` coefficients for a full
-        SH basis (default 4).
-    basis_type : {None, 'tournier07', 'descoteaux07'}
+        SH basis. Default: 4
+    basis_type : {None, 'tournier07', 'descoteaux07'}, optional
         ``None`` for the default DIPY basis,
         ``tournier07`` for the symmetric Tournier 2007 [2]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
         (``None`` defaults to ``descoteaux07``).
-    use_full_basis: bool
+    use_full_basis: bool, optional
         True for using a SH basis containing even and odd order SH functions.
         False for using a SH basis consisting only of even order SH functions.
-        default(false)
-    use_legacy_definition: bool
+        Default: False
+    use_legacy_definition: bool, optional
         True to use a legacy basis definition for backward compatibility
         with previous tournier07 and descoteaux07 implementations.
     smooth : float, optional
-        Lambda-regularization in the SH fit (default 0.0).
+        Lambda-regularization in the SH fit. Default: 0.0
 
     Returns
     -------
@@ -1127,19 +1129,20 @@ def sh_to_sf(sh, sphere, sh_order=4, basis_type=None,
         Maximum SH order in the SH fit.  For `sh_order`, there will be
         ``(sh_order + 1) * (sh_order + 2) / 2`` SH coefficients for a symmetric
         basis and ``(sh_order + 1) * (sh_order + 1)`` coefficients for a full
-        SH basis (default 4).
-    basis_type : {None, 'tournier07', 'descoteaux07'}
+        SH basis. Default: 4
+    basis_type : {None, 'tournier07', 'descoteaux07'}, optional
         ``None`` for the default DIPY basis,
         ``tournier07`` for the Tournier 2007 [2]_[3]_ basis,
         ``descoteaux07`` for the Descoteaux 2007 [1]_ basis,
         (``None`` defaults to ``descoteaux07``).
-    use_full_basis: bool
+    use_full_basis: bool, optional
         True for using a SH basis containing even and odd order SH functions.
         False for using a SH basis consisting only of even order SH functions.
-        default(false)
-    use_legacy_definition: bool
+        Default: False
+    use_legacy_definition: bool, optional
         True to use a legacy basis definition for backward compatibility
-        with previous tournier07 and descoteaux07 implementations.
+        with previous tournier07 and descoteaux07 implementations. 
+        Default: False
 
     Returns
     -------
@@ -1187,23 +1190,24 @@ def sh_to_sf_matrix(sphere, sh_order=4, basis_type=None, use_full_basis=False,
         Maximum SH order in the SH fit.  For `sh_order`, there will be
         ``(sh_order + 1) * (sh_order + 2) / 2`` SH coefficients for a symmetric
         basis and ``(sh_order + 1) * (sh_order + 1)`` coefficients for a full
-        SH basis (default 4).
-    basis_type : {None, 'tournier07', 'descoteaux07'}
+        SH basis. Default: 4
+    basis_type : {None, 'tournier07', 'descoteaux07'}, optional
         ``None`` for the default DIPY basis,
         ``tournier07`` for the symmetric Tournier 2007 [2]_[3]_ basis,
         ``descoteaux07`` for the symmetric Descoteaux 2007 [1]_ basis,
         (``None`` defaults to ``descoteaux07``).
-    use_full_basis: bool
+    use_full_basis: bool, optional
         True for using a SH basis containing even and odd order SH functions.
         False for using a SH basis consisting only of even order SH functions.
-        default(false)
-    use_legacy_definition: bool
+        Default: False
+    use_legacy_definition: bool, optional
         True to use a legacy basis definition for backward compatibility
         with previous tournier07 and descoteaux07 implementations.
-    return_inv : bool
-        If True then the inverse of the matrix is also returned
+        Default: False
+    return_inv : bool, optional
+        If True then the inverse of the matrix is also returned. Default: True
     smooth : float, optional
-        Lambda-regularization in the SH fit (default 0.0).
+        Lambda-regularization in the SH fit. Default: 0.0
 
     Returns
     -------
@@ -1253,9 +1257,10 @@ def calculate_max_order(n_coeffs, is_full_basis=False):
     ----------
     n_coeffs : int
         The number of SH coefficients
-    is_full_basis: bool
+    is_full_basis: bool, optional
         True if the used SH basis contains even and odd order SH functions.
         False if the SH basis consists only of even order SH functions.
+        Default: False
 
     Returns
     -------
@@ -1426,9 +1431,9 @@ def convert_sh_from_legacy(sh_coeffs, sh_basis, is_full_basis=False):
     sh_basis: {'descoteaux07', 'tournier07'}
         ``tournier07`` for the Tournier 2007 [2]_[3]_ basis,
         ``descoteaux07`` for the Descoteaux 2007 [1]_ basis.
-    is_full_basis: bool
+    is_full_basis: bool, optional
         True if the input SH basis includes both even and odd
-        order SH functions, else False.
+        order SH functions, else False. Default: False
 
     Returns
     -------
@@ -1479,9 +1484,9 @@ def convert_sh_to_legacy(sh_coeffs, sh_basis, is_full_basis=False):
     sh_basis: {'descoteaux07', 'tournier07'}
         ``tournier07`` for the Tournier 2007 [2]_[3]_ basis,
         ``descoteaux07`` for the Descoteaux 2007 [1]_ basis.
-    is_full_basis: bool
+    is_full_basis: bool, optional
         True if the input SH basis includes both even and odd
-        order SH functions, else False.
+        order SH functions. Default: False
 
     Returns
     -------

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -835,7 +835,8 @@ def test_mapmri_odf(radial_order=6):
     mapfit = mapmod.fit(data)
     odf = mapfit.odf(sphere)
     odf_sh = mapfit.odf_sh()
-    odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None)
+    odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None,
+                           use_legacy_definition=True)
     assert_almost_equal(odf, odf_from_sh, 10)
 
 

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -836,7 +836,7 @@ def test_mapmri_odf(radial_order=6):
     odf = mapfit.odf(sphere)
     odf_sh = mapfit.odf_sh()
     odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None,
-                           use_legacy_definition=True)
+                           legacy=True)
     assert_almost_equal(odf, odf_from_sh, 10)
 
 

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -183,9 +183,14 @@ def test_multi_shell_fiber_response():
                                               wm_response,
                                               gm_response,
                                               csf_response)
-        npt.assert_(issubclass(w[0].category, UserWarning))
+        # Test that the number of warnings raised is greater than 1, with
+        # deprecation warnings being raised from using legacy SH bases as well
+        # as a warning from multi_shell_fiber_response
+        npt.assert_(len(w) > 1)
+        # The last warning in list is the one from multi_shell_fiber_response
+        npt.assert_(issubclass(w[-1].category, UserWarning))
         npt.assert_("""No b0 given. Proceeding either way.""" in
-                    str(w[0].message))
+                    str(w[-1].message))
         npt.assert_equal(response.response.shape, (3, 7))
 
 

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -624,14 +624,15 @@ def test_convert_sh_from_legacy():
 
     sh_coeffs = sf_to_sh(odf, hemisphere, 8, legacy=True)
     converted_coeffs = convert_sh_from_legacy(sh_coeffs, 'descoteaux07')
-    expected_coeffs = sf_to_sh(odf, hemisphere, 8)
+    expected_coeffs = sf_to_sh(odf, hemisphere, 8, legacy=False)
 
     assert_array_almost_equal(converted_coeffs, expected_coeffs, 2)
 
     sh_coeffs = sf_to_sh(odf, hemisphere, 8, basis_type='tournier07',
                          legacy=True)
     converted_coeffs = convert_sh_from_legacy(sh_coeffs, 'tournier07')
-    expected_coeffs = sf_to_sh(odf, hemisphere, 8, basis_type='tournier07')
+    expected_coeffs = sf_to_sh(odf, hemisphere, 8,
+                               basis_type='tournier07', legacy=False)
 
     assert_array_almost_equal(converted_coeffs, expected_coeffs, 2)
 
@@ -642,7 +643,7 @@ def test_convert_sh_from_legacy():
     converted_coeffs = convert_sh_from_legacy(sh_coeffs, 'tournier07',
                                               full_basis=True)
     expected_coeffs = sf_to_sh(odfs, hemisphere, 8, basis_type='tournier07',
-                               full_basis=True)
+                               full_basis=True, legacy=False)
 
     assert_array_almost_equal(converted_coeffs, expected_coeffs, 2)
     assert_raises(ValueError, convert_sh_from_legacy, sh_coeffs, '', True)
@@ -654,13 +655,14 @@ def test_convert_sh_to_legacy():
     angles = [(0, 0), (60, 0)]
     odf = multi_tensor_odf(hemisphere.vertices, mevals, angles, [50, 50])
 
-    sh_coeffs = sf_to_sh(odf, hemisphere, 8)
+    sh_coeffs = sf_to_sh(odf, hemisphere, 8, legacy=False)
     converted_coeffs = convert_sh_to_legacy(sh_coeffs, 'descoteaux07')
     expected_coeffs = sf_to_sh(odf, hemisphere, 8, legacy=True)
 
     assert_array_almost_equal(converted_coeffs, expected_coeffs, 2)
 
-    sh_coeffs = sf_to_sh(odf, hemisphere, 8, basis_type='tournier07')
+    sh_coeffs = sf_to_sh(odf, hemisphere, 8, basis_type='tournier07',
+                         legacy=False)
     converted_coeffs = convert_sh_to_legacy(sh_coeffs, 'tournier07')
     expected_coeffs = sf_to_sh(odf, hemisphere, 8, basis_type='tournier07',
                                legacy=True)
@@ -670,7 +672,7 @@ def test_convert_sh_to_legacy():
     # 2D case
     odfs = np.array([odf, odf])
     sh_coeffs = sf_to_sh(odfs, hemisphere, 8, basis_type='tournier07',
-                         full_basis=True)
+                         full_basis=True, legacy=False)
     converted_coeffs = convert_sh_to_legacy(sh_coeffs, 'tournier07',
                                             full_basis=True)
     expected_coeffs = sf_to_sh(odfs, hemisphere, 8, basis_type='tournier07',

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -30,7 +30,8 @@ def test_shore_odf():
     asmfit = asm.fit(data)
     odf = asmfit.odf(sphere)
     odf_sh = asmfit.odf_sh()
-    odf_from_sh = sh_to_sf(odf_sh, sphere, 6, basis_type=None)
+    odf_from_sh = sh_to_sf(odf_sh, sphere, 6, basis_type=None,
+                           use_legacy_definition=True)
     assert_almost_equal(odf, odf_from_sh, 10)
 
     directions, _, _ = peak_directions(odf, sphere, .35, 25)
@@ -50,7 +51,7 @@ def test_shore_odf():
         data, golden_directions = sb_dummies[sbd]
         asmfit = asm.fit(data)
         odf = asmfit.odf(sphere2)
-        directions, _ , _ = peak_directions(odf, sphere2, .35, 25)
+        directions, _, _ = peak_directions(odf, sphere2, .35, 25)
         if len(directions) <= 3:
             assert_equal(len(directions), len(golden_directions))
         if len(directions) > 3:

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -31,7 +31,7 @@ def test_shore_odf():
     odf = asmfit.odf(sphere)
     odf_sh = asmfit.odf_sh()
     odf_from_sh = sh_to_sf(odf_sh, sphere, 6, basis_type=None,
-                           use_legacy_definition=True)
+                           legacy=True)
     assert_almost_equal(odf, odf_from_sh, 10)
 
     directions, _, _ = peak_directions(odf, sphere, .35, 25)

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -150,12 +150,13 @@ if interactive:
 As we can see, a symmetric basis fails to properly represent asymmetric SF.
 Fortunately, DIPY_ also implements full SH bases, which can deal with symmetric
 as well as asymmetric signals. For this tutorial, we will demonstrate it using
-the ``descoteaux07`` full SH basis by setting ``use_full_basis=true``.
+the ``descoteaux07`` full SH basis by setting ``full_basis=true``.
 """
 
-sh_coeffs = sf_to_sh(asym_odf, sph, sh_order, sh_basis, use_full_basis=True)
-reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis,
-                   use_full_basis=True)
+sh_coeffs = sf_to_sh(asym_odf, sph, sh_order,
+                     sh_basis, full_basis=True)
+reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order,
+                   sh_basis, full_basis=True)
 
 scene.clear()
 odf_actor = actor.odf_slicer(reconst[None, None, None, :], sphere=high_res_sph)

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -150,14 +150,12 @@ if interactive:
 As we can see, a symmetric basis fails to properly represent asymmetric SF.
 Fortunately, DIPY_ also implements full SH bases, which can deal with symmetric
 as well as asymmetric signals. For this tutorial, we will demonstrate it using
-the ``descoteaux07_full`` SH basis.
+the ``descoteaux07`` full SH basis by setting ``use_full_basis=true``.
 """
 
-# Change this value to try out other bases
-sh_basis = 'descoteaux07_full'
-
-sh_coeffs = sf_to_sh(asym_odf, sph, sh_order, sh_basis)
-reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis)
+sh_coeffs = sf_to_sh(asym_odf, sph, sh_order, sh_basis, use_full_basis=True)
+reconst = sh_to_sf(sh_coeffs, high_res_sph, sh_order, sh_basis,
+                   use_full_basis=True)
 
 scene.clear()
 odf_actor = actor.odf_slicer(reconst[None, None, None, :], sphere=high_res_sph)

--- a/doc/theory/sh_basis.rst
+++ b/doc/theory/sh_basis.rst
@@ -14,9 +14,17 @@ Spherical harmonics are ortho-normal functions defined by:
 
     Y_l^m(\theta, \phi) = \sqrt{\frac{2l + 1}{4 \pi} \frac{(l - m)!}{(l + m)!}} P_l^m( cos \theta) e^{i m \phi}
 
-where $l$ is the band index, $m$ is the order, $P_l^m$ is an associated
-$l$-th degree, $m$-th order Legendre polynomial, and $(\theta, \phi)$ is the
-representation of the direction vector in the spherical coordinate.
+where $l$ is the order, $m$ is the degree, $P_l^m$ is an associated
+$l$-th order, $m$-th degree Legendre polynomial, and $(\theta, \phi)$ is the
+representation of the direction vector in the spherical coordinate. The relation
+between $Y_l^{m}$ and $Y_l^{-m}$ is given by:
+
+..  math::
+
+    Y_l^{-m}(\theta, \phi) = (-1)^m \overline{Y_l^m}
+
+where $\overline{Y_l^m}$ is the complex conjugate of $Y_l^m$ defined as
+$\overline{Y_l^m} = \Re(Y_l^m) - \Im(Y_l^m)$.
 
 A function $f(\theta, \phi)$ can be represented using a spherical harmonics
 basis using the spherical harmonics coefficients $a_l^m$, which can be
@@ -27,18 +35,21 @@ computed using the expression:
     a_l^m = \int_S f(\theta, \phi) Y_l^m(\theta, \phi) ds
 
 Once the coefficients are computed, the function $f(\theta, \phi)$ can be
-approximately computed as:
+computed as:
 
 ..  math::
 
     f(\theta, \phi) = \sum_{l = 0}^{\inf} \sum_{m = -l}^{l} a^m_l Y_l^m(\theta, \phi)
 
 In HARDI, the Orientation Distribution Function (ODF) is a function on the
-sphere.
+sphere. Therefore, SH functions offer the ideal framework for reconstructing
+the ODF. Descoteaux *et al.* [1]_ use the Q-Ball Imaging (QBI) formalization
+to recover the ODF, while Tournier *et al.* [2]_ use the Spherical Deconvolution
+(SD) framework.
 
 Several Spherical Harmonics bases have been proposed in the diffusion imaging
 literature for the computation of the ODF. DIPY implements two of these in the
-:mod:`~dipy.reconst.shm` module tool set:
+:mod:`~dipy.reconst.shm` module set:
 
 - The basis proposed by Descoteaux *et al.* [1]_:
 
@@ -46,7 +57,7 @@ literature for the computation of the ODF. DIPY implements two of these in the
 
     Y_i(\theta, \phi) =
      \begin{cases}
-     \sqrt{2} \Re(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     \sqrt{2} \Re(Y_l^{m}(\theta, \phi)) & -l \leq m < 0, \\
      Y_l^0(\theta, \phi) & m = 0, \\
      \sqrt{2} \Im(Y_l^m(\theta, \phi)) & 0 < m \leq l
      \end{cases}
@@ -57,28 +68,42 @@ literature for the computation of the ODF. DIPY implements two of these in the
 
     Y_i(\theta, \phi) =
      \begin{cases}
-     \Im(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     \Im(Y_l^{m}(\theta, \phi)) & -l \leq m < 0, \\
      Y_l^0(\theta, \phi) & m = 0, \\
      \Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
      \end{cases}
 
 In both cases, $\Re$ denotes the real part of the spherical harmonic basis, and
-$\Im$ denotes the imaginary part.
+$\Im$ denotes the imaginary part. The SH bases are both orthogonal and real. Moreover,
+the `descoteaux07` basis is orthonormal. 
 
-In practice, a maximum even order $k$ is chosen such that $k \leq l$. By only
+The basis proposed by Tournier is the one used in MRtrix [3]_. However, the MRtrix
+implementation differs from the cited paper definition, as it is given by:
+
+..  math::
+
+    Y_i(\theta, \phi) =
+     \begin{cases}
+     \sqrt{2}\Im(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     Y_l^0(\theta, \phi) & m = 0, \\
+     \sqrt{2}\Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
+     \end{cases}
+
+As we can see, the differences include a $\sqrt{2}$ factor multiplying the SH functions
+when $m$ is different than 0 as well as an absolute value for the degree $m$ when $m$ is negative.
+The $\sqrt{2}$ factor has been added to the definition in MRtrix3 in order to make the Tournier basis
+orthonormal. Considering the absolute value of $m$ when $m < 0$ only affects the sign of the
+resulting SH functions, due to the relations $-p=|p|$ $\forall p < 0$ and 
+$Y_l^{-m} = (-1)^m\overline{Y_l^{m}}$, and therefore still results in a valid basis.
+
+In practice, a maximum even order $k$ is used to truncated the SH series. By only
 taking into account even order SH functions, the above bases can be used to
 reconstruct symmetric spherical functions. The choice of an even order is
 motivated by the symmetry of the diffusion process around the origin.
 
-Both bases are also available as full SH bases, where odd order SH functions are
-also taken into account when reconstructing a spherical function. These full
-bases can successfully reconstruct asymmetric signals as well as symmetric
-signals.
-
-Descoteaux *et al.* [1]_ use the Q-Ball Imaging (QBI) formalization to recover
-the ODF, while Tournier *et al.* [2]_ use the Spherical Deconvolution (SD)
-framework to recover the ODF.
-
+Both bases are also available as full SH bases, where odd order SH functions are 
+also taken into account when reconstructing a spherical function. These full bases
+can successfully reconstruct asymmetric signals as well as symmetric signals.
 
 References
 ----------
@@ -89,3 +114,7 @@ References
        of the fibre orientation distribution in diffusion MRI:
        Non-negativity constrained super-resolved spherical deconvolution.
        NeuroImage. 2007;35(4):1459–1472.
+.. [3] Tournier J-D, Smith R, Raffelt D, Tabbara R, Dhollander T,
+       Pietsch M, et al. MRtrix3: A fast, flexible and open software
+       framework for medical image processing and visualisation.
+       NeuroImage. 2019 Nov 15;202:116-137.

--- a/doc/theory/sh_basis.rst
+++ b/doc/theory/sh_basis.rst
@@ -4,11 +4,11 @@
 Spherical Harmonic bases
 ========================
 
-Spherical Harmonics (SH) are functions defined on the sphere. A collection of SH
-can used as a basis function to represent and reconstruct any function on the
-surface of a unit sphere.
+Spherical Harmonics (SH) are functions defined on the sphere. A collection of
+SH can be used as a basis function to represent and reconstruct any function on
+the surface of a unit sphere.
 
-Spherical harmonics are ortho-normal functions defined by:
+Spherical harmonics are orthonormal functions defined by:
 
 ..  math::
 
@@ -39,7 +39,7 @@ computed as:
 
 ..  math::
 
-    f(\theta, \phi) = \sum_{l = 0}^{\inf} \sum_{m = -l}^{l} a^m_l Y_l^m(\theta, \phi)
+    f(\theta, \phi) = \sum_{l = 0}^{\infty} \sum_{m = -l}^{l} a^m_l Y_l^m(\theta, \phi)
 
 In HARDI, the Orientation Distribution Function (ODF) is a function on the
 sphere. Therefore, SH functions offer the ideal framework for reconstructing
@@ -47,9 +47,10 @@ the ODF. Descoteaux *et al.* [1]_ use the Q-Ball Imaging (QBI) formalization
 to recover the ODF, while Tournier *et al.* [2]_ use the Spherical Deconvolution
 (SD) framework.
 
-Several Spherical Harmonics bases have been proposed in the diffusion imaging
-literature for the computation of the ODF. DIPY implements two of these in the
-:mod:`~dipy.reconst.shm` module set:
+Several modified SH bases have been proposed in the diffusion imaging literature
+for the computation of the ODF. DIPY implements two of these in the 
+:mod:`~dipy.reconst.shm` module set. Below are the formal definitions taken
+directly from the literature.
 
 - The basis proposed by Descoteaux *et al.* [1]_:
 
@@ -75,35 +76,88 @@ literature for the computation of the ODF. DIPY implements two of these in the
 
 In both cases, $\Re$ denotes the real part of the spherical harmonic basis, and
 $\Im$ denotes the imaginary part. The SH bases are both orthogonal and real. Moreover,
-the `descoteaux07` basis is orthonormal. 
+the `descoteaux07` basis is orthonormal.
 
-The basis proposed by Tournier is the one used in MRtrix [3]_. However, the MRtrix
-implementation differs from the cited paper definition, as it is given by:
+In both cases, $\Re$ denotes the real part of the SH basis, and $\Im$ denotes
+the imaginary part. By alternately selecting the real or imaginary part of the
+original SH basis, the modified SH bases have the properties of being both
+orthogonal and real. Moreover, due to the presence of the $\sqrt{2}$ factor,
+the basis proposed by Descoteaux *et al.* is orthonormal.
+
+The SH bases implemented in DIPY for versions 1.2 and below differ slighly
+from the litterature. Their implementation is given below.
+
+- The ``descoteaux07`` basis is based on the one proposed by Descoteaux *et al.*
+  [1]_ and is given by:
 
 ..  math::
 
     Y_i(\theta, \phi) =
      \begin{cases}
-     \sqrt{2}\Im(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     \sqrt{2} \Re(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
      Y_l^0(\theta, \phi) & m = 0, \\
-     \sqrt{2}\Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
+     \sqrt{2} \Im(Y_l^m(\theta, \phi)) & 0 < m \leq l
      \end{cases}
 
-As we can see, the differences include a $\sqrt{2}$ factor multiplying the SH functions
-when $m$ is different than 0 as well as an absolute value for the degree $m$ when $m$ is negative.
-The $\sqrt{2}$ factor has been added to the definition in MRtrix3 in order to make the Tournier basis
-orthonormal. Considering the absolute value of $m$ when $m < 0$ only affects the sign of the
-resulting SH functions, due to the relations $-p=|p|$ $\forall p < 0$ and 
-$Y_l^{-m} = (-1)^m\overline{Y_l^{m}}$, and therefore still results in a valid basis.
+- The ``tournier07`` basis is based on the one proposed by Tournier *et al.*
+  [2]_ and is given by:
 
-In practice, a maximum even order $k$ is used to truncated the SH series. By only
-taking into account even order SH functions, the above bases can be used to
-reconstruct symmetric spherical functions. The choice of an even order is
+..  math::
+
+    Y_i(\theta, \phi) =
+     \begin{cases}
+     \Im(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     Y_l^0(\theta, \phi) & m = 0, \\
+     \Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
+     \end{cases}
+
+These bases differ from the literature by the presence of an absolute value around
+$m$ when $m < 0$. Due to relations $-p = |p| ; \forall p < 0$ and
+$Y_l^{-m}(\theta, \phi) = (-1)^m \overline{Y_l^m}$, the effect of this change is a
+sign flip for the SH functions of even degree $m < 0$. This has no effect on the
+mathematical properties of each basis.
+
+The ``tournier07`` SH basis defined above is the basis used in MRtrix 0.2 [3]_.
+However, the omission of the $\sqrt{2}$ factor seen in the basis from Descoteaux
+*et al.* [1]_ makes it non-orthonormal. For this reason, the MRtrix3 [4]_ SH
+basis uses a new basis including the normalization factor.
+
+Since DIPY 1.3, the ``descoteaux07`` and ``tournier07`` SH bases have been
+updated in order to agree with the litterature and the latest MRtrix3
+implementation. While previous bases are still available as *legacy* bases, 
+the ``descoteaux07`` and ``tournier07`` bases now default to:
+
+..  math::
+
+    Y_i(\theta, \phi) =
+     \begin{cases}
+     \sqrt{2} \Re(Y_l^{m}(\theta, \phi)) & -l \leq m < 0, \\
+     Y_l^0(\theta, \phi) & m = 0, \\
+     \sqrt{2} \Im(Y_l^m(\theta, \phi)) & 0 < m \leq l
+     \end{cases}
+
+for the ``descoteaux07`` basis and
+
+..  math::
+
+    Y_i(\theta, \phi) =
+     \begin{cases}
+     \sqrt{2} \Im(Y_l^{|m|}(\theta, \phi)) & -l \leq m < 0, \\
+     Y_l^0(\theta, \phi) & m = 0, \\
+     \sqrt{2} \Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
+     \end{cases}
+
+for the ``tournier07`` basis.
+
+In practice, a maximum order $k$ is used to truncate the SH series. By
+only taking into account even order SH functions, the above bases can be used
+to reconstruct symmetric spherical functions. The choice of an even order is
 motivated by the symmetry of the diffusion process around the origin.
 
-Both bases are also available as full SH bases, where odd order SH functions are 
-also taken into account when reconstructing a spherical function. These full bases
-can successfully reconstruct asymmetric signals as well as symmetric signals.
+Both bases are also available as full SH bases, where odd order SH functions
+are also taken into account when reconstructing a spherical function. These
+full bases can successfully reconstruct asymmetric signals as well as
+symmetric signals.
 
 References
 ----------
@@ -115,6 +169,10 @@ References
        Non-negativity constrained super-resolved spherical deconvolution.
        NeuroImage. 2007;35(4):1459–1472.
 .. [3] Tournier J-D, Smith R, Raffelt D, Tabbara R, Dhollander T,
+       Pietsch M, et al. MRtrix3: A fast, flexible and open software
+       framework for medical image processing and visualisation.
+       NeuroImage. 2019 Nov 15;202:116-137.
+.. [4] Tournier J-D, Smith R, Raffelt D, Tabbara R, Dhollander T,
        Pietsch M, et al. MRtrix3: A fast, flexible and open software
        framework for medical image processing and visualisation.
        NeuroImage. 2019 Nov 15;202:116-137.

--- a/doc/theory/sh_basis.rst
+++ b/doc/theory/sh_basis.rst
@@ -49,7 +49,7 @@ to recover the ODF, while Tournier *et al.* [2]_ use the Spherical Deconvolution
 
 Several modified SH bases have been proposed in the diffusion imaging literature
 for the computation of the ODF. DIPY implements two of these in the 
-:mod:`~dipy.reconst.shm` module set. Below are the formal definitions taken
+:mod:`~dipy.reconst.shm` module. Below are the formal definitions taken
 directly from the literature.
 
 - The basis proposed by Descoteaux *et al.* [1]_:
@@ -123,7 +123,7 @@ However, the omission of the $\sqrt{2}$ factor seen in the basis from Descoteaux
 basis uses a new basis including the normalization factor.
 
 Since DIPY 1.3, the ``descoteaux07`` and ``tournier07`` SH bases have been
-updated in order to agree with the litterature and the latest MRtrix3
+updated in order to agree with the literature and the latest MRtrix3
 implementation. While previous bases are still available as *legacy* bases, 
 the ``descoteaux07`` and ``tournier07`` bases now default to:
 
@@ -147,7 +147,9 @@ for the ``descoteaux07`` basis and
      \sqrt{2} \Re(Y_{l}^m(\theta, \phi)) & 0 < m \leq l
      \end{cases}
 
-for the ``tournier07`` basis.
+for the ``tournier07`` basis. Both bases are very similar, with their only
+difference being the sign of $m$ for which the imaginary and real parts of
+the spherical harmonic $Y_{l}^m$ are used.
 
 In practice, a maximum order $k$ is used to truncate the SH series. By
 only taking into account even order SH functions, the above bases can be used

--- a/doc/theory/sh_basis.rst
+++ b/doc/theory/sh_basis.rst
@@ -16,7 +16,7 @@ Spherical harmonics are orthonormal functions defined by:
 
 where $l$ is the order, $m$ is the degree, $P_l^m$ is an associated
 $l$-th order, $m$-th degree Legendre polynomial, and $(\theta, \phi)$ is the
-representation of the direction vector in the spherical coordinate. The relation
+representation of the direction vector in spherical coordinates. The relation
 between $Y_l^{m}$ and $Y_l^{-m}$ is given by:
 
 ..  math::


### PR DESCRIPTION
Update of spherical harmonics and their associated documentation for better agreement with literature as well as MRtrix. This pull request mostly consists of:

1. A new `descoteaux07` basis corresponding exactly to the one from the cited paper, that is without an absolute value for negative values of `m`;
2. A new `tournier07` basis corresponding to the new MRtrix3 definition;
3. New functions `real_sh_descoteaux` and `real_sh_tournier` to replace `real_sym_sh_mrtrix` and `real_sym_sh_basis`. These function allow to chose between the new bases (by default) and the _legacy_ bases. Furthermore, they allow the user to use a full SH basis by setting `is_full_basis=True`;
4. Deprecation warnings for the _legacy_ bases and functions `real_sym_sh_mrtrix` and `real_sym_sh_basis`;
5. Utility methods for converting to and from _legacy_ bases;
6. An updated documentation on SH theory giving further explanation regarding the differences between implementations and definitions.

Looking forward to your feedback,
Have a great day!