### PR TITLE
RF: configure num_threads==-1 as the value to use all cores

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -96,7 +96,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
         Distance matrix
     num_threads : int, optional
         Number of threads. If -1 (default) then all available threads will be
-        used.        
+        used.
 
     Returns
     -------
@@ -160,7 +160,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
     num_threads : int, optional
         Number of threads. If -1 (default) then all available threads will be
         used.
-        
+
     Returns
     -------
     cost : double

--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -74,7 +74,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
                                     cnp.npy_intp moving_size,
                                     cnp.npy_intp rows,
                                     double [:, ::1] D,
-                                    num_threads=None):
+                                    num_threads=0):
     """ MDF-based pairwise distance optimization function
 
     We minimize the distance between moving streamlines of the same number of
@@ -94,8 +94,8 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
         Number of points per streamline
     D : 2D array
         Distance matrix
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used.
 
     Returns
@@ -108,7 +108,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
         int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads is not None:
+    if num_threads > 0:
         threads_to_use = num_threads
     else:
         threads_to_use = all_cores
@@ -126,7 +126,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
                                                &moving[j * rows, 0],
                                                rows)
 
-    if have_openmp and num_threads is not None:
+    if have_openmp and num_threads >0:
         openmp.omp_set_num_threads(all_cores)
 
     return np.asarray(D)
@@ -137,7 +137,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
                              cnp.npy_intp static_size,
                              cnp.npy_intp moving_size,
                              cnp.npy_intp rows,
-                             num_threads=None):
+                             num_threads=0):
     """ MDF-based pairwise distance optimization function
 
     We minimize the distance between moving streamlines of the same number of
@@ -155,8 +155,8 @@ def _bundle_minimum_distance(double [:, ::1] static,
         Number of moving streamlines
     rows : int
         Number of points per streamline
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used.
 
     Returns
@@ -180,7 +180,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
         int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads is not None:
+    if num_threads > 0:
         threads_to_use = num_threads
     else:
         threads_to_use = all_cores
@@ -236,7 +236,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
 
         dist = 0.25 * dist * dist
 
-    if have_openmp and num_threads is not None:
+    if have_openmp and num_threads > 0:
         openmp.omp_set_num_threads(all_cores)
 
     return dist

--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -13,7 +13,9 @@ from safe_openmp cimport have_openmp
 from cython.parallel import prange
 from libc.stdlib cimport malloc, free
 from libc.math cimport sqrt, sin, cos
-from multiprocessing import cpu_count
+
+from dipy.utils.omp import cpu_count, determine_num_threads
+from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
 
 cdef cnp.dtype f64_dt = np.dtype(np.float64)
 
@@ -95,8 +97,11 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
     D : 2D array
         Distance matrix
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
 
     Returns
     -------
@@ -105,19 +110,10 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
 
     cdef:
         cnp.npy_intp i=0, j=0, mov_i=0, mov_j=0
-        int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads in (None, -1):
-        threads_to_use = all_cores
-    elif num_threads > 0:
-        threads_to_use = num_threads
-    else:
-        raise ValueError("num_threads must be > 0 or -1 (all cores)")
-
-    if have_openmp:
-        openmp.omp_set_dynamic(0)
-        openmp.omp_set_num_threads(threads_to_use)
+    threads_to_use = determine_num_threads(num_threads)
+    set_num_threads(threads_to_use)
 
     with nogil:
 
@@ -128,8 +124,8 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
                                                &moving[j * rows, 0],
                                                rows)
 
-    if have_openmp and num_threads not in (None, -1):
-        openmp.omp_set_num_threads(all_cores)
+    if num_threads is not None:
+        restore_default_num_threads()
 
     return np.asarray(D)
 
@@ -158,8 +154,11 @@ def _bundle_minimum_distance(double [:, ::1] static,
     rows : int
         Number of points per streamline
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
 
     Returns
     -------
@@ -179,19 +178,10 @@ def _bundle_minimum_distance(double [:, ::1] static,
         double * min_j
         double * min_i
         openmp.omp_lock_t lock
-        int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads in (None, -1):
-        threads_to_use = all_cores
-    elif num_threads > 0:
-        threads_to_use = num_threads
-    else:
-        raise ValueError("num_threads must be > 0 or -1 (all cores)")
-
-    if have_openmp:
-        openmp.omp_set_dynamic(0)
-        openmp.omp_set_num_threads(threads_to_use)
+    threads_to_use = determine_num_threads(num_threads)
+    set_num_threads(threads_to_use)
 
     with nogil:
 
@@ -240,8 +230,8 @@ def _bundle_minimum_distance(double [:, ::1] static,
 
         dist = 0.25 * dist * dist
 
-    if have_openmp and num_threads not in (None, -1):
-        openmp.omp_set_num_threads(all_cores)
+    if num_threads is not None:
+        restore_default_num_threads()
 
     return dist
 

--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -74,7 +74,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
                                     cnp.npy_intp moving_size,
                                     cnp.npy_intp rows,
                                     double [:, ::1] D,
-                                    num_threads=0):
+                                    num_threads=None):
     """ MDF-based pairwise distance optimization function
 
     We minimize the distance between moving streamlines of the same number of
@@ -95,8 +95,8 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
     D : 2D array
         Distance matrix
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
+        Number of threads. If -1 (default) then all available threads will be
+        used.        
 
     Returns
     -------
@@ -108,10 +108,12 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
         int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads > 0:
+    if num_threads in (None, -1):
+        threads_to_use = all_cores
+    elif num_threads > 0:
         threads_to_use = num_threads
     else:
-        threads_to_use = all_cores
+        raise ValueError("num_threads must be > 0 or -1 (all cores)")
 
     if have_openmp:
         openmp.omp_set_dynamic(0)
@@ -126,7 +128,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
                                                &moving[j * rows, 0],
                                                rows)
 
-    if have_openmp and num_threads >0:
+    if have_openmp and num_threads not in (None, -1):
         openmp.omp_set_num_threads(all_cores)
 
     return np.asarray(D)
@@ -137,7 +139,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
                              cnp.npy_intp static_size,
                              cnp.npy_intp moving_size,
                              cnp.npy_intp rows,
-                             num_threads=0):
+                             num_threads=None):
     """ MDF-based pairwise distance optimization function
 
     We minimize the distance between moving streamlines of the same number of
@@ -156,9 +158,9 @@ def _bundle_minimum_distance(double [:, ::1] static,
     rows : int
         Number of points per streamline
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
-
+        Number of threads. If -1 (default) then all available threads will be
+        used.
+        
     Returns
     -------
     cost : double
@@ -180,10 +182,12 @@ def _bundle_minimum_distance(double [:, ::1] static,
         int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
-    if num_threads > 0:
+    if num_threads in (None, -1):
+        threads_to_use = all_cores
+    elif num_threads > 0:
         threads_to_use = num_threads
     else:
-        threads_to_use = all_cores
+        raise ValueError("num_threads must be > 0 or -1 (all cores)")
 
     if have_openmp:
         openmp.omp_set_dynamic(0)
@@ -236,7 +240,7 @@ def _bundle_minimum_distance(double [:, ::1] static,
 
         dist = 0.25 * dist * dist
 
-    if have_openmp and num_threads > 0:
+    if have_openmp and num_threads not in (None, -1):
         openmp.omp_set_num_threads(all_cores)
 
     return dist

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -130,7 +130,7 @@ cdef inline void _update_factors(double[:, :, :, :] factors,
 @cython.cdivision(True)
 def precompute_cc_factors_3d(floating[:, :, :] static,
                              floating[:, :, :] moving,
-                             cnp.npy_intp radius):
+                             cnp.npy_intp radius, num_threads=None):
     r"""Precomputations to quickly compute the gradient of the CC Metric
 
     Pre-computes the separate terms of the cross correlation metric and image
@@ -146,7 +146,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
         the moving volume (notice that both images must already be in a common
         reference domain, i.e. the same S, R, C)
     radius : the radius of the neighborhood (cube of (2 * radius + 1)^3 voxels)
-        
+
     Returns
     -------
     factors : array, shape (S, R, C, 5)

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -130,7 +130,7 @@ cdef inline void _update_factors(double[:, :, :, :] factors,
 @cython.cdivision(True)
 def precompute_cc_factors_3d(floating[:, :, :] static,
                              floating[:, :, :] moving,
-                             cnp.npy_intp radius, num_threads=None):
+                             cnp.npy_intp radius):
     r"""Precomputations to quickly compute the gradient of the CC Metric
 
     Pre-computes the separate terms of the cross correlation metric and image
@@ -146,7 +146,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
         the moving volume (notice that both images must already be in a common
         reference domain, i.e. the same S, R, C)
     radius : the radius of the neighborhood (cube of (2 * radius + 1)^3 voxels)
-
+        
     Returns
     -------
     factors : array, shape (S, R, C, 5)

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -13,7 +13,7 @@ def _affine_transform(kwargs):
 
 
 def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
-            num_processes=1):
+            num_threads=1):
     """Reslice data with new voxel resolution defined by ``new_zooms``
 
     Parameters
@@ -36,11 +36,9 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     cval : float
         Value used for points outside the boundaries of the input if
         mode='constant'.
-    num_processes : int
-        Split the calculation to a pool of children processes. This only
-        applies to 4D `data` arrays. If a positive integer then it defines
-        the size of the multiprocessing pool that will be used. If 0, then
-        the size of the pool will equal the number of cores available.
+    num_threads : int, optional
+        Number of threads. Default is 1. If <=0 then all available threads
+        will be used.
 
     Returns
     -------
@@ -85,9 +83,10 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
             data2 = affine_transform(input=data, **kwargs)
         if data.ndim == 4:
             data2 = np.zeros(new_shape+(data.shape[-1],), data.dtype)
-            if not num_processes:
-                num_processes = cpu_count()
-            if num_processes < 2:
+            if num_threads <= 0:
+                num_threads = cpu_count()
+
+            if num_threads == 1:
                 for i in range(data.shape[-1]):
                     affine_transform(input=data[..., i], output=data2[..., i],
                                      **kwargs)
@@ -97,7 +96,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
                     _kwargs = {'input': data[..., i]}
                     _kwargs.update(kwargs)
                     params.append(_kwargs)
-                pool = Pool(num_processes)
+                pool = Pool(num_threads)
                 for i, res in enumerate(pool.imap(_affine_transform, params)):
                     data2[..., i] = res
                 pool.close()

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -37,7 +37,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     cval : float
         Value used for points outside the boundaries of the input if
         mode='constant'.
-    num_processes: int, optional
+    num_processes : int, optional
         Split the calculation to a pool of children processes. This only
         applies to 4D `data` arrays. Default is 1. If < 0 the maximal number
         of cores minus |num_processes + 1| is used (enter -1 to use as many

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -37,8 +37,12 @@ class StreamlineDistanceMetric(object, metaclass=abc.ABCMeta):
         Parameters
         ----------
         num_threads : int, optional
-            Number of threads. If -1 (default) then all available threads will
-            be used. Only metrics using OpenMP will use this variable.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter -1
+            to use as many threads as possible). 0 raises an error. Only
+            metrics using OpenMP will use this variable.
         """
         self.static = None
         self.moving = None
@@ -283,8 +287,12 @@ class StreamlineLinearRegistration(object):
             optimizer. Default is False. Supported only with Scipy >= 0.11.
 
         num_threads : int, optional
-            Number of threads. If -1 (default) then all available threads will
-            be used. Only metrics using OpenMP will use this variable.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter -1
+            to use as many threads as possible). 0 raises an error. Only
+            metrics using OpenMP will use this variable.
 
         References
         ----------
@@ -618,8 +626,11 @@ def bundle_min_distance_fast(t, static, moving, block_size, num_threads=None):
         should have the same number of points M.
 
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
 
     Returns
     -------
@@ -737,8 +748,12 @@ def progressive_slr(static, moving, metric, x0, bounds, method='L-BFGS-B',
     verbose :  bool, optional.
         If True, log messages. Default:
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used. Only metrics using OpenMP will use this variable.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error. Only metrics
+        using OpenMP will use this variable.
 
     References
     ----------
@@ -888,8 +903,12 @@ def slr_with_qbx(static, moving,
         If None creates RandomState in function.
 
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used. Only metrics using OpenMP will use this variable.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error. Only metrics
+        using OpenMP will use this variable.
 
     Notes
     -----

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class StreamlineDistanceMetric(object, metaclass=abc.ABCMeta):
 
-    def __init__(self, num_threads=None):
+    def __init__(self, num_threads=0):
         """ An abstract class for the metric used for streamline registration
 
         If the two sets of streamlines match exactly then method ``distance``
@@ -36,8 +36,8 @@ class StreamlineDistanceMetric(object, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        num_threads : int
-            Number of threads. If None (default) then all available threads
+        num_threads : int, optional
+            Number of threads. If <=0 (default) then all available threads
             will be used. Only metrics using OpenMP will use this variable.
         """
         self.static = None
@@ -81,9 +81,6 @@ class BundleMinDistanceMetric(StreamlineDistanceMetric):
             Fixed or reference set of streamlines.
         moving : streamlines
             Moving streamlines.
-        num_threads : int
-            Number of threads. If None (default) then all available threads
-            will be used.
 
         Notes
         -----
@@ -220,7 +217,7 @@ class StreamlineLinearRegistration(object):
 
     def __init__(self, metric=None, x0="rigid", method='L-BFGS-B',
                  bounds=None, verbose=False, options=None, evolution=False,
-                 num_threads=None):
+                 num_threads=0):
         r""" Linear registration of 2 sets of streamlines [Garyfallidis15]_.
 
         Parameters
@@ -285,8 +282,8 @@ class StreamlineLinearRegistration(object):
             If True save the transformation for each iteration of the
             optimizer. Default is False. Supported only with Scipy >= 0.11.
 
-        num_threads : int
-            Number of threads. If None (default) then all available threads
+        num_threads : int, optional
+            Number of threads. If <= 0 (default) then all available threads
             will be used. Only metrics using OpenMP will use this variable.
 
         References
@@ -513,7 +510,7 @@ class StreamlineRegistrationMap(object):
         return transform_streamlines(moving, self.matrix)
 
 
-def bundle_sum_distance(t, static, moving, num_threads=None):
+def bundle_sum_distance(t, static, moving):
     """ MDF distance optimization function (SUM)
 
     We minimize the distance between moving streamlines as they align
@@ -572,10 +569,6 @@ def bundle_min_distance(t, static, moving):
     moving : list
         Moving streamlines.
 
-    num_threads : int
-        Number of threads. If None (default) then all available threads
-        will be used.
-
     Returns
     -------
     cost: float
@@ -621,8 +614,8 @@ def bundle_min_distance_fast(t, static, moving, block_size, num_threads):
         Number of points per streamline. All streamlines in static and moving
         should have the same number of points M.
 
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used.
 
     Returns
@@ -713,7 +706,7 @@ def remove_clusters_by_size(clusters, min_size=0):
 
 
 def progressive_slr(static, moving, metric, x0, bounds, method='L-BFGS-B',
-                    verbose=False, num_threads=None):
+                    verbose=False, num_threads=0):
     """ Progressive SLR
 
     This is an utility function that allows for example to do affine
@@ -740,8 +733,8 @@ def progressive_slr(static, moving, metric, x0, bounds, method='L-BFGS-B',
         L_BFGS_B' or 'Powell' optimizers can be used. Default is 'L_BFGS_B'.
     verbose :  bool, optional.
         If True, log messages. Default:
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used. Only metrics using OpenMP will use this variable.
 
     References
@@ -848,7 +841,7 @@ def slr_with_qbx(static, moving,
                  less_than=250,
                  qbx_thr=[40, 30, 20, 15],
                  nb_pts=20,
-                 progressive=True, rng=None, num_threads=None):
+                 progressive=True, rng=None, num_threads=0):
     """ Utility function for registering large tractograms.
 
     For efficiency, we apply the registration on cluster centroids and remove
@@ -891,8 +884,8 @@ def slr_with_qbx(static, moving,
     rng : RandomState
         If None creates RandomState in function.
 
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used. Only metrics using OpenMP will use this variable.
 
     Notes

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class StreamlineDistanceMetric(object, metaclass=abc.ABCMeta):
 
-    def __init__(self, num_threads=0):
+    def __init__(self, num_threads=None):
         """ An abstract class for the metric used for streamline registration
 
         If the two sets of streamlines match exactly then method ``distance``
@@ -37,8 +37,8 @@ class StreamlineDistanceMetric(object, metaclass=abc.ABCMeta):
         Parameters
         ----------
         num_threads : int, optional
-            Number of threads. If <=0 (default) then all available threads
-            will be used. Only metrics using OpenMP will use this variable.
+            Number of threads. If -1 (default) then all available threads will
+            be used. Only metrics using OpenMP will use this variable.
         """
         self.static = None
         self.moving = None
@@ -217,7 +217,7 @@ class StreamlineLinearRegistration(object):
 
     def __init__(self, metric=None, x0="rigid", method='L-BFGS-B',
                  bounds=None, verbose=False, options=None, evolution=False,
-                 num_threads=0):
+                 num_threads=None):
         r""" Linear registration of 2 sets of streamlines [Garyfallidis15]_.
 
         Parameters
@@ -283,8 +283,8 @@ class StreamlineLinearRegistration(object):
             optimizer. Default is False. Supported only with Scipy >= 0.11.
 
         num_threads : int, optional
-            Number of threads. If <= 0 (default) then all available threads
-            will be used. Only metrics using OpenMP will use this variable.
+            Number of threads. If -1 (default) then all available threads will
+            be used. Only metrics using OpenMP will use this variable.
 
         References
         ----------
@@ -510,7 +510,7 @@ class StreamlineRegistrationMap(object):
         return transform_streamlines(moving, self.matrix)
 
 
-def bundle_sum_distance(t, static, moving):
+def bundle_sum_distance(t, static, moving, num_threads=None):
     """ MDF distance optimization function (SUM)
 
     We minimize the distance between moving streamlines as they align
@@ -533,6 +533,9 @@ def bundle_sum_distance(t, static, moving):
     moving : list
         Moving streamlines. These will be transformed to align with
         the static streamlines
+
+    num_threads : int, optional
+        Number of threads. If -1 then all available threads will be used.
 
     Returns
     -------
@@ -583,7 +586,7 @@ def bundle_min_distance(t, static, moving):
                    np.sum(np.min(d01, axis=1)) / float(rows)) ** 2
 
 
-def bundle_min_distance_fast(t, static, moving, block_size, num_threads):
+def bundle_min_distance_fast(t, static, moving, block_size, num_threads=None):
     """ MDF-based pairwise distance optimization function (MIN)
 
     We minimize the distance between moving streamlines as they align
@@ -615,8 +618,8 @@ def bundle_min_distance_fast(t, static, moving, block_size, num_threads):
         should have the same number of points M.
 
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
+        Number of threads. If -1 (default) then all available threads will be
+        used.
 
     Returns
     -------
@@ -706,7 +709,7 @@ def remove_clusters_by_size(clusters, min_size=0):
 
 
 def progressive_slr(static, moving, metric, x0, bounds, method='L-BFGS-B',
-                    verbose=False, num_threads=0):
+                    verbose=False, num_threads=None):
     """ Progressive SLR
 
     This is an utility function that allows for example to do affine
@@ -734,8 +737,8 @@ def progressive_slr(static, moving, metric, x0, bounds, method='L-BFGS-B',
     verbose :  bool, optional.
         If True, log messages. Default:
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used. Only metrics using OpenMP will use this variable.
+        Number of threads. If -1 (default) then all available threads will be
+        used. Only metrics using OpenMP will use this variable.
 
     References
     ----------
@@ -841,7 +844,7 @@ def slr_with_qbx(static, moving,
                  less_than=250,
                  qbx_thr=[40, 30, 20, 15],
                  nb_pts=20,
-                 progressive=True, rng=None, num_threads=0):
+                 progressive=True, rng=None, num_threads=None):
     """ Utility function for registering large tractograms.
 
     For efficiency, we apply the registration on cluster centroids and remove
@@ -885,8 +888,8 @@ def slr_with_qbx(static, moving,
         If None creates RandomState in function.
 
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used. Only metrics using OpenMP will use this variable.
+        Number of threads. If -1 (default) then all available threads will be
+        used. Only metrics using OpenMP will use this variable.
 
     Notes
     -----

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -3,7 +3,8 @@ import nibabel as nib
 from numpy.testing import (run_module_suite,
                            assert_,
                            assert_equal,
-                           assert_almost_equal)
+                           assert_almost_equal,
+                           assert_raises)
 from dipy.io.image import load_nifti
 from dipy.data import get_fnames
 from dipy.align.reslice import reslice
@@ -52,14 +53,20 @@ def test_resample():
         assert_almost_equal(affine2, _affine)
 
     # check use of multiprocessing pool of specified size
-    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_threads=4)
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=4)
     assert_almost_equal(data2, data3)
     assert_almost_equal(affine2, affine3)
 
     # check use of multiprocessing pool of autoconfigured size
-    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_threads=0)
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=-1)
     assert_almost_equal(data2, data3)
     assert_almost_equal(affine2, affine3)
+
+    # test invalid values of num_threads
+    assert_raises(ValueError, reslice, data, affine, zooms, new_zooms,
+                  num_processes=0)
+    assert_raises(ValueError, reslice, data, affine, zooms, new_zooms,
+                  num_processes=-2)
 
 
 if __name__ == '__main__':

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -65,8 +65,6 @@ def test_resample():
     # test invalid values of num_threads
     assert_raises(ValueError, reslice, data, affine, zooms, new_zooms,
                   num_processes=0)
-    assert_raises(ValueError, reslice, data, affine, zooms, new_zooms,
-                  num_processes=-2)
 
 
 if __name__ == '__main__':

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -52,12 +52,12 @@ def test_resample():
         assert_almost_equal(affine2, _affine)
 
     # check use of multiprocessing pool of specified size
-    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=4)
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_threads=4)
     assert_almost_equal(data2, data3)
     assert_almost_equal(affine2, affine3)
 
     # check use of multiprocessing pool of autoconfigured size
-    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=0)
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_threads=0)
     assert_almost_equal(data2, data3)
     assert_almost_equal(affine2, affine3)
 

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -475,7 +475,7 @@ def test_cascade_of_optimizations_and_threading():
 
     print('then affine')
     slr3 = StreamlineLinearRegistration(x0=12, options={'maxiter': 50},
-                                        num_threads=None)
+                                        num_threads=0)
     slm3 = slr3.optimize(cb1, cb2, slm2.matrix)
 
     assert_(slm2.fopt < slm.fopt)

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -475,11 +475,22 @@ def test_cascade_of_optimizations_and_threading():
 
     print('then affine')
     slr3 = StreamlineLinearRegistration(x0=12, options={'maxiter': 50},
-                                        num_threads=0)
+                                        num_threads=None)
     slm3 = slr3.optimize(cb1, cb2, slm2.matrix)
 
     assert_(slm2.fopt < slm.fopt)
     assert_(slm3.fopt < slm2.fopt)
+
+
+def test_wrong_num_threads():
+    A = [np.random.rand(10, 3), np.random.rand(10, 3)]
+    B = [np.random.rand(10, 3), np.random.rand(10, 3)]
+
+    slr = StreamlineLinearRegistration(num_threads=0)
+    assert_raises(ValueError, slr.optimize, A, B)
+
+    slr = StreamlineLinearRegistration(num_threads=-2)
+    assert_raises(ValueError, slr.optimize, A, B)
 
 
 if __name__ == '__main__':

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -489,9 +489,6 @@ def test_wrong_num_threads():
     slr = StreamlineLinearRegistration(num_threads=0)
     assert_raises(ValueError, slr.optimize, A, B)
 
-    slr = StreamlineLinearRegistration(num_threads=-2)
-    assert_raises(ValueError, slr.optimize, A, B)
-
 
 if __name__ == '__main__':
 

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -17,7 +17,7 @@ from libc.string cimport memcpy
 
 
 def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
-               block_radius=5, rician=True, num_threads=None):
+               block_radius=5, rician=True, num_threads=0):
     """ Non-local means for denoising 3D images
 
     Parameters
@@ -34,8 +34,8 @@ def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
     rician : boolean
         If True the noise is estimated as Rician, otherwise Gaussian noise
         is assumed.
-    num_threads : int
-        Number of threads. If None (default) then all available threads
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
         will be used.
 
     Returns
@@ -73,7 +73,7 @@ def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
 @cython.boundscheck(False)
 def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
                 double[:, :, ::1] sigma, patch_radius=1, block_radius=5,
-                rician=True, num_threads=None):
+                rician=True, num_threads=0):
     """ This algorithm denoises the value of every voxel (i, j, k) by
     calculating a weight between a moving 3D patch and a static 3D patch
     centered at (i, j, k). The moving patch can only move inside a
@@ -106,7 +106,7 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
 
                     out[i, j, k] = process_block(arr, i, j, k, B, P, sigma)
 
-    if num_threads is not None:
+    if num_threads > 0:
         restore_default_num_threads()
 
     new = np.asarray(out)

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -57,7 +57,7 @@ def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
 
     if sigma.ndim != 3:
         raise ValueError('sigma needs to be a 3D ndarray', sigma.shape)
-        
+
     arr = np.ascontiguousarray(arr, dtype='f8')
     arr = add_padding_reflection(arr, block_radius)
     mask = add_padding_reflection(mask.astype('f8'), block_radius)

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -10,7 +10,7 @@ from dipy.denoise.denspeed import nlmeans_3d
 
 
 def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
-            rician=True, num_threads=0):
+            rician=True, num_threads=None):
     r""" Non-local means for denoising 3D and 4D images
 
     Parameters
@@ -28,8 +28,8 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
         If True the noise is estimated as Rician, otherwise Gaussian noise
         is assumed.
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
+        Number of threads. If -1 (default) then all available threads will be
+        used.
 
     Returns
     -------

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -10,7 +10,7 @@ from dipy.denoise.denspeed import nlmeans_3d
 
 
 def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
-            rician=True, num_threads=None):
+            rician=True, num_threads=0):
     r""" Non-local means for denoising 3D and 4D images
 
     Parameters
@@ -27,9 +27,9 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
     rician : boolean
         If True the noise is estimated as Rician, otherwise Gaussian noise
         is assumed.
-    num_threads : int
-        Number of threads. If None (default) then all available threads
-        will be used (all CPU cores).
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
+        will be used.
 
     Returns
     -------

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -28,8 +28,11 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
         If True the noise is estimated as Rician, otherwise Gaussian noise
         is assumed.
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
 
     Returns
     -------

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -91,7 +91,7 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
         Reduced convolution in one direction only for testing
     num_threads : int, optional
         Number of threads. If -1 (default) then all available threads will be
-        used.        
+        used.
     normalize : boolean
         Apply max-normalization to the output such that its value range matches 
         the input ODF data.
@@ -135,7 +135,7 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
     num_threads : int, optional
         Number of threads. If -1 (default) then all available threads will be
         used.
-                
+
     Returns
     -------
     output : array of double

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,8 +11,11 @@ from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.data import get_sphere
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 
+from dipy.utils.omp import cpu_count, determine_num_threads
+from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
+
 def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, normalize=True):
-    """ Perform the shift-twist convolution with the ODF data and 
+    """ Perform the shift-twist convolution with the ODF data and
     the lookup-table of the kernel.
 
     Parameters
@@ -26,35 +29,38 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, norma
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
     normalize : boolean
-        Apply max-normalization to the output such that its value range matches 
+        Apply max-normalization to the output such that its value range matches
         the input ODF data.
-        
+
     Returns
     -------
     output : array of double
         The ODF data after convolution enhancement in spherical harmonics format
-        
+
     References
     ----------
-    [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis, 
-                         J. Portegies, R. Duits. (2016) Fast implementations of 
-                         contextual PDE’s for HARDI data processing in DIPY. 
+    [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis,
+                         J. Portegies, R. Duits. (2016) Fast implementations of
+                         contextual PDE’s for HARDI data processing in DIPY.
                          ISMRM 2016 conference.
-    [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
-                        on the space of positions and orientations and their 
-                        application to crossing-preserving smoothing of HARDI 
+    [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions
+                        on the space of positions and orientations and their
+                        application to crossing-preserving smoothing of HARDI
                         images. International Journal of Computer Vision, 92:231-264.
-    [Portegies2015] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits. 
+    [Portegies2015] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits.
                     (2015) New Approximation of a Scale Space Kernel on SE(3) and
                     Applications in Neuroimaging. Fifth International
                     Conference on Scale Space and Variational Methods in
                     Computer Vision
     [Portegies2015b] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters, G.Girard,
-                     and R. Duits. (2015) Improving Fiber Alignment in HARDI by 
-                     Combining Contextual PDE flow with Constrained Spherical 
+                     and R. Duits. (2015) Improving Fiber Alignment in HARDI by
+                     Combining Contextual PDE flow with Constrained Spherical
                      Deconvolution. PLoS One.
     """
 
@@ -63,22 +69,22 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, norma
     odfs_dsf = sh_to_sf(odfs_sh, sphere, sh_order=sh_order, basis_type=None)
 
     # perform the convolution
-    output = perform_convolution(odfs_dsf, 
+    output = perform_convolution(odfs_dsf,
                                  kernel.get_lookup_table(),
                                  test_mode,
                                  num_threads)
-    
+
     # normalize the output
     if normalize:
         output = np.multiply(output, np.amax(odfs_dsf)/np.amax(output))
-    
+
     # convert back to SH
     output_sh = sf_to_sh(output, sphere, sh_order=sh_order)
-    
+
     return output_sh
-    
+
 def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=True):
-    """ Perform the shift-twist convolution with the ODF data and 
+    """ Perform the shift-twist convolution with the ODF data and
     the lookup-table of the kernel.
 
     Parameters
@@ -90,10 +96,13 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
     normalize : boolean
-        Apply max-normalization to the output such that its value range matches 
+        Apply max-normalization to the output such that its value range matches
         the input ODF data.
 
     Returns
@@ -102,7 +111,7 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
         The ODF data after convolution enhancement, sampled on a sphere
     """
     # perform the convolution
-    output = perform_convolution(odfs_sf, 
+    output = perform_convolution(odfs_sf,
                                  kernel.get_lookup_table(),
                                  test_mode,
                                  num_threads)
@@ -112,16 +121,16 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
         output = np.multiply(output, np.amax(odfs_sf)/np.amax(output))
 
     return output
-    
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.cdivision(True)
-cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs, 
+cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                                                 double [:, :, :, :, ::1] lut,
                                                 cnp.npy_intp test_mode,
                                                 num_threads=None):
-    """ Perform the shift-twist convolution with the ODF data 
+    """ Perform the shift-twist convolution with the ODF data
     and the lookup-table of the kernel.
 
     Parameters
@@ -133,15 +142,18 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If -1 (default) then all available threads will be
-        used.
+        Number of threads to be used for OpenMP parallelization. If None
+        (default) the value of OMP_NUM_THREADS environment variable is used
+        if it is set, otherwise all available threads are used. If < 0 the
+        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        use as many threads as possible). 0 raises an error.
 
     Returns
     -------
     output : array of double
         The ODF data after convolution enhancement
     """
-        
+
     cdef:
         double [:, :, :, ::1] output = np.array(odfs, copy=True)
         cnp.npy_intp OR1 = lut.shape[0]
@@ -159,15 +171,9 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
         cnp.npy_intp expectedvox
         cnp.npy_intp edgeNormalization = True
 
-    if num_threads in (None, -1):
-        threads_to_use = all_cores
-    elif num_threads > 0:
-        threads_to_use = num_threads
+    threads_to_use = determine_num_threads(num_threads)
+    set_num_threads(threads_to_use)
 
-    if have_openmp:
-        openmp.omp_set_dynamic(0)
-        openmp.omp_set_num_threads(threads_to_use)
-    
     if test_mode:
         edgeNormalization = False
         OR2 = 1
@@ -185,11 +191,11 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                 for cy in range(ny):
                     for cz in range(nz):
                         # loop over kernel x,y,z,orient --> x and r
-                        for x in range(int_max(cx - hn, 0), 
+                        for x in range(int_max(cx - hn, 0),
                                        int_min(cx + hn + 1, ny - 1)):
-                             for y in range(int_max(cy - hn, 0), 
+                             for y in range(int_max(cy - hn, 0),
                                             int_min(cy + hn + 1, ny - 1)):
-                                 for z in range(int_max(cz - hn, 0), 
+                                 for z in range(int_max(cz - hn, 0),
                                                 int_min(cz + hn + 1, nz - 1)):
                                     voxcount[corient, cx, cy, cz] += 1.0
                                     for orient in range(0, OR2):
@@ -204,12 +210,12 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                                 totalval[corient, cx, cy, cz]
 
     # Reset number of OpenMP cores to default
-    if have_openmp and num_threads not in (None, -1):
-        openmp.omp_set_num_threads(all_cores)
+    if num_threads is not None:
+        restore_default_num_threads()
 
     return output
 
-cdef inline cnp.npy_intp int_max(cnp.npy_intp a, cnp.npy_intp b) nogil: 
+cdef inline cnp.npy_intp int_max(cnp.npy_intp a, cnp.npy_intp b) nogil:
     return a if a >= b else b
-cdef inline cnp.npy_intp int_min(cnp.npy_intp a, cnp.npy_intp b) nogil: 
+cdef inline cnp.npy_intp int_min(cnp.npy_intp a, cnp.npy_intp b) nogil:
     return a if a <= b else b

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,7 +11,7 @@ from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.data import get_sphere
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 
-def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=0, normalize=True):
+def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, normalize=True):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
 
@@ -26,8 +26,8 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=0, normaliz
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
+        Number of threads. If -1 (default) then all available threads will be
+        used.
     normalize : boolean
         Apply max-normalization to the output such that its value range matches 
         the input ODF data.
@@ -77,7 +77,7 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=0, normaliz
     
     return output_sh
     
-def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=0, normalize=True):
+def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=True):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
 
@@ -90,8 +90,8 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=0, normalize=True)
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
+        Number of threads. If -1 (default) then all available threads will be
+        used.        
     normalize : boolean
         Apply max-normalization to the output such that its value range matches 
         the input ODF data.
@@ -120,7 +120,7 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=0, normalize=True)
 cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs, 
                                                 double [:, :, :, :, ::1] lut,
                                                 cnp.npy_intp test_mode,
-                                                num_threads=0):
+                                                num_threads=None):
     """ Perform the shift-twist convolution with the ODF data 
     and the lookup-table of the kernel.
 
@@ -133,9 +133,9 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
     test_mode : boolean
         Reduced convolution in one direction only for testing
     num_threads : int, optional
-        Number of threads. If <=0 (default) then all available threads
-        will be used.
-        
+        Number of threads. If -1 (default) then all available threads will be
+        used.
+                
     Returns
     -------
     output : array of double
@@ -159,10 +159,10 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
         cnp.npy_intp expectedvox
         cnp.npy_intp edgeNormalization = True
 
-    if num_threads > 0:
-        threads_to_use = num_threads
-    else:
+    if num_threads in (None, -1):
         threads_to_use = all_cores
+    elif num_threads > 0:
+        threads_to_use = num_threads
 
     if have_openmp:
         openmp.omp_set_dynamic(0)
@@ -204,7 +204,7 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                                 totalval[corient, cx, cy, cz]
 
     # Reset number of OpenMP cores to default
-    if have_openmp and num_threads > 0:
+    if have_openmp and num_threads not in (None, -1):
         openmp.omp_set_num_threads(all_cores)
 
     return output

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,7 +11,7 @@ from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.data import get_sphere
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 
-def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, normalize=True):
+def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=0, normalize=True):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
 
@@ -25,9 +25,9 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, norma
         Maximal spherical harmonics order
     test_mode : boolean
         Reduced convolution in one direction only for testing
-    num_threads : int
-            Number of threads. If None (default) then all available threads
-            will be used.
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
+        will be used.
     normalize : boolean
         Apply max-normalization to the output such that its value range matches 
         the input ODF data.
@@ -77,7 +77,7 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, norma
     
     return output_sh
     
-def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=True):
+def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=0, normalize=True):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
 
@@ -89,9 +89,9 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
         The 5D lookup table
     test_mode : boolean
         Reduced convolution in one direction only for testing
-    num_threads : int
-            Number of threads. If None (default) then all available threads
-            will be used.
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
+        will be used.
     normalize : boolean
         Apply max-normalization to the output such that its value range matches 
         the input ODF data.
@@ -120,7 +120,7 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
 cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs, 
                                                 double [:, :, :, :, ::1] lut,
                                                 cnp.npy_intp test_mode,
-                                                num_threads=None):
+                                                num_threads=0):
     """ Perform the shift-twist convolution with the ODF data 
     and the lookup-table of the kernel.
 
@@ -132,9 +132,9 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
         The 5D lookup table
     test_mode : boolean
         Reduced convolution in one direction only for testing
-    num_threads : int
-            Number of threads. If None (default) then all available threads
-            will be used.
+    num_threads : int, optional
+        Number of threads. If <=0 (default) then all available threads
+        will be used.
         
     Returns
     -------
@@ -159,7 +159,7 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
         cnp.npy_intp expectedvox
         cnp.npy_intp edgeNormalization = True
 
-    if num_threads is not None:
+    if num_threads > 0:
         threads_to_use = num_threads
     else:
         threads_to_use = all_cores
@@ -204,7 +204,7 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                                 totalval[corient, cx, cy, cz]
 
     # Reset number of OpenMP cores to default
-    if have_openmp and num_threads is not None:
+    if have_openmp and num_threads > 0:
         openmp.omp_set_num_threads(all_cores)
 
     return output

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -193,7 +193,7 @@ def test_gibbs_errors():
         TypeError, gibbs_removal, image_gibbs.copy(), num_threads="1"
     )
     assert_raises(
-        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=-1
+        ValueError, gibbs_removal, image_gibbs.copy(), num_threads=0
     )
     # Test for valid input dimensionality
     assert_raises(ValueError, gibbs_removal, np.ones(2))  # 1D

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -33,7 +33,6 @@ def test_nlmeans_wrong():
     data = np.ones((10, 10, 10))
     sigma = 1
     assert_raises(ValueError, nlmeans, data, sigma, num_threads=0)
-    assert_raises(ValueError, nlmeans, data, sigma, num_threads=-2)
 
 
 def test_nlmeans_random_noise():

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -29,6 +29,12 @@ def test_nlmeans_wrong():
     S0 = np.ones((2, 2, 2, 2, 2))
     assert_raises(ValueError, nlmeans, S0, 1.0)
 
+    # test invalid values of num_threads
+    data = np.ones((10, 10, 10))
+    sigma = 1
+    assert_raises(ValueError, nlmeans, data, sigma, num_threads=0)
+    assert_raises(ValueError, nlmeans, data, sigma, num_threads=-2)
+
 
 def test_nlmeans_random_noise():
     S0 = 100 + 2 * np.random.standard_normal((22, 23, 30))
@@ -111,7 +117,7 @@ def test_nlmeans_4d_3dsigma_and_threads():
 
     print('All')
     t = time()
-    new_data2 = nlmeans(data, sigma, mask, num_threads=0)
+    new_data2 = nlmeans(data, sigma, mask, num_threads=None)
     duration_all_core = time() - t
     print(duration_all_core)
 

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -111,7 +111,7 @@ def test_nlmeans_4d_3dsigma_and_threads():
 
     print('All')
     t = time()
-    new_data2 = nlmeans(data, sigma, mask, num_threads=None)
+    new_data2 = nlmeans(data, sigma, mask, num_threads=0)
     duration_all_core = time() - t
     print(duration_all_core)
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -543,65 +543,51 @@ def test_peaksFromModelParallel():
                                       normalize_peaks=True, return_odf=True,
                                       return_sh=True, parallel=False)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", category=UserWarning)
-            pam_multi_inv1 = peaks_from_model(model, data, sphere, .5, 45,
-                                              normalize_peaks=True,
-                                              return_odf=True,
-                                              return_sh=True, parallel=True,
-                                              nbr_processes=0)
+        pam_multi_inv1 = peaks_from_model(model, data, sphere, .5, 45,
+                                          normalize_peaks=True,
+                                          return_odf=True,
+                                          return_sh=True, parallel=True,
+                                          nbr_processes=-1)
 
-            pam_multi_inv2 = peaks_from_model(model, data, sphere, .5, 45,
-                                              normalize_peaks=True,
-                                              return_odf=True,
-                                              return_sh=True, parallel=True,
-                                              nbr_processes=-2)
+        pam_multi_inv2 = peaks_from_model(model, data, sphere, .5, 45,
+                                          normalize_peaks=True,
+                                          return_odf=True,
+                                          return_sh=True, parallel=True,
+                                          nbr_processes=-2)
 
-            # Both previous calls to peaks_from_model raise a
-            # PendingDeprecationWarning when sh_to_sf_basis is called, then a
-            # UserWarning when _peaks_from_model_parallel is called with an
-            # invalid number of processes, and finally another
-            # PendingDeprecationWarning when peaks_from_model is called a
-            # second time with parallel=False
-            assert_(len(w) == 6)
-            assert_(issubclass(w[1].category, UserWarning))
-            assert_(issubclass(w[4].category, UserWarning))
-            assert_("Invalid number of processes " in str(w[1].message))
-            assert_("Invalid number of processes " in str(w[4].message))
+        for pam in [pam_multi, pam_multi_inv1, pam_multi_inv2]:
+            assert_equal(pam.gfa.dtype, pam_single.gfa.dtype)
+            assert_equal(pam.gfa.shape, pam_single.gfa.shape)
+            assert_array_almost_equal(pam.gfa, pam_single.gfa)
 
-            for pam in [pam_multi, pam_multi_inv1, pam_multi_inv2]:
-                assert_equal(pam.gfa.dtype, pam_single.gfa.dtype)
-                assert_equal(pam.gfa.shape, pam_single.gfa.shape)
-                assert_array_almost_equal(pam.gfa, pam_single.gfa)
+            assert_equal(pam.qa.dtype, pam_single.qa.dtype)
+            assert_equal(pam.qa.shape, pam_single.qa.shape)
+            assert_array_almost_equal(pam.qa, pam_single.qa)
 
-                assert_equal(pam.qa.dtype, pam_single.qa.dtype)
-                assert_equal(pam.qa.shape, pam_single.qa.shape)
-                assert_array_almost_equal(pam.qa, pam_single.qa)
+            assert_equal(pam.peak_values.dtype,
+                         pam_single.peak_values.dtype)
+            assert_equal(pam.peak_values.shape,
+                         pam_single.peak_values.shape)
+            assert_array_almost_equal(pam.peak_values,
+                                      pam_single.peak_values)
 
-                assert_equal(pam.peak_values.dtype,
-                             pam_single.peak_values.dtype)
-                assert_equal(pam.peak_values.shape,
-                             pam_single.peak_values.shape)
-                assert_array_almost_equal(pam.peak_values,
-                                          pam_single.peak_values)
+            assert_equal(pam.peak_indices.dtype,
+                         pam_single.peak_indices.dtype)
+            assert_equal(pam.peak_indices.shape,
+                         pam_single.peak_indices.shape)
+            assert_array_equal(pam.peak_indices, pam_single.peak_indices)
 
-                assert_equal(pam.peak_indices.dtype,
-                             pam_single.peak_indices.dtype)
-                assert_equal(pam.peak_indices.shape,
-                             pam_single.peak_indices.shape)
-                assert_array_equal(pam.peak_indices, pam_single.peak_indices)
+            assert_equal(pam.peak_dirs.dtype, pam_single.peak_dirs.dtype)
+            assert_equal(pam.peak_dirs.shape, pam_single.peak_dirs.shape)
+            assert_array_almost_equal(pam.peak_dirs, pam_single.peak_dirs)
 
-                assert_equal(pam.peak_dirs.dtype, pam_single.peak_dirs.dtype)
-                assert_equal(pam.peak_dirs.shape, pam_single.peak_dirs.shape)
-                assert_array_almost_equal(pam.peak_dirs, pam_single.peak_dirs)
+            assert_equal(pam.shm_coeff.dtype, pam_single.shm_coeff.dtype)
+            assert_equal(pam.shm_coeff.shape, pam_single.shm_coeff.shape)
+            assert_array_almost_equal(pam.shm_coeff, pam_single.shm_coeff)
 
-                assert_equal(pam.shm_coeff.dtype, pam_single.shm_coeff.dtype)
-                assert_equal(pam.shm_coeff.shape, pam_single.shm_coeff.shape)
-                assert_array_almost_equal(pam.shm_coeff, pam_single.shm_coeff)
-
-                assert_equal(pam.odf.dtype, pam_single.odf.dtype)
-                assert_equal(pam.odf.shape, pam_single.odf.shape)
-                assert_array_almost_equal(pam.odf, pam_single.odf)
+            assert_equal(pam.odf.dtype, pam_single.odf.dtype)
+            assert_equal(pam.odf.shape, pam_single.odf.shape)
+            assert_array_almost_equal(pam.odf, pam_single.odf)
 
 
 def test_peaks_shm_coeff():

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -1101,9 +1101,11 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     parallel : bool, optional
         Whether to use parallelization in peak-finding during the calibration
         procedure. Default: True
-    nbr_processes: int
+    nbr_processes: int, optional
         If `parallel` is True, the number of subprocesses to use
-        (default multiprocessing.cpu_count()).
+        (default multiprocessing.cpu_count()). If < 0 the maximal number of
+        cores minus |nbr_processes + 1| is used (enter -1 to use as many cores
+        as possible). 0 raises an error.
     sphere : Sphere, optional.
         The sphere used for peak finding. Default: default_sphere.
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -1101,7 +1101,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     parallel : bool, optional
         Whether to use parallelization in peak-finding during the calibration
         procedure. Default: True
-    nbr_processes: int, optional
+    nbr_processes : int, optional
         If `parallel` is True, the number of subprocesses to use
         (default multiprocessing.cpu_count()). If < 0 the maximal number of
         cores minus |nbr_processes + 1| is used (enter -1 to use as many cores

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -322,7 +322,7 @@ class RecoBundles(object):
                   reduction_thr=10,
                   reduction_distance='mdf',
                   slr=True,
-                  slr_num_threads=None,
+                  slr_num_threads=0,
                   slr_metric=None,
                   slr_x0=None,
                   slr_bounds=None,
@@ -346,6 +346,9 @@ class RecoBundles(object):
         slr : bool, optional
             Use Streamline-based Linear Registration (SLR) locally
             (default True)
+        slr_num_threads : int, optional
+            Number of threads to use. If <=0 (default) then all available
+            threads will be used.
         slr_metric : BundleMinDistanceMetric
         slr_x0 : array or int or str, optional
             Transformation allowed. translation, rigid, similarity or scaling
@@ -720,7 +723,7 @@ class RecoBundles(object):
                                   metric=None, x0=None, bounds=None,
                                   select_model=400, select_target=600,
                                   method='L-BFGS-B',
-                                  nb_pts=20, num_threads=None):
+                                  nb_pts=20, num_threads=0):
         if self.verbose:
             logger.info('# Local SLR of neighb_streamlines to model')
             t = time()

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -347,8 +347,11 @@ class RecoBundles(object):
             Use Streamline-based Linear Registration (SLR) locally
             (default True)
         slr_num_threads : int, optional
-            Number of threads. If -1 (default) then all available threads will
-            be used.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter -1
+            to use as many threads as possible). 0 raises an error.
         slr_metric : BundleMinDistanceMetric
         slr_x0 : array or int or str, optional
             Transformation allowed. translation, rigid, similarity or scaling

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -322,7 +322,7 @@ class RecoBundles(object):
                   reduction_thr=10,
                   reduction_distance='mdf',
                   slr=True,
-                  slr_num_threads=0,
+                  slr_num_threads=None,
                   slr_metric=None,
                   slr_x0=None,
                   slr_bounds=None,
@@ -347,8 +347,8 @@ class RecoBundles(object):
             Use Streamline-based Linear Registration (SLR) locally
             (default True)
         slr_num_threads : int, optional
-            Number of threads to use. If <=0 (default) then all available
-            threads will be used.
+            Number of threads. If -1 (default) then all available threads will
+            be used.
         slr_metric : BundleMinDistanceMetric
         slr_x0 : array or int or str, optional
             Transformation allowed. translation, rigid, similarity or scaling
@@ -723,7 +723,7 @@ class RecoBundles(object):
                                   metric=None, x0=None, bounds=None,
                                   select_model=400, select_target=600,
                                   method='L-BFGS-B',
-                                  nb_pts=20, num_threads=0):
+                                  nb_pts=20, num_threads=None):
         if self.verbose:
             logger.info('# Local SLR of neighb_streamlines to model')
             t = time()

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -105,7 +105,7 @@ def test_rb_slr_threads():
                                                     model_clust_thr=5.,
                                                     reduction_thr=10,
                                                     slr=True,
-                                                    slr_num_threads=0)
+                                                    slr_num_threads=None)
 
     rb_single = RecoBundles(f, greater_than=0, clust_thr=10,
                             rng=np.random.RandomState(42))

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -105,7 +105,7 @@ def test_rb_slr_threads():
                                                     model_clust_thr=5.,
                                                     reduction_thr=10,
                                                     slr=True,
-                                                    slr_num_threads=None)
+                                                    slr_num_threads=0)
 
     rb_single = RecoBundles(f, greater_than=0, clust_thr=10,
                             rng=np.random.RandomState(42))

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -26,7 +26,7 @@ cdef class FBCMeasures:
                  kernel,
                  min_fiberlength=10,
                  max_windowsize=7,
-                 num_threads=0,
+                 num_threads=None,
                  verbose=False):
         """ Compute the fiber to bundle coherence measures for a set of
         streamlines.
@@ -44,7 +44,7 @@ cdef class FBCMeasures:
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
         num_threads : int, optional
-            Number of threads to use for OpenMP. If <=0 (default) then all
+            Number of threads to use for OpenMP. If -1 (default) then all 
             available threads will be used.
         verbose : boolean
             Enable verbose mode.
@@ -144,7 +144,7 @@ cdef class FBCMeasures:
                       kernel,
                       min_fiberlength,
                       max_windowsize,
-                      num_threads=0,
+                      num_threads=None,
                       verbose=False):
         """ Compute the fiber to bundle coherence measures for a set of
         streamlines.
@@ -162,7 +162,7 @@ cdef class FBCMeasures:
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
         num_threads : int, optional
-            Number of threads to use for OpenMP. If <=0 (default) then all
+            Number of threads to use for OpenMP. If -1 (default) then all 
             available threads will be used.
         verbose : boolean
             Enable verbose mode.
@@ -187,10 +187,10 @@ cdef class FBCMeasures:
             int threads_to_use = -1
             int all_cores = openmp.omp_get_num_procs()
 
-        if num_threads > 0:
-            threads_to_use = num_threads
-        else:
+        if num_threads in (None, -1):
             threads_to_use = all_cores
+        elif num_threads >0:
+            threads_to_use = num_threads
 
         if have_openmp:
             openmp.omp_set_dynamic(0)
@@ -306,7 +306,7 @@ cdef class FBCMeasures:
                     streamline_scores[line_id, point_id] = score_mp[line_id]
 
         # Reset number of OpenMP cores to default
-        if have_openmp and num_threads > 0:
+        if have_openmp and num_threads not in (None, -1):
             openmp.omp_set_num_threads(all_cores)
 
         # Save LFBC as class member

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -14,6 +14,9 @@ from dipy.data import get_sphere
 from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.core.ndindex import ndindex
 
+from dipy.utils.omp import cpu_count, determine_num_threads
+from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
+
 cdef class FBCMeasures:
 
     cdef int [:] streamline_length
@@ -44,8 +47,11 @@ cdef class FBCMeasures:
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
         num_threads : int, optional
-            Number of threads to use for OpenMP. If -1 (default) then all 
-            available threads will be used.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter -1
+            to use as many threads as possible). 0 raises an error.
         verbose : boolean
             Enable verbose mode.
 
@@ -162,8 +168,11 @@ cdef class FBCMeasures:
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
         num_threads : int, optional
-            Number of threads to use for OpenMP. If -1 (default) then all 
-            available threads will be used.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter -1
+            to use as many threads as possible). 0 raises an error.
         verbose : boolean
             Enable verbose mode.
         """
@@ -185,16 +194,9 @@ cdef class FBCMeasures:
             int xd, yd, zd, N, hn
             double [:, :, :, :, ::1] lut
             int threads_to_use = -1
-            int all_cores = openmp.omp_get_num_procs()
 
-        if num_threads in (None, -1):
-            threads_to_use = all_cores
-        elif num_threads >0:
-            threads_to_use = num_threads
-
-        if have_openmp:
-            openmp.omp_set_dynamic(0)
-            openmp.omp_set_num_threads(threads_to_use)
+        threads_to_use = determine_num_threads(num_threads)
+        set_num_threads(threads_to_use)
 
         # if the fibers are too short FBC measures cannot be applied,
         # remove these.
@@ -306,8 +308,8 @@ cdef class FBCMeasures:
                     streamline_scores[line_id, point_id] = score_mp[line_id]
 
         # Reset number of OpenMP cores to default
-        if have_openmp and num_threads not in (None, -1):
-            openmp.omp_set_num_threads(all_cores)
+        if num_threads is not None:
+            restore_default_num_threads()
 
         # Save LFBC as class member
         self.streamlines_lfbc = streamline_scores

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -26,7 +26,7 @@ cdef class FBCMeasures:
                  kernel,
                  min_fiberlength=10,
                  max_windowsize=7,
-                 num_threads=None,
+                 num_threads=0,
                  verbose=False):
         """ Compute the fiber to bundle coherence measures for a set of
         streamlines.
@@ -43,8 +43,9 @@ cdef class FBCMeasures:
             computation.
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
-        num_threads : int
-            Number of threads to use for OpenMP.
+        num_threads : int, optional
+            Number of threads to use for OpenMP. If <=0 (default) then all
+            available threads will be used.
         verbose : boolean
             Enable verbose mode.
 
@@ -143,7 +144,7 @@ cdef class FBCMeasures:
                       kernel,
                       min_fiberlength,
                       max_windowsize,
-                      num_threads=None,
+                      num_threads=0,
                       verbose=False):
         """ Compute the fiber to bundle coherence measures for a set of
         streamlines.
@@ -160,8 +161,9 @@ cdef class FBCMeasures:
             computation.
         max_windowsize : int
             The maximal window size used to calculate the average LFBC region
-        num_threads : int
-            Number of threads to use for OpenMP.
+        num_threads : int, optional
+            Number of threads to use for OpenMP. If <=0 (default) then all
+            available threads will be used.
         verbose : boolean
             Enable verbose mode.
         """
@@ -185,7 +187,7 @@ cdef class FBCMeasures:
             int threads_to_use = -1
             int all_cores = openmp.omp_get_num_procs()
 
-        if num_threads is not None:
+        if num_threads > 0:
             threads_to_use = num_threads
         else:
             threads_to_use = all_cores
@@ -304,7 +306,7 @@ cdef class FBCMeasures:
                     streamline_scores[line_id, point_id] = score_mp[line_id]
 
         # Reset number of OpenMP cores to default
-        if have_openmp and num_threads is not None:
+        if have_openmp and num_threads > 0:
             openmp.omp_set_num_threads(all_cores)
 
         # Save LFBC as class member

--- a/dipy/utils/multiproc.py
+++ b/dipy/utils/multiproc.py
@@ -1,6 +1,7 @@
 """Function for determining the effective number of processes to be used."""
 
 from multiprocessing import cpu_count
+from warnings import warn
 
 
 def determine_num_processes(num_processes):
@@ -28,10 +29,14 @@ def determine_num_processes(num_processes):
     if num_processes == 0:
         raise ValueError("num_processes cannot be 0")
 
-    if num_processes is None:
-        return cpu_count()
+    try:
+        if num_processes is None:
+            return cpu_count()
 
-    if num_processes < 0:
-        return max(1, cpu_count() + num_processes + 1)
+        if num_processes < 0:
+            return max(1, cpu_count() + num_processes + 1)
+    except NotImplementedError:
+        warn("Cannot determine number of cores. Using only 1.")
+        return 1
 
     return num_processes

--- a/dipy/utils/multiproc.py
+++ b/dipy/utils/multiproc.py
@@ -1,0 +1,37 @@
+"""Function for determining the effective number of processes to be used."""
+
+from multiprocessing import cpu_count
+
+
+def determine_num_processes(num_processes):
+    """Determine the effective number of processes for parallelization.
+
+    - For `num_processes = None`` return the maximum number of cores retrieved
+    by cpu_count().
+
+    - For ``num_processes > 0``, return this value.
+
+    - For ``num_processes < 0``, return the maximal number of cores minus
+    ``|num_processes + 1|``. In particular ``num_processes = -1`` will use as
+    many cores as possible.
+
+    - For ``num_processes = 0`` a ValueError is raised.
+
+    Parameters
+    ----------
+    num_processes : int or None
+        Desired number of processes to be used.
+    """
+    if not isinstance(num_processes, int) and num_processes is not None:
+        raise TypeError("num_processes must be an int or None")
+
+    if num_processes == 0:
+        raise ValueError("num_processes cannot be 0")
+
+    if num_processes is None:
+        return cpu_count()
+
+    if num_processes < 0:
+        return max(1, cpu_count() + num_processes + 1)
+    else:
+        return num_processes

--- a/dipy/utils/multiproc.py
+++ b/dipy/utils/multiproc.py
@@ -33,5 +33,5 @@ def determine_num_processes(num_processes):
 
     if num_processes < 0:
         return max(1, cpu_count() + num_processes + 1)
-    else:
-        return num_processes
+
+    return num_processes

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -65,7 +65,7 @@ def determine_num_threads(num_threads):
         Desired number of threads to be used.
     """
     if not isinstance(num_threads, int) and num_threads is not None:
-        raise TypeError("num_processes must be an int or None")
+        raise TypeError("num_threads must be an int or None")
 
     if num_threads == 0:
         raise ValueError("num_threads cannot be 0")

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -71,7 +71,7 @@ def determine_num_threads(num_threads):
         return default_threads
 
     if num_threads < 0:
-        return max(1, cpu_count() - num_threads + 1)
+        return max(1, cpu_count() + num_threads + 1)
     else:
         return num_threads
 

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -64,6 +64,9 @@ def determine_num_threads(num_threads):
     num_threads : int or None
         Desired number of threads to be used.
     """
+    if not isinstance(num_threads, int) and num_threads is not None:
+        raise TypeError("num_processes must be an int or None")
+
     if num_threads == 0:
         raise ValueError("num_threads cannot be 0")
 

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -75,8 +75,8 @@ def determine_num_threads(num_threads):
 
     if num_threads < 0:
         return max(1, cpu_count() + num_threads + 1)
-    else:
-        return num_threads
+
+    return num_threads
 
 
 cdef void set_num_threads(num_threads):

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -54,7 +54,7 @@ cdef void set_num_threads(num_threads):
     """
     cdef:
         int threads_to_use
-    if num_threads is not None:
+    if num_threads > 0:
         threads_to_use = num_threads
     else:
         threads_to_use = <int> default_threads

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -54,10 +54,11 @@ cdef void set_num_threads(num_threads):
     """
     cdef:
         int threads_to_use
-    if num_threads > 0:
+
+    if num_threads == -1:
+        threads_to_use = <int> default_threads      
+    elif num_threads > 0:
         threads_to_use = num_threads
-    else:
-        threads_to_use = <int> default_threads
 
     if openmp.have_openmp:
         openmp.omp_set_dynamic(0)

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -20,13 +20,13 @@ def test_determine_num_processs():
     # A positive integer should not change
     assert_equal(determine_num_processes(4), 4)
 
-    # None and -1 shoul be equal (all cores)
+    # None and -1 should be equal (all cores)
     assert_equal(determine_num_processes(None), determine_num_processes(-1))
 
     # A big negative number should be 1
     assert_equal(determine_num_processes(-10000), 1)
 
-    # -2 should be one less than -1 (if there are more than 1 core)
+    # -2 should be one less than -1 (if there are more than 1 cores)
     if determine_num_processes(-1) > 1:
         assert_equal(determine_num_processes(-1),
                      determine_num_processes(-2) + 1)

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -1,0 +1,37 @@
+""" Testing multiproc utilities
+"""
+
+from dipy.utils.multiproc import determine_num_processes
+from numpy.testing import assert_equal, assert_raises, run_module_suite
+
+
+def test_determine_num_processs():
+    # Test that the correct number of effective num_processes is returned
+
+    # 0 should raise an error
+    assert_raises(ValueError, determine_num_processes, 0)
+
+    # A string should raise an error
+    assert_raises(TypeError, determine_num_processes, "0")
+
+    # 1 should be 1
+    assert_equal(determine_num_processes(1), 1)
+
+    # A positive integer should not change
+    assert_equal(determine_num_processes(4), 4)
+
+    # None and -1 shoul be equal (all cores)
+    assert_equal(determine_num_processes(None), determine_num_processes(-1))
+
+    # A big negative number should be 1
+    assert_equal(determine_num_processes(-10000), 1)
+
+    # -2 should be one less than -1 (if there are more than 1 core)
+    if determine_num_processes(-1) > 1:
+        assert_equal(determine_num_processes(-1),
+                     determine_num_processes(-2) + 1)
+
+
+if __name__ == '__main__':
+
+    run_module_suite()

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -40,10 +40,26 @@ def test_default_threads():
     assert_equal(default_threads, expected_threads)
 
 
-def test_wrong_num_threads():
+def test_determine_num_threads():
+    # 0 should raise an error
     assert_raises(ValueError, determine_num_threads, 0)
 
+    # A string should raise an error
     assert_raises(TypeError, determine_num_threads, "1")
+
+    # 1 should be 1
+    assert_equal(determine_num_threads(1), 1)
+
+    # A positive integer should not change
+    assert_equal(determine_num_threads(4), 4)
+
+    # A big negative number should be 1
+    assert_equal(determine_num_threads(-10000), 1)
+
+    # -2 should be one less than -1 (if there are more than 1 cores)
+    if determine_num_threads(-1) > 1:
+        assert_equal(determine_num_threads(-1),
+                     determine_num_threads(-2) + 1)
 
 
 if __name__ == '__main__':

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -43,6 +43,8 @@ def test_default_threads():
 def test_wrong_num_threads():
     assert_raises(ValueError, determine_num_threads, 0)
 
+    assert_raises(TypeError, determine_num_threads, "1")
+
 
 if __name__ == '__main__':
 

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -4,8 +4,8 @@
 import os
 from dipy.utils.omp import (cpu_count, thread_count, default_threads,
                             _set_omp_threads, _restore_omp_threads,
-                            have_openmp)
-from numpy.testing import assert_equal, run_module_suite
+                            have_openmp, determine_num_threads)
+from numpy.testing import assert_equal, assert_raises, run_module_suite
 
 
 def test_set_omp_threads():
@@ -38,6 +38,10 @@ def test_default_threads():
     else:
         expected_threads = 1
     assert_equal(default_threads, expected_threads)
+
+
+def test_wrong_num_threads():
+    assert_raises(ValueError, determine_num_threads, 0)
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -50,7 +50,7 @@ class ResliceFlow(Workflow):
         return 'reslice'
 
     def run(self, input_files, new_vox_size, order=1, mode='constant', cval=0,
-            num_processes=1, out_dir='', out_resliced='resliced.nii.gz'):
+            num_threads=1, out_dir='', out_resliced='resliced.nii.gz'):
         """Reslice data with new voxel resolution defined by ``new_vox_sz``
 
         Parameters
@@ -70,11 +70,9 @@ class ResliceFlow(Workflow):
         cval : float, optional
             Value used for points outside the boundaries of the input if
             mode='constant'.
-        num_processes : int, optional
-            Split the calculation to a pool of children processes. This only
-            applies to 4D `data` arrays. If a positive integer then it defines
-            the size of the multiprocessing pool that will be used. If 0, then
-            the size of the pool will equal the number of cores available.
+        num_threads : int, optional
+            Number of threads. Default is 1. If <=0 then all available threads
+            will be used. This only applies to 4D `data` arrays.
         out_dir : string, optional
             Output directory. (default current directory)
         out_resliced : string, optional
@@ -88,7 +86,7 @@ class ResliceFlow(Workflow):
             logging.info('Processing {0}'.format(inputfile))
             new_data, new_affine = reslice(data, affine, vox_sz, new_vox_size,
                                            order, mode=mode, cval=cval,
-                                           num_processes=num_processes)
+                                           num_threads=num_threads)
             save_nifti(outpfile, new_data, new_affine)
             logging.info('Resliced file save in {0}'.format(outpfile))
 
@@ -103,7 +101,6 @@ class SlrWithQbxFlow(Workflow):
             x0='affine',
             rm_small_clusters=50,
             qbx_thr=[40, 30, 20, 15],
-            num_threads=None,
             greater_than=50,
             less_than=250,
             nb_pts=20,
@@ -129,9 +126,6 @@ class SlrWithQbxFlow(Workflow):
             Remove clusters that have less than `rm_small_clusters`.
         qbx_thr : variable int, optional
             Thresholds for QuickBundlesX.
-        num_threads : int, optional
-            Number of threads. If 'None' then all available threads
-            will be used. Only metrics using OpenMP will use this variable.
         greater_than : int, optional
             Keep streamlines that have length greater than
             this value.

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -72,10 +72,9 @@ class ResliceFlow(Workflow):
             mode='constant'.
         num_processes : int, optional
             Split the calculation to a pool of children processes. This only
-            applies to 4D `data` arrays. If a positive integer then it defines
-            the size of the multiprocessing pool that will be used. If -1, then
-            the size of the pool will equal the number of cores available.
-            Default is 1.
+            applies to 4D `data` arrays. Default is 1. If < 0 the maximal
+            number of cores minus |num_processes + 1| is used (enter -1 to use
+            as many cores as possible). 0 raises an error.
         out_dir : string, optional
             Output directory. (default current directory)
         out_resliced : string, optional
@@ -131,7 +130,11 @@ class SlrWithQbxFlow(Workflow):
         qbx_thr : variable int, optional
             Thresholds for QuickBundlesX.
         num_threads : int, optional
-            Number of threads. If -1 then all available threads will be used.
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is
+            used if it is set, otherwise all available threads are used. If
+            < 0 the maximal number of threads minus |num_threads + 1| is used
+            (enter -1 to use as many threads as possible). 0 raises an error.
             Only metrics using OpenMP will use this variable.
         greater_than : int, optional
             Keep streamlines that have length greater than

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -50,7 +50,7 @@ class ResliceFlow(Workflow):
         return 'reslice'
 
     def run(self, input_files, new_vox_size, order=1, mode='constant', cval=0,
-            num_processes=None, out_dir='', out_resliced='resliced.nii.gz'):
+            num_processes=1, out_dir='', out_resliced='resliced.nii.gz'):
         """Reslice data with new voxel resolution defined by ``new_vox_sz``
 
         Parameters

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -50,7 +50,7 @@ class ResliceFlow(Workflow):
         return 'reslice'
 
     def run(self, input_files, new_vox_size, order=1, mode='constant', cval=0,
-            num_threads=1, out_dir='', out_resliced='resliced.nii.gz'):
+            num_processes=None, out_dir='', out_resliced='resliced.nii.gz'):
         """Reslice data with new voxel resolution defined by ``new_vox_sz``
 
         Parameters
@@ -70,9 +70,12 @@ class ResliceFlow(Workflow):
         cval : float, optional
             Value used for points outside the boundaries of the input if
             mode='constant'.
-        num_threads : int, optional
-            Number of threads. Default is 1. If <=0 then all available threads
-            will be used. This only applies to 4D `data` arrays.
+        num_processes : int, optional
+            Split the calculation to a pool of children processes. This only
+            applies to 4D `data` arrays. If a positive integer then it defines
+            the size of the multiprocessing pool that will be used. If -1, then
+            the size of the pool will equal the number of cores available.
+            Default is 1.
         out_dir : string, optional
             Output directory. (default current directory)
         out_resliced : string, optional
@@ -86,7 +89,7 @@ class ResliceFlow(Workflow):
             logging.info('Processing {0}'.format(inputfile))
             new_data, new_affine = reslice(data, affine, vox_sz, new_vox_size,
                                            order, mode=mode, cval=cval,
-                                           num_threads=num_threads)
+                                           num_processes=num_processes)
             save_nifti(outpfile, new_data, new_affine)
             logging.info('Resliced file save in {0}'.format(outpfile))
 
@@ -101,6 +104,7 @@ class SlrWithQbxFlow(Workflow):
             x0='affine',
             rm_small_clusters=50,
             qbx_thr=[40, 30, 20, 15],
+            num_threads=None,
             greater_than=50,
             less_than=250,
             nb_pts=20,
@@ -126,6 +130,9 @@ class SlrWithQbxFlow(Workflow):
             Remove clusters that have less than `rm_small_clusters`.
         qbx_thr : variable int, optional
             Thresholds for QuickBundlesX.
+        num_threads : int, optional
+            Number of threads. If -1 then all available threads will be used.
+            Only metrics using OpenMP will use this variable.
         greater_than : int, optional
             Keep streamlines that have length greater than
             this value.
@@ -167,6 +174,7 @@ class SlrWithQbxFlow(Workflow):
         bundles using local and global streamline-based registration
         and clustering, NeuroImage, 2017.
         """
+
         io_it = self.get_io_iterator()
 
         logging.info("QuickBundlesX clustering is in use")

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -323,9 +323,10 @@ class GibbsRingingFlow(Workflow):
         n_points : int, optional
             Number of neighbour points to access local TV (see note).
         num_threads : int or None, optional
-            Number of threads. Only applies to 3D or 4D `data` arrays. If None
-            then all available threads will be used. Otherwise, must be a
-            positive integer.
+            Split the calculation to a pool of children processes. Only
+            applies to 3D or 4D `data` arrays. Default is 1. If < 0 the maximal
+            number of cores minus |num_threads + 1| is used (enter -1 to use
+            as many cores as possible). 0 raises an error.
         out_dir : string, optional
             Output directory. (default current directory)
         out_unrig : string, optional

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -456,9 +456,11 @@ class ReconstCSDFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure.
-        nbr_processes : int, optional
+        nbr_processes: int, optional
             If `parallel` is True, the number of subprocesses to use
-            (default multiprocessing.cpu_count()).
+            (default multiprocessing.cpu_count()). If < 0 the maximal number
+            of cores minus |nbr_processes + 1| is used (enter -1 to use as
+            many cores as possible). 0 raises an error.
         out_dir : string, optional
             Output directory. (default current directory)
         out_pam : string, optional
@@ -618,9 +620,11 @@ class ReconstCSAFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure.
-        nbr_processes : int, optional
+        nbr_processes: int, optional
             If `parallel` is True, the number of subprocesses to use
-            (default multiprocessing.cpu_count()).
+            (default multiprocessing.cpu_count()). If < 0 the maximal number
+            of cores minus |nbr_processes + 1| is used (enter -1 to use as
+            many cores as possible). 0 raises an error.
         out_dir : string, optional
             Output directory. (default current directory)
         out_pam : string, optional

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -456,7 +456,7 @@ class ReconstCSDFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure.
-        nbr_processes: int, optional
+        nbr_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
             (default multiprocessing.cpu_count()). If < 0 the maximal number
             of cores minus |nbr_processes + 1| is used (enter -1 to use as
@@ -620,7 +620,7 @@ class ReconstCSAFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure.
-        nbr_processes: int, optional
+        nbr_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
             (default multiprocessing.cpu_count()). If < 0 the maximal number
             of cores minus |nbr_processes + 1| is used (enter -1 to use as

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,17 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.4.1 changes
+------------------
+
+- Change in the parallelization logic when using OpenMP:
+    - If ``ǹum_threads = None`` the value of ``OMP_NUM_THREADS`` environmental variable is used. If it is not set then all available cores are used.
+    - If ``num_threads > 0`` that number is used as the number of cores.
+    - If ``num_threads < 0`` the maximum between ``1`` and ``num_cpu_cores - |num_threads+1|`` is selected. If ``-1`` then all available cores are used.
+    - If ``num_threads = 0`` an error is raised.
+- Change in the parallelization logic when using multiprocessing package:
+    - The same as with OpenMP with the difference that ``num_threads = None`` uses all cores directly.
+
 DIPY 1.4.0 changes
 ------------------
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -9,9 +9,9 @@ DIPY 1.4.1 changes
 ------------------
 
 - Change in the parallelization logic when using OpenMP:
-    - If ``ǹum_threads = None`` the value of ``OMP_NUM_THREADS`` environmental variable is used. If it is not set then all available cores are used.
-    - If ``num_threads > 0`` that number is used as the number of cores.
-    - If ``num_threads < 0`` the maximum between ``1`` and ``num_cpu_cores - |num_threads+1|`` is selected. If ``-1`` then all available cores are used.
+    - If ``ǹum_threads = None`` the value of ``OMP_NUM_THREADS`` environment variable is used. If it is not set then all available threads are used.
+    - If ``num_threads > 0`` that number is used as the number of threads.
+    - If ``num_threads < 0`` the maximum between ``1`` and ``num_cpu_cores - |num_threads + 1|`` is selected. If ``-1`` then all available threads are used.
     - If ``num_threads = 0`` an error is raised.
 - Change in the parallelization logic when using multiprocessing package:
     - The same as with OpenMP with the difference that ``num_threads = None`` uses all cores directly.

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -168,7 +168,7 @@ Gibbs oscillation suppression of all multi-shell data and all slices
 can be performed in the following way:
 """
 
-data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=None)
+data_corrected = gibbs_removal(data_slices, slice_axis=2, num_threads=-1)
 
 """
 Due to the high dimensionality of diffusion-weighted data, we recommend

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -32,11 +32,13 @@ ringing-free volume::
 
 To run the Gibbs unringing method, we need to specify the path to the input
 data. This path may contain wildcards to process multiple inputs at once.
-
-You can also specify optional arguments such as:
-
-- ``num_threads``: the number of threads to be used in parallel to accelerate processing. Set it to ``-1``  to use all available threads.
-- ``out_dir``: directory to save the output.
+You can also specify the optional arguments. In this case, we will be
+specifying the number of threads (``num_threads``) and output directory
+(``out_dir``). The number of threads allows to exploit the available
+computational power and accelerate the processing. The maximum number of
+threads available depends on the CPU of the computer, so users are expected
+to set an appropriate value based on their platform. Set ``num_threads`` to
+``-1`` to use all available cores.
 
 To run the Gibbs unringing on the data it suffices to execute the
 ``dipy_gibbs_ringing`` command, e.g.::

--- a/doc/interfaces/gibbs_unringing_flow.rst
+++ b/doc/interfaces/gibbs_unringing_flow.rst
@@ -32,12 +32,11 @@ ringing-free volume::
 
 To run the Gibbs unringing method, we need to specify the path to the input
 data. This path may contain wildcards to process multiple inputs at once.
-You can also specify the optional arguments. In this case, we will be
-specifying the number of threads (``num_threads``) and output directory
-(``out_dir``). The number of threads allows to exploit the available
-computational power and accelerate the processing. The maximum number of
-threads available depends on the CPU of the computer, so users are expected
-to set an appropriate value based on their platform.
+
+You can also specify optional arguments such as:
+
+- ``num_threads``: the number of threads to be used in parallel to accelerate processing. Set it to ``-1``  to use all available threads.
+- ``out_dir``: directory to save the output.
 
 To run the Gibbs unringing on the data it suffices to execute the
 ``dipy_gibbs_ringing`` command, e.g.::


### PR DESCRIPTION
Related to #2300 and a continuation of #2341.

### Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Configure  ``num_threads<=0`` as the option to use all cores across the codebase
  - Modify the name of the argument ``num_proceses --> num_threads`` in **reslice.py** and **test_reslice.py**
  - Delete the ``num_threads`` argument where it is not used

### Important point
Unlike in #2341, most of the functions edited here used all cores by default (using ``None``) so, to keep this behavior, I set the new default to ``0``.  This implies that:
1. The number of used cores by default differs between functions. Does it make sense to use all cores by default in some functions and only ``1`` in others?
2. This PR modifies the default value of ``num_threads`` in several functions, which was one of the main concerns discussed in #2300. What do you think @jhlegarreta,@skoudoro?  