### PR TITLE
[DOC] Fix incorrect default output directory in doctsrings

### DIFF
--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -78,7 +78,7 @@ class ResliceFlow(Workflow):
             the size of the pool will equal the number of cores available.
             (default 1)
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_resliced : string, optional
             Name of the resliced dataset to be saved
             (default 'resliced.nii.gz')
@@ -146,7 +146,7 @@ class SlrWithQbxFlow(Workflow):
         progressive : boolean, optional
             (default True)
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_moved : string, optional
             Filename of moved tractogram (default 'moved.trk')
         out_affine : string, optional

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -42,7 +42,7 @@ class NLMeansFlow(Workflow):
             If True the noise is estimated as Rician, otherwise Gaussian noise
             is assumed.
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_denoised : string, optional
             Name of the resulting denoised volume (default: dwi_nlmeans.nii.gz)
 
@@ -129,7 +129,7 @@ class LPCAFlow(Workflow):
             Marcenko-Pastur distribution [2]_.
             Default: 2.3 (according to [1]_)
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_denoised : string, optional
             Name of the resulting denoised volume (default: dwi_lpca.nii.gz)
 
@@ -202,7 +202,7 @@ class MPPCAFlow(Workflow):
             Marcenko-Pastur distribution is returned [2]_.
             Default: False.
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_denoised : string, optional
             Name of the resulting denoised volume (default: dwi_mppca.nii.gz)
         out_sigma : string, optional
@@ -262,7 +262,7 @@ class GibbsRingingFlow(Workflow):
             positive integer.
             Default is set to 1.
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_unrig : string, optional
             Name of the resulting denoised volume (default: dwi_unrig.nii.gz)
 

--- a/dipy/workflows/mask.py
+++ b/dipy/workflows/mask.py
@@ -26,7 +26,7 @@ class MaskFlow(Workflow):
         ub : float, optional
             Upper bound value (default Inf)
         out_dir : string, optional
-           Output directory (default input file directory)
+           Output directory (default current directory)
         out_mask : string, optional
            Name of the masked file (default 'mask.nii.gz')
         """

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -50,7 +50,7 @@ class MedianOtsuFlow(Workflow):
         dilate : int, optional
             number of iterations for binary dilation (default 'None')
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_mask : string, optional
             Name of the mask volume to be saved (default 'brain_mask.nii.gz')
         out_masked : string, optional
@@ -156,7 +156,7 @@ class RecoBundlesFlow(Workflow):
             Don't enable Refine local Streamline-based Linear
             Registration (default False).
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_recognized_transf : string, optional
             Recognized bundle in the space of the model bundle
             (default 'recognized.trk')
@@ -308,7 +308,7 @@ class LabelsBundlesFlow(Workflow):
         labels_files : string
             The path of model bundle files
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
         out_bundle : string, optional
             Recognized bundle in the space of the model bundle
             (default 'recognized_orig.trk')

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -208,7 +208,7 @@ def buan_bundle_profiles(model_bundle_folder, bundle_folder,
     no_disks : integer, optional
         Number of disks used for dividing bundle into disks. (Default 100)
     out_dir : string, optional
-        Output directory (default input file directory)
+        Output directory (default current directory)
 
     References
     ----------
@@ -329,7 +329,7 @@ class BundleAnalysisTractometryFlow(Workflow):
             Number of disks used for dividing bundle into disks. (Default 100)
 
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
 
         References
         ----------
@@ -472,7 +472,7 @@ class LinearMixedModelsFlow(Workflow):
             Number of disks used for dividing bundle into disks. (Default 100)
 
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
 
         """
 
@@ -546,7 +546,7 @@ class BundleShapeAnalysis(Workflow):
             Bundle shape similarity threshold.
 
         out_dir : string, optional
-            Output directory (default input file directory)
+            Output directory (default current directory)
 
         References
         ----------

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -168,7 +168,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
             Maximum angle between streamline segments (range [0, 90],
             default 30).
         out_dir : string, optional
-           Output directory (default input file directory).
+           Output directory (default current directory).
         out_tractogram : string, optional
            Name of the tractogram file to be saved (default 'tractogram.trk').
         save_seeds : bool, optional
@@ -258,7 +258,7 @@ class PFTrackingPAMFlow(Workflow):
         pft_count : int, optional
             Number of particles to use in the particle filter (default 15).
         out_dir : string, optional
-           Output directory (default input file directory)
+           Output directory (default current directory)
         out_tractogram : string, optional
            Name of the tractogram file to be saved (default 'tractogram.trk')
         save_seeds : bool, optional


### PR DESCRIPTION
If no output directory is specified, the results are saved to the current directory, not the input data directory.