### PR TITLE
Updating Vec2vec_rotmat to deal with numerical issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Please see the developers' list at
 https://mail.python.org/mailman/listinfo/neuroimaging
 
 Please see the users' forum at
-https://neurostars.org/tags/dipy
+https://github.com/dipy/dipy/discussions
 
 Please join the gitter chatroom `here <https://gitter.im/dipy/dipy>`_.
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -873,8 +873,6 @@ def vec2vec_rotmat(u, v):
     # cosa = np.dot(u, v)
     cosa = np.clip(np.dot(u, v), -1, 1)
     sina = np.sqrt(1 - cosa ** 2)
-    # if (cosa > 1):
-    #     print("cosa is greater than 1!!")
     R = np.array([[cosa, -sina, 0], [sina, cosa, 0], [0, 0, 1]])
     Rp = np.dot(Pt, np.dot(R, P))
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -870,7 +870,6 @@ def vec2vec_rotmat(u, v):
     # (u vp w) is an orthonormal basis
     P = np.array([u, vp, w])
     Pt = P.T
-    # cosa = np.dot(u, v)
     cosa = np.clip(np.dot(u, v), -1, 1)
     sina = np.sqrt(1 - cosa ** 2)
     R = np.array([[cosa, -sina, 0], [sina, cosa, 0], [0, 0, 1]])

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -870,8 +870,11 @@ def vec2vec_rotmat(u, v):
     # (u vp w) is an orthonormal basis
     P = np.array([u, vp, w])
     Pt = P.T
-    cosa = np.dot(u, v)
+    # cosa = np.dot(u, v)
+    cosa = np.clip(np.dot(u, v), -1, 1)
     sina = np.sqrt(1 - cosa ** 2)
+    # if (cosa > 1):
+    #     print("cosa is greater than 1!!")
     R = np.array([[cosa, -sina, 0], [sina, cosa, 0], [0, 0, 1]])
     Rp = np.dot(Pt, np.dot(R, P))
 

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -219,6 +219,17 @@ def test_vec2vec_rotmat():
         R = vec2vec_rotmat(a, b)
         assert_array_almost_equal(np.dot(R, a), b)
 
+    a = np.array([0.33950729, 0.92041729, 0.1938216])
+    a_norm = np.linalg.norm(a)
+    print(a_norm)
+    b = np.array([0.40604787, 0.97518325, 0.2057731])
+    b_norm = np.linalg.norm(b)
+    print(b_norm)
+    R = vec2vec_rotmat(a, b)
+    res = np.dot(a, b)
+    if (res > 1):
+        print("cosa is greater than 1!!")
+    tmp = 1
 
 def test_compose_transformations():
 

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -221,14 +221,19 @@ def test_vec2vec_rotmat():
 
     a = np.array([0.33950729, 0.92041729, 0.1938216])
     a_norm = np.linalg.norm(a)
+    a2 = a/a_norm
     print(a_norm)
     b = np.array([0.40604787, 0.97518325, 0.2057731])
     b_norm = np.linalg.norm(b)
+    b2 = b/b_norm
     print(b_norm)
     R = vec2vec_rotmat(a, b)
+    R2 = vec2vec_rotmat(a2, b2)
+    print(R)
+    print(R2)
     res = np.dot(a, b)
     if (res > 1):
-        print("cosa is greater than 1!!")
+        pass
     tmp = 1
 
 def test_compose_transformations():

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -219,22 +219,36 @@ def test_vec2vec_rotmat():
         R = vec2vec_rotmat(a, b)
         assert_array_almost_equal(np.dot(R, a), b)
 
-    a = np.array([0.33950729, 0.92041729, 0.1938216])
-    a_norm = np.linalg.norm(a)
-    a2 = a/a_norm
-    print(a_norm)
-    b = np.array([0.40604787, 0.97518325, 0.2057731])
-    b_norm = np.linalg.norm(b)
-    b2 = b/b_norm
-    print(b_norm)
-    R = vec2vec_rotmat(a, b)
-    R2 = vec2vec_rotmat(a2, b2)
-    print(R)
-    print(R2)
-    res = np.dot(a, b)
-    if (res > 1):
-        pass
-    tmp = 1
+    # These vectors are not unit norm
+    c = np.array([0.33950729, 0.92041729, 0.1938216])
+    d = np.array([0.40604787, 0.97518325, 0.2057731])
+    R1 = vec2vec_rotmat(c, d)
+
+    c_norm = c / np.linalg.norm(c)
+    d_norm = d / np.linalg.norm(d)
+    R2 = vec2vec_rotmat(c_norm, d_norm)
+
+    assert_array_almost_equal(R1, R2, decimal=1)
+    assert_array_almost_equal(np.diag(R1),
+                              np.diag(R2), decimal=3)
+
+    # we are catching collinear vectors
+    # but in the case where they are not
+    # exactly collinear and slightly different
+    # the cosine can be larger than 1 or smaller than
+    # -1 and therefore we have to catch that issue
+    e = np.array([1.0001, 0, 0])
+    f = np.array([1.001, 0.01, 0])
+    R3 = vec2vec_rotmat(e, f)
+
+    g = np.array([1.001, 0.0, 0])
+    R4 = vec2vec_rotmat(e, g)
+
+    assert_array_almost_equal(R3, R4, decimal=1)
+
+    assert_array_almost_equal(np.diag(R3),
+                              np.diag(R4), decimal=3)
+
 
 def test_compose_transformations():
 


### PR DESCRIPTION
``vec2vec_rotmat`` function can provide incorrect results when the dot product of the input vectors is slightly a bit beyond one. This is happening when both vectors (u, v) are close to collinear. Or at least this is what I currently observe. I found this problem when I used this function for a FURY application. In both bellow examples, I used ``vec2vec_rotmat`` function to rotate the arrows. In these examples, one arrow that is rotating around the center (0,0,0) is the leader and the other arrow is follower. 

Here in  ``vec2vec_rotmat`` function, using ``cosa = np.dot(u, v)`` . Notice that at some point the follower vector (purple) is flipping which is not correct.
![without_clip](https://user-images.githubusercontent.com/32108826/113644479-d8941480-9652-11eb-8306-d545e683521d.gif)

Here in  ``vec2vec_rotmat`` function, ``cosa = np.clip(np.dot(u, v), -1, 1)``. The follower vector does not flip anymore.
![with_clip](https://user-images.githubusercontent.com/32108826/113644455-c6b27180-9652-11eb-8f05-086e28ab5a9f.gif)
