### PR TITLE
Allow use of all threads in the gibbs ringing workflow

### DIFF
--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -255,7 +255,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
         a new array.
         Default is set to True.
     num_threads : int, optional
-        Number of threads. Only applies to 3D or 4D `data` arrays. If 0 then
+        Number of threads. Only applies to 3D or 4D `data` arrays. If <=0 then
         all available threads will be used. Otherwise, must be a positive
         integer.
         Default is set to 1.
@@ -295,9 +295,6 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
 
     if not isinstance(num_threads, int):
         raise TypeError("num_threads must be an int.")
-    else:
-        if num_threads < 0:
-            raise ValueError("num_threads must be >= 0.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -327,7 +324,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        if num_threads == 0:
+        if num_threads <= 0:
             pool = Pool()
         else:
             pool = Pool(num_threads)

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -255,10 +255,8 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
         a new array.
         Default is set to True.
     num_threads : int, optional
-        Number of threads. Only applies to 3D or 4D `data` arrays. If <=0 then
-        all available threads will be used. Otherwise, must be a positive
-        integer.
-        Default is set to 1.
+        Number of threads. If -1 then all available threads will be used.
+        Default is 1. Only applies to 3D or 4D `data` arrays.
 
     Returns
     -------
@@ -294,7 +292,10 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
         raise TypeError("inplace must be a boolean.")
 
     if not isinstance(num_threads, int):
-        raise TypeError("num_threads must be an int.")
+        raise TypeError("num_threads must be an int")
+
+    if num_threads < -1 or num_threads == 0:
+        raise ValueError("num_threads must be > 0 or -1 (all cores)")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -324,7 +325,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        if num_threads <= 0:
+        if num_threads == -1:
             pool = Pool()
         else:
             pool = Pool(num_threads)

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -254,8 +254,8 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
         If True, the input data is replaced with results. Otherwise, returns
         a new array.
         Default is set to True.
-    num_threads : int or None, optional
-        Number of threads. Only applies to 3D or 4D `data` arrays. If None then
+    num_threads : int, optional
+        Number of threads. Only applies to 3D or 4D `data` arrays. If 0 then
         all available threads will be used. Otherwise, must be a positive
         integer.
         Default is set to 1.
@@ -293,12 +293,11 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if not isinstance(inplace, bool):
         raise TypeError("inplace must be a boolean.")
 
-    if (not isinstance(num_threads, int)) and (num_threads is not None):
-        raise TypeError("num_processes must be an int or None.")
+    if not isinstance(num_threads, int):
+        raise TypeError("num_threads must be an int.")
     else:
-        if isinstance(num_threads, int):
-            if num_threads <= 0:
-                raise ValueError("num_processes must be > 0.")
+        if num_threads < 0:
+            raise ValueError("num_threads must be >= 0.")
 
     # check the axis corresponding to different slices
     # 1) This axis cannot be larger than 2
@@ -328,7 +327,7 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True, num_threads=1):
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        if num_threads is None:
+        if num_threads == 0:
             pool = Pool()
         else:
             pool = Pool(num_threads)

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -192,9 +192,6 @@ def test_gibbs_errors():
     assert_raises(
         TypeError, gibbs_removal, image_gibbs.copy(), num_threads="1"
     )
-    assert_raises(
-        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=-1
-    )
     # Test for valid input dimensionality
     assert_raises(ValueError, gibbs_removal, np.ones(2))  # 1D
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2)))  # 5D

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -60,9 +60,9 @@ def test_parallel():
     )
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
-    # Test num_threads=None case
+    # Test num_threads=0 case
     output_4d_all_cpu = gibbs_removal(
-        input_4d, inplace=False, num_threads=None
+        input_4d, inplace=False, num_threads=0
     )
     assert_array_almost_equal(output_4d_all_cpu, output_4d_no_parallel)
 

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -60,9 +60,9 @@ def test_parallel():
     )
     assert_array_almost_equal(output_4d_parallel, output_4d_no_parallel)
 
-    # Test num_threads=0 case
+    # Test num_threads=-1 case
     output_4d_all_cpu = gibbs_removal(
-        input_4d, inplace=False, num_threads=0
+        input_4d, inplace=False, num_threads=-1
     )
     assert_array_almost_equal(output_4d_all_cpu, output_4d_no_parallel)
 
@@ -99,6 +99,7 @@ def test_inplace():
 
     output_4d = gibbs_removal(input_4d, inplace=True)
     assert_array_almost_equal(input_4d, output_4d)
+
 
 def test_gibbs_2d():
 
@@ -190,8 +191,11 @@ def test_gibbs_errors():
     assert_raises(TypeError, gibbs_removal, image_gibbs.copy(), inplace="True")
     # Test for valid num_threads
     assert_raises(
-        TypeError, gibbs_removal, image_gibbs.copy(), num_threads="1"
-    )
+        TypeError, gibbs_removal, image_gibbs.copy(), num_threads="1")
+    assert_raises(
+        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=0)
+    assert_raises(
+        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=-2)
     # Test for valid input dimensionality
     assert_raises(ValueError, gibbs_removal, np.ones(2))  # 1D
     assert_raises(ValueError, gibbs_removal, np.ones((2, 2, 2, 2, 2)))  # 5D

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -323,7 +323,7 @@ class GibbsRingingFlow(Workflow):
         n_points : int, optional
             Number of neighbour points to access local TV (see note).
         num_threads : int, optional
-            Number of threads. Only applies to 3D or 4D `data` arrays. If 0
+            Number of threads. Only applies to 3D or 4D `data` arrays. If <= 0
             then all available threads will be used. Otherwise, must be a
             positive integer.
         out_dir : string, optional

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -322,8 +322,8 @@ class GibbsRingingFlow(Workflow):
             third axis.
         n_points : int, optional
             Number of neighbour points to access local TV (see note).
-        num_threads : int or None, optional
-            Number of threads. Only applies to 3D or 4D `data` arrays. If None
+        num_threads : int, optional
+            Number of threads. Only applies to 3D or 4D `data` arrays. If 0
             then all available threads will be used. Otherwise, must be a
             positive integer.
         out_dir : string, optional

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -323,9 +323,8 @@ class GibbsRingingFlow(Workflow):
         n_points : int, optional
             Number of neighbour points to access local TV (see note).
         num_threads : int, optional
-            Number of threads. Only applies to 3D or 4D `data` arrays. If <= 0
-            then all available threads will be used. Otherwise, must be a
-            positive integer.
+            Number of threads. If -1 then all available threads will be used.
+            Default is 1. Only applies to 3D or 4D `data` arrays.
         out_dir : string, optional
             Output directory. (default current directory)
         out_unrig : string, optional

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,10 +5,10 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
-DIPY 1.5.0 changes
+DIPY 1.4.1 changes
 ------------------
 
-- Configured ``<=0`` as the value of ``num_threads`` argument to use all available cores in ``dipy.denoise.gibbs.gibbs_removal``.
+- Configured ``-1`` as the value of ``num_threads`` argument to use all available cores.
 
 DIPY 1.4.0 changes
 ------------------

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,11 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.5.0 changes
+------------------
+
+- Configured ``<=0`` as the value of ``num_threads`` argument to use all available cores in ``dipy.denoise.gibbs.gibbs_removal``.
+
 DIPY 1.4.0 changes
 ------------------
 

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -168,7 +168,7 @@ Gibbs oscillation suppression of all multi-shell data and all slices
 can be performed in the following way:
 """
 
-data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=0)
+data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=-1)
 
 """
 Due to the high dimensionality of diffusion-weighted data, we recommend

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -168,7 +168,7 @@ Gibbs oscillation suppression of all multi-shell data and all slices
 can be performed in the following way:
 """
 
-data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=None)
+data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=0)
 
 """
 Due to the high dimensionality of diffusion-weighted data, we recommend

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -40,7 +40,7 @@ You can also specify optional arguments such as:
 To run the Gibbs unringing on the data it suffices to execute the
 ``dipy_gibbs_ringing`` command, e.g.::
 
-    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads 0 --out_dir "gibbs_ringing_output"
+    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads 4 --out_dir "gibbs_ringing_output"
 
 This command will apply the Gibbs unringing procedure to the input MR image
 and write the artefact-free result to the ``gibbs_ringing_output`` directory.

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -34,7 +34,7 @@ To run the Gibbs unringing method, we need to specify the path to the input
 data. This path may contain wildcards to process multiple inputs at once.
 You can also specify optional arguments such as:
 
-- ``num_threads``: the number of threads to be used in parallel to accelerate processing. Set it to ``0``  to use all available threads.
+- ``num_threads``: the number of threads to be used in parallel to accelerate processing. Set it to ``-1``  to use all available threads.
 - ``out_dir``: directory to save the output.
 
 To run the Gibbs unringing on the data it suffices to execute the

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -32,17 +32,15 @@ ringing-free volume::
 
 To run the Gibbs unringing method, we need to specify the path to the input
 data. This path may contain wildcards to process multiple inputs at once.
-You can also specify the optional arguments. In this case, we will be
-specifying the number of threads (``num_threads``) and output directory
-(``out_dir``). The number of threads allows to exploit the available
-computational power and accelerate the processing. The maximum number of
-threads available depends on the CPU of the computer, so users are expected
-to set an appropriate value based on their platform.
+You can also specify optional arguments such as:
+
+- ``num_threads``: the number of threads to be used in parallel to accelerate processing. Set it to ``0``  to use all available threads.
+- ``out_dir``: directory to save the output.
 
 To run the Gibbs unringing on the data it suffices to execute the
 ``dipy_gibbs_ringing`` command, e.g.::
 
-    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads 4 --out_dir "gibbs_ringing_output"
+    dipy_gibbs_ringing data/tissue_data/t1_brain_denoised.nii.gz --num_threads 0 --out_dir "gibbs_ringing_output"
 
 This command will apply the Gibbs unringing procedure to the input MR image
 and write the artefact-free result to the ``gibbs_ringing_output`` directory.


### PR DESCRIPTION
Closes #2300 

The dipy_gibbs_ringing workflow raised an error when the user specified `num_threads = None` to use all available cores. This PR fixes that by configuring `0` instead of `None` as the value for using all cores.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Modify the behaviour of gibbs_removal to choose all available threads when  the user sets `num_threads` to `0`
  - Update corresponding docstrings, tests, example and documentation
 