### PR TITLE
[Fix] bundles_distances_mdf asymmetric values

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1480,8 +1480,10 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
     dipy.tracking.distances.local_skeleton_clustering
     """
     cdef:
-        long i=0,j=0
-        float sub=0,subf=0,distf=0,dist=0,tmprow=0, tmprowf=0
+        cnp.npy_intp i=0
+        cnp.npy_intp j=0
+        cnp.float32_t sub=0,subf=0, tmprow=0, tmprowf=0
+        double distf=0,dist=0
 
     for i from 0<=i<rows:
         tmprow=0
@@ -1494,8 +1496,8 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
         dist+=sqrt(tmprow)
         distf+=sqrt(tmprowf)
 
-    out[0]=dist/<float>rows
-    out[1]=distf/<float>rows
+    out[0]=<cnp.float32_t>dist/<cnp.float32_t>rows
+    out[1]=<cnp.float32_t>distf/<cnp.float32_t>rows
 
 
 @cython.cdivision(True)

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -142,6 +142,11 @@ def test_bundles_distances_mdf(verbose=False):
     tracksA = [xyz1A, xyz2A]
     tracksB = [xyz1B, xyz1A, xyz2A]
 
+    dist = pf.bundles_distances_mdf(tracksA, tracksA)
+    assert_equal(dist[0, 0], 0)
+    assert_equal(dist[1, 1], 0)
+    assert_equal(dist[1, 0], dist[0, 1])
+
     pf.bundles_distances_mdf(tracksA, tracksB)
 
     tracksA = [xyz1A, xyz1A]

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -1196,7 +1196,7 @@ def test_cluster_confidence():
 
     cci = cluster_confidence(test_streamlines, override=True)
 
-    assert_equal(cci[0], cci[2])
+    assert_almost_equal(cci[0], cci[2])
     assert_true(cci[1] > cci[0])
 
     # 3 parallel streamlines


### PR DESCRIPTION
The goal of this PR is to fix #2310.  `bundles_distances_mdf` had asymmetric values due to some rounding effect. 

Now we have:
```python
>>> import numpy as np
>>> import dipy.tracking.streamline as dts
>>> A = np.load('max_asymmetric_mdf.npy')
>>> dts.bundles_distances_mdf(A,A)
array([[ 0.        , 27.01377869],
       [27.01377869,  0.        ]])
```

Can you try and confirm @bloomdt-uw?  Thank you