### PR TITLE
TST: Assert the shape of the output based on the docstring.

### DIFF
--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -302,6 +302,8 @@ def test_auto_response_msmt():
         with bvalues lower than 1200, followed by response_from_mask_msmt
         to overcome this.""" in str(w[0].message))
 
+        npt.assert_equal(response_auto_wm.shape, (len(gtab.bvals)-1, 4))
+
         mask_wm, mask_gm, mask_csf = mask_for_response_msmt(gtab, data,
                                                             roi_center=None,
                                                             roi_radii=(1, 1, 0),


### PR DESCRIPTION
This one is a question for @karanphil. According to the [docstring](https://github.com/dipy/dipy/blob/master/dipy/reconst/mcsd.py#L746), each of the outputs of this function should have the shape: (len(gtab.bvals)-1, 4). And yet, this test fails. Am I missing something?