### PR TITLE
[CI] Replace Rackspace by https://anaconda.org/scipy-wheels-nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pkl
 *.orig
 *.trk
+*.pam5
 build
 *~
 doc/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
       # Check against latest available pre-release version of all packages
       env:
         - USE_PRE=1
-        - DEPENDS="$DEPENDS scipy"
+        - DEPENDS="$DEPENDS scipy statsmodels pandas scikit_learn"
   allow_failures:
     - python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ env:
         - DEPENDS="cython numpy matplotlib h5py nibabel cvxpy"
         - VENV_ARGS="--python=python"
         - INSTALL_TYPE="setup"
-        - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
-        - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-        - EXTRA_PIP_FLAGS="--timeout=60 --find-links=$EXTRA_WHEELS"
+        - PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"
+        - EXTRA_PIP_FLAGS="--timeout=60 "
 
 python:
     - 3.6
@@ -102,12 +101,12 @@ matrix:
       dist: xenial
       env:
         - USE_PRE=1
-        - DEPENDS="$DEPENDS scipy"
+        - DEPENDS="$DEPENDS scipy statsmodels pandas scikit_learn"
 
 before_install:
     - PIPI="pip install $EXTRA_PIP_FLAGS"
     - if [ -n "$USE_PRE" ]; then
-        PIPI="$PIPI --find-links=$PRE_WHEELS --pre";
+        PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
       fi
     - pip install --upgrade virtualenv
     - virtualenv $VENV_ARGS venv

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,11 @@ jobs:
         MESA_GL_VERSION_OVERRIDE: '3.3'
         LIBGL_ALWAYS_INDIRECT: 'y'
         EXTRA_DEPENDS: "scikit_learn vtk fury scipy xvfbwrapper"
+      # TODO: Need to figure out how to allow failure before any activation
+      # Python37-64bit - PRE:
+      #   USE_PRE: 1
+      #   python.version: '3.7'
+      #   EXTRA_DEPENDS: "scikit_learn scipy statsmodels pandas "
 
 - template: ci/azure/windows.yml
   parameters:
@@ -121,3 +126,8 @@ jobs:
         MESA_GL_VERSION_OVERRIDE: '3.3'
         LIBGL_ALWAYS_INDIRECT: 'y'
         EXTRA_DEPENDS: "scikit_learn vtk fury scipy"
+      # TODO: Need to figure out how to allow failure before any activation
+      # Python37-64bit - PRE:
+      #   USE_PRE: 1
+      #   python.version: '3.7'
+      #   EXTRA_DEPENDS: "scikit_learn scipy statsmodels pandas "

--- a/ci/azure/osx.yml
+++ b/ci/azure/osx.yml
@@ -11,8 +11,7 @@ jobs:
     DEPENDS: "cython numpy matplotlib h5py nibabel cvxpy"
     VENV_ARGS: "--python=python"
     INSTALL_TYPE: "setup"
-    EXTRA_WHEELS: "https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
-    PRE_WHEELS: "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+    PRE_WHEELS: "https://pypi.anaconda.org/scipy-wheels-nightly/simple"
   strategy:
     # maxParallel: 3
     matrix:

--- a/ci/azure/script.ps1
+++ b/ci/azure/script.ps1
@@ -20,7 +20,7 @@ if($env:INSTALL_TYPE -match "conda")
     Invoke-CmdScript $env:CONDA\Scripts\activate.bat testenv
 }
 
-$env:PIPI = "pip install --timeout=60 --find-links=$env:EXTRA_WHEELS"
+$env:PIPI = "pip install --timeout=60"
 # Print and check this environment variable
 Write-Output "Pip command: $env:PIPI"
 

--- a/ci/azure/script.sh
+++ b/ci/azure/script.sh
@@ -7,10 +7,10 @@ else
     source venv/bin/activate
 fi
 
-PIPI="pip install --timeout=60 --find-links=$EXTRA_WHEELS"
+PIPI="pip install --timeout=60"
 
 if [ -n "$USE_PRE" ]; then
-    PIPI="$PIPI --find-links=$PRE_WHEELS --pre";
+    PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
 fi
 
 #---------- DIPY Installation -----------------

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -12,8 +12,7 @@ jobs:
     DEPENDS: "cython numpy matplotlib h5py nibabel cvxpy"
     VENV_ARGS: "--python=python"
     INSTALL_TYPE: "setup"
-    EXTRA_WHEELS: "https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
-    PRE_WHEELS: "https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+    PRE_WHEELS: "https://pypi.anaconda.org/scipy-wheels-nightly/simple"
   strategy:
     # maxParallel: 3
     matrix:


### PR DESCRIPTION
This PR should fix #2214.

As explained before, Rackspace does not exist anymore. Many packages (numpy, scipy, pandas) upload their nightly wheels to [this anaconda server. ](https://anaconda.org/scipy-wheels-nightly)

Also, DIPY uploads to this server (twice per week)  `dev` wheels from `master`.

EDIT :  ~~The only important missing package is Cython. We need to find a solution to test the future wheels of this package.~~  it is available