### PR TITLE
Transform points with DiffeormorphicMap

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -6,6 +6,7 @@ import abc
 import numpy as np
 import numpy.linalg as npl
 import nibabel as nib
+from nibabel.streamlines import ArraySequence as Streamlines
 
 from dipy.align import vector_fields as vfu
 from dipy.align import floating
@@ -650,6 +651,9 @@ class DiffeomorphicMap(object):
 
     def transform_points(self, points, coord2world=None,
                          world2coord=None):
+        if isinstance(points, Streamlines):
+            points = points.get_data()
+
         if self.is_inverse:
             out = self._warp_coordinates_backward(points, coord2world,
                                                   world2coord)
@@ -660,6 +664,9 @@ class DiffeomorphicMap(object):
 
     def transform_points_inverse(self, points, coord2world=None,
                                  world2coord=None):
+        if isinstance(points, Streamlines):
+            points = points.get_data()
+
         if self.is_inverse:
             out = self._warp_coordinates_forward(points, coord2world,
                                                  world2coord)

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -1035,7 +1035,7 @@ def test_coordinate_mapping():
             random_df = vfu.create_random_displacement_3d
             interpolate_f = interpolate_scalar_3d
 
-        #create the random displacement field
+        # create the random displacement field
         domain_grid2world = gt_affine
         codomain_grid2world = gt_affine
         disp, assign = random_df(np.array(domain_shape, dtype=np.int32),

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -13,6 +13,7 @@ from dipy.align import metrics as metrics
 from dipy.align import vector_fields as vfu
 from dipy.align import VerbosityLevels
 from dipy.align.imwarp import DiffeomorphicMap
+from dipy.tracking.streamline import deform_streamlines
 
 
 def test_mult_aff():
@@ -1066,3 +1067,10 @@ def test_coordinate_mapping():
         # Interpolate at warped points and verify it's equal to direct warping
         actual, inside = interpolate_f(moving_image, wpoints)
         assert_array_almost_equal(actual, expected, decimal=5)
+
+        if dim in [3, 4]:
+            wpoints_2 = deform_streamlines([points, ], disp, np.eye(4),
+                                           domain_grid2world, np.eye(4),
+                                           codomain_grid2world)
+
+            assert_array_almost_equal(wpoints, wpoints_2[0])

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -4,6 +4,8 @@ from numpy.testing import (assert_equal,
                            assert_array_equal,
                            assert_array_almost_equal,
                            assert_raises)
+from dipy.core.interpolation import (interpolate_scalar_2d,
+                                     interpolate_scalar_3d)
 from dipy.data import get_fnames
 from dipy.align import floating
 from dipy.align import imwarp as imwarp
@@ -1004,7 +1006,7 @@ def test_coordinate_mapping():
             points[:, 0] = np.random.randint(1, nr-1, npoints)
             points[:, 1] = np.random.randint(1, nc-1, npoints)
             random_df = vfu.create_random_displacement_2d
-            interpolate_f = vfu.interpolate_scalar_2d
+            interpolate_f = interpolate_scalar_2d
         else:
             domain_shape = (10, 10, 10)
             codomain_shape = (15, 15, 15)
@@ -1031,7 +1033,7 @@ def test_coordinate_mapping():
             points[:, 1] = np.random.randint(1, nc-1, npoints)
             points[:, 2] = np.random.randint(1, ns-1, npoints)
             random_df = vfu.create_random_displacement_3d
-            interpolate_f = vfu.interpolate_scalar_3d
+            interpolate_f = interpolate_scalar_3d
 
         #create the random displacement field
         domain_grid2world = gt_affine

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -1195,11 +1195,11 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
         cnp.npy_intp n = points.shape[0]
         cnp.npy_intp i
         double x, y, z, wx, wy, wz, gx, gy, gz
-        double[:,:] out = np.zeros(shape=(n, 3), dtype=np.float64)
-        double[:,:] _points = np.array(points, dtype=np.float64)
-        double[:,:] in2grid
+        double[:, :] out = np.zeros(shape=(n, 3), dtype=np.float64)
+        double[:, :] _points = np.array(points, dtype=np.float64)
+        double[:, :] in2grid
         int inside
-        floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+        floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
         in2grid = field_world2grid
@@ -1235,7 +1235,7 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
                 gz = z
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, tmp)
+            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, &tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -1271,11 +1271,11 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
         cnp.npy_intp n = points.shape[0]
         cnp.npy_intp i
         double x, y, wx, wy, gx, gy
-        double[:,:] out = np.zeros(shape=(n, 2), dtype=np.float64)
-        double[:,:] _points = np.array(points, dtype=np.float64)
-        double[:,:] in2grid
+        double[:, :] out = np.zeros(shape=(n, 2), dtype=np.float64)
+        double[:, :] _points = np.array(points, dtype=np.float64)
+        double[:, :] in2grid
         int inside
-        floating[:] tmp = np.zeros(shape=(2,), dtype = np.asarray(d1).dtype)
+        floating[:] tmp = np.zeros(shape=(2,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
         in2grid = field_world2grid
@@ -1305,7 +1305,7 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
                 gy = y
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_2d[floating](d1, gx, gy, tmp)
+            inside = _interpolate_vector_2d[floating](d1, gx, gy, &tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -1401,7 +1401,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
 
     cdef floating[:, :, :] warped = np.zeros(shape=(nslices, nrows, ncols),
                                              dtype=np.asarray(volume).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+    cdef floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
 
     with nogil:
 
@@ -1451,7 +1451,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
 
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                                                               dii, djj,
-                                                              &warped[k,i,j])
+                                                              &warped[k, i, j])
     return np.asarray(warped)
 
 
@@ -1517,7 +1517,7 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
                         dii = i
                         djj = j
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
-                        dii, djj, &out[k,i,j])
+                        dii, djj, &out[k, i, j])
     return np.asarray(out)
 
 
@@ -1649,8 +1649,8 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
                         dii = di + i
                         djj = dj + j
 
-                    inside = _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
-                                                       &warped[k,i,j])
+                    inside = _interpolate_scalar_nn_3d[number](volume,
+                                        dkk, dii, djj, &warped[k, i, j])
     return np.asarray(warped)
 
 
@@ -1715,7 +1715,7 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
                         dii = i
                         djj = j
                     _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
-                                                      &out[k,i,j])
+                                                      &out[k, i, j])
     return np.asarray(out)
 
 
@@ -2168,11 +2168,11 @@ def create_random_displacement_2d(int[:] from_shape,
     Creates a random 2D displacement field mapping points of an input discrete
     domain (with dimensions given by from_shape) to points of an output
     discrete domain (with shape given by to_shape). The affine matrices
-    bringing discrete coordinates to physical space are given by from_grid2world
-    (for the displacement field discretization) and to_grid2world (for the target
-    discretization). Since this function is intended to be used for testing,
-    voxels in the input domain will never be assigned to boundary voxels on the
-    output domain.
+    bringing discrete coordinates to physical space are given by
+    from_grid2world (for the displacement field discretization) and
+    to_grid2world (for the target discretization). Since this function is
+    intended to be used for testing, voxels in the input domain will never be
+    assigned to boundary voxels on the output domain.
 
     Parameters
     ----------
@@ -2196,7 +2196,7 @@ def create_random_displacement_2d(int[:] from_shape,
         cnp.npy_intp i, j, ri, rj
         double di, dj, dii, djj
         int[:, :, :] int_field = np.empty(tuple(from_shape) + (2,),
-                                            dtype=np.int32)
+                                          dtype=np.int32)
         double[:, :, :] output = np.zeros(tuple(from_shape) + (2,),
                                           dtype=np.float64)
         cnp.npy_intp dom_size = from_shape[0]*from_shape[1]
@@ -2241,18 +2241,20 @@ def create_random_displacement_2d(int[:] from_shape,
     return np.asarray(output), np.asarray(int_field)
 
 
-def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2world,
-                                  int[:] to_shape, double[:, :] to_grid2world):
+def create_random_displacement_3d(int[:] from_shape,
+                                  double[:, :] from_grid2world,
+                                  int[:] to_shape,
+                                  double[:, :] to_grid2world):
     r"""Creates a random 3D displacement 'exactly' mapping points of two grids
 
     Creates a random 3D displacement field mapping points of an input discrete
     domain (with dimensions given by from_shape) to points of an output
     discrete domain (with shape given by to_shape). The affine matrices
-    bringing discrete coordinates to physical space are given by from_grid2world
-    (for the displacement field discretization) and to_grid2world (for the target
-    discretization). Since this function is intended to be used for testing,
-    voxels in the input domain will never be assigned to boundary voxels on the
-    output domain.
+    bringing discrete coordinates to physical space are given by
+    from_grid2world (for the displacement field discretization) and
+    to_grid2world (for the target discretization). Since this function is
+    intended to be used for testing, voxels in the input domain will never be
+    assigned to boundary voxels on the output domain.
 
     Parameters
     ----------
@@ -2276,7 +2278,7 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
         cnp.npy_intp i, j, k, ri, rj, rk
         double di, dj, dk, dii, djj, dkk
         int[:, :, :, :] int_field = np.empty(tuple(from_shape) + (3,),
-                                               dtype=np.int32)
+                                             dtype=np.int32)
         double[:, :, :, :] output = np.zeros(tuple(from_shape) + (3,),
                                              dtype=np.float64)
         cnp.npy_intp dom_size = from_shape[0]*from_shape[1]*from_shape[2]
@@ -2318,8 +2320,8 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
                     dii = ri
                     djj = rj
 
-                # the displacement vector at (i,j) must be the target point minus
-                # the original point, both in physical space
+                # the displacement vector at (i,j) must be the target point
+                # minus the original point, both in physical space
 
                 output[k, i, j, 0] = dkk - dk
                 output[k, i, j, 1] = dii - di
@@ -2605,12 +2607,13 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                                                    img_world2grid)
                         # Interpolate img at q
                         in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
+                                                q[1], q[2], &out[k, i, j, p])
                         if in_flag == 0:
                             out[k, i, j, p] = 0
                             inside[k, i, j] = 0
                             continue
-                        out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
+                        out[k, i, j, p] = ((out[k, i, j, p] - tmp) /
+                                           img_spacing[p])
                         dx[p] = x[p]
 
 
@@ -2674,7 +2677,7 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                                            img_world2grid)
                 # Interpolate img at q
                 in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1],
-                    q[2], &out[i, p])
+                                                           q[2], &out[i, p])
                 if in_flag == 0:
                     out[i, p] = 0
                     inside[i] = 0
@@ -2689,8 +2692,8 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                 q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
                                            img_world2grid)
                 # Interpolate img at q
-                in_flag = _interpolate_scalar_3d[floating](img, q[0], q[1], q[2],
-                                                 &out[i, p])
+                in_flag = _interpolate_scalar_3d[floating](img,
+                                                q[0], q[1], q[2], &out[i, p])
                 if in_flag == 0:
                     out[i, p] = 0
                     inside[i] = 0
@@ -2761,7 +2764,7 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
                     in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
+                                                    q[1], &out[i, j, p])
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0
@@ -2773,7 +2776,7 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
                     in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                        q[1], &out[i, j, p])
+                                                    q[1], &out[i, j, p])
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -123,7 +123,7 @@ def deform_streamlines(streamlines,
                                        np.eye(4))
     stream_in_world = transform_streamlines(stream_in_curr_grid,
                                             current_grid_to_world)
-    new_streams_in_world = [sum(d, s) for d, s in zip(displacements,
+    new_streams_in_world = [np.add(d, s) for d, s in zip(displacements,
                                                       stream_in_world)]
     new_streams_grid = transform_streamlines(new_streams_in_world,
                                              np.linalg.inv(ref_grid_to_world))

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -55,7 +55,7 @@ from dipy.data.fetcher import (fetch_mni_template, read_mni_template)
 from dipy.align.reslice import reslice
 
 fetch_mni_template()
-img_t2_mni = read_mni_template("a", contrast="T2")
+img_t2_mni = read_mni_template(version="a", contrast="T2")
 
 new_zooms = (2., 2., 2.)
 data2, affine2 = reslice(np.asarray(img_t2_mni.dataobj), img_t2_mni.affine,
@@ -63,7 +63,7 @@ data2, affine2 = reslice(np.asarray(img_t2_mni.dataobj), img_t2_mni.affine,
 img_t2_mni = nib.Nifti1Image(data2, affine=affine2)
 
 """
-We filter the diffusion data from the Stanford HARDI dataset to find the b0
+We filter the diffusion data from the Stanford HARDI dataset to find all the b0
 images.
 
 """


### PR DESCRIPTION
This PR is just a follow-up and close #936. Many people ask for this feature and we never merged it. 

it adds 2 functions to apply warp fields on point: `transform_points` and `transform_points_inverse`.  After registering two images, you can use this function to transform your streamlines/points. 

You might be interested @vigji @wjy73 @dPys. Feel free to test this PR and give feedback/review. Thanks in advance!

fixes #2327
fixes #2313

TODO
------ 

- [ ] Create or Improves the current tutorial.
- [x] Need to compare with `deform_streamlines` in `dipy.tracking.streamline` before merging. Performance should be better. Results should be similar.
- [x] After comparison, remove duplicate? or make sure it uses the same codebase?