### PR TITLE
BF: Fix `dipy_align_syn` default value assumptions

### DIFF
--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -280,10 +280,61 @@ def test_syn_registration_flow():
         nib.save(moving_img, fname_moving)
 
         positional_args = [fname_static, fname_moving]
+
+        # Test the cc metric
+        metric_optional_args = {'metric': 'cc',
+                                'mopt_sigma_diff': 2.0,
+                                'mopt_radius': 4
+                                }
+        optimizer_optional_args = {'level_iters': [10, 10, 5],
+                                   'step_length': 0.25,
+                                   'opt_tol': 1e-5,
+                                   'inv_iter': 20,
+                                   'inv_tol': 1e-3,
+                                   'ss_sigma_factor': 0.2
+                                   }
+
+        all_args = dict(metric_optional_args, **optimizer_optional_args)
+        syn_flow.run(*positional_args,
+                     out_dir=out_dir,
+                     **all_args
+                     )
+
+        warped_path = syn_flow.last_generated_outputs['out_warped']
+        npt.assert_equal(os.path.isfile(warped_path), True)
+        warped_map_path = syn_flow.last_generated_outputs['out_field']
+        npt.assert_equal(os.path.isfile(warped_map_path), True)
+
+        # Test the ssd metric
         metric_optional_args = {'metric': 'ssd',
                                 'mopt_smooth': 4.0,
                                 'mopt_inner_iter': 5,
                                 'mopt_step_type': 'demons',
+                                }
+        optimizer_optional_args = {'level_iters': [200, 100, 50, 25],
+                                   'step_length': 0.5,
+                                   'opt_tol': 1e-4,
+                                   'inv_iter': 40,
+                                   'inv_tol': 1e-3,
+                                   'ss_sigma_factor': 0.2
+                                   }
+
+        all_args = dict(metric_optional_args, **optimizer_optional_args)
+        syn_flow.run(*positional_args,
+                     out_dir=out_dir,
+                     **all_args
+                     )
+
+        warped_path = syn_flow.last_generated_outputs['out_warped']
+        npt.assert_equal(os.path.isfile(warped_path), True)
+        warped_map_path = syn_flow.last_generated_outputs['out_field']
+        npt.assert_equal(os.path.isfile(warped_map_path), True)
+
+        # Test the em metric
+        metric_optional_args = {'metric': 'em',
+                                'mopt_smooth': 1.0,
+                                'mopt_inner_iter': 5,
+                                'mopt_step_type': 'gauss_newton',
                                 }
         optimizer_optional_args = {'level_iters': [200, 100, 50, 25],
                                    'step_length': 0.5,


### PR DESCRIPTION
Fix `dipy_align_syn` default value assumptions: ensure that the `mopt_smooth`,
`mopt_inner_iter` and `mopt_step_type`/`step_type` parameters get appropriate
values for all possible combinations of the optional input arguments.

Fixes:
```
INFO:Starting Diffeomorphic Registration
INFO:Using CC Metric
Traceback (most recent call last):
  File "./bin/dipy_align_syn", line 7, in <module>
    run_flow(SynRegistrationFlow())
  File "/path/to/dipy/dipy/workflows/flow_runner.py", line 89, in run_flow
    return flow.run(**args)
  File "/path/to/dipy/dipy/workflows/align.py", line 869, in run
    mopt_smooth = mopt_smooth or init_param[metric]['mopt_smooth']
KeyError: 'cc'
```

The workflow was failing with the above error when being called with default
parameters, e.g.
```
dipy_align_syn /path/to/data/static.nii.gz /path/to/data/moving.nii.gz
```

This happened because the `cc` metric does not require the same arguments as the
`em` and `ssd` metric, and hence the `init_param` variable contained no
information for the `cc` metric.

The fix ensures that if using the `cc` metric or the `mopt_smooth` and
`mopt_inner_iter` have their default values (which evaluate to `False`), the
sensible default values from `init_param` are used to initialize the `em` and
`ssd` metrics.

Similarly, the `mopt_step_type` now gets a default initialization depending on
the metric type: if using the `cc` metric, its value is set to an empty string
if provided, since `cc` does not use it, and `em` and `ssd`'s `step_type`
parameter is initialized to their corresponding values in `init_param`. If
specifying `mopt_step_type` and the `em` or `ssd` metric, its value is only
applied to the specified metric, the other one taking its default initialization
value from `init_param`.

Rather than initializing the value of the step type to a common or shared
default value, the proposed solution ensures that if at some point either
the `em` or the `ssd` metric support an exclusive step type, their preferred
default is exclusive or if all their step types were exclusive, the workflow
will initialize each to the appropriate value.

Take advantage of the commit to make the `mopt_inner_iter` parameter have a
default integer value.