### PR TITLE
[FIX] update tests to respect numpy NEP 34 

### DIFF
--- a/dipy/segment/tests/test_clustering.py
+++ b/dipy/segment/tests/test_clustering.py
@@ -412,7 +412,8 @@ def test_cluster_map_getitem():
 
     # Test slicing and negative indexing
     assert_equal(cluster_map[-1], clusters[-1])
-    assert_array_equal(cluster_map[::2], clusters[::2])
+    assert_array_equal(np.array(cluster_map[::2], dtype=object),
+                       np.array(clusters[::2], dtype=object))
     assert_arrays_equal(cluster_map[::-1], clusters[::-1])
     assert_arrays_equal(cluster_map[:-1], clusters[:-1])
     assert_arrays_equal(cluster_map[1:], clusters[1:])
@@ -540,7 +541,8 @@ def test_cluster_map_comparison_with_object():
 
     # Comparison with another ClusterMap object
     other_cluster_map = copy.deepcopy(cluster_map)
-    assert_equal(cluster_map, other_cluster_map)
+    assert_equal(np.array(cluster_map, dtype=object),
+                 np.array(other_cluster_map, dtype=object))
 
     other_cluster_map = copy.deepcopy(cluster_map)
     assert_false(cluster_map != other_cluster_map)
@@ -754,7 +756,3 @@ def test_subclassing_clustering():
     assert_raises(NotImplementedError,
                   super(SubClustering, clustering_algo).cluster,
                   None)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -550,8 +550,9 @@ def test_deform_streamlines():
                                                   stream2world)
 
     # Subtract disps from new_streamlines in world space
-    orig_streamlines_world = list(np.subtract(new_streamlines_world, disps,
-                                              dtype=object))
+    orig_streamlines_world = np.subtract(np.array(new_streamlines_world,
+                                                  dtype=object),
+                                         np.array(disps, dtype=object))
 
     # Put orig_streamlines_world into voxmm
     orig_streamlines = transform_streamlines(orig_streamlines_world,
@@ -1162,7 +1163,8 @@ def test_streamlines_generator():
     npt.assert_equal(len(streamlines_generator), len(streamlines))
 
     # Test append error
-    npt.assert_raises(ValueError, streamlines_generator.append, streamlines)
+    npt.assert_raises(ValueError, streamlines_generator.append,
+                      np.array(streamlines, dtype=object))
 
     # Test empty streamlines
     streamlines_generator = Streamlines(np.array([]))
@@ -1191,7 +1193,10 @@ def test_cluster_confidence():
     test_streamlines.append(mysl+1)
     test_streamlines.append(mysl+2)
     test_streamlines.finalize_append()
-    cci = cluster_confidence(test_streamlines, override=True)
+    with warnings.catch_warnings(record=True) as w:
+        cci = cluster_confidence(test_streamlines, override=True)
+        assert_true("do not have the same number of points" in
+                    str(w[0].message))
     assert_equal(cci[0], cci[2])
     assert_true(cci[1] > cci[0])
 
@@ -1224,8 +1229,11 @@ def test_cluster_confidence():
     test_streamlines_p3.append(mysl5)
     test_streamlines_p3.finalize_append()
 
-    cci_p1 = cluster_confidence(test_streamlines_p1, override=True)
-    cci_p2 = cluster_confidence(test_streamlines_p2, override=True)
+    with warnings.catch_warnings(record=True) as w:
+        cci_p1 = cluster_confidence(test_streamlines_p1, override=True)
+        cci_p2 = cluster_confidence(test_streamlines_p2, override=True)
+        assert_true("do not have the same number of points" in
+                    str(w[0].message))
 
     # test relative distance
     assert_array_equal(cci_p1, cci_p2*2)
@@ -1237,20 +1245,24 @@ def test_cluster_confidence():
     assert_array_equal(expected_p2, cci_p2)
 
     # test power variable calculation (dropoff with distance)
-    cci_p1_pow2 = cluster_confidence(test_streamlines_p1, power=2,
-                                     override=True)
+    with warnings.catch_warnings(record=True) as w:
+        cci_p1_pow2 = cluster_confidence(test_streamlines_p1, power=2,
+                                         override=True)
+        assert_true("do not have the same number of points" in
+                    str(w[0].message))
+
     expected_p1_pow2 = np.array([np.power(1./1, 2)+np.power(1./2, 2),
                                  np.power(1./1, 2)+np.power(1./1, 2),
                                  np.power(1./1, 2)+np.power(1./2, 2)])
 
     assert_array_equal(cci_p1_pow2, expected_p1_pow2)
 
-    # test max distance (ignore distant sls)
-    cci_dist = cluster_confidence(test_streamlines_p3,
-                                  max_mdf=5, override=True)
+    with warnings.catch_warnings(record=True) as w:
+        # test max distance (ignore distant sls)
+        cci_dist = cluster_confidence(test_streamlines_p3,
+                                      max_mdf=5, override=True)
+        assert_true("do not have the same number of points" in
+                    str(w[0].message))
+
     expected_cci_dist = np.concatenate([cci_p1, np.zeros(1)])
     assert_array_equal(cci_dist, expected_cci_dist)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()


### PR DESCRIPTION
This PR fixes #2132.  [NEP 34](https://numpy.org/neps/nep-0034-infer-dtype-is-object.html) disallow inferring `dtype=object` from sequences. So the tests have been updated to follow this rule.