### PR TITLE
[Fix] Better error handling in Diffeomorphic map `get_map`

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -997,6 +997,11 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
         Returns the DiffeomorphicMap registering the moving image towards
         the static image.
         """
+        if not hasattr(self, 'static_to_ref'):
+            msg = 'Diffeormorphic map can not be obtain without running '
+            msg += 'the optimizer. Please call first '
+            msg += 'SymmetricDiffeomorphicRegistration.optimize()'
+            raise ValueError(msg)
         return self.static_to_ref
 
     def _connect_functions(self):

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1000,7 +1000,7 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
 
         """
         if not hasattr(self, 'static_to_ref'):
-            msg = 'Diffeormorphic map can not be obtain without running '
+            msg = 'Diffeormorphic map can not be obtained without running '
             msg += 'the optimizer. Please call first '
             msg += 'SymmetricDiffeomorphicRegistration.optimize()'
             raise ValueError(msg)

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -993,9 +993,11 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
         return np.array(current_displacement), np.array(mean_norm)
 
     def get_map(self):
-        """Returns the resulting diffeomorphic map
+        """Return the resulting diffeomorphic map.
+
         Returns the DiffeomorphicMap registering the moving image towards
         the static image.
+
         """
         if not hasattr(self, 'static_to_ref'):
             msg = 'Diffeormorphic map can not be obtain without running '

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -326,6 +326,7 @@ def test_optimizer_exceptions():
     # Verify exception thrown when attempting to fit the energy profile without
     # enough data
     assert_raises(ValueError, optimizer._get_energy_derivative)
+    assert_raises(ValueError, optimizer.get_map)
 
 
 def test_get_direction_and_spacings():


### PR DESCRIPTION
This PR fixes #2202. It replaces a cryptic error with an error message when the user tries to get the Diffeormorphic map before running the optimizer.