### PR TITLE
[Fix] Add "None" options in the CLIs

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -266,7 +266,8 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
                 if isnarg:
                     _kwargs['nargs'] = '*'
 
-                _kwargs['type'] = none_or_dtype(_kwargs['type'])
+                if _kwargs['action'] != 'store_true':
+                    _kwargs['type'] = none_or_dtype(_kwargs['type'])
                 flow_args.add_argument(*_args, **_kwargs)
 
         return sub_flow_optionals

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -184,7 +184,8 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
             if 'out_' in arg:
                 output_args.add_argument(*_args, **_kwargs)
             else:
-                _kwargs['type'] = none_or_dtype(_kwargs['type'])
+                if _kwargs['action'] != 'store_true':
+                    _kwargs['type'] = none_or_dtype(_kwargs['type'])
                 self.add_argument(*_args, **_kwargs)
 
         if nb_positional_variable > 1:

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -57,7 +57,7 @@ class MedianOtsuFlow(Workflow):
         """
         io_it = self.get_io_iterator()
         if vol_idx is not None:
-            vol_idx = map(int, vol_idx)
+            vol_idx = [int(idx) for idx in vol_idx]
 
         for fpath, mask_out_path, masked_out_path in io_it:
             logging.info('Applying median_otsu segmentation on {0}'.

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -18,16 +18,16 @@ def test_none_or_dtype():
         npt.assert_equal(dec('none'), 'None')
 
     dec = none_or_dtype(int)
-    npt.assert_raises(ValueError, dec, 'ma valeur')
+    npt.assert_raises(ValueError, dec, 'my value')
     npt.assert_equal(dec(4), 4)
 
     dec = none_or_dtype(str)
     npt.assert_equal(dec(4), '4')
-    npt.assert_equal(dec('ma valeur'), 'ma valeur')
+    npt.assert_equal(dec('my value'), 'my value')
     npt.assert_equal(dec([4]), '[4]')
 
     dec = none_or_dtype(float)
-    npt.assert_raises(ValueError, dec, 'ma valeur')
+    npt.assert_raises(ValueError, dec, 'my value')
     for val in [(4,), [4, ]]:
         npt.assert_raises(TypeError, dec, val)
     npt.assert_equal(dec(True), 1.0)

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -3,11 +3,39 @@ import sys
 from os.path import join as pjoin
 
 from nibabel.tmpdirs import TemporaryDirectory
-from dipy.workflows.base import IntrospectiveArgumentParser
+from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import DummyFlow, \
     DummyCombinedWorkflow, DummyWorkflow1, DummyVariableTypeWorkflow, \
     DummyVariableTypeErrorWorkflow
+
+
+def test_none_or_dtype():
+    # test None
+    for typ in [int, float, str, tuple, list]:
+        dec = none_or_dtype(typ)
+        npt.assert_equal(dec('None'), 'None')
+        npt.assert_equal(dec('none'), 'None')
+
+    dec = none_or_dtype(int)
+    npt.assert_raises(ValueError, dec, 'ma valeur')
+    npt.assert_equal(dec(4), 4)
+
+    dec = none_or_dtype(str)
+    npt.assert_equal(dec(4), '4')
+    npt.assert_equal(dec('ma valeur'), 'ma valeur')
+    npt.assert_equal(dec([4]), '[4]')
+
+    dec = none_or_dtype(float)
+    npt.assert_raises(ValueError, dec, 'ma valeur')
+    for val in [(4,), [4, ]]:
+        npt.assert_raises(TypeError, dec, val)
+    npt.assert_equal(dec(True), 1.0)
+    npt.assert_equal(dec(4), 4.0)
+    npt.assert_equal(dec(4.0), 4.0)
+
+    dec = none_or_dtype(bool)
+    dec = none_or_dtype(tuple)
 
 
 def test_variable_type():
@@ -38,10 +66,10 @@ def test_iap():
                 'positional_float']
 
     opt_keys = ['optional_str', 'optional_bool', 'optional_int',
-                'optional_float']
+                'optional_float', 'optional_int_2', 'optional_float_2']
 
     pos_results = ['test', 0, 10, 10.2]
-    opt_results = ['opt_test', True, 20, 20.2]
+    opt_results = ['opt_test', True, 20, 20.2, None, None]
 
     inputs = inputs_from_results(opt_results, opt_keys, optional=True)
     inputs.extend(inputs_from_results(pos_results))
@@ -121,4 +149,6 @@ if __name__ == '__main__':
     # test_iap()
     # test_flow_runner()
     # test_variable_type()
-    test_iap_epilog_and_description()
+    # test_iap_epilog_and_description()
+    test_iap()
+    test_none_or_dtype()

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -85,7 +85,7 @@ class DummyFlow(Workflow):
     def run(self, positional_str, positional_bool, positional_int,
             positional_float, optional_str='default', optional_bool=False,
             optional_int=0, optional_float=1.0, optional_float_2=2.0,
-            out_dir=''):
+            optional_int_2=5, optional_float_3=2.0, out_dir=''):
         """ Workflow used to test the introspective argument parser.
 
         Parameters
@@ -108,12 +108,17 @@ class DummyFlow(Workflow):
             optional float argument (default 1.0)
         optional_float_2 : float, optional
             optional float argument #2 (default 2.0)
+        optional_int_2 : int, optional
+            optional int argument #2 (default 5)
+        optional_float_3 : float, optional
+            optional float argument #3 (default 2.0)
         out_dir : string
             output directory (default '')
         """
         return (positional_str, positional_bool, positional_int,
                 positional_float, optional_str, optional_bool,
-                optional_int, optional_float, optional_float_2)
+                optional_int, optional_float, optional_int_2, optional_float_2,
+                optional_float_3)
 
 
 class DummyVariableTypeWorkflow(Workflow):


### PR DESCRIPTION
This PR fix #2300. It allows `None` value as a parameter of a Worflow.  An example below to change the default value of `num_threads` from `1` to `None`:

`dipy_gibbs_ringing ~/.dipy/tissue_data/t1_brain_denoised.nii.gz --num_threads None  --out_dir "gibbs_ringing_output"`