### PR TITLE
[ENH] Deprecate interp parameter name in AffineMap

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -56,7 +56,7 @@ from dipy.align.parzenhist import (ParzenJointHistogram,
                                    compute_parzen_mi)
 from dipy.align.imwarp import (get_direction_and_spacings, ScaleSpace)
 from dipy.align.scalespace import IsotropicScaleSpace
-from warnings import warn
+from dipy.utils.deprecator import deprecated_params
 
 _interp_options = ['nearest', 'linear']
 _transform_method = {}
@@ -245,9 +245,11 @@ class AffineMap(object):
                                           .format(format_spec,
                                                   allowed_formats_print_map))
 
-    def _apply_transform(self, image, interp='linear', image_grid2world=None,
-                         sampling_grid_shape=None, sampling_grid2world=None,
-                         resample_only=False, apply_inverse=False):
+    @deprecated_params('interp', 'interpolation', since='1.13', until='1.15')
+    def _apply_transform(self, image, interpolation='linear',
+                         image_grid2world=None, sampling_grid_shape=None,
+                         sampling_grid2world=None, resample_only=False,
+                         apply_inverse=False):
         """Transform the input image applying this affine transform.
 
         This is a generic function to transform images using either this
@@ -267,7 +269,7 @@ class AffineMap(object):
         ----------
         image :  2D or 3D array
             the image to be transformed
-        interp : string, either 'linear' or 'nearest'
+        interpolation : string, either 'linear' or 'nearest'
             the type of interpolation to be used, either 'linear'
             (for k-linear interpolation) or 'nearest' for nearest neighbor
         image_grid2world : array, shape (dim + 1, dim + 1), optional
@@ -302,8 +304,9 @@ class AffineMap(object):
 
         """
         # Verify valid interpolation requested
-        if interp not in _interp_options:
-            raise ValueError('Unknown interpolation method: %s' % (interp,))
+        if interpolation not in _interp_options:
+            msg = 'Unknown interpolation method: %s' % (interpolation,)
+            raise ValueError(msg)
 
         # Obtain sampling grid
         if sampling_grid_shape is None:
@@ -354,12 +357,14 @@ class AffineMap(object):
             comp = image_world2grid.dot(aff.dot(sampling_grid2world))
 
         # Transform the input image
-        if interp == 'linear':
+        if interpolation == 'linear':
             image = image.astype(np.float64)
-        transformed = _transform_method[(dim, interp)](image, shape, comp)
+        transformed = _transform_method[(dim, interpolation)](image, shape,
+                                                              comp)
         return transformed
 
-    def transform(self, image, interp='linear', image_grid2world=None,
+    @deprecated_params('interp', 'interpolation', since='1.13', until='1.15')
+    def transform(self, image, interpolation='linear', image_grid2world=None,
                   sampling_grid_shape=None, sampling_grid2world=None,
                   resample_only=False):
         """Transform the input image from co-domain to domain space.
@@ -372,7 +377,7 @@ class AffineMap(object):
         ----------
         image :  2D or 3D array
             the image to be transformed
-        interp : string, either 'linear' or 'nearest'
+        interpolation : string, either 'linear' or 'nearest'
             the type of interpolation to be used, either 'linear'
             (for k-linear interpolation) or 'nearest' for nearest neighbor
         image_grid2world : array, shape (dim + 1, dim + 1), optional
@@ -401,16 +406,18 @@ class AffineMap(object):
             the transformed image, sampled at the requested grid
 
         """
-        transformed = self._apply_transform(image, interp, image_grid2world,
+        transformed = self._apply_transform(image, interpolation,
+                                            image_grid2world,
                                             sampling_grid_shape,
                                             sampling_grid2world,
                                             resample_only,
                                             apply_inverse=False)
         return np.array(transformed)
 
-    def transform_inverse(self, image, interp='linear', image_grid2world=None,
-                          sampling_grid_shape=None, sampling_grid2world=None,
-                          resample_only=False):
+    @deprecated_params('interp', 'interpolation', since='1.13', until='1.15')
+    def transform_inverse(self, image, interpolation='linear',
+                          image_grid2world=None, sampling_grid_shape=None,
+                          sampling_grid2world=None, resample_only=False):
         """Transform the input image from domain to co-domain space.
 
         By default, the transformed image is sampled at a grid defined by
@@ -421,7 +428,7 @@ class AffineMap(object):
         ----------
         image :  2D or 3D array
             the image to be transformed
-        interp : string, either 'linear' or 'nearest'
+        interpolation : string, either 'linear' or 'nearest'
             the type of interpolation to be used, either 'linear'
             (for k-linear interpolation) or 'nearest' for nearest neighbor
         image_grid2world : array, shape (dim + 1, dim + 1), optional
@@ -450,7 +457,8 @@ class AffineMap(object):
             the transformed image, sampled at the requested grid
 
         """
-        transformed = self._apply_transform(image, interp, image_grid2world,
+        transformed = self._apply_transform(image, interpolation,
+                                            image_grid2world,
                                             sampling_grid_shape,
                                             sampling_grid2world,
                                             resample_only,

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -498,14 +498,16 @@ def test_affine_map():
                                             cod_shape[:dim],
                                             codomain_grid2world,
                                             dom_shape[:dim], domain_grid2world)
-            actual_linear = affine_map.transform_inverse(img, interpolation='linear')
-            actual_nn = affine_map.transform_inverse(img, interpolation='nearest')
+            actual_linear = affine_map.transform_inverse(
+                img, interpolation='linear')
+            actual_nn = affine_map.transform_inverse(img,
+                                                     interpolation='nearest')
             assert_array_almost_equal(actual_linear, expected_linear)
             assert_array_almost_equal(actual_nn, expected_nn)
 
         # Verify AffineMap can not be created with non-square matrix
-        non_square_shapes = [ np.zeros((dim, dim + 1), dtype=np.float64),
-                           np.zeros((dim + 1, dim), dtype=np.float64) ]
+        non_square_shapes = [np.zeros((dim, dim + 1), dtype=np.float64),
+                             np.zeros((dim + 1, dim), dtype=np.float64)]
         for nsq in non_square_shapes:
             assert_raises(AffineInversionError, AffineMap, nsq)
 
@@ -516,7 +518,7 @@ def test_affine_map():
                 continue
             bad_aug = aff_map.affine
             # no zeros in the first n-1 columns on last row
-            bad_aug[-1,:] = 1
+            bad_aug[-1, :] = 1
             assert_raises(AffineInvalidValuesError, AffineMap, bad_aug)
 
             bad_aug = aff_map.affine
@@ -575,8 +577,10 @@ def test_affine_map():
                 AffineInvalidValuesError,
                 affine_map.set_affine,
                 aff_sing)
-            assert_raises(AffineInvalidValuesError, affine_map.set_affine, aff_nan)
-            assert_raises(AffineInvalidValuesError, affine_map.set_affine, aff_inf)
+            assert_raises(AffineInvalidValuesError, affine_map.set_affine,
+                          aff_nan)
+            assert_raises(AffineInvalidValuesError, affine_map.set_affine,
+                          aff_inf)
 
     # Verify AffineMap can not be created with non-2D matrices : len(shape) != 2
     for dim_not_2 in range(10):

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -458,8 +458,8 @@ def test_affine_map():
                                             dom_shape[:dim], domain_grid2world,
                                             cod_shape[:dim],
                                             codomain_grid2world)
-            actual_linear = affine_map.transform(img, interp='linear')
-            actual_nn = affine_map.transform(img, interp='nearest')
+            actual_linear = affine_map.transform(img, interpolation='linear')
+            actual_nn = affine_map.transform(img, interpolation='nearest')
             assert_array_almost_equal(actual_linear, expected_linear)
             assert_array_almost_equal(actual_nn, expected_nn)
 
@@ -498,8 +498,8 @@ def test_affine_map():
                                             cod_shape[:dim],
                                             codomain_grid2world,
                                             dom_shape[:dim], domain_grid2world)
-            actual_linear = affine_map.transform_inverse(img, interp='linear')
-            actual_nn = affine_map.transform_inverse(img, interp='nearest')
+            actual_linear = affine_map.transform_inverse(img, interpolation='linear')
+            actual_nn = affine_map.transform_inverse(img, interpolation='nearest')
             assert_array_almost_equal(actual_linear, expected_linear)
             assert_array_almost_equal(actual_nn, expected_nn)
 

--- a/dipy/utils/deprecator.py
+++ b/dipy/utils/deprecator.py
@@ -11,6 +11,7 @@ the Nibabel package for the copyright and license terms.
 import functools
 import warnings
 import re
+from inspect import signature
 from dipy import __version__
 from packaging.version import parse as version_cmp
 
@@ -22,6 +23,16 @@ class ExpiredDeprecationError(RuntimeError):
 
     Error raised when a called function or method has passed out of its
     deprecation period.
+
+    """
+
+    pass
+
+
+class ArgsDeprecationWarning(DeprecationWarning):
+    """Warning for args deprecation.
+
+    Warning raised when a function or method argument has changed or removed.
 
     """
 
@@ -106,6 +117,11 @@ def cmp_pkg_version(version_str, pkg_version_str=__version__):
         return -1
 
 
+def is_bad_version(version_str, version_comparator=cmp_pkg_version):
+    """Return True if `version_str` is too high."""
+    return version_comparator(version_str) == -1
+
+
 def deprecate_with_version(message, since='', until='',
                            version_comparator=cmp_pkg_version,
                            warn_class=DeprecationWarning,
@@ -148,10 +164,6 @@ def deprecate_with_version(message, since='', until='',
         Function returning a decorator.
 
     """
-    def is_bad_version(version_str):
-        """Return True if `version_str` is too high."""
-        return version_comparator(version_str) == -1
-
     messages = [message]
     if (since, until) != ('', ''):
         messages.append('')
@@ -168,7 +180,7 @@ def deprecate_with_version(message, since='', until='',
 
         @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
-            if until and is_bad_version(until):
+            if until and is_bad_version(until, version_comparator):
                 raise error_class(message)
             warnings.warn(message, warn_class, stacklevel=2)
             return func(*args, **kwargs)
@@ -177,4 +189,221 @@ def deprecate_with_version(message, since='', until='',
                                                message)
         return deprecated_func
 
+    return deprecator
+
+
+def deprecated_params(old_name, new_name=None, since='', until='',
+                      version_comparator=cmp_pkg_version,
+                      arg_in_kwargs=False,
+                      warn_class=ArgsDeprecationWarning,
+                      error_class=ExpiredDeprecationError,
+                      alternative=''):
+    """Deprecate a *renamed* or *removed* function argument.
+
+    The decorator assumes that the argument with the ``old_name`` was removed
+    from the function signature and the ``new_name`` replaced it at the
+    **same position** in the signature.  If the ``old_name`` argument is
+    given when calling the decorated function the decorator will catch it and
+    issue a deprecation warning and pass it on as ``new_name`` argument.
+
+    Parameters
+    ----------
+    old_name : str or list/tuple thereof
+        The old name of the argument.
+    new_name : str or list/tuple thereof or ``None``, optional
+        The new name of the argument. Set this to `None` to remove the
+        argument ``old_name`` instead of renaming it.
+    since : str or number or list/tuple thereof, optional
+        The release at which the old argument became deprecated.
+    until : str or number or list/tuple thereof, optional
+        Last released version at which this function will still raise a
+        deprecation warning.  Versions higher than this will raise an
+        error.
+    version_comparator : callable
+        Callable accepting string as argument, and return 1 if string
+        represents a higher version than encoded in the ``version_comparator``,
+        0 if the version is equal, and -1 if the version is lower. For example,
+        the ``version_comparator`` may compare the input version string to the
+        current package version string.
+    arg_in_kwargs : bool or list/tuple thereof, optional
+        If the argument is not a named argument (for example it
+        was meant to be consumed by ``**kwargs``) set this to
+        ``True``.  Otherwise the decorator will throw an Exception
+        if the ``new_name`` cannot be found in the signature of
+        the decorated function.
+        Default is ``False``.
+    warn_class : warning, optional
+        Warning to be issued.
+    error_class : Exception, optional
+        Error to be issued
+    alternative : str, optional
+        An alternative function or class name that the user may use in
+        place of the deprecated object if ``new_name`` is None. The deprecation
+        warning will tell the user about this alternative if provided.
+
+    Raises
+    ------
+    TypeError
+        If the new argument name cannot be found in the function
+        signature and arg_in_kwargs was False or if it is used to
+        deprecate the name of the ``*args``-, ``**kwargs``-like arguments.
+        At runtime such an Error is raised if both the new_name
+        and old_name were specified when calling the function and
+        "relax=False".
+
+    Notes
+    -----
+    This function is based on the Astropy (major modification).
+    https://github.com/astropy/astropy. See COPYING file distributed along with
+    the astropy package for the copyright and license terms.
+
+    Examples
+    --------
+    The deprecation warnings are not shown in the following examples.
+    To deprecate a positional or keyword argument::
+    >>> from dipy.utils.deprecator import deprecated_params
+    >>> @deprecated_params('sig', 'sigma', '0.3')
+    ... def test(sigma):
+    ...     return sigma
+    >>> test(2)
+    2
+    >>> test(sigma=2)
+    2
+    >>> test(sig=2)  # doctest: +SKIP
+    2
+
+    It is also possible to replace multiple arguments. The ``old_name``,
+    ``new_name`` and ``since`` have to be `tuple` or `list` and contain the
+    same number of entries::
+    >>> @deprecated_params(['a', 'b'], ['alpha', 'beta'],
+    ...                    ['0.2', 0.4])
+    ... def test(alpha, beta):
+    ...     return alpha, beta
+    >>> test(a=2, b=3)  # doctest: +SKIP
+    (2, 3)
+
+    """
+    if isinstance(old_name, (list, tuple)):
+        # Normalize input parameters
+        if not isinstance(arg_in_kwargs, (list, tuple)):
+            arg_in_kwargs = [arg_in_kwargs] * len(old_name)
+        if not isinstance(since, (list, tuple)):
+            since = [since] * len(old_name)
+        if not isinstance(until, (list, tuple)):
+            until = [until] * len(old_name)
+        if not isinstance(new_name, (list, tuple)):
+            new_name = [new_name] * len(old_name)
+
+        if len(set([len(old_name), len(new_name), len(since),
+                    len(until), len(arg_in_kwargs)])) != 1:
+            raise ValueError("All parameters should have the same length")
+    else:
+        # To allow a uniform approach later on, wrap all arguments in lists.
+        old_name = [old_name]
+        new_name = [new_name]
+        since = [since]
+        until = [until]
+        arg_in_kwargs = [arg_in_kwargs]
+
+    def deprecator(function):
+        # The named arguments of the function.
+        arguments = signature(function).parameters
+        positions = [None] * len(old_name)
+
+        for i, (o_name, n_name, in_keywords) in enumerate(zip(old_name,
+                                                              new_name,
+                                                              arg_in_kwargs)):
+            # Determine the position of the argument.
+            if in_keywords:
+                continue
+
+            if n_name is not None and n_name not in arguments:
+                # In case the argument is not found in the list of arguments
+                # the only remaining possibility is that it should be caught
+                # by some kind of **kwargs argument.
+                msg = '"{}" was not specified in the function '.format(n_name)
+                msg += 'signature. If it was meant to be part of '
+                msg += '"**kwargs" then set "arg_in_kwargs" to "True"'
+                raise TypeError(msg)
+
+            key = o_name if n_name is None else n_name
+            param = arguments[key]
+
+            if param.kind == param.POSITIONAL_OR_KEYWORD:
+                key = o_name if n_name is None else n_name
+                positions[i] = list(arguments.keys()).index(key)
+            elif param.kind == param.KEYWORD_ONLY:
+                # These cannot be specified by position.
+                positions[i] = None
+            else:
+                # positional-only argument, varargs, varkwargs or some
+                # unknown type:
+                msg = 'cannot replace argument "{}" '.format(n_name)
+                msg += 'of kind {}.'.format(repr(param.kind))
+                raise TypeError(msg)
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            for i, (o_name, n_name) in enumerate(zip(old_name, new_name)):
+                messages = ['"{}" was deprecated'.format(o_name), ]
+                if (since[i], until[i]) != ('', ''):
+                    messages.append('')
+                if since[i]:
+                    messages.append('* deprecated from version: ' +
+                                    str(since[i]))
+                if until[i]:
+                    messages.append('* {0} {1} as of version: {2}'.format(
+                        "Raises" if is_bad_version(until[i]) else "Will raise",
+                        error_class,
+                        until[i]))
+                messages.append('')
+                message = '\n'.join(messages)
+
+                # The only way to have oldkeyword inside the function is
+                # that it is passed as kwarg because the oldkeyword
+                # parameter was renamed to newkeyword.
+                if o_name in kwargs:
+                    value = kwargs.pop(o_name)
+                    # Check if the newkeyword was given as well.
+                    newarg_in_args = (positions[i] is not None and
+                                      len(args) > positions[i])
+                    newarg_in_kwargs = n_name in kwargs
+
+                    if newarg_in_args or newarg_in_kwargs:
+                        msg = 'cannot specify both "{}"'.format(o_name)
+                        msg += ' (deprecated parameter) and '
+                        msg += '"{}" (new parameter name).'.format(n_name)
+                        raise TypeError(msg)
+
+                    # Pass the value of the old argument with the
+                    # name of the new argument to the function
+                    key = n_name or o_name
+                    kwargs[key] = value
+
+                    if n_name is not None:
+                        message += '* Use argument "{}" instead.' \
+                            .format(n_name)
+                    elif alternative:
+                        message += '* Use {} instead.'.format(alternative)
+
+                    if until[i] and is_bad_version(until[i],
+                                                   version_comparator):
+                        raise error_class(message)
+                    warnings.warn(message, warn_class, stacklevel=2)
+
+                # Deprecated keyword without replacement is given as
+                # positional argument.
+                elif (not n_name and positions[i] and
+                      len(args) > positions[i]):
+                    if alternative:
+                        message += '* Use {} instead.'.format(alternative)
+                    if until[i] and is_bad_version(until[i],
+                                                   version_comparator):
+                        raise error_class(message)
+
+                    warnings.warn(message, warn_class, stacklevel=2)
+
+            return function(*args, **kwargs)
+
+        return wrapper
     return deprecator

--- a/dipy/utils/tests/test_deprecator.py
+++ b/dipy/utils/tests/test_deprecator.py
@@ -223,6 +223,12 @@ def test_deprecated_argument():
         # One positional, one keyword
         npt.assert_raises(TypeError, method, 1, scale=2)
 
+    with pytest.warns(None) as w_record:
+        res = CustomActor().test5(4)
+
+    npt.assert_equal(len(w_record), 0)
+    npt.assert_equal(res, 4)
+
 
 def test_deprecated_argument_in_kwargs():
     # To rename an argument that is consumed by "kwargs" the "arg_in_kwargs"

--- a/dipy/utils/tests/test_deprecator.py
+++ b/dipy/utils/tests/test_deprecator.py
@@ -16,6 +16,7 @@ import dipy
 from dipy.testing import clear_and_catch_warnings, assert_true
 from dipy.utils.deprecator import (cmp_pkg_version, _add_dep_doc,
                                    _ensure_cr, deprecate_with_version,
+                                   deprecated_params, ArgsDeprecationWarning,
                                    ExpiredDeprecationError)
 
 
@@ -167,3 +168,179 @@ def test_deprecate_with_version():
 
     func = dec('foo', until='0.3', error_class=CustomError)(func_no_doc)
     npt.assert_raises(CustomError, func)
+
+
+def test_deprecated_argument():
+    # Tests the decorator with function, method, staticmethod and classmethod.
+    class CustomActor:
+
+        @classmethod
+        @deprecated_params('height', 'scale', '0.3')
+        def test1(cls, scale):
+            return scale
+
+        @staticmethod
+        @deprecated_params('height', 'scale', '0.3')
+        def test2(scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3')
+        def test3(self, scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3', '0.5')
+        def test4(self, scale):
+            return scale
+
+        @deprecated_params('height', 'scale', '0.3', '10.0.0')
+        def test5(self, scale):
+            return scale
+
+    @deprecated_params('height', 'scale', '0.3')
+    def custom_actor(scale):
+        return scale
+
+    @deprecated_params('height', 'scale', '0.3', '0.5')
+    def custom_actor_2(scale):
+        return scale
+
+    for method in [CustomActor().test1, CustomActor().test2,
+                   CustomActor().test3, CustomActor().test4, custom_actor,
+                   custom_actor_2]:
+        # As positional argument only
+        npt.assert_equal(method(1), 1)
+        # As new keyword argument
+        npt.assert_equal(method(scale=1), 1)
+        # As old keyword argument
+        if method.__name__ not in ['test4', 'custom_actor_2']:
+            res = npt.assert_warns(ArgsDeprecationWarning, method, height=1)
+            npt.assert_equal(res, 1)
+        else:
+            npt.assert_raises(ExpiredDeprecationError, method, height=1)
+
+        # Using both. Both keyword
+        npt.assert_raises(TypeError, method, height=2, scale=1)
+        # One positional, one keyword
+        npt.assert_raises(TypeError, method, 1, scale=2)
+
+
+def test_deprecated_argument_in_kwargs():
+    # To rename an argument that is consumed by "kwargs" the "arg_in_kwargs"
+    # parameter is used.
+    @deprecated_params('height', 'scale', '0.3', arg_in_kwargs=True)
+    def test(**kwargs):
+        return kwargs['scale']
+
+    @deprecated_params('height', 'scale', '0.3', '0.5', arg_in_kwargs=True)
+    def test2(**kwargs):
+        return kwargs['scale']
+
+    # As positional argument only
+    npt.assert_raises(TypeError, test, 1)
+
+    # As new keyword argument
+    npt.assert_equal(test(scale=1), 1)
+
+    # Using the deprecated name
+    res = npt.assert_warns(ArgsDeprecationWarning, test, height=1)
+    npt.assert_equal(res, 1)
+
+    npt.assert_raises(ExpiredDeprecationError, test2, height=1)
+
+    # Using both. Both keyword
+    npt.assert_raises(TypeError, test, height=2, scale=1)
+    # One positional, one keyword
+    npt.assert_raises(TypeError, test, 1, scale=2)
+
+
+def test_deprecated_argument_multi_deprecation():
+
+    @deprecated_params(['x', 'y', 'z'], ['a', 'b', 'c'],
+                       [0.3, 0.2, 0.4])
+    def test(a, b, c):
+        return a, b, c
+
+    @deprecated_params(['x', 'y', 'z'], ['a', 'b', 'c'],
+                       '0.3')
+    def test2(a, b, c):
+        return a, b, c
+
+    with pytest.warns(ArgsDeprecationWarning) as w:
+        npt.assert_equal(test(x=1, y=2, z=3), (1, 2, 3))
+        npt.assert_equal(test2(x=1, y=2, z=3), (1, 2, 3))
+    npt.assert_equal(len(w), 6)
+
+    npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
+    npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
+
+
+def test_deprecated_argument_not_allowed_use():
+    # If the argument is supposed to be inside the kwargs one needs to set the
+    # arg_in_kwargs parameter. Without it it raises a TypeError.
+    with pytest.raises(TypeError):
+        @deprecated_params('height', 'scale', '0.3')
+        def test1(**kwargs):
+            return kwargs['scale']
+
+    # Cannot replace "*args".
+    with pytest.raises(TypeError):
+        @deprecated_params('scale', 'args', '0.3')
+        def test2(*args):
+            return args
+
+    # Cannot replace "**kwargs".
+    with pytest.raises(TypeError):
+        @deprecated_params('scale', 'kwargs', '0.3')
+        def test3(**kwargs):
+            return kwargs
+
+    # wrong number of arguments
+    with pytest.raises(ValueError):
+        @deprecated_params(['a', 'b', 'c'], ['x', 'y'], '0.3')
+        def test4(**kwargs):
+            return kwargs
+
+
+def test_deprecated_argument_remove():
+    @deprecated_params('x', None, '0.3', alternative='test2.y')
+    def test(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params('x', None, '0.3', '0.5', alternative='test2.y')
+    def test2(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params(['dummy', 'x'], None, '0.3', alternative='test2.y')
+    def test3(dummy=11, x=3):
+        return dummy, x
+
+    @deprecated_params(['dummy', 'x'], None, '0.3', '0.5',
+                       alternative='test2.y')
+    def test4(dummy=11, x=3):
+        return dummy, x
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test(x=1), (11, 1))
+    npt.assert_equal(len(w), 1)
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test(x=1, dummy=10), (10, 1))
+    npt.assert_equal(len(w), 1)
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead'):
+        npt.assert_equal(test(121, 1), (121, 1))
+
+    with pytest.warns(ArgsDeprecationWarning,
+                      match=r'Use test2\.y instead') as w:
+        npt.assert_equal(test3(121, 1), (121, 1))
+
+    npt.assert_raises(ExpiredDeprecationError, test4, 121, 1)
+    npt.assert_raises(ExpiredDeprecationError, test4, dummy=121, x=1)
+    npt.assert_raises(ExpiredDeprecationError, test4, 121, x=1)
+    npt.assert_raises(ExpiredDeprecationError, test2, x=1)
+    npt.assert_equal(test(), (11, 3))
+    npt.assert_equal(test(121), (121, 3))
+    npt.assert_equal(test(dummy=121), (121, 3))

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,15 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.3.0 changes
+------------------
+
+**Registration**
+
+- The argument `interp` of the method `dipy.align.imaffine.AffineMap.transform`  has been renamed `interpolation`.
+- The argument `interp` of the method `dipy.align.imaffine.AffineMap.transform_inverse`  has been renamed `interpolation`.
+
+
 DIPY 1.2.0 changes
 ------------------
 


### PR DESCRIPTION
The goal is to improve consistency between `AffineMap` and `DiffeomorpicMap`. More information on issue #2192.

To do so, a new decorator has been added: `deprecate_params`.

This PR close #2192.  



