### PR TITLE
Expand patch radius if input is int

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -236,7 +236,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
     """
     if isinstance(patch_radius, int):
         patch_radius = np.ones(3, dtype=int) * patch_radius
-        
+
     patch_radius = np.asarray(patch_radius, dtype=int)
 
     if not data.ndim == 4:

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -234,6 +234,9 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
                     Denoising Diffusion MRI with Self-supervised Learning,
                     Advances in Neural Information Processing Systems 33 (2020)
     """
+    if isinstance(patch_radius, int):
+        patch_radius = np.ones(3, dtype=int) * patch_radius
+        
     patch_radius = np.asarray(patch_radius, dtype=int)
 
     if not data.ndim == 4:

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -31,8 +31,8 @@ def test_patch2self_random_noise():
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
 
-    # both clip and shift = True
-    S0den_clip = p2s.patch2self(S0, bvals, model='ols',
+    # both clip and shift = True, and int patch_radius
+    S0den_clip = p2s.patch2self(S0, bvals, patch_radius=0, model='ols',
                                 clip_negative_vals=True,
                                 shift_intensity=True)
 


### PR DESCRIPTION
if patch radius is an int, it needs to be expanded to (1,3) array before calling _extract_3d_patches.