### PR TITLE
[fix] fix value_range in HORIZON

### DIFF
--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -105,7 +105,6 @@ def slicer_panel(scene, iren,
     if not world_coords:
         affine = np.eye(4)
 
-    # import ipdb; ipdb.set_trace()
     image_actor_z = actor.slicer(tmp, affine=affine, value_range=value_range,
                                  interpolation='nearest', picking_tol=0.025)
 

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from dipy.utils.optpkg import optional_package
 import itertools
@@ -77,25 +78,34 @@ def slicer_panel(scene, iren,
     panel : Panel
 
     """
-
     orig_shape = data.shape
     print('Original shape', orig_shape)
     ndim = data.ndim
     tmp = data
     if ndim == 4:
         if orig_shape[-1] > 3:
-            tmp = data[..., 0]
             orig_shape = orig_shape[:3]
-            value_range = np.percentile(data[..., 0], q=[2, 98])
+            # Sometimes, first volume is null, so we try the next one.
+            for i in range(orig_shape[-1]):
+                tmp = data[..., i]
+                value_range = np.percentile(data[..., i], q=[2, 98])
+                if np.sum(np.diff(value_range)) != 0:
+                    break
         if orig_shape[-1] == 3:
             value_range = (0, 1.)
             mem.slicer_rgb = True
     if ndim == 3:
         value_range = np.percentile(tmp, q=[2, 98])
 
+    if np.sum(np.diff(value_range)) == 0:
+        msg = "Your data does not have any contrast. "
+        msg += "Please, check the value range of your data."
+        warnings.warn(msg)
+
     if not world_coords:
         affine = np.eye(4)
 
+    # import ipdb; ipdb.set_trace()
     image_actor_z = actor.slicer(tmp, affine=affine, value_range=value_range,
                                  interpolation='nearest', picking_tol=0.025)
 


### PR DESCRIPTION
This PR fix #2243.

Sometimes, the range value of the first dataset volume is empty/null. This is the case with our isbi2013_3shell dataset. 
So the goal of this fix is to select the volume with a relevant value range for the HORIZON visualization