### PR TITLE
[FIX] fix tests for all new deprecated functions

### DIFF
--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -14,17 +14,14 @@ from dipy.core.gradients import (gradient_table, GradientTable,
                                  unique_bvals_magnitude,
                                  unique_bvals_tolerance, unique_bvals,
                                  params_to_btens, btens_to_params)
-
-
-from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.geometry import vec2vec_rotmat
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.utils.deprecator import ExpiredDeprecationError
 
 
 def test_unique_bvals_deprecated():
-    with warnings.catch_warnings(record=True) as cw:
-        warnings.simplefilter("always", DeprecationWarning)
-        _ = unique_bvals(np.array([0, 800, 1400, 1401, 1405]))
-        npt.assert_(issubclass(cw[0].category, DeprecationWarning))
+    npt.assert_raises(ExpiredDeprecationError, unique_bvals,
+                      np.array([0, 800, 1400, 1401, 1405]))
 
 
 def test_btable_prepare():
@@ -141,12 +138,14 @@ def test_GradientTable_btensor_calculation():
             if btens == ('LTE' or 'CTE'):
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]), bvec)
+                    dot_prod = np.dot(np.real(evecs[:, np.argmax(evals)]),
+                                      bvec)
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
             elif btens == 'PTE':
                 if bval != 0:
                     evals, evecs = np.linalg.eig(bten)
-                    dot_prod = np.dot(np.real(evecs[:, np.argmin(evals)]), bvec)
+                    dot_prod = np.dot(np.real(evecs[:, np.argmin(evals)]),
+                                      bvec)
                     npt.assert_almost_equal(np.abs(dot_prod), 1)
 
     # Check btens input option 2
@@ -627,7 +626,6 @@ def test_btens_to_params():
         npt.assert_array_almost_equal(i_bdelta, expected_bdeltas[i])
         npt.assert_array_almost_equal(i_b_eta, expected_b_etas[i])
 
-
     # Test function on a 3D input
     base_tensors_array = np.empty((4, 3, 3))
     base_tensors_array[0, :, :] = linear_tensor
@@ -652,7 +650,7 @@ def test_btens_to_params():
         ebs = expected_bvals*scale
 
         # Generate `n_rotations` random 3-element vectors of norm 1
-        v = np.random.random((n_rotations, 3))-0.5
+        v = np.random.random((n_rotations, 3)) - 0.5
         u = np.apply_along_axis(lambda w: w/np.linalg.norm(w), axis=1, arr=v)
 
         for rot_idx in range(n_rotations):
@@ -738,7 +736,3 @@ def test_params_to_btens():
 
     for i, (bval, bdelta, b_eta) in enumerate(zip(bvals, bdeltas, b_etas)):
         npt.assert_raises(ValueError, params_to_btens, bval, bdelta, b_eta)
-
-if __name__ == "__main__":
-    from numpy.testing import run_module_suite
-    run_module_suite()

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -11,6 +11,8 @@ from dipy.sims.voxel import (multi_tensor,
                              multi_tensor_odf,
                              all_tensor_evecs, single_tensor_odf)
 from dipy.core.gradients import gradient_table
+from dipy.core.sphere import Sphere, HemiSphere
+from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    ConstrainedSDTModel,
                                    forward_sdeconv_mat,
@@ -23,13 +25,11 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response,
                                    recursive_response)
 from dipy.direction.peaks import peak_directions
-from dipy.core.sphere import HemiSphere
-from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.reconst.shm import (QballModel, sf_to_sh, sh_to_sf,
                               real_sym_sh_basis, sph_harm_ind_list)
 from dipy.reconst.shm import lazy_index
-from dipy.core.sphere import Sphere
+from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.io.gradients import read_bvals_bvecs
 
 
@@ -55,23 +55,15 @@ def get_test_data():
 
 
 def test_auto_response_deprecated():
-    with warnings.catch_warnings(record=True) as cw:
-        warnings.simplefilter("always", DeprecationWarning)
-        gtab, data, _, _, _ = get_test_data()
-        _, _ = auto_response(gtab,
-                             data,
-                             roi_center=None,
-                             roi_radius=1,
-                             fa_thr=0.7)
-        npt.assert_(issubclass(cw[0].category, DeprecationWarning))
+    gtab, data, _, _, _ = get_test_data()
+    npt.assert_raises(ExpiredDeprecationError, auto_response,
+                      gtab, data, roi_center=None, roi_radius=1, fa_thr=0.7)
 
 
 def test_response_from_mask_deprecated():
-    with warnings.catch_warnings(record=True) as cw:
-        warnings.simplefilter("always", DeprecationWarning)
-        gtab, data, mask, _, _ = get_test_data()
-        _ = response_from_mask(gtab, data, mask)
-        npt.assert_(issubclass(cw[0].category, DeprecationWarning))
+    gtab, data, mask, _, _ = get_test_data()
+    npt.assert_raises(ExpiredDeprecationError, response_from_mask,
+                      gtab, data, mask)
 
 
 def test_recursive_response_calibration():

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -1,23 +1,16 @@
 """ Testing track_metrics module """
-
-import warnings
-
 import numpy as np
 import numpy.testing as npt
 from numpy.testing import assert_equal, assert_array_almost_equal
 
 from dipy.tracking import metrics as tm
 from dipy.tracking import distances as pf
+from dipy.utils.deprecator import ExpiredDeprecationError
 
 
 def test_downsample_deprecated():
-    with warnings.catch_warnings(record=True) as cw:
-        warnings.simplefilter("always", DeprecationWarning)
-        streamline = [np.array([[0, 0, 0], [1, 1, 1]])]
-
-        streamline_12 = tm.downsample(streamline, 12)
-        npt.assert_equal(len(streamline_12[0]), 12)
-        npt.assert_(issubclass(cw[0].category, DeprecationWarning))
+    streamline = [np.array([[0, 0, 0], [1, 1, 1]])]
+    npt.assert_raises(ExpiredDeprecationError, tm.downsample, streamline, 12)
 
 
 def test_splines():


### PR DESCRIPTION
4 functions were deprecated after release 1.4.0. This is just an update of these deprecated functions.