### PR TITLE
[MNT]  Update and fix Cython warnings and use cnp.PyArray_DATA wherever possible

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -389,10 +389,10 @@ def distance_matrix_mdf(streamlines_a, streamlines_b):
 
     for i from 0 <= i < lentA:
         t1 = tracksA64[i]
-        t1_ptr = <cnp.float64_t *>t1.data
+        t1_ptr = <cnp.float64_t *> cnp.PyArray_DATA(t1)
         for j from 0 <= j < lentB:
             t2 = tracksB64[j]
-            t2_ptr = <cnp.float64_t *>t2.data
+            t2_ptr = <cnp.float64_t *> cnp.PyArray_DATA(t2)
 
             DM[i, j] = min_direct_flip_dist(t1_ptr, t2_ptr,t_len)
 

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -141,9 +141,8 @@ cdef inline float wght(int i, float r) nogil:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def trilinear_interp(np.ndarray[np.float32_t, ndim=4, mode='strided'] data,
-                     np.ndarray[np.float_t, ndim=1, mode='strided'] index,
-                     np.ndarray[np.float_t, ndim=1, mode='c'] voxel_size):
+def trilinear_interp(cnp.float32_t[:, :, :, :] data, cython.floating[:] index,
+                     cython.floating[::1] voxel_size):
     """Interpolates vector from 4D `data` at 3D point given by `index`
 
     Interpolates a vector of length T from a 4D volume of shape (I, J, K, T),
@@ -159,6 +158,7 @@ def trilinear_interp(np.ndarray[np.float32_t, ndim=4, mode='strided'] data,
         size_t last_d = data.shape[3]
         bint bounds_check
         np.ndarray[cnp.float32_t, ndim=1, mode='c'] result
+
     bounds_check = (x < 0 or y < 0 or z < 0 or
                     x > data.shape[0] or
                     y > data.shape[1] or
@@ -222,13 +222,13 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
         cnp.npy_intp *strides = <cnp.npy_intp *> cnp.PyArray_DATA(data_strides)
         double *rs=<double *> cnp.PyArray_DATA(result)
 
-    if not cnp.PyArray_CHKFLAGS(data, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(data, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"data is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(points, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(points, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"points is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(data_strides, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(data_strides, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"data_strides is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(result, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(result, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"result is not C contiguous")
     with nogil:
         for i in range(len_points):

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -28,16 +28,16 @@ cnp.import_array()
 
 #numpy pointers
 cdef inline float* asfp(cnp.ndarray pt):
-    return <float *>pt.data
+    return <float *> cnp.PyArray_DATA(pt)
 
 cdef inline double* asdp(cnp.ndarray pt):
-    return <double *>pt.data
+    return <double *> cnp.PyArray_DATA(pt)
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def remove_similar_vertices(
-    cnp.ndarray[cnp.float_t, ndim=2, mode='strided'] vertices,
+    cython.floating[:, :] vertices,
     double theta,
     bint return_mapping=False,
     bint return_index=False):
@@ -140,8 +140,7 @@ def remove_similar_vertices(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def search_descending(cnp.ndarray[cnp.float_t, ndim=1, mode='c'] a,
-                      double relative_threshold):
+def search_descending(cython.floating[::1] a, double relative_threshold):
     """`i` in descending array `a` so `a[i] < a[0] * relative_threshold`
 
     Call ``T = a[0] * relative_threshold``. Return value `i` will be the
@@ -482,7 +481,7 @@ def argmax_from_countarrs(cnp.ndarray vals,
        For every vertex ``i`` in ``vertex_inds``, the number of
        neighbors for vertex ``i``
     adj_inds : (P,) array, dtype uint32
-       Indices for neighbors for each point.  ``P=sum(adj_counts)`` 
+       Indices for neighbors for each point.  ``P=sum(adj_counts)``
 
     Returns
     -------
@@ -514,14 +513,14 @@ def argmax_from_countarrs(cnp.ndarray vals,
             cnp.PyArray_ISCONTIGUOUS(cadj_counts) and
             cnp.PyArray_ISCONTIGUOUS(cadj_inds)):
         raise ValueError('Need contiguous arrays as input')
-    vals_size = cvals.shape[0]
-    vals_ptr = <cnp.float64_t *>cvals.data
-    vertinds_ptr = <cnp.uint32_t *>cvertinds.data
-    adj_ptr = <cnp.uint32_t *>cadj_inds.data
-    counts_ptr = <cnp.uint32_t *>cadj_counts.data
-    V = cadj_counts.shape[0]
-    adj_size = cadj_inds.shape[0]
-    if cvertinds.shape[0] < V:
+    vals_size = cnp.PyArray_DIM(cvals, 0)
+    vals_ptr = <cnp.float64_t *> cnp.PyArray_DATA(cvals)
+    vertinds_ptr = <cnp.uint32_t *> cnp.PyArray_DATA(cvertinds)
+    adj_ptr = <cnp.uint32_t *> cnp.PyArray_DATA(cadj_inds)
+    counts_ptr = <cnp.uint32_t *> cnp.PyArray_DATA(cadj_counts)
+    V = cnp.PyArray_DIM(cadj_counts, 0)
+    adj_size = cnp.PyArray_DIM(cadj_inds, 0)
+    if cnp.PyArray_DIM(cvertinds, 0) < V:
         raise ValueError('Too few indices for adj arrays')
     for i in range(V):
         vert_ind = vertinds_ptr[i]

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -37,7 +37,7 @@ cdef inline cnp.ndarray[cnp.float32_t, ndim=1] as_float_3vec(object vec):
 
 
 cdef inline float* asfp(cnp.ndarray pt):
-    return <float *>pt.data
+    return <float *> cnp.PyArray_DATA(pt)
 
 
 def normalized_3vec(vec):
@@ -55,7 +55,7 @@ def normalized_3vec(vec):
     """
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_in = as_float_3vec(vec)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    cnormalized_3vec(<float *>vec_in.data, <float*>vec_out.data)
+    cnormalized_3vec(<float *> cnp.PyArray_DATA(vec_in), <float*> cnp.PyArray_DATA(vec_out))
     return vec_out
 
 
@@ -72,7 +72,7 @@ def norm_3vec(vec):
        Euclidean norm
     """
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_in = as_float_3vec(vec)
-    return cnorm_3vec(<float *>vec_in.data)
+    return cnorm_3vec(<float *> cnp.PyArray_DATA(vec_in))
 
 
 cdef inline float cnorm_3vec(float *vec):
@@ -115,7 +115,7 @@ cdef inline void cnormalized_3vec(float *vec_in, float *vec_out):
 def inner_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
-    return cinner_3vecs(<float *>fvec1.data, <float*>fvec2.data)
+    return cinner_3vecs(<float *> cnp.PyArray_DATA(fvec1), <float*> cnp.PyArray_DATA(fvec2))
 
 
 cdef inline float cinner_3vecs(float *vec1, float *vec2) nogil:
@@ -130,7 +130,9 @@ def sub_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    csub_3vecs(<float *>fvec1.data, <float*>fvec2.data, <float *>vec_out.data)
+    csub_3vecs(<float *> cnp.PyArray_DATA(fvec1),
+               <float *> cnp.PyArray_DATA(fvec2),
+               <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
 
@@ -144,7 +146,9 @@ def add_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    cadd_3vecs(<float *>fvec1.data, <float*>fvec2.data, <float *>vec_out.data)
+    cadd_3vecs(<float *> cnp.PyArray_DATA(fvec1),
+               <float *> cnp.PyArray_DATA(fvec2),
+               <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
 
@@ -157,7 +161,9 @@ def mul_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    cmul_3vecs(<float *>fvec1.data, <float*>fvec2.data, <float *>vec_out.data)
+    cmul_3vecs(<float *> cnp.PyArray_DATA(fvec1),
+               <float *> cnp.PyArray_DATA(fvec2),
+               <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
 cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) nogil:
@@ -168,7 +174,8 @@ cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) nogil:
 def mul_3vec(a, vec):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec = as_float_3vec(vec)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    cmul_3vec(a,<float *>fvec.data, <float *>vec_out.data)
+    cmul_3vec(a, <float *> cnp.PyArray_DATA(fvec),
+              <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
 cdef inline void cmul_3vec(float a, float *vec, float *vec_out) nogil:
@@ -238,11 +245,11 @@ def cut_plane(tracks, ref):
     track_lengths = np.empty((N_tracks,), dtype=np.uint64)
     for t_no in range(N_tracks):
         track = np.ascontiguousarray(tracks[t_no], f32_dt)
-        track_lengths[t_no] = track.shape[0]
+        track_lengths[t_no] = cnp.PyArray_DIM(track, 0)
         tracks32.append(track)
     # set up loop across reference fiber points
     cdef:
-        size_t N_ref = ref32.shape[0]
+        size_t N_ref = cnp.PyArray_DIM(ref32, 0)
         size_t p_no, q_no
         float *this_ref_p
         float *next_ref_p
@@ -331,7 +338,7 @@ def cut_plane(tracks, ref):
                                 hits.append(one_hit)
                             else:
                                 one_hit = hits[hit_no]
-                            hit_ptr = <float *>one_hit.data
+                            hit_ptr = <float *> cnp.PyArray_DATA(one_hit)
                             hit_ptr[0] = hit[0]
                             hit_ptr[1] = hit[1]
                             hit_ptr[2] = hit[2]
@@ -420,7 +427,7 @@ def most_similar_track_mam(tracks,metric='avg'):
     track2others = np.zeros((lent,), dtype=np.double)
     # use this buffer also for working space containing summed distances
     # of candidate track to all other tracks
-    cdef cnp.double_t *sum_track2others = <cnp.double_t *>track2others.data
+    cdef cnp.double_t *sum_track2others = <cnp.double_t *> cnp.PyArray_DATA(track2others)
     # preallocate buffer array for track distance calculations
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=1] distances_buffer
@@ -429,19 +436,19 @@ def most_similar_track_mam(tracks,metric='avg'):
         cnp.float32_t *min_buffer
         cnp.float32_t distance
     distances_buffer = np.zeros((longest_track_len*2,), dtype=np.float32)
-    min_buffer = <cnp.float32_t *> distances_buffer.data
+    min_buffer = <cnp.float32_t *> cnp.PyArray_DATA(distances_buffer)
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
         size_t t1_len, t2_len
     for i from 0 <= i < lent-1:
         t1 = tracks32[i]
-        t1_len = t1.shape[0]
-        t1_ptr = <cnp.float32_t *>t1.data
+        t1_len = cnp.PyArray_DIM(t1, 0)
+        t1_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t1)
         for j from i+1 <= j < lent:
             t2 = tracks32[j]
-            t2_len = t2.shape[0]
-            t2_ptr = <cnp.float32_t *>t2.data
+            t2_len = cnp.PyArray_DIM(t2, 0)
+            t2_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t2)
             distance = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
             # get metric
             sum_track2others[i]+=distance
@@ -455,12 +462,12 @@ def most_similar_track_mam(tracks,metric='avg'):
             mn = sum_track2others[i]
     # recalculate distance of this track from the others
     t1 = tracks32[si]
-    t1_len = t1.shape[0]
-    t1_ptr = <cnp.float32_t *>t1.data
+    t1_len = cnp.PyArray_DIM(t1, 0)
+    t1_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t1)
     for j from 0 <= j < lent:
         t2 = tracks32[j]
-        t2_len = t2.shape[0]
-        t2_ptr = <cnp.float32_t *>t2.data
+        t2_len = cnp.PyArray_DIM(t2, 0)
+        t2_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t2)
         track2others[j] = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
     return si, track2others
 
@@ -537,19 +544,19 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
         cnp.float32_t *t2_ptr
         cnp.float32_t *min_buffer
     distances_buffer = np.zeros((longest_track_lenA*2,), dtype=np.float32)
-    min_buffer = <cnp.float32_t *> distances_buffer.data
+    min_buffer = <cnp.float32_t *> cnp.PyArray_DATA(distances_buffer)
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
         size_t t1_len, t2_len
     for i from 0 <= i < lentA:
         t1 = tracksA32[i]
-        t1_len = t1.shape[0]
-        t1_ptr = <cnp.float32_t *>t1.data
+        t1_len = cnp.PyArray_DIM(t1, 0)
+        t1_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t1)
         for j from 0 <= j < lentB:
             t2 = tracksB32[j]
-            t2_len = t2.shape[0]
-            t2_ptr = <cnp.float32_t *>t2.data
+            t2_len = cnp.PyArray_DIM(t2, 0)
+            t2_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t2)
             DM[i,j] = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
 
     return DM
@@ -619,11 +626,11 @@ def bundles_distances_mdf(tracksA, tracksB):
     for i from 0 <= i < lentA:
         t1 = tracksA32[i]
         #t1_len = t1.shape[0]
-        t1_ptr = <cnp.float32_t *>t1.data
+        t1_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t1)
         for j from 0 <= j < lentB:
             t2 = tracksB32[j]
             #t2_len = t2.shape[0]
-            t2_ptr = <cnp.float32_t *>t2.data
+            t2_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t2)
             #DM[i,j] = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
             track_direct_flip_dist(t1_ptr, t2_ptr,t_len,<float *>d)
             if d[0]<d[1]:
@@ -770,19 +777,19 @@ def mam_distances(xyz1,xyz2,metric='all'):
         cnp.ndarray[cnp.float32_t, ndim=2] track2
         size_t t1_len, t2_len
     track1 = np.ascontiguousarray(xyz1, dtype=f32_dt)
-    t1_len = track1.shape[0]
+    t1_len = cnp.PyArray_DIM(track1, 0)
     track2 = np.ascontiguousarray(xyz2, dtype=f32_dt)
-    t2_len = track2.shape[0]
+    t2_len = cnp.PyArray_DIM(track2, 0)
     # preallocate buffer array for track distance calculations
     cdef:
         cnp.float32_t *min_t2t1
         cnp.float32_t *min_t1t2
         cnp.ndarray [cnp.float32_t, ndim=1] distances_buffer
     distances_buffer = np.zeros((t1_len + t2_len,), dtype=np.float32)
-    min_t2t1 = <cnp.float32_t *> distances_buffer.data
+    min_t2t1 = <cnp.float32_t *> cnp.PyArray_DATA(distances_buffer)
     min_t1t2 = min_t2t1 + t2_len
-    min_distances(t1_len, <cnp.float32_t *>track1.data,
-                  t2_len, <cnp.float32_t *>track2.data,
+    min_distances(t1_len, <cnp.float32_t *> cnp.PyArray_DATA(track1),
+                  t2_len, <cnp.float32_t *> cnp.PyArray_DATA(track2),
                   min_t2t1,
                   min_t1t2)
     cdef:
@@ -839,19 +846,19 @@ def minimum_closest_distance(xyz1,xyz2):
         cnp.ndarray[cnp.float32_t, ndim=2] track2
         size_t t1_len, t2_len
     track1 = np.ascontiguousarray(xyz1, dtype=f32_dt)
-    t1_len = track1.shape[0]
+    t1_len = cnp.PyArray_DIM(track1, 0)
     track2 = np.ascontiguousarray(xyz2, dtype=f32_dt)
-    t2_len = track2.shape[0]
+    t2_len = cnp.PyArray_DIM(track2, 0)
     # preallocate buffer array for track distance calculations
     cdef:
         cnp.float32_t *min_t2t1
         cnp.float32_t *min_t1t2
         cnp.ndarray [cnp.float32_t, ndim=1] distances_buffer
     distances_buffer = np.zeros((t1_len + t2_len,), dtype=np.float32)
-    min_t2t1 = <cnp.float32_t *> distances_buffer.data
+    min_t2t1 = <cnp.float32_t *> cnp.PyArray_DATA(distances_buffer)
     min_t1t2 = min_t2t1 + t2_len
-    min_distances(t1_len, <cnp.float32_t *>track1.data,
-                  t2_len, <cnp.float32_t *>track2.data,
+    min_distances(t1_len, <cnp.float32_t *> cnp.PyArray_DATA(track1),
+                  t2_len, <cnp.float32_t *> cnp.PyArray_DATA(track2),
                   min_t2t1,
                   min_t1t2)
     cdef:
@@ -921,7 +928,10 @@ def lee_perpendicular_distance(start0, end0, start1, end1):
     fvec3 = as_float_3vec(start1)
     fvec4 = as_float_3vec(end1)
 
-    return clee_perpendicular_distance(<float *>fvec1.data,<float *>fvec2.data,<float *>fvec3.data,<float *>fvec4.data)
+    return clee_perpendicular_distance(<float *> cnp.PyArray_DATA(fvec1),
+                                       <float *> cnp.PyArray_DATA(fvec2),
+                                       <float *> cnp.PyArray_DATA(fvec3),
+                                       <float *> cnp.PyArray_DATA(fvec4))
 
 
 cdef float clee_perpendicular_distance(float *start0, float *end0,float *start1, float *end1):
@@ -1017,7 +1027,10 @@ def lee_angle_distance(start0, end0, start1, end1):
     fvec3 = as_float_3vec(start1)
     fvec4 = as_float_3vec(end1)
 
-    return clee_angle_distance(<float *>fvec1.data,<float *>fvec2.data,<float *>fvec3.data,<float *>fvec4.data)
+    return clee_angle_distance(<float *> cnp.PyArray_DATA(fvec1),
+                               <float *> cnp.PyArray_DATA(fvec2),
+                               <float *> cnp.PyArray_DATA(fvec3),
+                               <float *> cnp.PyArray_DATA(fvec4))
 
 
 cdef float clee_angle_distance(float *start0, float *end0,float *start1, float *end1):
@@ -1113,11 +1126,11 @@ def approx_polygon_track(xyz,alpha=0.392):
 
     while mid_index < t_len-1:
         #fvec0 = as_float_3vec(track[mid_index-1])
-        #<float *>track[0].data
+        #<float *> cnp.PyArray_DATA(track[0])
         fvec0 = asfp(track[mid_index-1])
         fvec1 = asfp(track[mid_index])
         fvec2 = asfp(track[mid_index+1])
-        #csub_3vecs(<float *>fvec1.data,<float *>fvec0.data,vec0)
+        #csub_3vecs(<float *> cnp.PyArray_DATA(fvec1),<float *> cnp.PyArray_DATA(fvec0),vec0)
         csub_3vecs(fvec1,fvec0,vec0)
         csub_3vecs(fvec2,fvec1,vec1)
         tmp=<double>fabs(acos(cinner_3vecs(vec0,vec1)/(cnorm_3vec(vec0)*cnorm_3vec(vec1))))
@@ -1175,7 +1188,8 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
         fvec1 = as_float_3vec(track[start_index])
         fvec2 = as_float_3vec(track[current_index])
         # L(H)
-        csub_3vecs(<float *>fvec2.data,<float *>fvec1.data,tmp)
+        csub_3vecs(<float *> cnp.PyArray_DATA(fvec2),
+                   <float *> cnp.PyArray_DATA(fvec1), tmp)
         cost_par=dpy_log2(sqrt(cinner_3vecs(tmp,tmp)))
         cost_nopar=0
         #print start_index,current_index
@@ -1185,9 +1199,16 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
             #print i
             fvec3 = as_float_3vec(track[i])
             fvec4 = as_float_3vec(track[i+1])
-            cost_par += dpy_log2(clee_perpendicular_distance(<float *>fvec3.data,<float *>fvec4.data,<float *>fvec1.data,<float *>fvec2.data))
-            cost_par += dpy_log2(clee_angle_distance(<float *>fvec3.data,<float *>fvec4.data,<float *>fvec1.data,<float *>fvec2.data))
-            csub_3vecs(<float *>fvec4.data,<float *>fvec3.data,tmp)
+            cost_par += dpy_log2(clee_perpendicular_distance(<float *> cnp.PyArray_DATA(fvec3),
+                                                             <float *> cnp.PyArray_DATA(fvec4),
+                                                             <float *> cnp.PyArray_DATA(fvec1),
+                                                             <float *> cnp.PyArray_DATA(fvec2)))
+            cost_par += dpy_log2(clee_angle_distance(<float *> cnp.PyArray_DATA(fvec3),
+                                                     <float *> cnp.PyArray_DATA(fvec4),
+                                                     <float *> cnp.PyArray_DATA(fvec1),
+                                                     <float *> cnp.PyArray_DATA(fvec2)))
+            csub_3vecs(<float *> cnp.PyArray_DATA(fvec4),
+                       <float *> cnp.PyArray_DATA(fvec3), tmp)
             cost_nopar += dpy_log2(cinner_3vecs(tmp,tmp))
         cost_nopar /= 2
         #print cost_par, cost_nopar, start_index,length
@@ -1612,7 +1633,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
     cluster[0].hidden=<float *>realloc(NULL,dim*sizeof(float))
     cluster[0].indices[0]=0
     track=np.ascontiguousarray(tracks[0],dtype=f32_dt)
-    ptr=<float *>track.data
+    ptr=<float *> cnp.PyArray_DATA(track)
     for i from 0<=i<dim:
         cluster[0].hidden[i]=ptr[i]
     cluster[0].N=1
@@ -1627,7 +1648,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
     lent=len(tracks)
     for it in range(1,lent):
         track=np.ascontiguousarray(tracks[it],dtype=f32_dt)
-        ptr=<float *>track.data
+        ptr=<float *> cnp.PyArray_DATA(track)
         cit=it
 
         with nogil:
@@ -2039,8 +2060,8 @@ def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
     """
 
     cdef:
-        float *t=<float *>track.data
-        float *p=<float *>point.data
+        float *t=<float *> cnp.PyArray_DATA(track)
+        float *p=<float *> cnp.PyArray_DATA(point)
         float a[3]
         float b[3]
         int tlen = len(track)
@@ -2092,8 +2113,8 @@ def track_roi_intersection_check(cnp.ndarray[float,ndim=2] track, cnp.ndarray[fl
     """
 
     cdef:
-        float *t=<float *>track.data
-        float *r=<float *>roi.data
+        float *t=<float *> cnp.PyArray_DATA(track)
+        float *r=<float *> cnp.PyArray_DATA(roi)
         float a[3]
         float b[3]
         float p[3]

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -161,6 +161,7 @@ cdef int _local_tracker(DirectionGetter dg,
                         StreamlineStatus* stream_status):
     cdef:
         size_t i
+        size_t len_streamlines = streamline.shape[0]
         double point[3]
         double voxdir[3]
         void (*step)(double*, double*, double) nogil
@@ -174,7 +175,7 @@ cdef int _local_tracker(DirectionGetter dg,
     copy_point(seed, &streamline[0,0])
 
     stream_status[0] = TRACKPOINT
-    for i in range(1, streamline.shape[0]):
+    for i in range(1, len_streamlines):
         if dg.get_direction_c(point, dir):
             break
         for j in range(3):

--- a/dipy/tracking/mesh.py
+++ b/dipy/tracking/mesh.py
@@ -36,9 +36,9 @@ def random_coordinates_from_surface(nb_triangles, nb_seed, triangles_mask=None,
     # Compute triangles_weight in vts_mask
     if triangles_mask is not None:
         if triangles_weight is None:
-            triangles_weight = triangles_mask.astype(np.float)
+            triangles_weight = triangles_mask.astype(float)
         else:
-            triangles_weight *= triangles_mask.astype(np.float)
+            triangles_weight *= triangles_mask.astype(float)
 
     # Normalize weights to have probability (sum to 1)
     if triangles_weight is not None:

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -62,9 +62,9 @@ def ndarray_offset(cnp.ndarray[cnp.npy_intp, ndim=1] indices,
     >>> A.ravel()[4]==A[1,1]
     True
     """
-    if not cnp.PyArray_CHKFLAGS(indices, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(indices, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"indices is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(strides, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(strides, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"strides is not C contiguous")
     return offset(<cnp.npy_intp*> cnp.PyArray_DATA(indices),
                   <cnp.npy_intp*> cnp.PyArray_DATA(strides),
@@ -301,22 +301,22 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
         double *pqa = <double*> cnp.PyArray_DATA(qa)
         double *pin = <double*> cnp.PyArray_DATA(ind)
         double *pverts = <double*> cnp.PyArray_DATA(odf_vertices)
-        cnp.npy_intp *pstr = <cnp.npy_intp *> qa.strides
-        cnp.npy_intp *qa_shape = <cnp.npy_intp *> qa.shape
-        cnp.npy_intp *pvstr = <cnp.npy_intp *> odf_vertices.strides
+        cnp.npy_intp *pstr = <cnp.npy_intp *> cnp.PyArray_STRIDES(qa)
+        cnp.npy_intp *qa_shape = <cnp.npy_intp *> cnp.PyArray_DIMS(qa)
+        cnp.npy_intp *pvstr = <cnp.npy_intp *> cnp.PyArray_STRIDES(odf_vertices)
         cnp.npy_intp d, i, j, cnt
         double direction[3]
         double dx[3]
         double idirection[3]
         double ps2[3]
         double tmp, ftmp
-    if not cnp.PyArray_CHKFLAGS(seed, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(seed, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"seed is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(qa, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(qa, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"qa is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(ind, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(ind, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"ind is not C contiguous")
-    if not cnp.PyArray_CHKFLAGS(odf_vertices, cnp.NPY_C_CONTIGUOUS):
+    if not cnp.PyArray_CHKFLAGS(odf_vertices, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError(u"odf_vertices is not C contiguous")
 
     cnt = 0

--- a/dipy/tracking/tests/test_mesh.py
+++ b/dipy/tracking/tests/test_mesh.py
@@ -52,7 +52,7 @@ def test_surface_seeds():
     for i in range(len(cube_tri)):
         tri_mask = np.zeros([len(cube_tri)])
         tri_mask[i] = 1.0
-        tri_maskb = tri_mask.astype(np.bool)
+        tri_maskb = tri_mask.astype(bool)
         t_idx, _ = random_coordinates_from_surface(nb_tri, nb_seed,
                                                    triangles_mask=tri_maskb)
         npt.assert_array_equal(t_idx, i)

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -123,7 +123,7 @@ def streamline_mapping(streamlines, affine=None,
 
     """
     cdef:
-        cnp.ndarray[cnp.int_t, ndim=2, mode='strided'] voxel_indices
+        cnp.int_t[:, :] voxel_indices
 
     lin, offset = _mapping_to_voxel(affine)
     if mapping_as_streamlines:
@@ -428,7 +428,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
         # set to find unique voxel points in track
         in_inds = set()
         # the loop below is time-critical
-        for pno in range(t.shape[0]):
+        for pno in range(cnp.PyArray_DIM(t, 0)):
             in_pt = t[pno]
             # Round to voxel coordinates, and set coordinates outside
             # volume to volume edges

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ gcc_flag_defines = [[['-msse2', '-mfpmath=sse'], [], simple_test_c, 'USING_GCC_S
                     ]
 
 if 'clang' not in platform.python_compiler().lower():
-    gcc_flag_defines += [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP']
+    gcc_flag_defines += [[['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP'], ]
 
 # Test if it is a 32 bits version
 if not sys.maxsize > 2 ** 32:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,10 @@ if using_setuptools:
 EXTS = []
 
 # We use some defs from npymath, but we don't want to link against npymath lib
-ext_kwargs = {'include_dirs': ['src']}  # We add np.get_include() later
+ext_kwargs = {
+    'include_dirs': ['src'],  # We add np.get_include() later
+    'define_macros': [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+    }
 
 for modulename, other_sources, language in (
         ('dipy.core.interpolation', [], 'c'),

--- a/setup.py
+++ b/setup.py
@@ -129,8 +129,10 @@ int main(int argc, char** argv) { return(0); }"""
 msc_flag_defines = [[['/openmp'], [], omp_test_c, 'HAVE_VC_OPENMP'],
                     ]
 gcc_flag_defines = [[['-msse2', '-mfpmath=sse'], [], simple_test_c, 'USING_GCC_SSE2'],
-                    [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP'],
                     ]
+
+if 'clang' not in platform.python_compiler().lower():
+    gcc_flag_defines += [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP']
 
 # Test if it is a 32 bits version
 if not sys.maxsize > 2 ** 32:

--- a/src/conditional_omp.h
+++ b/src/conditional_omp.h
@@ -21,10 +21,10 @@ void omp_init_lock(omp_lock_t *lock) {};
 void omp_destroy_lock(omp_lock_t *lock) {};
 void omp_set_lock(omp_lock_t *lock) {};
 void omp_unset_lock(omp_lock_t *lock) {};
-int omp_test_lock(omp_lock_t *lock) {};
+int omp_test_lock(omp_lock_t *lock) { return -1;};
 void omp_set_dynamic(int dynamic_threads) {};
 void omp_set_num_threads(int num_threads) {};
-int omp_get_num_procs() {};
-int omp_get_max_threads() {};
+int omp_get_num_procs() { return -1;};
+int omp_get_max_threads() { return -1; };
 #define have_openmp 0
 #endif


### PR DESCRIPTION
The goal of this PR is to prepare Cython 0.3.x. it fixes the following warnings:

```python
# warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
```

```python
In function ‘__Pyx_InitGlobals’:

dipy/tracking/fbcmeasures.c:23988:1: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]

PyEval_InitThreads();
```

```python
# warning    xxxxxxxx     may be used uninitialized in this function
```

Also, 
- it closes #545 by replacing `cnp.PyArray_DATA` wherever possible 
- it closes #1895
