### PR TITLE
STYLE: Conform to `reStructuredText` syntax in examples sections

### DIFF
--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -52,7 +52,8 @@ gtab = gradient_table(bvals, bvecs)
 print("Input Volume", data.shape)
 
 """
-## Estimate the noise standard deviation
+Estimate the noise standard deviation
+=====================================
 
 We use the ``pca_noise_estimate`` method to estimate the value of sigma to be
 used in local PCA algorithm proposed by Manjon et al. [Manjon2013]_.
@@ -71,7 +72,8 @@ sigma = pca_noise_estimate(data, gtab, correct_bias=True, smooth=3)
 print("Sigma estimation time", time() - t)
 
 """
-## Perform the localPCA using the function localpca.
+Perform the localPCA using the function `localpca`
+==================================================
 
 The localpca algorithm takes into account the multi-dimensional information of
 the diffusion MR data. It performs PCA on local 4D patch and

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -207,7 +207,8 @@ the upper panels, while the DKI maps from the denoised data are shown in the
 lower panels. Substantial improvements on measurements robustness can be
 visually appreciated, particularly for the FA and MK estimates.
 
-## noise standard deviation estimation using the Marcenko-Pastur PCA algorithm
+Noise standard deviation estimation using the Marcenko-Pastur PCA algorithm
+===========================================================================
 
 As mentioned above, the Marcenko-Pastur PCA algorithm can also be used to
 estimate the image's noise standard deviation (std). The noise std

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -44,7 +44,8 @@ You can verify the b-values of the dataset by looking at the attribute
 ``gtab.bvals``. Now that a datasets with multiple gradient directions is
 loaded, we can proceed with the two steps of CSD.
 
-## Step 1. Estimation of the fiber response function.
+Step 1. Estimation of the fiber response function
+=================================================
 
 There are many strategies to estimate the fiber response function. Here two
 different strategies are presented.
@@ -212,7 +213,8 @@ if interactive:
 scene.rm(response_actor)
 
 """
-## Step 2. fODF reconstruction
+Step 2. fODF reconstruction
+===========================
 
 After estimating a response function for one of the strategies shown above,
 we are ready to start the deconvolution process. Let's import the CSD model

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -304,7 +304,8 @@ diffusion-weighted signals. The details on how to compute
 the kurtosis from powder-average signals in dipy are described in follow the
 tutorial (:ref:`example-reconst-msdki`).
 
-## Mean kurtosis tensor and kurtosis fractional anisotropy
+Mean kurtosis tensor and kurtosis fractional anisotropy
+=======================================================
 
 As pointed by previous studies [Hansen2013]_, axial, radial and mean kurtosis
 depends on the information of both diffusion and kurtosis tensor. DKI measures


### PR DESCRIPTION
Conform to `reStructuredText` syntax in examples sections.