### PR TITLE
Allowing response_from_mask_msmt to take btens into account

### DIFF
--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -703,7 +703,7 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
             bvecs_sub = np.concatenate([[bvecs[b0_indices[0]]],
                                        bvecs[indices]])
             bvals_sub = np.concatenate([[0], bvals[indices]])
-            if btens:
+            if btens is not None:
                 btens_b0 = btens[b0_indices[0]].reshape((1, 3, 3))
                 btens_sub = np.concatenate([btens_b0, btens[indices]])
             else:

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -686,6 +686,7 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
 
     bvals = gtab.bvals
     bvecs = gtab.bvecs
+    btens = gtab.btens
 
     list_bvals = unique_bvals_tolerance(bvals, tol)
 
@@ -702,10 +703,11 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
             bvecs_sub = np.concatenate([[bvecs[b0_indices[0]]],
                                        bvecs[indices]])
             bvals_sub = np.concatenate([[0], bvals[indices]])
+            btens_sub = np.concatenate([btens[b0_indices[0]].reshape((1,3,3)), btens[indices]])
 
             data_conc = np.concatenate([b0_map, data[..., indices]], axis=3)
 
-            gtab = gradient_table(bvals_sub, bvecs_sub)
+            gtab = gradient_table(bvals_sub, bvecs_sub, btens=btens_sub)
             response, _ = response_from_mask_ssst(gtab, data_conc, mask)
 
             responses.append(list(np.concatenate([response[0], [response[1]]])))

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -703,8 +703,11 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
             bvecs_sub = np.concatenate([[bvecs[b0_indices[0]]],
                                        bvecs[indices]])
             bvals_sub = np.concatenate([[0], bvals[indices]])
-            btens_b0 = btens[b0_indices[0]].reshape((1, 3, 3))
-            btens_sub = np.concatenate([btens_b0, btens[indices]])
+            if btens:
+                btens_b0 = btens[b0_indices[0]].reshape((1, 3, 3))
+                btens_sub = np.concatenate([btens_b0, btens[indices]])
+            else:
+                btens_sub = None
 
             data_conc = np.concatenate([b0_map, data[..., indices]], axis=3)
 

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -703,7 +703,8 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
             bvecs_sub = np.concatenate([[bvecs[b0_indices[0]]],
                                        bvecs[indices]])
             bvals_sub = np.concatenate([[0], bvals[indices]])
-            btens_sub = np.concatenate([btens[b0_indices[0]].reshape((1,3,3)), btens[indices]])
+            btens_b0 = btens[b0_indices[0]].reshape((1, 3, 3))
+            btens_sub = np.concatenate([btens_b0, btens[indices]])
 
             data_conc = np.concatenate([b0_map, data[..., indices]], axis=3)
 


### PR DESCRIPTION
This is a very small PR where I only added some lines to the function `response_from_mask_msmt` from `dipy.reconst.mcsd` in order to keep track of the b-tensor (the attribute `btens` from `gtab`) associated with each bvalue. This allows for the calculation of response functions from different b-tensor encodings. The function `response_from_mask_ssst` did not have to be modified, since it only uses `TensorModel`, which already works with `btens`.