### PR TITLE
[Fix] warning if not the same number of points

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -64,7 +64,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     if norm == "angle":
         norm = angle
     elif norm == "euclidean_norm":
-        w_s = "The Euclidian norm used for interpolation is inaccurate "
+        w_s = "The Euclidean norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
         warnings.warn(w_s, PendingDeprecationWarning)

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -64,7 +64,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     if norm == "angle":
         norm = angle
     elif norm == "euclidean_norm":
-        w_s = "The Eucldian norm used for interpolation is inaccurate "
+        w_s = "The Euclidian norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
         warnings.warn(w_s, PendingDeprecationWarning)

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -12,6 +12,7 @@ from libc.string cimport memcpy
 
 import time
 import numpy as np
+from warnings import warn
 cimport numpy as cnp
 
 
@@ -482,6 +483,10 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
     DM : array, shape (len(tracksA), len(tracksB))
         distances between tracksA and tracksB according to metric
 
+    See Also
+    ---------
+    dipy.tracking.streamline.set_number_of_points
+
     """
     cdef:
         size_t i, j, lentA, lentB
@@ -503,6 +508,12 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
         cnp.ndarray[cnp.double_t, ndim=2] DM
     lentA = len(tracksA)
     lentB = len(tracksB)
+    if lentA != lentB:
+        w_s = "Streamlines do not have the same number of points. "
+        w_s += "All streamlines need to have the same number of points. "
+        w_s += "Use dipy.tracking.streamline.set_number_of_points to adjust "
+        w_s += "your streamlines"
+        warn(w_s)
     tracksA32 = np.zeros((lentA,), dtype=object)
     tracksB32 = np.zeros((lentB,), dtype=object)
     DM = np.zeros((lentA,lentB), dtype=np.double)
@@ -565,7 +576,7 @@ def bundles_distances_mdf(tracksA, tracksB):
 
     See Also
     ---------
-    dipy.metrics.downsample
+    dipy.tracking.streamline.set_number_of_points
 
     """
     cdef:
@@ -579,6 +590,12 @@ def bundles_distances_mdf(tracksA, tracksB):
         cnp.ndarray[cnp.double_t, ndim=2] DM
     lentA = len(tracksA)
     lentB = len(tracksB)
+    if lentA != lentB:
+        w_s = "Streamlines do not have the same number of points. "
+        w_s += "All streamlines need to have the same number of points. "
+        w_s += "Use dipy.tracking.streamline.set_number_of_points to adjust "
+        w_s += "your streamlines"
+        warn(w_s)
     tracksA32 = np.zeros((lentA,), dtype=object)
     tracksB32 = np.zeros((lentB,), dtype=object)
     DM = np.zeros((lentA,lentB), dtype=np.double)

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -1,9 +1,8 @@
 
 import warnings
 import numpy as np
-from numpy.testing._private.utils import assert_warns
 from dipy.testing import assert_true
-from numpy.testing import (assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal, assert_warns,
                            assert_equal, assert_almost_equal)
 from dipy.tracking import distances as pf
 from dipy.tracking.streamline import set_number_of_points


### PR DESCRIPTION
This PR fixes #342 (a very old "issue"). This is just adding a warning to the user when `bundles_distances_mdf` or `bundles_distances_mam` do not have 2 tracks with the same number of points.

Also, pep8 and docstring has been updated too.