### PR TITLE
Modifying dti.design_matrix to take gtab.btens into account

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -2029,14 +2029,24 @@ def design_matrix(gtab, dtype=None):
         Design matrix or B matrix assuming Gaussian distributed tensor model
         design_matrix[j, :] = (Bxx, Byy, Bzz, Bxy, Bxz, Byz, dummy)
     """
-    B = np.zeros((gtab.gradients.shape[0], 7))
-    B[:, 0] = gtab.bvecs[:, 0] * gtab.bvecs[:, 0] * 1. * gtab.bvals   # Bxx
-    B[:, 1] = gtab.bvecs[:, 0] * gtab.bvecs[:, 1] * 2. * gtab.bvals   # Bxy
-    B[:, 2] = gtab.bvecs[:, 1] * gtab.bvecs[:, 1] * 1. * gtab.bvals   # Byy
-    B[:, 3] = gtab.bvecs[:, 0] * gtab.bvecs[:, 2] * 2. * gtab.bvals   # Bxz
-    B[:, 4] = gtab.bvecs[:, 1] * gtab.bvecs[:, 2] * 2. * gtab.bvals   # Byz
-    B[:, 5] = gtab.bvecs[:, 2] * gtab.bvecs[:, 2] * 1. * gtab.bvals   # Bzz
-    B[:, 6] = np.ones(gtab.gradients.shape[0])
+    if gtab.btens is None:
+        B = np.zeros((gtab.gradients.shape[0], 7))
+        B[:, 0] = gtab.bvecs[:, 0] * gtab.bvecs[:, 0] * 1. * gtab.bvals   # Bxx
+        B[:, 1] = gtab.bvecs[:, 0] * gtab.bvecs[:, 1] * 2. * gtab.bvals   # Bxy
+        B[:, 2] = gtab.bvecs[:, 1] * gtab.bvecs[:, 1] * 1. * gtab.bvals   # Byy
+        B[:, 3] = gtab.bvecs[:, 0] * gtab.bvecs[:, 2] * 2. * gtab.bvals   # Bxz
+        B[:, 4] = gtab.bvecs[:, 1] * gtab.bvecs[:, 2] * 2. * gtab.bvals   # Byz
+        B[:, 5] = gtab.bvecs[:, 2] * gtab.bvecs[:, 2] * 1. * gtab.bvals   # Bzz
+        B[:, 6] = np.ones(gtab.gradients.shape[0])
+    else:
+        B = np.zeros((gtab.gradients.shape[0], 7))
+        B[:, 0] = gtab.btens[:, 0, 0]   # Bxx
+        B[:, 1] = gtab.btens[:, 0, 1] * 2  # Bxy
+        B[:, 2] = gtab.btens[:, 1, 1]   # Byy
+        B[:, 3] = gtab.btens[:, 0, 2] * 2  # Bxz
+        B[:, 4] = gtab.btens[:, 1, 2] * 2  # Byz
+        B[:, 5] = gtab.btens[:, 2, 2]   # Bzz
+        B[:, 6] = np.ones(gtab.gradients.shape[0])
 
     return -B
 

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -793,3 +793,12 @@ def test_decompose_tensor_nan():
                                            from_lower_triangular(D_alter))
     npt.assert_array_almost_equal(lalter, np.array([1.6e-3, 0.4e-3, 0.3e-3]))
     npt.assert_array_almost_equal(valter, vref)
+
+def test_design_matrix_lte():
+    _, fbval, fbvec = get_fnames('small_25')
+    gtab_btens_none = grad.gradient_table(fbval, fbvec)
+    gtab_btens_lte = grad.gradient_table(fbval, fbvec, btens="LTE")
+
+    B_btens_none = dti.design_matrix(gtab_btens_none)
+    B_btens_lte = dti.design_matrix(gtab_btens_lte)
+    npt.assert_array_almost_equal(B_btens_none, B_btens_lte, decimal=1)

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -763,7 +763,6 @@ def test_eig_from_lo_tri():
                                   dmfit.model_params)
 
 
-
 def test_min_signal_alone():
     fdata, fbvals, fbvecs = get_fnames()
     data = load_nifti_data(fdata)
@@ -793,6 +792,7 @@ def test_decompose_tensor_nan():
                                            from_lower_triangular(D_alter))
     npt.assert_array_almost_equal(lalter, np.array([1.6e-3, 0.4e-3, 0.3e-3]))
     npt.assert_array_almost_equal(valter, vref)
+
 
 def test_design_matrix_lte():
     _, fbval, fbvec = get_fnames('small_25')


### PR DESCRIPTION
Here is a small modification to `dti.design_matrix`, that enables the used of DTI on btensor data, using the new `gtab.btens` feature. The way to use and call `dti.TensorModel` and `dti.TensorFit` is the same as before. The user just has to create the `GradientTable` with the right `btens` option, and the tensor fit will work as before.

It allows to compute an FA map from a planar acquisition, for example. Unfortunately, the FA map from planar data seems to be extremely sensitive to noise (not in the white matter), but I think this is due to the nature of the data, not the method.

Let me know what you think of it!