### PR TITLE
[ENH] Add inplace kwarg to gibbs_removal

### DIFF
--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -220,7 +220,7 @@ def _gibbs_removal_2d(image, n_points=3, G0=None, G1=None):
     return imagec
 
 
-def gibbs_removal(vol, slice_axis=2, n_points=3):
+def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True):
     """Suppresses Gibbs ringing artefacts of images volumes.
 
     Parameters
@@ -233,6 +233,10 @@ def gibbs_removal(vol, slice_axis=2, n_points=3):
     n_points : int, optional
         Number of neighbour points to access local TV (see note).
         Default is set to 3.
+    inplace : bool, optional
+        If True, the input data is replaced with results. Otherwise, returns
+        a new array.
+        Default is set to True.
 
     Returns
     -------
@@ -257,6 +261,9 @@ def gibbs_removal(vol, slice_axis=2, n_points=3):
 
     """
     nd = vol.ndim
+
+    if not isinstance(inplace, bool):
+        raise TypeError("inplace must be a boolean.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -283,9 +290,13 @@ def gibbs_removal(vol, slice_axis=2, n_points=3):
     shap = vol.shape
     G0, G1 = _weights(shap[:2])
 
+    # Copy data if not inplace
+    if not inplace:
+        vol = vol.copy()
+
     # Run Gibbs removal of 2D images
     if nd == 2:
-        vol = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
+        vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
         for vi in range(shap[2]):
             vol[:, :, vi] = _gibbs_removal_2d(vol[:, :, vi], n_points=n_points,

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -38,6 +38,33 @@ def setup_module():
     image_cor = _gibbs_removal_2d(image_gibbs)
 
 
+def test_inplace():
+    # Make input data
+    input_2d = image_gibbs.copy()
+    input_3d = np.stack([input_2d, input_2d], axis=2)
+    input_4d = np.stack([input_3d, input_3d], axis=3)
+
+    # Test 2d cases
+    output_2d = gibbs_removal(input_2d, inplace=False)
+    assert_raises(AssertionError, assert_array_almost_equal, input_2d, output_2d)
+
+    output_2d = gibbs_removal(input_2d, inplace=True)
+    assert_array_almost_equal(input_2d, output_2d)
+
+    # Test 3d case
+    output_3d = gibbs_removal(input_3d, inplace=False)
+    assert_raises(AssertionError, assert_array_almost_equal, input_3d, output_3d)
+
+    output_3d = gibbs_removal(input_3d, inplace=True)
+    assert_array_almost_equal(input_3d, output_3d)
+
+    # Test 4d case
+    output_4d = gibbs_removal(input_4d, inplace=False)
+    assert_raises(AssertionError, assert_array_almost_equal, input_4d, output_4d)
+
+    output_4d = gibbs_removal(input_4d, inplace=True)
+    assert_array_almost_equal(input_4d, output_4d)
+
 def test_gibbs_2d():
 
     # Correction of gibbs ringing have to be closer to gt than denoised image
@@ -46,7 +73,7 @@ def test_gibbs_2d():
     assert_(diff_raw > diff_cor)
 
     # Test if gibbs_removal works for 2D data
-    image_cor2 = gibbs_removal(image_gibbs)
+    image_cor2 = gibbs_removal(image_gibbs, inplace=False)
     assert_array_almost_equal(image_cor2, image_cor)
 
 
@@ -79,13 +106,13 @@ def test_gibbs_4d():
 def test_swapped_gibbs_2d():
     # 2D case: In this case slice_axis is a dummy variable. Since data is
     # already a single 2D image, to axis swapping is required
-    image_cor0 = gibbs_removal(image_gibbs, slice_axis=0)
+    image_cor0 = gibbs_removal(image_gibbs, slice_axis=0, inplace=False)
     assert_array_almost_equal(image_cor0, image_cor)
 
-    image_cor1 = gibbs_removal(image_gibbs, slice_axis=1)
+    image_cor1 = gibbs_removal(image_gibbs, slice_axis=1, inplace=False)
     assert_array_almost_equal(image_cor1, image_cor)
 
-    image_cor2 = gibbs_removal(image_gibbs, slice_axis=2)
+    image_cor2 = gibbs_removal(image_gibbs, slice_axis=2, inplace=False)
     assert_array_almost_equal(image_cor2, image_cor)
 
 
@@ -182,7 +209,7 @@ def test_non_square_image():
     img_gt[4 * Nre: 5 * Nre, 3 * Nori: 5 * Nori] = 3
 
     # Suppressing gibbs artefacts
-    img_cor = gibbs_removal(img_gibbs)
+    img_cor = gibbs_removal(img_gibbs, inplace=False)
 
     # Correction of gibbs ringing have to be closer to gt than denoised image
     diff_raw = np.mean(abs(img_gibbs - img_gt))

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -46,21 +46,27 @@ def test_inplace():
 
     # Test 2d cases
     output_2d = gibbs_removal(input_2d, inplace=False)
-    assert_raises(AssertionError, assert_array_almost_equal, input_2d, output_2d)
+    assert_raises(
+        AssertionError, assert_array_almost_equal, input_2d, output_2d
+    )
 
     output_2d = gibbs_removal(input_2d, inplace=True)
     assert_array_almost_equal(input_2d, output_2d)
 
     # Test 3d case
     output_3d = gibbs_removal(input_3d, inplace=False)
-    assert_raises(AssertionError, assert_array_almost_equal, input_3d, output_3d)
+    assert_raises(
+        AssertionError, assert_array_almost_equal, input_3d, output_3d
+    )
 
     output_3d = gibbs_removal(input_3d, inplace=True)
     assert_array_almost_equal(input_3d, output_3d)
 
     # Test 4d case
     output_4d = gibbs_removal(input_4d, inplace=False)
-    assert_raises(AssertionError, assert_array_almost_equal, input_4d, output_4d)
+    assert_raises(
+        AssertionError, assert_array_almost_equal, input_4d, output_4d
+    )
 
     output_4d = gibbs_removal(input_4d, inplace=True)
     assert_array_almost_equal(input_4d, output_4d)

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -158,6 +158,7 @@ def test_gibbs_errors():
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2)), 3)
+    assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
 
 
 def test_gibbs_subfunction():


### PR DESCRIPTION
Added `inplace` kwarg to `gibbs_removal`. Set to `True` by default. The inplace behavior is consistent regardless of the dimensionality of input data. 

Note that I had to modify the original tests by adding `inplace=False` in some cases to keep the original behavior, which assumed 2d inputs always returned a copy.

Closes #2237 