### PR TITLE
STYLE: minor refactoring in TissueClassifierHMRF

### DIFF
--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -154,7 +154,7 @@ def test_grayscale_iter():
         image_gauss = image
 
     final_segmentation = np.empty_like(image)
-    seg_init = initial_segmentation.copy()
+    seg_init = initial_segmentation
     energies = []
 
     for i in range(max_iter):
@@ -215,9 +215,9 @@ def test_grayscale_iter():
         print(energy[energy > -np.inf].sum())
         energies.append(energy[energy > -np.inf].sum())
 
-        initial_segmentation = final_segmentation.copy()
-        mu = mu_upd.copy()
-        sigmasq = sigmasq_upd.copy()
+        initial_segmentation = final_segmentation
+        mu = mu_upd
+        sigmasq = sigmasq_upd
 
     npt.assert_(energies[-1] < energies[0])
 
@@ -244,7 +244,7 @@ def test_square_iter():
     npt.assert_(sigmasq[3] >= 0.0)
 
     final_segmentation = np.empty_like(square_gauss)
-    seg_init = initial_segmentation.copy()
+    seg_init = initial_segmentation
     energies = []
 
     for i in range(max_iter):
@@ -309,9 +309,9 @@ def test_square_iter():
 
         energies.append(energy[energy > -np.inf].sum())
 
-        initial_segmentation = final_segmentation.copy()
-        mu = mu_upd.copy()
-        sigmasq = sigmasq_upd.copy()
+        initial_segmentation = final_segmentation
+        mu = mu_upd
+        sigmasq = sigmasq_upd
 
     difference_map = np.abs(seg_init - final_segmentation)
     npt.assert_(np.abs(np.sum(difference_map)) == 0.0)
@@ -322,7 +322,7 @@ def test_icm_square():
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
-    initial_segmentation = square.copy()
+    initial_segmentation = square
 
     mu, sigma = com.seg_stats(square_1, initial_segmentation,
                               nclasses)
@@ -351,10 +351,10 @@ def test_icm_square():
 
         final_segmentation_1, energy_1 = icm.icm_ising(negll, beta,
                                                        initial_segmentation)
-        initial_segmentation = final_segmentation_1.copy()
+        initial_segmentation = final_segmentation_1
 
     beta = 2
-    initial_segmentation = square.copy()
+    initial_segmentation = square
 
     for j in range(max_iter):
 
@@ -364,7 +364,7 @@ def test_icm_square():
 
         final_segmentation_2, energy_2 = icm.icm_ising(negll, beta,
                                                        initial_segmentation)
-        initial_segmentation = final_segmentation_2.copy()
+        initial_segmentation = final_segmentation_2
 
     difference_map = np.abs(final_segmentation_1 - final_segmentation_2)
     npt.assert_(np.abs(np.sum(difference_map)) != 0)

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -61,10 +61,8 @@ def test_grayscale_image():
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
-    mu, sigma = com.initialize_param_uniform(image, nclasses)
-    sigmasq = sigma ** 2
+    mu, sigmasq = com.initialize_param_uniform(image, nclasses)
     npt.assert_array_almost_equal(mu, np.array([0., 0.25, 0.5, 0.75]))
-    npt.assert_array_almost_equal(sigma, np.array([1.0, 1.0, 1.0, 1.0]))
     npt.assert_array_almost_equal(sigmasq, np.array([1.0, 1.0, 1.0, 1.0]))
 
     neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
@@ -132,15 +130,13 @@ def test_grayscale_iter():
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
-    mu, sigma = com.initialize_param_uniform(image, nclasses)
-    sigmasq = sigma ** 2
+    mu, sigmasq = com.initialize_param_uniform(image, nclasses)
     neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
     initial_segmentation = icm.initialize_maximum_likelihood(neglogl)
     npt.assert_(initial_segmentation.max() == nclasses - 1)
     npt.assert_(initial_segmentation.min() == 0)
 
-    mu, sigma = com.seg_stats(image, initial_segmentation, nclasses)
-    sigmasq = sigma ** 2
+    mu, sigmasq = com.seg_stats(image, initial_segmentation, nclasses)
     npt.assert_(mu[0] >= 0.0)
     npt.assert_(mu[1] >= 0.0)
     npt.assert_(mu[2] >= 0.0)
@@ -236,9 +232,8 @@ def test_square_iter():
 
     initial_segmentation = square
 
-    mu, sigma = com.seg_stats(square_gauss, initial_segmentation,
-                              nclasses)
-    sigmasq = sigma ** 2
+    mu, sigmasq = com.seg_stats(square_gauss, initial_segmentation,
+                                nclasses)
     npt.assert_(mu[0] >= 0.0)
     npt.assert_(mu[1] >= 0.0)
     npt.assert_(mu[2] >= 0.0)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -83,42 +83,15 @@ class TissueClassifierHMRF(object):
         final_segmentation = np.empty_like(image)
         initial_segmentation = seg_init
 
-        if max_iter is not None and tolerance is None:
+        allow_break = max_iter is None or tolerance is not None
 
-            for i in range(max_iter):
-
-                if self.verbose:
-                    print('>> Iteration: ' + str(i))
-
-                PLN = icm.prob_neighborhood(seg_init, beta, nclasses)
-                PVE = com.prob_image(image_gauss, nclasses, mu, sigmasq, PLN)
-
-                mu_upd, sigmasq_upd = com.update_param(image_gauss,
-                                                       PVE, mu, nclasses)
-                ind = np.argsort(mu_upd)
-                mu_upd = mu_upd[ind]
-                sigmasq_upd = sigmasq_upd[ind]
-
-                negll = com.negloglikelihood(image_gauss,
-                                             mu_upd, sigmasq_upd, nclasses)
-                final_segmentation, energy = icm.icm_ising(negll,
-                                                           beta, seg_init)
-
-                if self.save_history:
-                    self.segmentations.append(final_segmentation)
-                    self.pves.append(PVE)
-                    self.energies.append(energy)
-                    self.energies_sum.append(energy[energy > -np.inf].sum())
-
-                seg_init = final_segmentation
-                mu = mu_upd
-                sigmasq = sigmasq_upd
-
-        else:
+        if max_iter is None:
             max_iter = 100
 
-            if tolerance is None:
-                tolerance = 1e-05
+        if tolerance is None:
+            tolerance = 1e-05
+
+        if max_iter is not None and tolerance is None:
             for i in range(max_iter):
 
                 if self.verbose:

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -118,19 +118,15 @@ class TissueClassifierHMRF(object):
                     self.energies.append(energy)
                     self.energies_sum.append(energy[energy > -np.inf].sum())
 
+                if allow_break and i > 5:
 
-                if i % 10 == 0 and i != 0:
+                    e_sum = np.asarray(energy_sum)
+                    tol = tolerance * (np.amax(e_sum) - np.amin(e_sum))
 
-                    tol = tolerance * (np.amax(energy_sum) -
-                                       np.amin(energy_sum))
-
-                    test_dist = np.absolute(np.amax(
-                                energy_sum[np.size(energy_sum) - 5: i]) -
-                                np.amin(energy_sum[np.size(energy_sum) - 5: i])
-                                )
+                    e_end = e_sum[e_sum.size - 5:]
+                    test_dist = np.abs(np.amax(e_end) - np.amin(e_end))
 
                     if test_dist < tol:
-
                         break
 
                 seg_init = final_segmentation

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -81,7 +81,7 @@ class TissueClassifierHMRF(object):
         image_gauss = np.where(image == 0, zero_noise, image)
 
         final_segmentation = np.empty_like(image)
-        initial_segmentation = seg_init.copy()
+        initial_segmentation = seg_init
 
         if max_iter is not None and tolerance is None:
 
@@ -110,9 +110,9 @@ class TissueClassifierHMRF(object):
                     self.energies.append(energy)
                     self.energies_sum.append(energy[energy > -np.inf].sum())
 
-                seg_init = final_segmentation.copy()
-                mu = mu_upd.copy()
-                sigmasq = sigmasq_upd.copy()
+                seg_init = final_segmentation
+                mu = mu_upd
+                sigmasq = sigmasq_upd
 
         else:
             max_iter = 100
@@ -160,9 +160,9 @@ class TissueClassifierHMRF(object):
 
                         break
 
-                seg_init = final_segmentation.copy()
-                mu = mu_upd.copy()
-                sigmasq = sigmasq_upd.copy()
+                seg_init = final_segmentation
+                mu = mu_upd
+                sigmasq = sigmasq_upd
 
         PVE = PVE[..., 1:]
 

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -64,17 +64,15 @@ class TissueClassifierHMRF(object):
         if image.max() > 1:
             image = np.interp(image, [0, image.max()], [0.0, 1.0])
 
-        mu, sigma = com.initialize_param_uniform(image, nclasses)
+        mu, sigmasq = com.initialize_param_uniform(image, nclasses)
         p = np.argsort(mu)
         mu = mu[p]
-        sigma = sigma[p]
-        sigmasq = sigma ** 2
+        sigma = sigmasq[p]
 
         neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
-        mu, sigma = com.seg_stats(image, seg_init, nclasses)
-        sigmasq = sigma ** 2
+        mu, sigmasq = com.seg_stats(image, seg_init, nclasses)
 
         zero = np.zeros_like(image) + 0.001
         zero_noise = add_noise(zero, 10000, 1, noise_type='gaussian')
@@ -91,47 +89,51 @@ class TissueClassifierHMRF(object):
         if tolerance is None:
             tolerance = 1e-05
 
-        if max_iter is not None and tolerance is None:
-            for i in range(max_iter):
+        for i in range(max_iter):
 
-                if self.verbose:
-                    print('>> Iteration: ' + str(i))
+            if self.verbose:
+                print('>> Iteration: ' + str(i))
 
-                PLN = icm.prob_neighborhood(seg_init, beta, nclasses)
-                PVE = com.prob_image(image_gauss, nclasses, mu, sigmasq, PLN)
+            PLN = icm.prob_neighborhood(seg_init, beta, nclasses)
+            PVE = com.prob_image(image_gauss, nclasses, mu, sigmasq, PLN)
 
-                mu_upd, sigmasq_upd = com.update_param(image_gauss,
-                                                       PVE, mu, nclasses)
-                ind = np.argsort(mu_upd)
-                mu_upd = mu_upd[ind]
-                sigmasq_upd = sigmasq_upd[ind]
+            mu_upd, sigmasq_upd = com.update_param(image_gauss,
+                                                   PVE, mu, nclasses)
+            ind = np.argsort(mu_upd)
+            mu_upd = mu_upd[ind]
+            sigmasq_upd = sigmasq_upd[ind]
 
-                negll = com.negloglikelihood(image_gauss,
-                                             mu_upd, sigmasq_upd, nclasses)
-                final_segmentation, energy = icm.icm_ising(negll,
-                                                           beta, seg_init)
+            negll = com.negloglikelihood(image_gauss,
+                                         mu_upd, sigmasq_upd, nclasses)
+            final_segmentation, energy = icm.icm_ising(negll,
+                                                       beta, seg_init)
+
+            if allow_break:
                 energy_sum.append(energy[energy > -np.inf].sum())
 
-                if self.save_history:
-                    self.segmentations.append(final_segmentation)
-                    self.pves.append(PVE)
-                    self.energies.append(energy)
+            if self.save_history:
+                self.segmentations.append(final_segmentation)
+                self.pves.append(PVE)
+                self.energies.append(energy)
+                if allow_break:
+                    self.energies_sum.append(energy_sum[-1])
+                else:
                     self.energies_sum.append(energy[energy > -np.inf].sum())
 
-                if allow_break and i > 5:
+            if allow_break and i > 5:
 
-                    e_sum = np.asarray(energy_sum)
-                    tol = tolerance * (np.amax(e_sum) - np.amin(e_sum))
+                e_sum = np.asarray(energy_sum)
+                tol = tolerance * (np.amax(e_sum) - np.amin(e_sum))
 
-                    e_end = e_sum[e_sum.size - 5:]
-                    test_dist = np.abs(np.amax(e_end) - np.amin(e_end))
+                e_end = e_sum[e_sum.size - 5:]
+                test_dist = np.abs(np.amax(e_end) - np.amin(e_end))
 
-                    if test_dist < tol:
-                        break
+                if test_dist < tol:
+                    break
 
-                seg_init = final_segmentation
-                mu = mu_upd
-                sigmasq = sigmasq_upd
+            seg_init = final_segmentation
+            mu = mu_upd
+            sigmasq = sigmasq_upd
 
         PVE = PVE[..., 1:]
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -13,6 +13,9 @@ DIPY 1.3.0 changes
 - The argument `interp` of the method `dipy.align.imaffine.AffineMap.transform`  has been renamed `interpolation`.
 - The argument `interp` of the method `dipy.align.imaffine.AffineMap.transform_inverse`  has been renamed `interpolation`.
 
+**Segmentation**
+
+- The tissue segmentation method ``dipy.segment.TissueClassifierHMRF`` now checks the tolerance-based stopping criterion at every iteration (previously it was only checked every 10th iteration). This may result in earlier termination of iterations than with previous releases.
 
 DIPY 1.2.0 changes
 ------------------


### PR DESCRIPTION
This PR is mainly a style-based refactor of some things in the tissue segmentation code that I had modified some time ago when working on a GPU-based implementation. It will be best to review the various commits in isolation as they tend to address different aspects.

Overall, I don't consider this PR very high priority as there is no new feature or substantial performance impact. Commit 
4a1678d does result in a net decrease in code to maintain, however, as there were two code paths with nearly identical code in each.

The one behavior change here is that in bca8123 I switched to checking the tolerance at every iteration rather than every 10 iterations, so it is possible the loop will might terminate earlier than before if the tolerance is reached at a number of iterations that s not a multiple of 10. The added time for the tolerance check is negligible, so I don't see a strong reason to only check it every 10th iteration.