### PR TITLE
[DOC] fix inconsistent citation style

### DIFF
--- a/doc/interfaces/buan_flow.rst
+++ b/doc/interfaces/buan_flow.rst
@@ -4,15 +4,15 @@
 BUndle ANalytics (BUAN) framework
 =================================
 
-This tutorial walks through the steps for reproducing Bundle Analytics [1]_
-results on Parkinson's Progression Markers Initiative (PPMI) [2]_ data derivatives.
+This tutorial walks through the steps for reproducing Bundle Analytics [Chandio20]_
+results on Parkinson's Progression Markers Initiative (PPMI) [Marek11]_ data derivatives.
 Bundle Analytics is a framework for comparing bundle profiles and shapes of
 different groups. In this example, we will be comparing healthy controls and
 patients with parkinson's disease. We will be using PPMI data derivatives generated
-using DIPY [3]_.
+using DIPY [Garyfallidis14]_.
 
 
-First we need to download streamline atlas [4]_ with 30 white matter bundles
+First we need to download streamline atlas [Yeh18]_ with 30 white matter bundles
 in MNI space from
 
     `<https://figshare.com/articles/Atlas_of_30_Human_Brain_Bundles_in_MNI_space/12089652>`_
@@ -25,7 +25,7 @@ from the link below
 
 .. note::
 
-    If you prefer to run experiments on the complete dataset to reproduce the paper [1]_
+    If you prefer to run experiments on the complete dataset to reproduce the paper [Chandio20]_
     results please see the "Reproducing results on larger dataset" section at end of
     the page for more information.
 
@@ -124,24 +124,24 @@ For more information about each command line, you can go to
 
 If you are using any of these commands do cite the relevant papers.
 
-.. [1] Chandio, B.Q., Risacher, S.L., Pestilli, F., Bullock, D.,
+.. [Chandio20] Chandio, B.Q., Risacher, S.L., Pestilli, F., Bullock, D.,
     Yeh, FC., Koudoro, S., Rokem, A., Harezlack, J., and Garyfallidis, E.
     Bundle analytics, a computational framework for investigating the
     shapes and profiles of brain pathways across populations.
     Sci Rep 10, 17149 (2020)
 
-.. [2] Marek, Kenneth and Jennings, Danna and Lasch, Shirley and Siderowf,
+.. [Marek11] Marek, Kenneth and Jennings, Danna and Lasch, Shirley and Siderowf,
     Andrew and Tanner, Caroline and Simuni, Tanya and Coffey, Chris and Kieburtz,
     Karl and Flagg, Emily and Chowdhury, Sohini and others.
     The parkinson progression marker initiative (PPMI).
     Progress in neurobiology, 2011.
 
-.. [3] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
+.. [Garyfallidis14] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
     S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith.
     "DIPY, a library for the analysis of diffusion MRI data".
     Frontiers in Neuroinformatics, 1-18, 2014.
 
-.. [4] Yeh F.C., Panesar S., Fernandes D., Meola A., Yoshino M.,
+.. [Yeh18] Yeh F.C., Panesar S., Fernandes D., Meola A., Yoshino M.,
     Fernandez-Miranda J.C., Vettel J.M., Verstynen T.
     Population-averaged atlas of the macroscale human structural
     connectome and its network topology.

--- a/doc/interfaces/bundle_segmentation_flow.rst
+++ b/doc/interfaces/bundle_segmentation_flow.rst
@@ -4,12 +4,12 @@
 White Matter Bundle Segmentation with RecoBundles
 =================================================
 
-This tutorial explains how we can use RecoBundles [1]_ to extract
+This tutorial explains how we can use RecoBundles [Garyfallidis17]_ to extract
 bundles from input tractograms.
 
 
 First, we need to download a reference streamline atlas. Here, we downloaded an atlas with
-30 bundles in MNI space [2]_ from:
+30 bundles in MNI space [Yeh18]_ from:
 
     `<https://figshare.com/articles/Atlas_of_30_Human_Brain_Bundles_in_MNI_space/12089652>`_
 
@@ -38,7 +38,7 @@ Streamline-Based Linear Registration
 
 To extract the bundles from the tractogram, we first need move our target tractogram to
 be in the same space as the atlas (MNI, in this case). We can directly register the target tractogram to
-the space of the atlas, using streamline-based linear registration (SLR) [3]_.
+the space of the atlas, using streamline-based linear registration (SLR) [Garyfallidis15]_.
 
 The following workflows require two positional input arguments; ``static`` and
 ``moving`` .trk files. In our case, the ``static`` input is the atlas and the ``moving`` is
@@ -106,26 +106,26 @@ original space, run following commands::
 For more information about each command line, please visit DIPY website `<https://dipy.org/>`_ .
 
 If you are using any of these commands please be sure to cite the relevant papers and
-DIPY [4]_.
+DIPY [Garyfallidis14]_.
 
 ----------
 References
 ----------
 
-.. [1] Garyfallidis et al. Recognition of white matter bundles using local and
+.. [Garyfallidis17] Garyfallidis et al. Recognition of white matter bundles using local and
     global streamline-based registration and clustering, Neuroimage, 2017
 
-.. [2] Yeh F.C., Panesar S., Fernandes D., Meola A., Yoshino M.,
+.. [Yeh18] Yeh F.C., Panesar S., Fernandes D., Meola A., Yoshino M.,
     Fernandez-Miranda J.C., Vettel J.M., Verstynen T.
     Population-averaged atlas of the macroscale human structural
     connectome and its network topology.
     Neuroimage, 2018.
 
-.. [3] Garyfallidis et al., “Robust and efficient linear registration of
+.. [Garyfallidis15] Garyfallidis et al., “Robust and efficient linear registration of
     white-matter fascicles in the space of streamlines”, Neuroimage,
     117:124-140, 2015.
 
-.. [4] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
+.. [Garyfallidis14] Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem,
     S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith.
     "DIPY, a library for the analysis of diffusion MRI data".
     Frontiers in Neuroinformatics, 1-18, 2014.

--- a/doc/interfaces/denoise_flow.rst
+++ b/doc/interfaces/denoise_flow.rst
@@ -220,8 +220,8 @@ Structural
 References
 ----------
 .. [Coupe08] P. Coupe, P. Yger, S. Prima, P. Hellier, C. Kervrann, C. Barillot,
-   "An Optimized Blockwise Non Local Means Denoising Filter for 3D Magnetic
-   Resonance Images", IEEE Transactions on Medical Imaging, 27(4):425-441, 2008
+    "An Optimized Blockwise Non Local Means Denoising Filter for 3D Magnetic
+    Resonance Images", IEEE Transactions on Medical Imaging, 27(4):425-441, 2008
 .. [Coupe11] Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins.
     "Adaptive Multiresolution Non-Local Means Filter for 3D MR Image Denoising"
     IET Image Processing, Institution of Engineering and Technology, 2011

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -17,9 +17,9 @@ Magnetic Resonance (MR) images are reconstructed from the Fourier coefficients
 of acquired k-space images. Since only a finite number of Fourier coefficients
 can be acquired in practice, reconstructed MR images can be corrupted by Gibbs
 artefacts, which is manifested by intensity oscillations adjacent to edges of
-different tissue types [1]_. Although this artefact affects MR images in
+different tissue types [Veraart15]_. Although this artefact affects MR images in
 general, in the context of diffusion-weighted imaging, Gibbs oscillations
-can be magnified in derived diffusion-based estimates [1]_, [2]_.
+can be magnified in derived diffusion-based estimates [Veraart15]_, [Perrone15]_.
 
 We will use the ``tissue_data`` dataset in DIPY to showcase the ability to
 remove Gibbs ringing artefacts. As with any other workflow in DIPY, you can
@@ -69,10 +69,10 @@ the Gibbs unringing effect.
 
 References
 ----------
-.. [1] Veraart, J., Fieremans, E., Jelescu, I.O., Knoll, F., Novikov, D.S.,
-       2015. Gibbs Ringing in Diffusion MRI. Magn Reson Med 76(1): 301-314.
-       https://doi.org/10.1002/mrm.25866
-.. [2] Perrone, D., Aelterman, J., Pižurica, A., Jeurissen, B., Philips, W.,
-       Leemans A., 2015. The effect of Gibbs ringing artifacts on measures
-       derived from diffusion MRI. Neuroimage 120, 441-455.
-       https://doi.org/10.1016/j.neuroimage.2015.06.068.
+.. [Veraart15] Veraart, J., Fieremans, E., Jelescu, I.O., Knoll, F., Novikov, D.S.,
+    2015. Gibbs Ringing in Diffusion MRI. Magn Reson Med 76(1): 301-314.
+    https://doi.org/10.1002/mrm.25866
+.. [Perrone15] Perrone, D., Aelterman, J., Pižurica, A., Jeurissen, B., Philips, W.,
+    Leemans A., 2015. The effect of Gibbs ringing artifacts on measures
+    derived from diffusion MRI. Neuroimage 120, 441-455.
+    https://doi.org/10.1016/j.neuroimage.2015.06.068.


### PR DESCRIPTION
We should stick to named references rather than numbered for consistent citation style.