### PR TITLE
[FIX] update Azure OSX CI + remove Azure Linux CI's

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,65 +7,10 @@ pr:
 - maint/*
 
 jobs:
-- template: ci/azure/linux.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-16.04
-    matrix:
-      Python36-64bit:
-        python.version: '3.6'
-      Python38-64bit:
-        python.version: '3.8'
-      Python37-64bit:
-        python.version: '3.7'
-      Python36-64bit + MIN_DEPS:
-        python.version: '3.6'
-        DEPENDS: "cython==0.29 numpy==1.12.0 scipy==1.0 nibabel==3.0.0 h5py==2.5.0 nose tqdm"
-      Python37-64bit + MIN_DEPS:
-        python.version: '3.7'
-        DEPENDS: "cython==0.29 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0 tqdm"
-      Python37-64bit + OPTIONAL_DEPS + COVERAGE:
-        python.version: '3.7'
-        EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
-        COVERAGE: "1"
-      Python37-64bit + VIZ + COVERAGE:
-        TEST_WITH_XVFB: "1"
-        COVERAGE: "1"
-        python.version: '3.7'
-        MESA_GL_VERSION_OVERRIDE: '3.3'
-        LIBGL_ALWAYS_INDIRECT: 'y'
-        EXTRA_DEPENDS: "scikit_learn vtk fury scipy pandas statsmodels tables xvfbwrapper"
-      Python37-64bit + SDIST:
-        python.version: '3.7'
-        INSTALL_TYPE: "sdist"
-        EXTRA_DEPENDS: "scipy"
-      Python37-64bit + PIP:
-        python.version: '3.7'
-        INSTALL_TYPE: "pip"
-        DEPENDS: "" # Dependency checking should get all needed dependencies
-      Python37-64bit + WHEEL:
-        python.version: '3.7'
-        INSTALL_TYPE: "wheel"
-        EXTRA_DEPENDS: "scipy"
-      Python37-64bit + Requirements:
-        python.version: '3.7'
-        INSTALL_TYPE: "requirements"
-        DEPENDS: ""
-      CONDA Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
-        EXTRA_DEPENDS: "scikit-learn pandas statsmodels pytables scipy"
-        INSTALL_TYPE: "conda"
-      CONDA Python37-64bit:
-        python.version: '3.7'
-        INSTALL_TYPE: "conda"
-      CONDA Python36-64bit:
-        python.version: '3.6'
-        INSTALL_TYPE: "conda"
-
 - template: ci/azure/osx.yml
   parameters:
     name: OSX
-    vmImage: macOS-10.14
+    vmImage: macOS-latest
     matrix:
       Python37-64bit + OPTIONAL_DEPS:
         python.version: '3.7'


### PR DESCRIPTION
- Update the version of our macOS virtual machine. from macOS-10.14 to macOS-latest. This should fix our SSL issue with python
- Remove all Linux matrix on Azure Pipeline. It was experimental. The goal was to see if we can have only one tool to maintain, stop Travis, and switch completely to Azure Pipeline. After this long experimental experience, I think we should keep both, Azure pipeline and Travis. So I just removed the duplicated Linux matrices to speed up a bit the building time of our PR