### PR TITLE
[FIX] update multiple models due to cvxpy 1.1 (part2)

### DIFF
--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -320,7 +320,3 @@ def test_auto_response_msmt():
         npt.assert_array_equal(response_auto_wm, response_from_mask_wm)
         npt.assert_array_equal(response_auto_gm, response_from_mask_gm)
         npt.assert_array_equal(response_auto_csf, response_from_mask_csf)
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -575,7 +575,3 @@ def test_visualise_gradient_table_G_Delta_rainbow():
     gtab_4d.small_delta[4] += 0.001  # so now the gtab has multiple small_delta
     assert_raises(ValueError,
                   qtdmri.visualise_gradient_table_G_Delta_rainbow, gtab_4d)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_shore.py
+++ b/dipy/reconst/tests/test_shore.py
@@ -83,7 +83,3 @@ def compute_e0(shorefit):
                       gamma(n + 1.5))) ** 0.5))
 
     return signal_0
-
-
-if __name__ == '__main__':
-    run_module_suite()


### PR DESCRIPTION
This PR fixes #2190 and more specifically the following errors/warnings:

```
/home/travis/build/dipy/dipy/venv/lib/python3.5/site-packages/cvxpy/expressions/expression.py:516: UserWarning: 
  This use of ``*`` has resulted in matrix multiplication.
  Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
      Use ``*`` for matrix-scalar and vector-scalar multiplication.
      Use ``@`` for matrix-matrix and matrix-vector multiplication.
      Use ``multiply`` for elementwise multiplication.
  
    warnings.warn(__STAR_MATMUL_WARNING__, UserWarning)
```

The problem was fixed in the MAPMRI module via #2188 so this PR is just an extension of it.