### PR TITLE
Replacing Data in NLMeans Tutorial

### DIFF
--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -10,26 +10,20 @@ modeling the noise as Gaussian or Rician (default).
 """
 
 import numpy as np
-import nibabel as nib
 import matplotlib.pyplot as plt
 from time import time
 from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.noise_estimate import estimate_sigma
 from dipy.data import get_fnames
-from dipy.io.image import load_nifti
+from dipy.io.image import load_nifti, save_nifti
 
 
-dwi_fname, dwi_bval_fname, dwi_bvec_fname = get_fnames('sherbrooke_3shell')
-data, affine = load_nifti(dwi_fname)
+t1_fname = get_fnames('stanford_t1')
+data, affine = load_nifti(t1_fname)
 
-mask = data[..., 0] > 80
-
-# We select only one volume for the example to run quickly.
-data = data[..., 1]
+mask = data > 1500
 
 print("vol size", data.shape)
-
-# lets create a noisy data with Gaussian data
 
 """
 In order to call ``non_local_means`` first you need to estimate the standard
@@ -39,8 +33,6 @@ on a 1.5T Siemens scanner with a 4 array head coil.
 
 sigma = estimate_sigma(data, N=4)
 
-t = time()
-
 """
 Calling the main function ``non_local_means``
 """
@@ -48,9 +40,10 @@ Calling the main function ``non_local_means``
 t = time()
 
 den = nlmeans(data, sigma=sigma, mask=mask, patch_radius=1,
-              block_radius=1, rician=True)
+              block_radius=2, rician=True)
 
 print("total time", time() - t)
+
 """
 Let us plot the axial slice of the denoised output
 """
@@ -75,7 +68,6 @@ ax[2].set_title('difference')
 
 plt.savefig('denoised.png', bbox_inches='tight')
 
-
 """
 .. figure:: denoised.png
    :align: center
@@ -83,7 +75,7 @@ plt.savefig('denoised.png', bbox_inches='tight')
    **Showing axial slice before (left) and after (right) NLMEANS denoising**
 """
 
-nib.save(nib.Nifti1Image(den, affine), 'denoised.nii.gz')
+save_nifti('denoised.nii.gz', den, affine)
 
 """
 An improved version of non-local means denoising is adaptive soft coefficient
@@ -99,6 +91,7 @@ References
 .. [Coupe11] Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins.
     "Adaptive Multiresolution Non-Local Means Filter for 3D MR Image Denoising"
     IET Image Processing, Institution of Engineering and Technology, 2011
+
 
 .. include:: ../links_names.inc
 """

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -28,7 +28,7 @@ print("vol size", data.shape)
 """
 In order to call ``non_local_means`` first you need to estimate the standard
 deviation of the noise. We use N=32 since the Stanford dataset was acquired
-on a scanner with a 32 array head coil.
+on a 3T GE scanner with a 32 array head coil.
 """
 
 sigma = estimate_sigma(data, N=32)

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -27,7 +27,7 @@ print("vol size", data.shape)
 
 """
 In order to call ``non_local_means`` first you need to estimate the standard
-deviation of the noise. We use N=32 since the Standford dataset was acquired
+deviation of the noise. We use N=32 since the Stanford dataset was acquired
 on a scanner with a 32 array head coil.
 """
 

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -27,11 +27,11 @@ print("vol size", data.shape)
 
 """
 In order to call ``non_local_means`` first you need to estimate the standard
-deviation of the noise. We use N=4 since the Sherbrooke dataset was acquired
-on a 1.5T Siemens scanner with a 4 array head coil.
+deviation of the noise. We use N=32 since the Standford dataset was acquired
+on a scanner with a 32 array head coil.
 """
 
-sigma = estimate_sigma(data, N=4)
+sigma = estimate_sigma(data, N=32)
 
 """
 Calling the main function ``non_local_means``


### PR DESCRIPTION
This PR fixes #1847. The tutorial of Nlmeans looks as if it is not working because of the data being used. 

This PR replaces the `sherbrooke_3shell` with `stanford_t1 hardi`