### PR TITLE
[FIX] warning if not the same number of points

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -515,7 +515,8 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
         cnp.ndarray[cnp.double_t, ndim=2] DM
     lentA = len(tracksA)
     lentB = len(tracksB)
-    if lentA != lentB:
+    # for performance issue, we just check the first streamline
+    if len(tracksA[0]) != len(tracksB[0]):
         w_s = "Streamlines do not have the same number of points. "
         w_s += "All streamlines need to have the same number of points. "
         w_s += "Use dipy.tracking.streamline.set_number_of_points to adjust "
@@ -597,7 +598,8 @@ def bundles_distances_mdf(tracksA, tracksB):
         cnp.ndarray[cnp.double_t, ndim=2] DM
     lentA = len(tracksA)
     lentB = len(tracksB)
-    if lentA != lentB:
+    # for performance issue, we just check the first streamline
+    if len(tracksA[0]) != len(tracksB[0]):
         w_s = "Streamlines do not have the same number of points. "
         w_s += "All streamlines need to have the same number of points. "
         w_s += "Use dipy.tracking.streamline.set_number_of_points to adjust "

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -136,7 +136,8 @@ def test_bundles_distances_mdf(verbose=False):
     xyz2A = np.array([[0, 1, 1], [1, 0, 1], [2, 3, -2]], dtype='float32')
     xyz3A = np.array([[0, 0, 0], [1, 0, 0], [3, 0, 0]], dtype='float32')
     xyz1B = np.array([[-1, 0, 0], [2, 0, 0], [2, 3, 0]], dtype='float32')
-    xyz1C = np.array([[-1, 0, 0], [2, 0, 0], [2, 3, 0], [3, 0, 0]], dtype='float32')
+    xyz1C = np.array([[-1, 0, 0], [2, 0, 0], [2, 3, 0], [3, 0, 0]],
+                     dtype='float32')
 
     tracksA = [xyz1A, xyz2A]
     tracksB = [xyz1B, xyz1A, xyz2A]

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -118,13 +118,13 @@ def test_bundles_distances_mam():
     tracksA = [xyz1A, xyz2A]
     tracksB = [xyz1B, xyz1A, xyz2A]
 
-    with assert_warns(UserWarning):
-        for metric in ('avg', 'min', 'max'):
-            pf.bundles_distances_mam(tracksA, tracksB, metric=metric)
+    for metric in ('avg', 'min', 'max'):
+        pf.bundles_distances_mam(tracksA, tracksB, metric=metric)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
-        _ = pf.bundles_distances_mam(tracksA, tracksB)
+        tracksC = [xyz2A, xyz1A]
+        _ = pf.bundles_distances_mam(tracksA, tracksC)
         print(w)
         assert_true(len(w) == 1)
         assert_true(issubclass(w[0].category, UserWarning))
@@ -136,11 +136,12 @@ def test_bundles_distances_mdf(verbose=False):
     xyz2A = np.array([[0, 1, 1], [1, 0, 1], [2, 3, -2]], dtype='float32')
     xyz3A = np.array([[0, 0, 0], [1, 0, 0], [3, 0, 0]], dtype='float32')
     xyz1B = np.array([[-1, 0, 0], [2, 0, 0], [2, 3, 0]], dtype='float32')
+    xyz1C = np.array([[-1, 0, 0], [2, 0, 0], [2, 3, 0], [3, 0, 0]], dtype='float32')
 
     tracksA = [xyz1A, xyz2A]
     tracksB = [xyz1B, xyz1A, xyz2A]
-    with assert_warns(UserWarning):
-        pf.bundles_distances_mdf(tracksA, tracksB)
+
+    pf.bundles_distances_mdf(tracksA, tracksB)
 
     tracksA = [xyz1A, xyz1A]
     tracksB = [xyz1A, xyz1A]
@@ -151,8 +152,7 @@ def test_bundles_distances_mdf(verbose=False):
     tracksA = [xyz1A, xyz3A]
     tracksB = [xyz2A]
 
-    with assert_warns(UserWarning):
-        DM2 = pf.bundles_distances_mdf(tracksA, tracksB)
+    DM2 = pf.bundles_distances_mdf(tracksA, tracksB)
     if verbose:
         print(DM2)
 
@@ -178,7 +178,8 @@ def test_bundles_distances_mdf(verbose=False):
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
-        _ = pf.bundles_distances_mdf(tracksA, tracksB[:2])
+        tracksC = [xyz1C, xyz1A]
+        _ = pf.bundles_distances_mdf(tracksA, tracksC)
         print(w)
         assert_true(len(w) == 1)
         assert_true(issubclass(w[0].category, UserWarning))

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -559,7 +559,7 @@ def test_deform_streamlines():
                                              np.linalg.inv(stream2world))
     # All close because of floating pt imprecision
     for o, s in zip(orig_streamlines, streamlines):
-        assert_allclose(s, o, rtol=1e-6, atol=1e-6)
+        assert_allclose(s, o.astype(np.float32), rtol=1e-6, atol=1e-6)
 
 
 def test_center_and_transform():
@@ -1193,10 +1193,9 @@ def test_cluster_confidence():
     test_streamlines.append(mysl+1)
     test_streamlines.append(mysl+2)
     test_streamlines.finalize_append()
-    with warnings.catch_warnings(record=True) as w:
-        cci = cluster_confidence(test_streamlines, override=True)
-        assert_true("do not have the same number of points" in
-                    str(w[0].message))
+
+    cci = cluster_confidence(test_streamlines, override=True)
+
     assert_equal(cci[0], cci[2])
     assert_true(cci[1] > cci[0])
 
@@ -1229,11 +1228,8 @@ def test_cluster_confidence():
     test_streamlines_p3.append(mysl5)
     test_streamlines_p3.finalize_append()
 
-    with warnings.catch_warnings(record=True) as w:
-        cci_p1 = cluster_confidence(test_streamlines_p1, override=True)
-        cci_p2 = cluster_confidence(test_streamlines_p2, override=True)
-        assert_true("do not have the same number of points" in
-                    str(w[0].message))
+    cci_p1 = cluster_confidence(test_streamlines_p1, override=True)
+    cci_p2 = cluster_confidence(test_streamlines_p2, override=True)
 
     # test relative distance
     assert_array_equal(cci_p1, cci_p2*2)
@@ -1245,11 +1241,8 @@ def test_cluster_confidence():
     assert_array_equal(expected_p2, cci_p2)
 
     # test power variable calculation (dropoff with distance)
-    with warnings.catch_warnings(record=True) as w:
-        cci_p1_pow2 = cluster_confidence(test_streamlines_p1, power=2,
-                                         override=True)
-        assert_true("do not have the same number of points" in
-                    str(w[0].message))
+    cci_p1_pow2 = cluster_confidence(test_streamlines_p1, power=2,
+                                     override=True)
 
     expected_p1_pow2 = np.array([np.power(1./1, 2)+np.power(1./2, 2),
                                  np.power(1./1, 2)+np.power(1./1, 2),
@@ -1257,12 +1250,9 @@ def test_cluster_confidence():
 
     assert_array_equal(cci_p1_pow2, expected_p1_pow2)
 
-    with warnings.catch_warnings(record=True) as w:
-        # test max distance (ignore distant sls)
-        cci_dist = cluster_confidence(test_streamlines_p3,
-                                      max_mdf=5, override=True)
-        assert_true("do not have the same number of points" in
-                    str(w[0].message))
+    # test max distance (ignore distant sls)
+    cci_dist = cluster_confidence(test_streamlines_p3,
+                                  max_mdf=5, override=True)
 
     expected_cci_dist = np.concatenate([cci_p1, np.zeros(1)])
     assert_array_equal(cci_dist, expected_cci_dist)


### PR DESCRIPTION
This PR fixes #2320. This is just adding a warning to the user when bundles_distances_mdf or bundles_distances_mam do not have streamlines with the same number of points (instead of tracks)