### PR TITLE
Increase Azure pipeline timeout

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -5,6 +5,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 120
   pool:
     vmIMage: ${{ parameters.vmImage }}
   variables:

--- a/ci/azure/osx.yml
+++ b/ci/azure/osx.yml
@@ -5,6 +5,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 120
   pool:
     vmIMage: ${{ parameters.vmImage }}
   variables:

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -5,6 +5,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  timeoutInMinutes: 120
   pool:
     vmIMage: ${{ parameters.vmImage }}
   variables:


### PR DESCRIPTION
This is strange, the default timeout for Azure pipelines should be 6h. However, it is 1h for us.  It seems that we hit this limit with our windows Matrix. So, this PR increases the limit to 2h.  

Let's see if it behaves correctly...