### PR TITLE
[FIX] Cleanup deprecated np.float, np.bool, np.int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dipy/.idea/
 .idea
 .vscode
 .pytest_cache/*
+tmp/

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -20,10 +20,10 @@ def test_exceptions():
         dim = len(shape)
         metric = CCMetric(dim, radius=radius)
         metric.set_static_image(np.arange(np.prod(shape),
-                                          dtype=np.float).reshape(shape),
+                                          dtype=float).reshape(shape),
                                 np.eye(4), np.ones(dim), np.eye(3))
         metric.set_moving_image(np.arange(np.prod(shape),
-                                dtype=np.float).reshape(shape),
+                                dtype=float).reshape(shape),
                                 np.eye(4), np.ones(dim), np.eye(3))
         return metric
 

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -136,10 +136,10 @@ def test_rigid_partial_real_bundles():
 
     vol = np.zeros((100, 100, 100))
     spts = np.concatenate(static_center, axis=0)
-    spts = np.round(spts).astype(np.int) + np.array([50, 50, 50])
+    spts = np.round(spts).astype(int) + np.array([50, 50, 50])
 
     mpts = np.concatenate(moving_center, axis=0)
-    mpts = np.round(mpts).astype(np.int) + np.array([50, 50, 50])
+    mpts = np.round(mpts).astype(int) + np.array([50, 50, 50])
 
     for index in spts:
         i, j, k = index

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -278,8 +278,8 @@ def gradient_table_from_bvals_bvecs(bvals, bvecs, b0_threshold=50, atol=1e-2,
     GradientTable, gradient_table
 
     """
-    bvals = np.asarray(bvals, np.float)
-    bvecs = np.asarray(bvecs, np.float)
+    bvals = np.asarray(bvals, float)
+    bvecs = np.asarray(bvecs, float)
     dwi_mask = bvals > b0_threshold
 
     # check that bvals is (N,) array and bvecs is (N, 3) unit vectors

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -398,7 +398,7 @@ cpdef trilinear_interpolate4d(double[:, :, :, :] data, double[:] point,
 
 
 def nearestneighbor_interpolate(data, point):
-    index = tuple(np.round(point).astype(np.int))
+    index = tuple(np.round(point).astype(int))
     return data[index]
 
 

--- a/dipy/core/rng.py
+++ b/dipy/core/rng.py
@@ -129,8 +129,8 @@ def WichmannHill1982(ix=100001, iy=200002, iz=300003):
     if iz < 0:
         iz = iz + 30323
     """
-    return np.remainder(np.float(ix) / 30269. + np.float(iy) / 30307. +
-                        np.float(iz) / 30323., 1.0)
+    return np.remainder(float(ix) / 30269. + float(iy) / 30307. +
+                        float(iz) / 30323., 1.0)
 
 
 def LEcuyer(s1=100001, s2=200002):

--- a/dipy/core/sphere_stats.py
+++ b/dipy/core/sphere_stats.py
@@ -202,8 +202,8 @@ def compare_orientation_sets(S, T):
 
     v = [np.sum([np.abs(np.dot(p[i], T[i])) for i in range(n)])
          for p in permutations(S, n)]
-    return np.max(v)/np.float(n)
-    # return np.max(v)*np.float(n)/np.float(m)
+    return np.max(v)/float(n)
+    # return np.max(v)*float(n)/float(m)
 
 
 def angular_similarity(S, T):
@@ -289,4 +289,4 @@ def angular_similarity(S, T):
     v = [np.sum([np.abs(np.dot(p[i], T[i])) for i in range(n)])
          for p in permutations(S, n)]
 
-    return np.float(np.max(v))  # *np.float(n)/np.float(m)
+    return float(np.max(v))  # *float(n)/float(m)

--- a/dipy/denoise/adaptive_soft_matching.py
+++ b/dipy/denoise/adaptive_soft_matching.py
@@ -43,9 +43,9 @@ def adaptive_soft_matching(ima, fimau, fimao, sigma):
 
     s = fimau.shape
     p = [0, 0, 0]
-    p[0] = np.int(2**math.ceil(math.log(s[0], 2)))
-    p[1] = np.int(2**math.ceil(math.log(s[1], 2)))
-    p[2] = np.int(2**math.ceil(math.log(s[2], 2)))
+    p[0] = int(2**math.ceil(math.log(s[0], 2)))
+    p[1] = int(2**math.ceil(math.log(s[1], 2)))
+    p[2] = int(2**math.ceil(math.log(s[2], 2)))
     pad1 = np.zeros((p[0], p[1], p[2]))
     pad2 = np.zeros((p[0], p[1], p[2]))
     pad3 = np.zeros((p[0], p[1], p[2]))

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -110,7 +110,7 @@ def piesno(data, N, alpha=0.01, l=100, itermax=100, eps=1e-5,
     if data.ndim == 4:
 
         sigma = np.zeros(data.shape[-2], dtype=np.float32)
-        mask_noise = np.zeros(data.shape[:-1], dtype=np.bool)
+        mask_noise = np.zeros(data.shape[:-1], dtype=bool)
 
         for idx in range(data.shape[-2]):
             sigma[idx], mask_noise[..., idx] = _piesno_3D(data[..., idx, :],
@@ -208,7 +208,7 @@ def _piesno_3D(data, N, alpha=0.01, l=100, itermax=100, eps=1e-5,
 
     if np.all(data == 0):
         if return_mask:
-            return 0, np.zeros(data.shape[:-1], dtype=np.bool)
+            return 0, np.zeros(data.shape[:-1], dtype=bool)
 
         return 0
 
@@ -231,7 +231,7 @@ def _piesno_3D(data, N, alpha=0.01, l=100, itermax=100, eps=1e-5,
     sigma_prev = 0
     sigma = m
     prev_idx = 0
-    mask = np.zeros(data.shape[:-1], dtype=np.bool)
+    mask = np.zeros(data.shape[:-1], dtype=bool)
 
     lambda_minus = _inv_nchi_cdf(N, K, alpha/2)
     lambda_plus = _inv_nchi_cdf(N, K, 1 - alpha/2)
@@ -356,7 +356,7 @@ def estimate_sigma(arr, disable_background_masking=False, N=0):
     if disable_background_masking:
         mask = arr[..., 0].astype(np.bool)
     else:
-        mask = np.ones_like(arr[..., 0], dtype=np.bool)
+        mask = np.ones_like(arr[..., 0], dtype=bool)
 
     conv_out = np.zeros(arr[..., 0].shape, dtype=np.float64)
 

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -354,7 +354,7 @@ def estimate_sigma(arr, disable_background_masking=False, N=0):
         raise ValueError("Array shape is not supported!", arr.shape)
 
     if disable_background_masking:
-        mask = arr[..., 0].astype(np.bool)
+        mask = arr[..., 0].astype(bool)
     else:
         mask = np.ones_like(arr[..., 0], dtype=bool)
 

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -59,13 +59,13 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
             patch_radius,
             block_radius,
             sigma,
-            np.int(rician))).astype(arr.dtype)
+            int(rician))).astype(arr.dtype)
     elif arr.ndim == 4:
         denoised_arr = np.zeros_like(arr)
         for i in range(arr.shape[-1]):
             denoised_arr[..., i] = np.array(nlmeans_block(np.double(
                 arr[..., i]), mask, patch_radius, block_radius, sigma,
-                np.int(rician))).astype(arr.dtype)
+                int(rician))).astype(arr.dtype)
 
         return denoised_arr
 

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -234,7 +234,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
                     Denoising Diffusion MRI with Self-supervised Learning,
                     Advances in Neural Information Processing Systems 33 (2020)
     """
-    patch_radius = np.asarray(patch_radius, dtype=np.int)
+    patch_radius = np.asarray(patch_radius, dtype=int)
 
     if not data.ndim == 4:
         raise ValueError("Patch2Self can only denoise on 4D arrays.",

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -440,7 +440,7 @@ def test_degenerative_cases():
     assert_array_equal(values, odf[indices])
 
     odf = np.ones(sphere.vertices.shape[0])
-    odf[1:] = np.finfo(np.float).eps * np.random.rand(odf.shape[0] - 1)
+    odf[1:] = np.finfo(float).eps * np.random.rand(odf.shape[0] - 1)
     directions, values, indices = peak_directions(odf, sphere, .5, 25)
 
     assert_equal(values[0], 1)

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -136,7 +136,7 @@ def decfa_to_float(img_orig):
 
     # Remove the original intent
     new_hdr.set_intent(0)
-    new_hdr.set_data_dtype(np.float)
+    new_hdr.set_data_dtype(float)
 
     return Nifti1Image(out_data, affine=img_orig.affine, header=new_hdr)
 

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -94,7 +94,7 @@ def remove_similar_vertices(
         double cos_similarity = cos(DPY_PI/180 * theta)
     if n >= 2**16:  # constrained by input data type
         raise ValueError("too many vertices")
-    unique_vertices = np.empty((n, 3), dtype=np.float)
+    unique_vertices = np.empty((n, 3), dtype=float)
     if return_mapping:
         mapping = np.empty(n, dtype=np.uint16)
     if return_index:

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -427,7 +427,7 @@ def argmax_from_adj(vals, vertex_inds, adj_inds):
 
 
 def proc_reco_args(vals, vertinds):
-    vals = np.ascontiguousarray(vals.astype(np.float))
+    vals = np.ascontiguousarray(vals.astype(float))
     vertinds = np.ascontiguousarray(vertinds.astype(np.uint32))
     return vals, vertinds
 

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1455,7 +1455,7 @@ def convert_sh_to_full_basis(sh_coeffs):
     _, n = sph_harm_ind_list(sh_order, full_basis=True)
 
     full_sh_coeffs =\
-        np.zeros(np.append(sh_coeffs.shape[:-1], [n.size]).astype(np.int))
+        np.zeros(np.append(sh_coeffs.shape[:-1], [n.size]).astype(int))
     mask = np.mod(n, 2) == 0
 
     full_sh_coeffs[..., mask] = sh_coeffs

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -39,7 +39,7 @@ def test_squash():
     scalar_arr = np.zeros((2,), dtype=object)
     numeric_types = sum(
         [np.sctypes[t] for t in ('int', 'uint', 'float', 'complex')],
-        [np.bool_])
+        [bool])
     for dt0 in numeric_types:
         arr_arr[0] = np.zeros((3,), dtype=dt0)
         scalar_arr[0] = dt0(0)
@@ -80,7 +80,7 @@ def test_squash():
     arr_masked[1] = 99
     npt.assert_array_equal(_squash(obj_masked, mask=None, fill=99),
                            arr_masked)
-    msk = np.array([1, 0, 1], dtype=np.bool_)  # explicit mask
+    msk = np.array([1, 0, 1], dtype=bool)  # explicit mask
     npt.assert_array_equal(_squash(obj_masked, mask=msk, fill=99),
                            arr_masked)
 

--- a/dipy/reconst/tests/test_reco_utils.py
+++ b/dipy/reconst/tests/test_reco_utils.py
@@ -23,7 +23,7 @@ def test_adj_countarrs():
 
 def test_argmax_from_countarrs():
     # basic case
-    vals = np.arange(10, dtype=np.float)
+    vals = np.arange(10, dtype=float)
     vertinds = np.arange(10, dtype=np.uint32)
     adj_counts = np.ones((10,), dtype=np.uint32)
     adj_inds_raw = np.arange(10, dtype=np.uint32)[::-1]

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -73,8 +73,8 @@ def bundle_adjacency(dtracks0, dtracks1, threshold):
             pair21.append((i, j))
 
     pair21 = np.array(pair21)
-    A = len(pair12) / np.float(len(dtracks0))
-    B = len(pair21) / np.float(len(dtracks1))
+    A = len(pair12) / float(len(dtracks0))
+    B = len(pair21) / float(len(dtracks1))
     res = 0.5 * (A + B)
     return res
 

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -223,7 +223,7 @@ class ClusterMap(object):
             When `idx`is either a slice, list or boolean array, returns
             a list of `Cluster` objects.
         """
-        if isinstance(idx, np.ndarray) and idx.dtype == np.bool:
+        if isinstance(idx, np.ndarray) and idx.dtype == bool:
             return [self.clusters[i]
                     for i, take_it in enumerate(idx) if take_it]
         elif type(idx) is slice:
@@ -602,7 +602,7 @@ class TreeCluster(ClusterCentroid):
     @property
     def is_leaf(self):
         return len(self.children) == 0
-    
+
     def return_indices(self):
         return self.children
 

--- a/dipy/segment/threshold.py
+++ b/dipy/segment/threshold.py
@@ -20,7 +20,7 @@ def otsu(image, nbins=256):
         Threshold value.
     """
     hist, bin_centers = np.histogram(image, nbins)
-    hist = hist.astype(np.float)
+    hist = hist.astype(float)
 
     # class probabilities for all possible thresholds
     weight1 = np.cumsum(hist)

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -39,11 +39,11 @@ def gradient(f):
 
     Examples
     --------
-    >>> x = np.array([1, 2, 4, 7, 11, 16], dtype=np.float)
+    >>> x = np.array([1, 2, 4, 7, 11, 16], dtype=float)
     >>> gradient(x)
     array([ 1. ,  1.5,  2.5,  3.5,  4.5,  5. ])
 
-    >>> gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float))
+    >>> gradient(np.array([[1, 2, 6], [3, 4, 5]], dtype=float))
     [array([[ 2.,  2., -1.],
            [ 2.,  2., -1.]]), array([[ 1. ,  2.5,  4. ],
            [ 1. ,  1. ,  1. ]])]
@@ -366,7 +366,7 @@ class FiberModel(ReconstModel):
         n_unique_f = len(np.hstack(list(v2f.values())))
         # Preallocate these, which will be used to generate the sparse
         # matrix:
-        f_matrix_sig = np.zeros(n_unique_f * n_bvecs, dtype=np.float)
+        f_matrix_sig = np.zeros(n_unique_f * n_bvecs, dtype=float)
         f_matrix_row = np.zeros(n_unique_f * n_bvecs, dtype=np.intp)
         f_matrix_col = np.zeros(n_unique_f * n_bvecs, dtype=np.intp)
 

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -625,7 +625,7 @@ def _extract_vals(data, streamlines, affine, threedvec=False):
     array or list (depending on the input) : values interpolate to each
         coordinate along the length of each streamline
     """
-    data = data.astype(np.float)
+    data = data.astype(float)
     if (isinstance(streamlines, list) or
             isinstance(streamlines, types.GeneratorType) or
             isinstance(streamlines, Streamlines)):
@@ -635,15 +635,15 @@ def _extract_vals(data, streamlines, affine, threedvec=False):
         for sl in streamlines:
             if threedvec:
                 vals.append(list(interpolate_vector_3d(
-                    data, sl.astype(np.float))[0]))
+                    data, sl.astype(float))[0]))
             else:
                 vals.append(list(interpolate_scalar_3d(
-                    data, sl.astype(np.float))[0]))
+                    data, sl.astype(float))[0]))
 
     elif isinstance(streamlines, np.ndarray):
         sl_shape = streamlines.shape
         sl_cat = streamlines.reshape(sl_shape[0] *
-                                     sl_shape[1], 3).astype(np.float)
+                                     sl_shape[1], 3).astype(float)
 
         inv_affine = np.linalg.inv(affine)
         sl_cat = (np.dot(sl_cat, inv_affine[:3, :3]) +

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -581,8 +581,8 @@ def test_unique_rows():
 
 
 def test_reduce_rois():
-    roi1 = np.zeros((4, 4, 4), dtype=np.bool)
-    roi2 = np.zeros((4, 4, 4), dtype=np.bool)
+    roi1 = np.zeros((4, 4, 4), dtype=bool)
+    roi2 = np.zeros((4, 4, 4), dtype=bool)
     roi1[1, 1, 1] = 1
     roi2[2, 2, 2] = 1
     include_roi, exclude_roi = reduce_rois([roi1, roi2], [True, True])

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -394,12 +394,12 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
     >>> tcs[1,1,2], tcs[1,2,3]
     (1, 1)
     """
-    vol_dims = np.asarray(vol_dims).astype(np.int)
+    vol_dims = np.asarray(vol_dims).astype(int)
     vox_sizes = np.asarray(vox_sizes).astype(np.double)
     n_voxels = np.prod(vol_dims)
     # output track counts array, flattened
     cdef cnp.ndarray[cnp.int_t, ndim=1] tcs = \
-        np.zeros((n_voxels,), dtype=np.int)
+        np.zeros((n_voxels,), dtype=int)
     # pointer to output track indices
     cdef cnp.npy_intp i
     if return_elements:
@@ -424,7 +424,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
     # x slice size (C array ordering)
     cdef cnp.npy_intp yz = vd[1] * vd[2]
     for tno in range(len(tracks)):
-        t = tracks[tno].astype(np.float)
+        t = tracks[tno].astype(float)
         # set to find unique voxel points in track
         in_inds = set()
         # the loop below is time-critical

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -317,7 +317,7 @@ class ReconstDtiFlow(Workflow):
             data, affine = load_nifti(dwi)
 
             if mask is not None:
-                mask = load_nifti_data(mask).astype(np.bool)
+                mask = load_nifti_data(mask).astype(bool)
 
             tenfit, _ = self.get_fitted_tensor(data, mask, bval, bvec,
                                                b0_threshold, bvecs_tol)
@@ -497,7 +497,7 @@ class ReconstCSDFlow(Workflow):
                      "({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
                                   atol=bvecs_tol)
-            mask_vol = load_nifti_data(maskfile).astype(np.bool)
+            mask_vol = load_nifti_data(maskfile).astype(bool)
 
             n_params = ((sh_order + 1) * (sh_order + 2)) / 2
             if data.shape[-1] < n_params:
@@ -656,7 +656,7 @@ class ReconstCSAFlow(Workflow):
                      "({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs,
                                   b0_threshold=b0_threshold, atol=bvecs_tol)
-            mask_vol = load_nifti_data(maskfile).astype(np.bool)
+            mask_vol = load_nifti_data(maskfile).astype(bool)
 
             peaks_sphere = default_sphere
 
@@ -785,7 +785,7 @@ class ReconstDkiFlow(Workflow):
             data, affine = load_nifti(dwi)
 
             if mask is not None:
-                mask = load_nifti_data(mask).astype(np.bool)
+                mask = load_nifti_data(mask).astype(bool)
 
             dkfit, _ = self.get_fitted_tensor(data, mask, bval, bvec,
                                               b0_threshold)
@@ -947,7 +947,7 @@ class ReconstIvimFlow(Workflow):
             data, affine = load_nifti(dwi)
 
             if mask is not None:
-                mask = load_nifti_data(mask).astype(np.bool)
+                mask = load_nifti_data(mask).astype(bool)
 
             ivimfit, _ = self.get_fitted_ivim(data, mask, bval, bvec,
                                               b0_threshold)

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -271,11 +271,11 @@ def test_syn_registration_flow():
     syn_flow = SynRegistrationFlow()
 
     with TemporaryDirectory() as out_dir:
-        static_img = nib.Nifti1Image(static_data.astype(np.float), np.eye(4))
+        static_img = nib.Nifti1Image(static_data.astype(float), np.eye(4))
         fname_static = pjoin(out_dir, 'tmp_static.nii.gz')
         nib.save(static_img, fname_static)
 
-        moving_img = nib.Nifti1Image(moving_data.astype(np.float), np.eye(4))
+        moving_img = nib.Nifti1Image(moving_data.astype(float), np.eye(4))
         fname_moving = pjoin(out_dir, 'tmp_moving.nii.gz')
         nib.save(moving_img, fname_moving)
 

--- a/doc/examples/piesno.py
+++ b/doc/examples/piesno.py
@@ -84,7 +84,7 @@ save_nifti('mask_piesno.nii.gz', mask.astype(np.uint8), affine)
 
 print('The noise standard deviation is sigma = ', sigma)
 print('The std of the background is =',
-      np.std(data[mask[..., :].astype(np.bool)]))
+      np.std(data[mask[..., :].astype(bool)]))
 
 """
 

--- a/doc/examples/reconst_dsi_metrics.py
+++ b/doc/examples/reconst_dsi_metrics.py
@@ -56,7 +56,7 @@ dataslice = data[30:70, 20:80, data.shape[2] // 2]
 Normalize the signal by the b0
 """
 
-dataslice = dataslice / (dataslice[..., 0, None]).astype(np.float)
+dataslice = dataslice / (dataslice[..., 0, None]).astype(float)
 
 """
 Calculate the return to origin probability on the signal


### PR DESCRIPTION
This PR fixes the following warnings:
```python
DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

```