### PR TITLE
Really release the memory used by arclength variable.

### DIFF
--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -242,7 +242,7 @@ cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
         out[new_N-1, dim] = streamline[N-1, dim]
 
     free(arclengths)
-
+    arclengths = NULL
 
 cdef void c_set_number_of_points_from_arraysequence(Streamline points,
                                                     np.npy_intp[:] offsets,


### PR DESCRIPTION
This is a one-liner. I intermittently run into the following crash when running scripts that use particle filtering tractography: 

```
python(68504,0x11d1fcd40) malloc: Incorrect checksum for freed object 0x7fd1b24b2400: probably modified after being freed.
Corrupt value: 0x3fda8e5f3588a582
python(68504,0x11d1fcd40) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6

```

I found this SO post: https://stackoverflow.com/a/51546263/3532933, and this change was the only one that made sense given the context. 