### PR TITLE
[Fix]  Allow read_bvals_bvecs to have 1 or 2 dwi volumes only

### DIFF
--- a/dipy/io/gradients.py
+++ b/dipy/io/gradients.py
@@ -69,11 +69,11 @@ def read_bvals_bvecs(fbvals, fbvecs):
     if bvecs.ndim != 2:
         bvecs = bvecs[None, ...]
         bvals = bvals[None, ...]
-        msg = "Only 1 direction detected on your bvec file. For diffusion "
-        msg += "dataset, it is recommended to have minimum 3 directions."
-        msg += "You may have problem during the reconstruction step."
+        msg = "Detected only 1 direction on your bvec file. For diffusion "
+        msg += "dataset, it is recommended to have at least 3 directions."
+        msg += "You may have problems during the reconstruction step."
         warnings.warn(msg)
-    if bvecs.shape[1] !=3 and bvecs.shape[1] > bvecs.shape[0]:
+    if bvecs.shape[1] != 3 and bvecs.shape[1] > bvecs.shape[0]:
         bvecs = bvecs.T
 
     # If bvals is None, you don't need to check that they have the same shape:

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -129,4 +129,4 @@ def test_read_bvals_bvecs():
             npt.assert_array_equal(bval_5, np.zeros(1))
             assert_true(len(w) == 1)
             assert_true(issubclass(w[0].category, UserWarning))
-            assert_true("Only 1 direction detected on" in str(w[0].message))
+            assert_true("Detected only 1 direction on" in str(w[0].message))

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -1,10 +1,10 @@
-
+import warnings
 import os.path as osp
 from nibabel.tmpdirs import InTemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
-
+from dipy.testing import assert_true
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
@@ -26,6 +26,8 @@ def test_read_bvals_bvecs():
     # Test for error raising with unknown file formats:
     nan_fbvecs = osp.splitext(fbvecs)[0] + '.nan'  # Nonsense extension
     npt.assert_raises(ValueError, read_bvals_bvecs, fbvals, nan_fbvecs)
+    npt.assert_raises(ValueError, read_bvals_bvecs, bvals, nan_fbvecs)
+    npt.assert_raises(ValueError, read_bvals_bvecs, fbvals, bvecs)
 
     # Test for error raising with incorrect file-contents:
 
@@ -43,7 +45,6 @@ def test_read_bvals_bvecs():
         # These bvecs are saved as one long array:
         new_bvecs2 = np.ravel(bvecs)
         with open('test_bv_file2.npy', 'w') as bv_file2:
-            print('FILENAME:', bv_file2.name)
             np.save(bv_file2.name, new_bvecs2)
         npt.assert_raises(IOError, read_bvals_bvecs, fbvals, 'test_bv_file2.npy')
 
@@ -103,7 +104,29 @@ def test_read_bvals_bvecs():
         npt.assert_array_equal(ans, bvecs_3)
         npt.assert_array_equal(ans, bvecs_4)
 
+        bv_two_volume = 'bv_two_volume.txt'
+        with open(bv_two_volume, 'w') as f:
+            f.write("0 0 0\n0 0 0\n")
+        bval_two_volume = 'bval_two_volume.txt'
+        with open(bval_two_volume, 'w') as f:
+            f.write("0\n0\n")
+        bval_5, bvecs_5 = read_bvals_bvecs(bval_two_volume,
+                                           bv_two_volume)
+        npt.assert_array_equal(bvecs_5, np.zeros((2, 3)))
+        npt.assert_array_equal(bval_5, np.zeros(2))
 
-if __name__ == '__main__':
-    from numpy.testing import run_module_suite
-    run_module_suite()
+        bv_single_volume = 'test_single_volume.txt'
+        with open(bv_single_volume, 'w') as f:
+            f.write("0 0 0\n")
+        bval_single_volume = 'test_single_volume_2.txt'
+        with open(bval_single_volume, 'w') as f:
+            f.write("0\n")
+
+        with warnings.catch_warnings(record=True) as w:
+            bval_5, bvecs_5 = read_bvals_bvecs(bval_single_volume,
+                                               bv_single_volume)
+            npt.assert_array_equal(bvecs_5, np.zeros((1, 3)))
+            npt.assert_array_equal(bval_5, np.zeros(1))
+            assert_true(len(w) == 1)
+            assert_true(issubclass(w[0].category, UserWarning))
+            assert_true("Only 1 direction detected on" in str(w[0].message))


### PR DESCRIPTION
This PR fixes #2046.  Even if in diffusion, it is recommended to have at least 3 directions/volumes, `read_bvals_bvecs` should offer the possibility to load bvals/bvecs files of only 1-2 volume(s).  Now, it is possible with this PR.

bonus: pep8 + some reshaping of the function