### PR TITLE
[FIX] Use npy_intp variables instead of int and size_t to iterate over numpy arrays

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -352,10 +352,10 @@ def distance_matrix_mdf(streamlines_a, streamlines_b):
         distance matrix
     """
     cdef:
-        size_t i, j, lentA, lentB
+        cnp.npy_intp i, j, lentA, lentB
     # preprocess tracks
     cdef:
-        size_t longest_track_len = 0, track_len
+        cnp.npy_intp longest_track_len = 0, track_len
         longest_track_lenA, longest_track_lenB
         cnp.ndarray[object, ndim=1] tracksA64
         cnp.ndarray[object, ndim=1] tracksB64
@@ -383,7 +383,7 @@ def distance_matrix_mdf(streamlines_a, streamlines_b):
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float64_t, ndim=2] t1, t2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
         double d[2]
     t_len = tracksA64[0].shape[0]
 

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -56,8 +56,8 @@ cdef inline int _wrap(int x, int m)nogil:
 cdef inline void _update_factors(double[:, :, :, :] factors,
                                  floating[:, :, :] moving,
                                  floating[:, :, :] static,
-                                 int ss, int rr, int cc,
-                                 int s, int r, int c, int operation)nogil:
+                                 cnp.npy_intp ss, cnp.npy_intp rr, cnp.npy_intp cc,
+                                 cnp.npy_intp s, cnp.npy_intp r, cnp.npy_intp c, int operation)nogil:
     r"""Updates the precomputed CC factors of a rectangular window
 
     Updates the precomputed CC factors of the rectangular window centered

--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -56,8 +56,8 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
         double epsilon, delta
         double min_val = -1
         double max_val = -1
-        int[:] hist = np.zeros(shape=(num_levels,), dtype=np.int32)
-        int[:, :] out = np.zeros(shape=(nrows, ncols,), dtype=np.int32)
+        cnp.npy_int32[:] hist = np.zeros(shape=(num_levels,), dtype=np.int32)
+        cnp.npy_int32[:, :] out = np.zeros(shape=(nrows, ncols,), dtype=np.int32)
         floating[:] levels = np.zeros(shape=(num_levels,), dtype=ftype)
 
     #Quantizing at zero levels is undefined
@@ -65,6 +65,8 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
     #maximum level in the quantization is never greater than num_levels-1
     if(num_levels < 2):
         raise ValueError('Quantization levels must be at least 2')
+    if (num_levels >= 2**31):
+        raise ValueError('Quantization levels must be < 2**31')
 
     num_levels -= 1  # zero is one of the levels
 

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -214,8 +214,9 @@ cpdef double iterate_residual_displacement_field_ssd_2d(
         double* d = [0, 0]
         double* y = [0, 0]
         double* A = [0, 0, 0]
-        int yi
+
         double xx, yy, opt, nrm2, delta, sigmasq, max_displacement, det
+
     max_displacement = 0
 
     with nogil:
@@ -583,7 +584,7 @@ def compute_residual_displacement_field_ssd_3d(
         int* dCol = [0,  0, 1, 0, -1, 0]
         double* b = [0, 0, 0]
         double* y = [0, 0, 0]
-        int yi
+
         cnp.npy_intp nslices = delta_field.shape[0]
         cnp.npy_intp nrows = delta_field.shape[1]
         cnp.npy_intp ncols = delta_field.shape[2]
@@ -697,7 +698,7 @@ cpdef compute_residual_displacement_field_ssd_2d(
         int* dCol = [0, 1, 0, -1]
         double* b = [0, 0]
         double* y = [0, 0]
-        int yi
+
         cnp.npy_intp nrows = delta_field.shape[0]
         cnp.npy_intp ncols = delta_field.shape[1]
         double delta, sigmasq, dotP

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -2413,10 +2413,10 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
         point lies inside (=1) or outside (=0) the image grid
     """
     cdef:
-        int nslices = out.shape[0]
-        int nrows = out.shape[1]
-        int ncols = out.shape[2]
-        int i, j, k, in_flag
+        cnp.npy_intp nslices = out.shape[0]
+        cnp.npy_intp nrows = out.shape[1]
+        cnp.npy_intp ncols = out.shape[2]
+        cnp.npy_intp i, j, k, in_flag
         double tmp
         double[:] x = np.empty(shape=(3,), dtype=np.float64)
         double[:] dx = np.empty(shape=(3,), dtype=np.float64)
@@ -2505,8 +2505,8 @@ def _sparse_gradient_3d(floating[:, :, :] img,
         the buffer in which to store the image gradient
     """
     cdef:
-        int n = sample_points.shape[0]
-        int i, in_flag
+        cnp.npy_intp n = sample_points.shape[0]
+        cnp.npy_intp i, in_flag
         double tmp
         double[:] dx = np.empty(shape=(3,), dtype=np.float64)
         double[:] h = np.empty(shape=(3,), dtype=np.float64)
@@ -2593,9 +2593,9 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
         point lies inside (=1) or outside (=0) the image grid
     """
     cdef:
-        int nrows = out.shape[0]
-        int ncols = out.shape[1]
-        int i, j, k, in_flag
+        cnp.npy_intp nrows = out.shape[0]
+        cnp.npy_intp ncols = out.shape[1]
+        cnp.npy_intp i, j, k, in_flag
         double tmp
         double[:] x = np.empty(shape=(2,), dtype=np.float64)
         double[:] dx = np.empty(shape=(2,), dtype=np.float64)
@@ -2674,8 +2674,8 @@ def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
         point lies inside (=1) or outside (=0) the image grid
     """
     cdef:
-        int n = sample_points.shape[0]
-        int i, in_flag
+        cnp.npy_intp n = sample_points.shape[0]
+        cnp.npy_intp i, in_flag
         double tmp
         double[:] dx = np.empty(shape=(2,), dtype=np.float64)
         double[:] h = np.empty(shape=(2,), dtype=np.float64)

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -1,7 +1,6 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
 cimport cython
-cimport numpy as np
 cimport numpy as cnp
 
 import numpy as np
@@ -108,7 +107,7 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
     offset : integer
         Element position in array
     """
-    cdef int i
+    cdef cnp.npy_intp i
     cdef cnp.npy_intp summ = 0
     for i from 0 <= i < lenind:
         summ += strides[i] * indices[i]
@@ -116,7 +115,7 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
     return summ
 
 
-cdef void splitoffset(float *offset, size_t *index, size_t shape) nogil:
+cdef void splitoffset(float *offset, cnp.npy_intp *index, cnp.npy_intp shape) nogil:
     """Splits a global offset into an integer index and a relative offset"""
     offset[0] -= .5
     if offset[0] <= 0:
@@ -126,7 +125,7 @@ cdef void splitoffset(float *offset, size_t *index, size_t shape) nogil:
         index[0] = shape - 2
         offset[0] = 1.
     else:
-        index[0] = <size_t> offset[0]
+        index[0] = <cnp.npy_intp> offset[0]
         offset[0] = offset[0] - index[0]
 
 
@@ -154,10 +153,10 @@ def trilinear_interp(cnp.float32_t[:, :, :, :] data, cython.floating[:] index,
         float y = index[1] / voxel_size[1]
         float z = index[2] / voxel_size[2]
         float weight
-        size_t x_ind, y_ind, z_ind, ii, jj, kk, LL
-        size_t last_d = data.shape[3]
+        cnp.npy_intp x_ind, y_ind, z_ind, ii, jj, kk, LL
+        cnp.npy_intp last_d = data.shape[3]
         bint bounds_check
-        np.ndarray[cnp.float32_t, ndim=1, mode='c'] result
+        cnp.ndarray[cnp.float32_t, ndim=1, mode='c'] result
 
     bounds_check = (x < 0 or y < 0 or z < 0 or
                     x > data.shape[0] or
@@ -321,9 +320,9 @@ cdef int trilinear_interpolate4d_c(
 
     """
     cdef:
-        np.npy_intp flr, N
+        cnp.npy_intp flr, N
         double w, rem
-        np.npy_intp index[3][2]
+        cnp.npy_intp index[3][2]
         double weight[3][2]
 
     if data.shape[3] != result.shape[0]:
@@ -333,7 +332,7 @@ cdef int trilinear_interpolate4d_c(
         if point[i] < -.5 or point[i] >= (data.shape[i] - .5):
             return -1
 
-        flr = <np.npy_intp> floor(point[i])
+        flr = <cnp.npy_intp> floor(point[i])
         rem = point[i] - flr
 
         index[i][0] = flr + (flr == -1)
@@ -356,7 +355,7 @@ cdef int trilinear_interpolate4d_c(
 
 
 cpdef trilinear_interpolate4d(double[:, :, :, :] data, double[:] point,
-                              np.ndarray out=None):
+                              cnp.ndarray out=None):
     """Tri-linear interpolation along the last dimension of a 4d array
 
     Parameters

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -94,7 +94,6 @@ cdef void _average_block(double[:, :, :] ima, int x, int y, int z,
 
     cdef int a, b, c, x_pos, y_pos, z_pos
     cdef int is_outside
-    cdef int count = 0
     cdef int neighborhoodsize = average.shape[0] // 2
     for a in range(average.shape[0]):
         for b in range(average.shape[1]):

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -1,4 +1,4 @@
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 
 from dipy.data import default_sphere
@@ -64,7 +64,7 @@ cdef class BootDirectionGetter(BasePmfDirectionGetter):
         """
         cdef:
             double[:] pmf,
-            np.ndarray[np.float_t, ndim=2] peaks
+            cnp.ndarray[cnp.float_t, ndim=2] peaks
 
         for _ in range(self.max_attempts):
             pmf = self._get_pmf(point)

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -1,5 +1,5 @@
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from warnings import warn
 
@@ -33,8 +33,8 @@ cdef int closest_peak(np.ndarray[np.float_t, ndim=2] peak_dirs,
     1 : if no new direction is founded
     """
     cdef:
-        size_t _len=len(peak_dirs)
-        size_t i
+        cnp.npy_intp _len=len(peak_dirs)
+        cnp.npy_intp i
         int closest_peak_i=-1
         double _dot
         double closest_peak_dot=0
@@ -109,7 +109,7 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
 
     cdef _get_pmf(self, double* point):
         cdef:
-            size_t _len, i
+            cnp.npy_intp _len, i
             double[:] pmf
             double absolute_pmf_threshold
 

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -3,7 +3,7 @@
 # cython: wraparound=False
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from dipy.core.geometry import cart2sphere
 from dipy.reconst import shm
@@ -25,8 +25,8 @@ cdef class PmfGen:
 
     cdef void __clear_pmf(self):
         cdef:
-            size_t len_pmf = self.pmf.shape[0]
-            size_t i
+            cnp.npy_intp len_pmf = self.pmf.shape[0]
+            cnp.npy_intp i
 
         for i in range(len_pmf):
             self.pmf[i] = 0.0
@@ -70,9 +70,9 @@ cdef class SHCoeffPmfGen(PmfGen):
 
     cdef double[:] get_pmf_c(self, double* point):
         cdef:
-            size_t i, j
-            size_t len_pmf = self.pmf.shape[0]
-            size_t len_B = self.B.shape[1]
+            cnp.npy_intp i, j
+            cnp.npy_intp len_pmf = self.pmf.shape[0]
+            cnp.npy_intp len_B = self.B.shape[1]
             double _sum
 
         if trilinear_interpolate4d_c(self.data, point, self.coeff) != 0:

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -10,7 +10,7 @@ discrete distribution (pmf) at each step of the tracking.
 from random import random
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.direction.peaks import peak_directions, default_sphere
@@ -97,10 +97,10 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
 
         """
         cdef:
-            size_t i, idx, _len
+            cnp.npy_intp i, idx, _len
             double[:] newdir, pmf
             double last_cdf, random_sample
-            np.uint8_t[:] bool_array
+            cnp.uint8_t[:] bool_array
 
         pmf = self._get_pmf(point)
         _len = pmf.shape[0]
@@ -162,10 +162,10 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
             1 otherwise.
         """
         cdef:
-            size_t _len, max_idx
+            cnp.npy_intp _len, max_idx
             double[:] newdir, pmf
             double max_value
-            np.uint8_t[:] bool_array
+            cnp.uint8_t[:] bool_array
 
         pmf = self._get_pmf(point)
         _len = pmf.shape[0]

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -1,5 +1,5 @@
 cimport cython
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 
 from dipy.tracking.propspeed cimport _propagation_direction
@@ -41,7 +41,7 @@ cdef class EuDXDirectionGetter(DirectionGetter):
 
         self.initialized = True
 
-    cpdef np.ndarray[np.float_t, ndim=2] initial_direction(self,
+    cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(self,
                                                            double[::1] point):
         """The best starting directions for fiber tracking from point
 
@@ -53,12 +53,12 @@ cdef class EuDXDirectionGetter(DirectionGetter):
             self._initialize()
 
         cdef:
-            np.npy_intp numpeaks, i
-            np.npy_intp ijk[3]
+            cnp.npy_intp numpeaks, i
+            cnp.npy_intp ijk[3]
 
         # ijk is the closest voxel to point
         for i in range(3):
-            ijk[i] = <np.npy_intp> dpy_rint(point[i])
+            ijk[i] = <cnp.npy_intp> dpy_rint(point[i])
             if ijk[i] < 0 or ijk[i] >= self._ind.shape[i]:
                 raise IndexError("point outside data")
 
@@ -75,7 +75,7 @@ cdef class EuDXDirectionGetter(DirectionGetter):
         res = np.empty((numpeaks, 3))
         for i in range(numpeaks):
             peak_index = self._ind[ijk[0], ijk[1], ijk[2], i]
-            res[i, :] = self._odf_vertices[<np.npy_intp> peak_index, :]
+            res[i, :] = self._odf_vertices[<cnp.npy_intp> peak_index, :]
 
         return res
 
@@ -94,10 +94,10 @@ cdef class EuDXDirectionGetter(DirectionGetter):
             self._initialize()
 
         cdef:
-            np.npy_intp s
+            cnp.npy_intp s
             double newdirection[3]
-            np.npy_intp qa_shape[4]
-            np.npy_intp qa_strides[4]
+            cnp.npy_intp qa_shape[4]
+            cnp.npy_intp qa_strides[4]
 
         for i in range(4):
             qa_shape[i] = self._qa.shape[i]

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -254,8 +254,8 @@ def local_maxima(double[:] odf, cnp.uint16_t[:, :] edges):
 cdef void _cosort(double[::1] A, cnp.npy_intp[::1] B) nogil:
     """Sorts `A` in-place and applies the same reordering to `B`"""
     cdef:
-        size_t n = A.shape[0]
-        size_t hole
+        cnp.npy_intp n = A.shape[0]
+        cnp.npy_intp hole
         double insert_A
         long insert_B
 
@@ -298,9 +298,9 @@ cdef long _compare_neighbors(double[:] odf, cnp.uint16_t[:, :] edges,
             -2 : odf contains nans
     """
     cdef:
-        size_t lenedges = edges.shape[0]
-        size_t lenodf = odf.shape[0]
-        size_t i
+        cnp.npy_intp lenedges = edges.shape[0]
+        cnp.npy_intp lenodf = odf.shape[0]
+        cnp.npy_intp i
         cnp.uint16_t find0, find1
         double odf0, odf1
         long count = 0

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -1,8 +1,8 @@
 
-cimport numpy as np
+cimport numpy as cnp
 
 cdef class DirectionGetter:
-    cpdef np.ndarray[np.float_t, ndim=2] initial_direction(
+    cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(
             self, double[::1] point):
         pass
 

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -224,7 +224,7 @@ def cut_plane(tracks, ref):
     [[ 2.          2.5         0.          0.70710677  0.        ]]
     """
     cdef:
-        size_t n_hits, hit_no, max_hit_len
+        cnp.npy_intp n_hits, hit_no, max_hit_len
         float alpha,beta,lrq,rcd,lhp,ld
         cnp.ndarray[cnp.float32_t, ndim=2] ref32
         cnp.ndarray[cnp.float32_t, ndim=2] track
@@ -238,9 +238,9 @@ def cut_plane(tracks, ref):
     # convert all the tracks to something we can work with.  Get track
     # lengths
     cdef:
-        size_t N_tracks=len(tracks)
+        cnp.npy_intp N_tracks=len(tracks)
         cnp.ndarray[cnp.uint64_t, ndim=1] track_lengths
-        size_t t_no, N_track
+        cnp.npy_intp t_no, N_track
     cdef object tracks32 = []
     track_lengths = np.empty((N_tracks,), dtype=np.uint64)
     for t_no in range(N_tracks):
@@ -249,8 +249,8 @@ def cut_plane(tracks, ref):
         tracks32.append(track)
     # set up loop across reference fiber points
     cdef:
-        size_t N_ref = cnp.PyArray_DIM(ref32, 0)
-        size_t p_no, q_no
+        cnp.npy_intp N_ref = cnp.PyArray_DIM(ref32, 0)
+        cnp.npy_intp p_no, q_no
         float *this_ref_p
         float *next_ref_p
         float *this_trk_p
@@ -399,7 +399,7 @@ def most_similar_track_mam(tracks,metric='avg'):
     si holds the index of the track with min {avg,min,max} average metric
     """
     cdef:
-        size_t i, j, lent
+        cnp.npy_intp i, j, lent
         int metric_type
     if metric=='avg':
         metric_type = 0
@@ -411,7 +411,7 @@ def most_similar_track_mam(tracks,metric='avg'):
         raise ValueError('Metric should be one of avg, min, max')
     # preprocess tracks
     cdef:
-        size_t longest_track_len = 0, track_len
+        cnp.npy_intp longest_track_len = 0, track_len
         cnp.ndarray[object, ndim=1] tracks32
     lent = len(tracks)
     tracks32 = np.zeros((lent,), dtype=object)
@@ -440,7 +440,7 @@ def most_similar_track_mam(tracks,metric='avg'):
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
     for i from 0 <= i < lent-1:
         t1 = tracks32[i]
         t1_len = cnp.PyArray_DIM(t1, 0)
@@ -455,7 +455,7 @@ def most_similar_track_mam(tracks,metric='avg'):
             sum_track2others[j]+=distance
     # find track with smallest summed metric with other tracks
     cdef double mn = sum_track2others[0]
-    cdef size_t si = 0
+    cdef cnp.npy_intp si = 0
     for i in range(lent):
         if sum_track2others[i] < mn:
             si = i
@@ -496,7 +496,7 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
 
     """
     cdef:
-        size_t i, j, lentA, lentB
+        cnp.npy_intp i, j, lentA, lentB
         int metric_type
     if metric=='avg':
         metric_type = 0
@@ -508,8 +508,8 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
         raise ValueError('Metric should be one of avg, min, max')
     # preprocess tracks
     cdef:
-        size_t longest_track_len = 0, track_len
-        size_t longest_track_lenA = 0, longest_track_lenB = 0
+        cnp.npy_intp longest_track_len = 0, track_len
+        cnp.npy_intp longest_track_lenA = 0, longest_track_lenB = 0
         cnp.ndarray[object, ndim=1] tracksA32
         cnp.ndarray[object, ndim=1] tracksB32
         cnp.ndarray[cnp.double_t, ndim=2] DM
@@ -548,7 +548,7 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
     for i from 0 <= i < lentA:
         t1 = tracksA32[i]
         t1_len = cnp.PyArray_DIM(t1, 0)
@@ -587,10 +587,10 @@ def bundles_distances_mdf(tracksA, tracksB):
 
     """
     cdef:
-        size_t i, j, lentA, lentB
+        cnp.npy_intp i, j, lentA, lentB
     # preprocess tracks
     cdef:
-        size_t longest_track_len = 0, track_len
+        cnp.npy_intp longest_track_len = 0, track_len
         longest_track_lenA, longest_track_lenB
         cnp.ndarray[object, ndim=1] tracksA32
         cnp.ndarray[object, ndim=1] tracksB32
@@ -619,7 +619,7 @@ def bundles_distances_mdf(tracksA, tracksB):
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
         float d[2]
     t_len = tracksA32[0].shape[0]
 
@@ -645,9 +645,9 @@ def bundles_distances_mdf(tracksA, tracksB):
 cdef cnp.float32_t inf = np.inf
 
 @cython.cdivision(True)
-cdef inline cnp.float32_t czhang(size_t t1_len,
+cdef inline cnp.float32_t czhang(cnp.npy_intp t1_len,
                                  cnp.float32_t *track1_ptr,
-                                 size_t t2_len,
+                                 cnp.npy_intp t2_len,
                                  cnp.float32_t *track2_ptr,
                                  cnp.float32_t *min_buffer,
                                  int metric_type) nogil:
@@ -662,7 +662,7 @@ cdef inline cnp.float32_t czhang(size_t t1_len,
                   min_t2t1,
                   min_t1t2)
     cdef:
-        size_t t1_pi, t2_pi
+        cnp.npy_intp t1_pi, t2_pi
         cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0, dist_val = 0
     for t1_pi from 0<= t1_pi < t1_len:
         mean_t1t2+=min_t1t2[t1_pi]
@@ -685,9 +685,9 @@ cdef inline cnp.float32_t czhang(size_t t1_len,
     return dist_val
 
 @cython.cdivision(True)
-cdef inline void min_distances(size_t t1_len,
+cdef inline void min_distances(cnp.npy_intp t1_len,
                                cnp.float32_t *track1_ptr,
-                               size_t t2_len,
+                               cnp.npy_intp t2_len,
                                cnp.float32_t *track2_ptr,
                                cnp.float32_t *min_t2t1,
                                cnp.float32_t *min_t1t2) nogil:
@@ -696,7 +696,7 @@ cdef inline void min_distances(size_t t1_len,
         cnp.float32_t *t2_pt
         cnp.float32_t d0, d1, d2
         cnp.float32_t delta2
-        size_t t1_pi, t2_pi
+        cnp.npy_intp t1_pi, t2_pi
     for t2_pi from 0<= t2_pi < t2_len:
         min_t2t1[t2_pi] = inf
     for t1_pi from 0<= t1_pi < t1_len:
@@ -775,7 +775,7 @@ def mam_distances(xyz1,xyz2,metric='all'):
     cdef:
         cnp.ndarray[cnp.float32_t, ndim=2] track1
         cnp.ndarray[cnp.float32_t, ndim=2] track2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
     track1 = np.ascontiguousarray(xyz1, dtype=f32_dt)
     t1_len = cnp.PyArray_DIM(track1, 0)
     track2 = np.ascontiguousarray(xyz2, dtype=f32_dt)
@@ -793,7 +793,7 @@ def mam_distances(xyz1,xyz2,metric='all'):
                   min_t2t1,
                   min_t1t2)
     cdef:
-        size_t t1_pi, t2_pi
+        cnp.npy_intp t1_pi, t2_pi
         cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0
     for t1_pi from 0<= t1_pi < t1_len:
         mean_t1t2+=min_t1t2[t1_pi]
@@ -844,7 +844,7 @@ def minimum_closest_distance(xyz1,xyz2):
     cdef:
         cnp.ndarray[cnp.float32_t, ndim=2] track1
         cnp.ndarray[cnp.float32_t, ndim=2] track2
-        size_t t1_len, t2_len
+        cnp.npy_intp t1_len, t2_len
     track1 = np.ascontiguousarray(xyz1, dtype=f32_dt)
     t1_len = cnp.PyArray_DIM(track1, 0)
     track2 = np.ascontiguousarray(xyz2, dtype=f32_dt)
@@ -862,7 +862,7 @@ def minimum_closest_distance(xyz1,xyz2):
                   min_t2t1,
                   min_t1t2)
     cdef:
-        size_t t1_pi, t2_pi
+        cnp.npy_intp t1_pi, t2_pi
         double min_min_t2t1 = inf
         double min_min_t1t2 = inf
     for t1_pi in range(t1_len):
@@ -1106,13 +1106,13 @@ def approx_polygon_track(xyz,alpha=0.392):
     next point.
     """
     cdef :
-        size_t mid_index
+        cnp.npy_intp mid_index
         cnp.ndarray[cnp.float32_t, ndim=2] track
         float *fvec0
         float *fvec1
         float *fvec2
         object characteristic_points
-        size_t t_len
+        cnp.npy_intp t_len
         double angle,tmp
         float vec0[3]
         float vec1[3]
@@ -1169,7 +1169,7 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
         int start_index,length,current_index, i
         double cost_par,cost_nopar,alphac
         object characteristic_points
-        size_t t_len
+        cnp.npy_intp t_len
         cnp.ndarray[cnp.float32_t, ndim=2] track
         float tmp[3]
         cnp.ndarray[cnp.float32_t, ndim=1] fvec1,fvec2,fvec3,fvec4

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -2,7 +2,7 @@
 from random import random
 
 cimport cython
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 from .direction_getter cimport DirectionGetter
 from .stopping_criterion cimport(
@@ -86,10 +86,10 @@ cdef void fixed_step(double * point, double * direction, double step_size) nogil
 def local_tracker(
         DirectionGetter dg,
         StoppingCriterion sc,
-        np.float_t[:] seed_pos,
-        np.float_t[:] first_step,
-        np.float_t[:] voxel_size,
-        np.float_t[:, :] streamline,
+        cnp.float_t[:] seed_pos,
+        cnp.float_t[:] first_step,
+        cnp.float_t[:] voxel_size,
+        cnp.float_t[:, :] streamline,
         double step_size,
         int fixedstep):
     """Tracks one direction from a seed.
@@ -127,7 +127,7 @@ def local_tracker(
         Ending state of the streamlines as determined by the StoppingCriterion.
     """
     cdef:
-        size_t i
+        cnp.npy_intp i
         StreamlineStatus stream_status
         double dir[3]
         double vs[3]
@@ -155,13 +155,13 @@ cdef int _local_tracker(DirectionGetter dg,
                         double* seed,
                         double* dir,
                         double* voxel_size,
-                        np.float_t[:, :] streamline,
+                        cnp.float_t[:, :] streamline,
                         double step_size,
                         int fixedstep,
                         StreamlineStatus* stream_status):
     cdef:
-        size_t i
-        size_t len_streamlines = streamline.shape[0]
+        cnp.npy_intp i
+        cnp.npy_intp len_streamlines = streamline.shape[0]
         double point[3]
         double voxdir[3]
         void (*step)(double*, double*, double) nogil
@@ -198,21 +198,21 @@ cdef int _local_tracker(DirectionGetter dg,
 def pft_tracker(
         DirectionGetter dg,
         AnatomicalStoppingCriterion sc,
-        np.float_t[:] seed_pos,
-        np.float_t[:] first_step,
-        np.float_t[:] voxel_size,
-        np.float_t[:, :] streamline,
-        np.float_t[:, :] directions,
+        cnp.float_t[:] seed_pos,
+        cnp.float_t[:] first_step,
+        cnp.float_t[:] voxel_size,
+        cnp.float_t[:, :] streamline,
+        cnp.float_t[:, :] directions,
         double step_size,
         int pft_max_nbr_back_steps,
         int pft_max_nbr_front_steps,
         int pft_max_trials,
         int particle_count,
-        np.float_t[:, :, :, :] particle_paths,
-        np.float_t[:, :, :, :] particle_dirs,
-        np.float_t[:] particle_weights,
-        np.int_t[:, :]  particle_steps,
-        np.int_t[:, :]  particle_stream_statuses):
+        cnp.float_t[:, :, :, :] particle_paths,
+        cnp.float_t[:, :, :, :] particle_dirs,
+        cnp.float_t[:] particle_weights,
+        cnp.int_t[:, :]  particle_steps,
+        cnp.int_t[:, :]  particle_stream_statuses):
     """Tracks one direction from a seed using the particle filtering algorithm.
 
     This function is the main workhorse of the ``ParticleFilteringTracking``
@@ -270,7 +270,7 @@ def pft_tracker(
 
     """
     cdef:
-        size_t i
+        cnp.npy_intp i
         StreamlineStatus stream_status
         double dir[3]
         double vs[3]
@@ -302,19 +302,19 @@ cdef _pft_tracker(DirectionGetter dg,
                   double* seed,
                   double* dir,
                   double* voxel_size,
-                  np.float_t[:, :] streamline,
-                  np.float_t[:, :] directions,
+                  cnp.float_t[:, :] streamline,
+                  cnp.float_t[:, :] directions,
                   double step_size,
                   StreamlineStatus * stream_status,
                   int pft_max_nbr_back_steps,
                   int pft_max_nbr_front_steps,
                   int pft_max_trials,
                   int particle_count,
-                  np.float_t[:, :, :, :] particle_paths,
-                  np.float_t[:, :, :, :] particle_dirs,
-                  np.float_t[:] particle_weights,
-                  np.int_t[:, :] particle_steps,
-                  np.int_t[:, :] particle_stream_statuses):
+                  cnp.float_t[:, :, :, :] particle_paths,
+                  cnp.float_t[:, :, :, :] particle_dirs,
+                  cnp.float_t[:] particle_weights,
+                  cnp.int_t[:, :] particle_steps,
+                  cnp.int_t[:, :] particle_stream_statuses):
     cdef:
         int i, pft_trial, pft_streamline_i, back_steps, front_steps
         int strl_array_len
@@ -384,9 +384,9 @@ cdef _pft_tracker(DirectionGetter dg,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef _pft(np.float_t[:, :] streamline,
+cdef _pft(cnp.float_t[:, :] streamline,
           int streamline_i,
-          np.float_t[:, :] directions,
+          cnp.float_t[:, :] directions,
           DirectionGetter dg,
           AnatomicalStoppingCriterion sc,
           double* voxel_size,
@@ -394,11 +394,11 @@ cdef _pft(np.float_t[:, :] streamline,
           StreamlineStatus * stream_status,
           int pft_nbr_steps,
           int particle_count,
-          np.float_t[:, :, :, :] particle_paths,
-          np.float_t[:, :, :, :] particle_dirs,
-          np.float_t[:] particle_weights,
-          np.int_t[:, :] particle_steps,
-          np.int_t[:, :] particle_stream_statuses):
+          cnp.float_t[:, :, :, :] particle_paths,
+          cnp.float_t[:, :, :, :] particle_dirs,
+          cnp.float_t[:] particle_weights,
+          cnp.int_t[:, :] particle_steps,
+          cnp.int_t[:, :] particle_stream_statuses):
     cdef:
         double sum_weights, sum_squared, N_effective, rdm_sample
         double point[3]

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -6,7 +6,7 @@ import numpy as np
 from libc.math cimport sqrt
 from libc.stdlib cimport malloc, free
 
-cimport numpy as np
+cimport numpy as cnp
 
 from dipy.tracking import Streamlines
 
@@ -17,7 +17,7 @@ cdef extern from "dpy_math.h" nogil:
 
 cdef double c_length(Streamline streamline) nogil:
     cdef:
-        np.npy_intp i
+        cnp.npy_intp i
         double out = 0.0
         double dn, sum_dn_sqr
 
@@ -33,12 +33,12 @@ cdef double c_length(Streamline streamline) nogil:
 
 
 cdef void c_arclengths_from_arraysequence(Streamline points,
-                                          np.npy_intp[:] offsets,
-                                          np.npy_intp[:] lengths,
+                                          cnp.npy_intp[:] offsets,
+                                          cnp.npy_intp[:] lengths,
                                           double[:] arclengths) nogil:
     cdef:
-        np.npy_intp i, j, k
-        np.npy_intp offset
+        cnp.npy_intp i, j, k
+        cnp.npy_intp offset
         double dn, sum_dn_sqr
 
     for i in range(offsets.shape[0]):
@@ -117,7 +117,7 @@ def length(streamlines):
         return arclengths
 
     only_one_streamlines = False
-    if type(streamlines) is np.ndarray:
+    if type(streamlines) is cnp.ndarray:
         only_one_streamlines = True
         streamlines = [streamlines]
 
@@ -132,7 +132,7 @@ def length(streamlines):
 
     # Allocate memory for each streamline length.
     streamlines_length = np.empty(len(streamlines), dtype=np.float64)
-    cdef np.npy_intp i
+    cdef cnp.npy_intp i
 
     if dtype is None:
         # List of streamlines having different dtypes
@@ -182,7 +182,7 @@ def length(streamlines):
 
 
 cdef void c_arclengths(Streamline streamline, double* out) nogil:
-    cdef np.npy_intp i = 0
+    cdef cnp.npy_intp i = 0
     cdef double dn
 
     out[0] = 0.0
@@ -197,11 +197,11 @@ cdef void c_arclengths(Streamline streamline, double* out) nogil:
 
 cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
     cdef:
-        np.npy_intp N = streamline.shape[0]
-        np.npy_intp D = streamline.shape[1]
-        np.npy_intp new_N = out.shape[0]
+        cnp.npy_intp N = streamline.shape[0]
+        cnp.npy_intp D = streamline.shape[1]
+        cnp.npy_intp new_N = out.shape[0]
         double ratio, step, next_point, delta
-        np.npy_intp i, j, k, dim
+        cnp.npy_intp i, j, k, dim
 
     # Get arclength at each point.
     arclengths = <double*> malloc(streamline.shape[0] * sizeof(double))
@@ -245,14 +245,14 @@ cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
 
 
 cdef void c_set_number_of_points_from_arraysequence(Streamline points,
-                                                    np.npy_intp[:] offsets,
-                                                    np.npy_intp[:] lengths,
+                                                    cnp.npy_intp[:] offsets,
+                                                    cnp.npy_intp[:] lengths,
                                                     long nb_points,
                                                     Streamline out) nogil:
     cdef:
-        np.npy_intp i, j, k
-        np.npy_intp offset, length
-        np.npy_intp offset_out = 0
+        cnp.npy_intp i, j, k
+        cnp.npy_intp offset, length
+        cnp.npy_intp offset_out = 0
         double dn, sum_dn_sqr
 
     for i in range(offsets.shape[0]):
@@ -344,7 +344,7 @@ def set_number_of_points(streamlines, nb_points=3):
         return new_streamlines
 
     only_one_streamlines = False
-    if type(streamlines) is np.ndarray:
+    if type(streamlines) is cnp.ndarray:
         only_one_streamlines = True
         streamlines = [streamlines]
 
@@ -364,7 +364,7 @@ def set_number_of_points(streamlines, nb_points=3):
 
     # Allocate memory for each modified streamline
     new_streamlines = []
-    cdef np.npy_intp i
+    cdef cnp.npy_intp i
 
     if dtype is None:
         # List of streamlines having different dtypes
@@ -444,14 +444,14 @@ cdef double c_norm_of_cross_product(double bx, double by, double bz,
     return sqrt(ax*ax + ay*ay + az*az)
 
 
-cdef double c_dist_to_line(Streamline streamline, np.npy_intp prev,
-                           np.npy_intp next, np.npy_intp curr) nogil:
+cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp prev,
+                           cnp.npy_intp next, cnp.npy_intp curr) nogil:
     """ Computes the shortest Euclidean distance between a point `curr` and
         the line passing through `prev` and `next`. """
 
     cdef:
         double dn, norm1, norm2
-        np.npy_intp D = streamline.shape[1]
+        cnp.npy_intp D = streamline.shape[1]
 
     # Compute cross product of next-prev and curr-next
     norm1 = c_norm_of_cross_product(streamline[next, 0]-streamline[prev, 0],
@@ -472,11 +472,11 @@ cdef double c_dist_to_line(Streamline streamline, np.npy_intp prev,
 
 
 cdef double c_segment_length(Streamline streamline,
-                             np.npy_intp start, np.npy_intp end) nogil:
+                             cnp.npy_intp start, cnp.npy_intp end) nogil:
     """ Computes the length of the segment going from `start` to `end`. """
     cdef:
-        np.npy_intp D = streamline.shape[1]
-        np.npy_intp d
+        cnp.npy_intp D = streamline.shape[1]
+        cnp.npy_intp d
         double segment_length = 0.0
         double dn
 
@@ -487,14 +487,14 @@ cdef double c_segment_length(Streamline streamline,
     return sqrt(segment_length)
 
 
-cdef np.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
+cdef cnp.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
                                        double tol_error, double max_segment_length) nogil:
     """ Compresses a streamline (see function `compress_streamlines`)."""
     cdef:
-        np.npy_intp N = streamline.shape[0]
-        np.npy_intp D = streamline.shape[1]
-        np.npy_intp nb_points = 0
-        np.npy_intp d, prev, next, curr
+        cnp.npy_intp N = streamline.shape[0]
+        cnp.npy_intp D = streamline.shape[1]
+        cnp.npy_intp nb_points = 0
+        cnp.npy_intp d, prev, next, curr
         double segment_length
 
     # Copy first point since it is always kept.
@@ -609,7 +609,7 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
                  Metrics for Streamlines with Variable Step Sizes, ISMRM, 2015.
     """
     only_one_streamlines = False
-    if type(streamlines) is np.ndarray:
+    if type(streamlines) is cnp.ndarray:
         only_one_streamlines = True
         streamlines = [streamlines]
 
@@ -617,7 +617,7 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
         return []
 
     compressed_streamlines = []
-    cdef np.npy_intp i
+    cdef cnp.npy_intp i
     for i in range(len(streamlines)):
         dtype = streamlines[i].dtype
         # HACK: To avoid memleaks we have to recast with astype(dtype).


### PR DESCRIPTION
This PR fixes #423.

- [x] replace `cimport numpy as np`  by `cimport numpy as cnp` to respect the convention and be explicit
- [x] replace `size_t` by `npy_intp` (for more info, look at #423)
- [x] replace `int` by `npy_intp` when we use it for index
  