### PR TITLE
[DOC] Fix the 'None' value in num_threads attribute

### DIFF
--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -17,8 +17,8 @@ Magnetic Resonance (MR) images are reconstructed from the Fourier coefficients
 of acquired k-space images. Since only a finite number of Fourier coefficients
 can be acquired in practice, reconstructed MR images can be corrupted by Gibbs
 artefacts, which is manifested by intensity oscillations adjacent to edges of
-different tissue types [Veraart15]_. Although this artefact affects MR images in
-general, in the context of diffusion-weighted imaging, Gibbs oscillations
+different tissue types [Veraart15]_. Although this artefact affects MR images
+in general, in the context of diffusion-weighted imaging, Gibbs oscillations
 can be magnified in derived diffusion-based estimates [Veraart15]_, [Perrone15]_.
 
 We will use the ``tissue_data`` dataset in DIPY to showcase the ability to
@@ -32,24 +32,23 @@ ringing-free volume::
 
 To run the Gibbs unringing method, we need to specify the path to the input
 data. This path may contain wildcards to process multiple inputs at once.
-You can also specify the optional arguments. In this case, we will be 
-specifying the number of threads (``num_threads``) and output directory 
+You can also specify the optional arguments. In this case, we will be
+specifying the number of threads (``num_threads``) and output directory
 (``out_dir``). The number of threads allows to exploit the available
 computational power and accelerate the processing. The maximum number of
 threads available depends on the CPU of the computer, so users are expected
-to set an appropriate value based on their platform. If a ``None`` value is
-used, then all available threads are used.
+to set an appropriate value based on their platform.
 
 To run the Gibbs unringing on the data it suffices to execute the
 ``dipy_gibbs_ringing`` command, e.g.::
 
-    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads None --out_dir "gibbs_ringing_output"
+    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads 4 --out_dir "gibbs_ringing_output"
 
 This command will apply the Gibbs unringing procedure to the input MR image
 and write the artefact-free result to the ``gibbs_ringing_output`` directory.
 
-In case no output directory is specified, the Gibbs artefact-free output
-volume is saved to the current directory by default.
+In case no output directory is specified, the Gibbs artefact-free output volume
+is saved to the current directory by default.
 
 Note: Users are recommended to zoom on each image by clicking on them to see
 the Gibbs unringing effect.


### PR DESCRIPTION
Only positive integers can be passed to the num_threads attribute. ``None`` does not work.