### PR TITLE
[ENH] Add parallelization to gibbs denoising

### DIFF
--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -241,9 +241,9 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
         a new array.
         Default is set to True.
     workers : int, optional
-        Computation is subdivided into ``workers`` sections and evaluated in 
-        parallel (uses ``multiprocessing.Pool <multiprocessing>``). Supply 
-        ``-1`` to use all cores available to the Process. 
+        Computation is subdivided into ``workers`` sections and evaluated in
+        parallel (uses ``multiprocessing.Pool <multiprocessing>``). Supply
+        ``-1`` to use all cores available to the Process.
         Default is set to 1.
 
     Returns
@@ -311,7 +311,9 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
         mapwrapper = MapWrapper(workers)
-        partial_func = partial(_gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1)
+        partial_func = partial(
+            _gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1
+        )
         vol[:, :, :] = list(mapwrapper(partial_func, vol))
 
     # Reshape data to original format

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -241,11 +241,9 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
         a new array.
         Default is set to True.
     num_threads : int or None, optional
-        Split the calculation to a pool of children processes. This only
-        applies to 3D or 4D `data` arrays. If a positive integer then it
-        defines the size of the multiprocessing pool that will be used. If
-        None, then the size of the pool will equal the number of cores 
-        available.
+        Number of threads. Only applies to 3D or 4D `data` arrays. If None then
+        all available threads will be used. Otherwise, must be a positive
+        integer.
         Default is set to 1.
 
     Returns
@@ -281,7 +279,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if not isinstance(inplace, bool):
         raise TypeError("inplace must be a boolean.")
 
-    if not isinstance(num_threads, int) or None:
+    if (not isinstance(num_threads, int)) and (num_threads is not None):
         raise TypeError("num_processes must be an int or None.")
     else:
         if isinstance(num_threads, int):

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -1,8 +1,8 @@
 
 from functools import partial
+from multiprocessing import Pool
 
 import numpy as np
-from scipy._lib._util import MapWrapper
 
 
 def _image_tv(x, axis=0, n_points=3):
@@ -223,7 +223,7 @@ def _gibbs_removal_2d(image, n_points=3, G0=None, G1=None):
     return imagec
 
 
-def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
+def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
     """Suppresses Gibbs ringing artefacts of images volumes.
 
     Parameters
@@ -240,11 +240,12 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
         If True, the input data is replaced with results. Otherwise, returns
         a new array.
         Default is set to True.
-    workers : int, optional
-        Computation is subdivided into ``workers`` sections and evaluated in
-        parallel (uses ``multiprocessing.Pool <multiprocessing>``). Supply
-        ``-1`` to use all cores available to the Process.
-        Default is set to 1.
+    num_processes : int, optional
+        Split the calculation to a pool of children processes. This only
+        applies to 3D or 4D `data` arrays. If a positive integer then it
+        defines the size of the multiprocessing pool that will be used. If 0,
+        then the size of the pool will equal the number of cores available.
+        Default is set to 1. 
 
     Returns
     -------
@@ -279,8 +280,11 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
     if not isinstance(inplace, bool):
         raise TypeError("inplace must be a boolean.")
 
-    if not isinstance(workers, int):
-        raise TypeError("workers must be an int.")
+    if not isinstance(num_processes, int):
+        raise TypeError("num_processes must be an int.")
+    else:
+        if num_processes < 0:
+            raise ValueError("num_processes must be >= 0.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -310,11 +314,17 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, workers=1):
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        mapwrapper = MapWrapper(workers)
+        if num_processes == 0:
+            pool = Pool()
+        else:
+            pool = Pool(num_processes)
+        
         partial_func = partial(
             _gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1
         )
-        vol[:, :, :] = list(mapwrapper(partial_func, vol))
+        vol[:, :, :] = pool.map(partial_func, vol)
+        pool.close()
+        pool.join()
 
     # Reshape data to original format
     if nd == 3:

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -284,8 +284,9 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if not isinstance(num_threads, int) or None:
         raise TypeError("num_processes must be an int or None.")
     else:
-        if isinstance(num_threads, int) <= 0:
-            raise ValueError("num_processes must be > 0.")
+        if isinstance(num_threads, int):
+            if num_threads <= 0:
+                raise ValueError("num_processes must be > 0.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -245,7 +245,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
         applies to 3D or 4D `data` arrays. If a positive integer then it
         defines the size of the multiprocessing pool that will be used. If 0,
         then the size of the pool will equal the number of cores available.
-        Default is set to 1. 
+        Default is set to 1.
 
     Returns
     -------
@@ -318,7 +318,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
             pool = Pool()
         else:
             pool = Pool(num_processes)
-        
+
         partial_func = partial(
             _gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1
         )

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -223,7 +223,7 @@ def _gibbs_removal_2d(image, n_points=3, G0=None, G1=None):
     return imagec
 
 
-def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
+def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     """Suppresses Gibbs ringing artefacts of images volumes.
 
     Parameters
@@ -240,11 +240,12 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
         If True, the input data is replaced with results. Otherwise, returns
         a new array.
         Default is set to True.
-    num_processes : int, optional
+    num_threads : int or None, optional
         Split the calculation to a pool of children processes. This only
         applies to 3D or 4D `data` arrays. If a positive integer then it
-        defines the size of the multiprocessing pool that will be used. If 0,
-        then the size of the pool will equal the number of cores available.
+        defines the size of the multiprocessing pool that will be used. If
+        None, then the size of the pool will equal the number of cores 
+        available.
         Default is set to 1.
 
     Returns
@@ -280,11 +281,11 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
     if not isinstance(inplace, bool):
         raise TypeError("inplace must be a boolean.")
 
-    if not isinstance(num_processes, int):
-        raise TypeError("num_processes must be an int.")
+    if not isinstance(num_threads, int) or None:
+        raise TypeError("num_processes must be an int or None.")
     else:
-        if num_processes < 0:
-            raise ValueError("num_processes must be >= 0.")
+        if isinstance(num_threads, int) <= 0:
+            raise ValueError("num_processes must be > 0.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -314,10 +315,10 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_processes=1):
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        if num_processes == 0:
+        if num_threads is None:
             pool = Pool()
         else:
-            pool = Pool(num_processes)
+            pool = Pool(num_threads)
 
         partial_func = partial(
             _gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -38,6 +38,25 @@ def setup_module():
     image_cor = _gibbs_removal_2d(image_gibbs)
 
 
+def test_parallel():
+    # Only relevant for 3d or 4d inputs
+
+    # Make input data
+    input_2d = image_gibbs.copy()
+    input_3d = np.stack([input_2d, input_2d], axis=2)
+    input_4d = np.stack([input_3d, input_3d], axis=3)
+
+    # Test 3d case
+    output_3d_parallel = gibbs_removal(input_3d, inplace=False, workers=2)
+    output_3d_no_parallel = gibbs_removal(input_3d, inplace=False, workers=1)
+    assert_array_almost_equal(output_3d_parallel, output_3d_no_parallel)
+
+    # Test 4d case
+    output_4d_parallel = gibbs_removal(input_4d, inplace=False, workers=2)
+    output_4d_no_parallel = gibbs_removal(input_4d, inplace=False, workers=1)
+    assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
+
+
 def test_inplace():
     # Make input data
     input_2d = image_gibbs.copy()
@@ -159,6 +178,7 @@ def test_gibbs_errors():
     assert_raises(ValueError, gibbs_removal, np.ones((2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2)), 3)
     assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
+    assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), workers="1")
 
 
 def test_gibbs_subfunction():

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -47,13 +47,13 @@ def test_parallel():
     input_4d = np.stack([input_3d, input_3d], axis=3)
 
     # Test 3d case
-    output_3d_parallel = gibbs_removal(input_3d, inplace=False, workers=2)
-    output_3d_no_parallel = gibbs_removal(input_3d, inplace=False, workers=1)
+    output_3d_parallel = gibbs_removal(input_3d, inplace=False, num_processes=2)
+    output_3d_no_parallel = gibbs_removal(input_3d, inplace=False, num_processes=1)
     assert_array_almost_equal(output_3d_parallel, output_3d_no_parallel)
 
     # Test 4d case
-    output_4d_parallel = gibbs_removal(input_4d, inplace=False, workers=2)
-    output_4d_no_parallel = gibbs_removal(input_4d, inplace=False, workers=1)
+    output_4d_parallel = gibbs_removal(input_4d, inplace=False, num_processes=2)
+    output_4d_no_parallel = gibbs_removal(input_4d, inplace=False, num_processes=1)
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
 
@@ -178,7 +178,8 @@ def test_gibbs_errors():
     assert_raises(ValueError, gibbs_removal, np.ones((2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2)), 3)
     assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
-    assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), workers="1")
+    assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), num_processes="1")
+    assert_raises(ValueError, gibbs_removal, image_gibbs.copy(), num_processes=-1)
 
 
 def test_gibbs_subfunction():

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -48,12 +48,16 @@ def test_parallel():
 
     # Test 3d case
     output_3d_parallel = gibbs_removal(input_3d, inplace=False, num_processes=2)
-    output_3d_no_parallel = gibbs_removal(input_3d, inplace=False, num_processes=1)
+    output_3d_no_parallel = gibbs_removal(
+        input_3d, inplace=False, num_processes=1
+    )
     assert_array_almost_equal(output_3d_parallel, output_3d_no_parallel)
 
     # Test 4d case
     output_4d_parallel = gibbs_removal(input_4d, inplace=False, num_processes=2)
-    output_4d_no_parallel = gibbs_removal(input_4d, inplace=False, num_processes=1)
+    output_4d_no_parallel = gibbs_removal(
+        input_4d, inplace=False, num_processes=1
+    )
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
 
@@ -178,8 +182,12 @@ def test_gibbs_errors():
     assert_raises(ValueError, gibbs_removal, np.ones((2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2)), 3)
     assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
-    assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), num_processes="1")
-    assert_raises(ValueError, gibbs_removal, image_gibbs.copy(), num_processes=-1)
+    assert_raises(
+        TypeError, gibbs_removal, image_gibbs.copy(), num_processes="1"
+    )
+    assert_raises(
+        ValueError, gibbs_removal, image_gibbs.copy(), num_processes=-1
+    )
 
 
 def test_gibbs_subfunction():

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -196,8 +196,8 @@ def test_gibbs_errors():
         ValueError, gibbs_removal, image_gibbs.copy(), num_threads=-1
     )
     # Test for valid input dimensionality
-    assert_raises(ValueError, gibbs_removal, np.ones(2)) # 1D
-    assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2))) # 5D
+    assert_raises(ValueError, gibbs_removal, np.ones(2))  # 1D
+    assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2)))  # 5D
 
 
 def test_gibbs_subfunction():

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -47,16 +47,16 @@ def test_parallel():
     input_4d = np.stack([input_3d, input_3d], axis=3)
 
     # Test 3d case
-    output_3d_parallel = gibbs_removal(input_3d, inplace=False, num_processes=2)
+    output_3d_parallel = gibbs_removal(input_3d, inplace=False, num_threads=2)
     output_3d_no_parallel = gibbs_removal(
-        input_3d, inplace=False, num_processes=1
+        input_3d, inplace=False, num_threads=1
     )
     assert_array_almost_equal(output_3d_parallel, output_3d_no_parallel)
 
     # Test 4d case
-    output_4d_parallel = gibbs_removal(input_4d, inplace=False, num_processes=2)
+    output_4d_parallel = gibbs_removal(input_4d, inplace=False, num_threads=2)
     output_4d_no_parallel = gibbs_removal(
-        input_4d, inplace=False, num_processes=1
+        input_4d, inplace=False, num_threads=1
     )
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
@@ -182,12 +182,16 @@ def test_gibbs_errors():
     assert_raises(ValueError, gibbs_removal, np.ones((2)))
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2)), 3)
     assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
+    # Test for valid num_threads
     assert_raises(
-        TypeError, gibbs_removal, image_gibbs.copy(), num_processes="1"
+        TypeError, gibbs_removal, image_gibbs.copy(), num_threads="1"
     )
     assert_raises(
-        ValueError, gibbs_removal, image_gibbs.copy(), num_processes=-1
+        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=-1
     )
+    # Test for valid input dimensionality
+    assert_raises(ValueError, gibbs_removal, np.ones(2)) # 1D
+    assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2))) # 5D
 
 
 def test_gibbs_subfunction():

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -60,6 +60,12 @@ def test_parallel():
     )
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
+    # Test num_threads=None case
+    output_4d_all_cpu = gibbs_removal(
+        input_4d, inplace=False, num_threads=None
+    )
+    assert_array_almost_equal(output_4d_all_cpu, output_4d_no_parallel)
+
 
 def test_inplace():
     # Make input data

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -283,7 +283,7 @@ class GibbsRingingFlow(Workflow):
             data, affine, image = load_nifti(dwi, return_img=True)
 
             unring_data = gibbs_removal(data, slice_axis=slice_axis,
-                                        n_points=n_points, 
+                                        n_points=n_points,
                                         num_threads=num_threads)
 
             save_nifti(ounring, unring_data, affine, image.header)

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -241,7 +241,7 @@ class GibbsRingingFlow(Workflow):
     def get_short_name(cls):
         return 'gibbs_ringing'
 
-    def run(self, input_files, slice_axis=2, n_points=3, out_dir='',
+    def run(self, input_files, slice_axis=2, n_points=3, num_threads=1, out_dir='',
             out_unring='dwi_unrig.nii.gz'):
         r"""Workflow for applying Gibbs Ringing method.
 
@@ -256,6 +256,11 @@ class GibbsRingingFlow(Workflow):
         n_points : int, optional
             Number of neighbour points to access local TV (see note).
             Default is set to 3.
+        num_threads : int or None, optional
+            Number of threads. Only applies to 3D or 4D `data` arrays. If None then
+            all available threads will be used. Otherwise, must be a positive
+            integer.
+            Default is set to 1.
         out_dir : string, optional
             Output directory (default input file directory)
         out_unrig : string, optional
@@ -278,7 +283,7 @@ class GibbsRingingFlow(Workflow):
             data, affine, image = load_nifti(dwi, return_img=True)
 
             unring_data = gibbs_removal(data, slice_axis=slice_axis,
-                                        n_points=n_points)
+                                        n_points=n_points, num_threads=num_threads)
 
             save_nifti(ounring, unring_data, affine, image.header)
             logging.info('Denoised volume saved as %s', ounring)

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -241,8 +241,8 @@ class GibbsRingingFlow(Workflow):
     def get_short_name(cls):
         return 'gibbs_ringing'
 
-    def run(self, input_files, slice_axis=2, n_points=3, num_threads=1, out_dir='',
-            out_unring='dwi_unrig.nii.gz'):
+    def run(self, input_files, slice_axis=2, n_points=3, num_threads=1,
+            out_dir='', out_unring='dwi_unrig.nii.gz'):
         r"""Workflow for applying Gibbs Ringing method.
 
         Parameters
@@ -257,9 +257,9 @@ class GibbsRingingFlow(Workflow):
             Number of neighbour points to access local TV (see note).
             Default is set to 3.
         num_threads : int or None, optional
-            Number of threads. Only applies to 3D or 4D `data` arrays. If None then
-            all available threads will be used. Otherwise, must be a positive
-            integer.
+            Number of threads. Only applies to 3D or 4D `data` arrays. If None
+            then all available threads will be used. Otherwise, must be a
+            positive integer.
             Default is set to 1.
         out_dir : string, optional
             Output directory (default input file directory)
@@ -283,7 +283,8 @@ class GibbsRingingFlow(Workflow):
             data, affine, image = load_nifti(dwi, return_img=True)
 
             unring_data = gibbs_removal(data, slice_axis=slice_axis,
-                                        n_points=n_points, num_threads=num_threads)
+                                        n_points=n_points, 
+                                        num_threads=num_threads)
 
             save_nifti(ounring, unring_data, affine, image.header)
             logging.info('Denoised volume saved as %s', ounring)

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -79,7 +79,7 @@ Gibbs oscillation suppression of this single data slice can be performed by
 running the following command:
 """
 
-t1_unring = gibbs_removal(t1_gibbs)
+t1_unring = gibbs_removal(t1_gibbs, inplace=False)
 
 """
 Let’s plot the results:
@@ -168,7 +168,7 @@ Gibbs oscillation suppression of all multi-shell data and all slices
 can be performed in the following way:
 """
 
-data_corrected = gibbs_removal(data_slices, slice_axis=2)
+data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=None)
 
 """
 Due to the high dimensionality of diffusion-weighted data, we recommend


### PR DESCRIPTION
Added parallelization to gibbs denoising. I used the utility class `MapWrapper` from scipy for parallelization, which really just a wrapper for `Pool` in `multiprocessing` module with some convenient functionality for dealing with number of workers, etc. Let me know if this is acceptable.

Main thing I changed is how the axis of the input data are ordered within the `gibbs_denoise` function since its much easier to work with the array as an iterable if the axis we are iterating is the first one, not the last one. Some lines had to be changed to accommodate for this change in axis ordering.

Closes #2236