### PR TITLE
NF: extend the align workflow with Rigid+IsoScaling and Rigid+Scaling

### DIFF
--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -26,14 +26,10 @@ DEBUG : print as much information as possible to isolate the cause of a bug.
 
 from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
                                 write_mapping, read_mapping, resample,
-                                center_of_mass, translation, rigid,
-                                rigid_isoscaling, rigid_scaling, affine,
                                 affine_registration, register_series,
                                 register_dwi_series, streamline_registration)
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
-           "center_of_mass", "translation", "rigid",
-           "rigid_isoscaling", "rigid_scaling", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]

--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -26,12 +26,14 @@ DEBUG : print as much information as possible to isolate the cause of a bug.
 
 from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
                                 write_mapping, read_mapping, resample,
-                                center_of_mass, translation, rigid, affine,
+                                center_of_mass, translation, rigid,
+                                rigid_isoscaling, rigid_scaling, affine,
                                 affine_registration, register_series,
                                 register_dwi_series, streamline_registration)
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
-           "center_of_mass", "translation", "rigid", "affine",
+           "center_of_mass", "translation", "rigid",
+           "rigid_isoscaling", "rigid_scaling", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]

--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -26,10 +26,12 @@ DEBUG : print as much information as possible to isolate the cause of a bug.
 
 from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
                                 write_mapping, read_mapping, resample,
+                                center_of_mass, translation, rigid, affine,
                                 affine_registration, register_series,
                                 register_dwi_series, streamline_registration)
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
+           "center_of_mass", "translation", "rigid", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -6,6 +6,7 @@ streamlines.
 
 """
 import collections
+from functools import partial
 import numbers
 import numpy as np
 import nibabel as nib
@@ -36,6 +37,7 @@ from dipy.io.image import load_nifti, save_nifti
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
+           "center_of_mass", "translation", "rigid", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]
 
@@ -490,6 +492,23 @@ def affine_registration(moving, static,
     if ret_metric:
         return resampled, starting_affine, xopt, fopt
     return resampled, starting_affine
+
+
+center_of_mass = partial(affine_registration, pipeline=['center_of_mass'])
+center_of_mass.__doc__ = ("Implements a center of mass transform. "
+                          "Based on `affine_registration()`.")
+
+translation = partial(affine_registration, pipeline=['translation'])
+translation.__doc__ = ("Implements a translation transform. "
+                       "Based on `affine_registration()`.")
+
+rigid = partial(affine_registration, pipeline=['rigid'])
+rigid.__doc__ = ("Implements a rigid transform. "
+                 "Based on `affine_registration()`.")
+
+affine = partial(affine_registration, pipeline=['affine'])
+affine.__doc__ = ("Implements an affine transform. "
+                  "Based on `affine_registration()`.")
 
 
 def register_series(series, ref, pipeline=None, series_affine=None,

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -11,10 +11,8 @@ import dipy.data as dpd
 import dipy.core.gradients as dpg
 
 from dipy.align import (syn_registration, register_series, register_dwi_series,
-                        center_of_mass, translation, rigid, rigid_isoscaling,
-                        rigid_scaling, affine, affine_registration,
-                        streamline_registration, write_mapping, read_mapping,
-                        register_dwi_to_template)
+                        affine_registration, streamline_registration,
+                        write_mapping, read_mapping, register_dwi_to_template)
 
 from dipy.align.imwarp import DiffeomorphicMap
 
@@ -117,12 +115,12 @@ def test_affine_registration():
         xformed, affine_mat = affine_registration(moving, static,
                                                   moving_affine=moving_affine,
                                                   static_affine=static_affine,
-                                                  pipeline=[center_of_mass],
+                                                  pipeline=["center_of_mass"],
                                                   ret_metric=True)
 
     # Define list of methods
-    reg_methods = [center_of_mass, translation, rigid, rigid_isoscaling,
-                   rigid_scaling, affine]
+    reg_methods = ["center_of_mass", "translation", "rigid",
+                   "rigid_isoscaling", "rigid_scaling", "affine"]
 
     # Test methods individually (without returning any metric)
     for func in reg_methods:

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -132,7 +132,7 @@ def test_affine_registration():
                                                   level_iters=[5, 5],
                                                   sigmas=[3, 1],
                                                   factors=[2, 1],
-                                                  pipeline=[translation])
+                                                  pipeline=[func])
         # We don't ask for much:
         npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
 

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -11,8 +11,10 @@ import dipy.data as dpd
 import dipy.core.gradients as dpg
 
 from dipy.align import (syn_registration, register_series, register_dwi_series,
-                        affine_registration, streamline_registration,
-                        write_mapping, read_mapping, register_dwi_to_template)
+                        center_of_mass, translation, rigid, rigid_isoscaling,
+                        rigid_scaling, affine, affine_registration,
+                        streamline_registration, write_mapping, read_mapping,
+                        register_dwi_to_template)
 
 from dipy.align.imwarp import DiffeomorphicMap
 
@@ -86,48 +88,90 @@ def test_register_dwi_to_template():
     # Use affine registration (+ don't provide a template and inputs as
     # strings):
     fdata, fbval, fbvec = dpd.get_fnames('small_64D')
-    warped_data, affine = register_dwi_to_template(fdata, (fbval, fbvec),
-                                                   reg_method="aff",
-                                                   level_iters=[5, 5, 5],
-                                                   sigmas=[3, 1, 0],
-                                                   factors=[4, 2, 1])
-    npt.assert_(isinstance(affine, np.ndarray))
-    npt.assert_(affine.shape == (4, 4))
+    warped_data, affine_mat = register_dwi_to_template(fdata, (fbval, fbvec),
+                                                       reg_method="aff",
+                                                       level_iters=[5, 5, 5],
+                                                       sigmas=[3, 1, 0],
+                                                       factors=[4, 2, 1])
+    npt.assert_(isinstance(affine_mat, np.ndarray))
+    npt.assert_(affine_mat.shape == (4, 4))
 
 
 def test_affine_registration():
     moving = subset_b0
     static = subset_b0
     moving_affine = static_affine = np.eye(4)
-    xformed, affine = affine_registration(moving, static,
-                                          moving_affine=moving_affine,
-                                          static_affine=static_affine,
-                                          level_iters=[5, 5],
-                                          sigmas=[3, 1],
-                                          factors=[2, 1])
+    xformed, affine_mat = affine_registration(moving, static,
+                                              moving_affine=moving_affine,
+                                              static_affine=static_affine,
+                                              level_iters=[5, 5],
+                                              sigmas=[3, 1],
+                                              factors=[2, 1])
 
     # We don't ask for much:
-    npt.assert_almost_equal(affine[:3, :3], np.eye(3), decimal=1)
+    npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
+
+    # [center_of_mass] + ret_metric=True should raise an error
+    with pytest.raises(ValueError):
+        # For array input, must provide affines:
+        xformed, affine_mat = affine_registration(moving, static,
+                                                  moving_affine=moving_affine,
+                                                  static_affine=static_affine,
+                                                  pipeline=[center_of_mass],
+                                                  ret_metric=True)
+
+    # Define list of methods
+    reg_methods = [center_of_mass, translation, rigid, rigid_isoscaling,
+                   rigid_scaling, affine]
+
+    # Test methods individually (without returning any metric)
+    for func in reg_methods:
+        xformed, affine_mat = affine_registration(moving, static,
+                                                  moving_affine=moving_affine,
+                                                  static_affine=static_affine,
+                                                  level_iters=[5, 5],
+                                                  sigmas=[3, 1],
+                                                  factors=[2, 1],
+                                                  pipeline=[translation])
+        # We don't ask for much:
+        npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
+
+    # Test methods individually (returning quality metric)
+    expected_nparams = [3, 6, 7, 9, 12]
+    for i, func in enumerate(reg_methods[1:]):
+        xformed, affine_mat, \
+            xopt, fopt = affine_registration(moving, static,
+                                             moving_affine=moving_affine,
+                                             static_affine=static_affine,
+                                             level_iters=[5, 5],
+                                             sigmas=[3, 1],
+                                             factors=[2, 1],
+                                             pipeline=[func],
+                                             ret_metric=True)
+        # Expected number of optimization parameters
+        npt.assert_equal(len(xopt), expected_nparams[i])
+        # Optimization metric must be a single numeric value
+        npt.assert_equal(isinstance(fopt, (int, float)), True)
 
     with pytest.raises(ValueError):
         # For array input, must provide affines:
-        xformed, affine = affine_registration(moving, static)
+        xformed, affine_mat = affine_registration(moving, static)
 
     # If providing nifti image objects, don't need to provide affines:
     moving_img = nib.Nifti1Image(moving, moving_affine)
     static_img = nib.Nifti1Image(static, static_affine)
-    xformed, affine = affine_registration(moving_img, static_img)
-    npt.assert_almost_equal(affine[:3, :3], np.eye(3), decimal=1)
+    xformed, affine_mat = affine_registration(moving_img, static_img)
+    npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
 
     # Using strings with full paths as inputs also works:
     t1_name, b0_name = dpd.get_fnames('syn_data')
     moving = b0_name
     static = t1_name
-    xformed, affine = affine_registration(moving, static,
-                                          level_iters=[5, 5],
-                                          sigmas=[3, 1],
-                                          factors=[4, 2])
-    npt.assert_almost_equal(affine[:3, :3], np.eye(3), decimal=1)
+    xformed, affine_mat = affine_registration(moving, static,
+                                              level_iters=[5, 5],
+                                              sigmas=[3, 1],
+                                              factors=[4, 2])
+    npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
 
 
 def test_register_series():
@@ -162,11 +206,11 @@ def test_register_dwi_series():
 def test_streamline_registration():
     sl1 = [np.array([[0, 0, 0], [0, 0, 0.5], [0, 0, 1], [0, 0, 1.5]]),
            np.array([[0, 0, 0], [0, 0.5, 0.5], [0, 1, 1]])]
-    affine = np.eye(4)
-    affine[:3, 3] = np.random.randn(3)
-    sl2 = list(transform_tracking_output(sl1, affine))
+    affine_mat = np.eye(4)
+    affine_mat[:3, 3] = np.random.randn(3)
+    sl2 = list(transform_tracking_output(sl1, affine_mat))
     aligned, matrix = streamline_registration(sl2, sl1)
-    npt.assert_almost_equal(matrix, np.linalg.inv(affine))
+    npt.assert_almost_equal(matrix, np.linalg.inv(affine_mat))
     npt.assert_almost_equal(aligned[0], sl1[0])
     npt.assert_almost_equal(aligned[1], sl1[1])
 

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -748,7 +748,7 @@ class ImageRegistrationFlow(Workflow):
                                                  params0,
                                                  progressive)
                 else:
-                    raise ValueError('Invalid transformation:' + transform +
+                    raise ValueError('Invalid transformation:'
                                      ' Please see program\'s help'
                                      ' for allowed values of'
                                      ' transformation.')

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -8,8 +8,7 @@ from dipy.align.imwarp import (SymmetricDiffeomorphicRegistration,
                                DiffeomorphicMap)
 from dipy.align.metrics import CCMetric, SSDMetric, EMMetric
 from dipy.align.reslice import reslice
-from dipy.align import (affine_registration, center_of_mass, translation,
-                        rigid, rigid_isoscaling, rigid_scaling, affine)
+from dipy.align import affine_registration
 from dipy.align.streamlinear import slr_with_qbx
 from dipy.io.image import save_nifti, load_nifti, save_qa_metric
 from dipy.tracking.streamline import transform_streamlines
@@ -326,20 +325,22 @@ class ImageRegistrationFlow(Workflow):
 
         if progressive:
             pipeline_opt = {
-                'com': [center_of_mass],
-                'trans': [center_of_mass, translation],
-                'rigid': [center_of_mass, translation, rigid],
-                'rigid_isoscaling': [center_of_mass, rigid_isoscaling],
-                'rigid_scaling': [center_of_mass, translation, rigid_scaling],
-                'affine': [center_of_mass, translation, rigid, affine]}
+                "com": ["center_of_mass"],
+                "trans": ["center_of_mass", "translation"],
+                "rigid": ["center_of_mass", "translation", "rigid"],
+                "rigid_isoscaling": ["center_of_mass", "translation",
+                                     "rigid_isoscaling"],
+                "rigid_scaling": ["center_of_mass", "translation",
+                                  "rigid_scaling"],
+                "affine": ["center_of_mass", "translation", "rigid", "affine"]}
         else:
             pipeline_opt = {
-                'com': [center_of_mass],
-                'trans': [center_of_mass, translation],
-                'rigid': [center_of_mass, rigid],
-                'rigid_isoscaling': [center_of_mass, rigid_isoscaling],
-                'rigid_scaling': [center_of_mass, rigid_scaling],
-                'affine': [center_of_mass, affine]}
+                "com": ["center_of_mass"],
+                "trans": ["center_of_mass", "translation"],
+                "rigid": ["center_of_mass", "rigid"],
+                "rigid_isoscaling": ["center_of_mass", "rigid_isoscaling"],
+                "rigid_scaling": ["center_of_mass", "rigid_scaling"],
+                "affine": ["center_of_mass", "affine"]}
 
         pipeline = pipeline_opt.get(transform)
 
@@ -361,7 +362,7 @@ class ImageRegistrationFlow(Workflow):
             starting_affine = None
 
             # If only center of mass is selected do not return metric
-            if pipeline == [center_of_mass]:
+            if pipeline == ["center_of_mass"]:
                 moved_image, affine_matrix = \
                     affine_registration(moving,
                                         static,

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -164,7 +164,7 @@ def test_image_registration():
             npt.assert_almost_equal(dist, -0.6960044668271375, 1)
             check_existence(out_moved, out_affine)
 
-        def test_rigid_caling():
+        def test_rigid_scaling():
 
             out_moved = pjoin(temp_out_dir, "rigid_scaling_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "rigid_scaling_affine.txt")
@@ -226,6 +226,8 @@ def test_image_registration():
         test_com()
         test_translation()
         test_rigid()
+        test_rigid_isoscaling()
+        test_rigid_scaling()
         test_affine()
         test_err()
 

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -82,7 +82,7 @@ def test_image_registration():
         static_image_file = pjoin(temp_out_dir, 'b0.nii.gz')
         moving_image_file = pjoin(temp_out_dir, 't1.nii.gz')
 
-        image_registeration_flow = ImageRegistrationFlow()
+        image_registration_flow = ImageRegistrationFlow()
 
         def read_distance(qual_fname):
             temp_val = 0
@@ -95,13 +95,13 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "com_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "com_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='com',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine)
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='com',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine)
             check_existence(out_moved, out_affine)
 
         def test_translation():
@@ -109,16 +109,16 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "trans_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "trans_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='trans',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         save_metric=True,
-                                         level_iters=[100, 10, 1],
-                                         out_quality='trans_q.txt')
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='trans',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        save_metric=True,
+                                        level_iters=[100, 10, 1],
+                                        out_quality='trans_q.txt')
 
             dist = read_distance('trans_q.txt')
             npt.assert_almost_equal(float(dist), -0.3953547764454917, 1)
@@ -129,16 +129,16 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "rigid_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "rigid_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='rigid',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         save_metric=True,
-                                         level_iters=[100, 10, 1],
-                                         out_quality='rigid_q.txt')
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='rigid',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        save_metric=True,
+                                        level_iters=[100, 10, 1],
+                                        out_quality='rigid_q.txt')
 
             dist = read_distance('rigid_q.txt')
             npt.assert_almost_equal(dist, -0.6900534794005155, 1)
@@ -149,16 +149,16 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "rigid_isoscaling_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "rigid_isoscaling_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='rigid_isoscaling',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         save_metric=True,
-                                         level_iters=[100, 10, 1],
-                                         out_quality='rigid_isoscaling_q.txt')
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='rigid_isoscaling',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        save_metric=True,
+                                        level_iters=[100, 10, 1],
+                                        out_quality='rigid_isoscaling_q.txt')
 
             dist = read_distance('rigid_isoscaling_q.txt')
             npt.assert_almost_equal(dist, -0.6960044668271375, 1)
@@ -169,16 +169,16 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "rigid_scaling_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "rigid_scaling_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='rigid_scaling',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         save_metric=True,
-                                         level_iters=[100, 10, 1],
-                                         out_quality='rigid_scaling_q.txt')
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='rigid_scaling',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        save_metric=True,
+                                        level_iters=[100, 10, 1],
+                                        out_quality='rigid_scaling_q.txt')
 
             dist = read_distance('rigid_scaling_q.txt')
             npt.assert_almost_equal(dist, -0.698688892993124, 1)
@@ -189,16 +189,16 @@ def test_image_registration():
             out_moved = pjoin(temp_out_dir, "affine_moved.nii.gz")
             out_affine = pjoin(temp_out_dir, "affine_affine.txt")
 
-            image_registeration_flow._force_overwrite = True
-            image_registeration_flow.run(static_image_file,
-                                         moving_image_file,
-                                         transform='affine',
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         save_metric=True,
-                                         level_iters=[100, 10, 1],
-                                         out_quality='affine_q.txt')
+            image_registration_flow._force_overwrite = True
+            image_registration_flow.run(static_image_file,
+                                        moving_image_file,
+                                        transform='affine',
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        save_metric=True,
+                                        level_iters=[100, 10, 1],
+                                        out_quality='affine_q.txt')
 
             dist = read_distance('affine_q.txt')
             npt.assert_almost_equal(dist, -0.7670650775914811, 1)
@@ -206,14 +206,14 @@ def test_image_registration():
 
         # Creating the erroneous behavior
         def test_err():
-            image_registeration_flow._force_overwrite = True
-            npt.assert_raises(ValueError, image_registeration_flow.run,
+            image_registration_flow._force_overwrite = True
+            npt.assert_raises(ValueError, image_registration_flow.run,
                               static_image_file,
                               moving_image_file,
                               transform='notransform')
 
-            image_registeration_flow._force_overwrite = True
-            npt.assert_raises(ValueError, image_registeration_flow.run,
+            image_registration_flow._force_overwrite = True
+            npt.assert_raises(ValueError, image_registration_flow.run,
                               static_image_file,
                               moving_image_file,
                               metric='wrong_metric')
@@ -254,7 +254,7 @@ def test_apply_affine_transform():
                                                  0.05, 0.99, -0.10, 2.5,
                                                  -0.07, 0.10, 0.99, -1.4]))}
 
-        image_registeration_flow = ImageRegistrationFlow()
+        image_registration_flow = ImageRegistrationFlow()
         apply_trans = ApplyTransformFlow()
 
         for i in factors.keys():
@@ -290,13 +290,13 @@ def test_apply_affine_transform():
             else:
                 transform_type = str(i[0]).lower()
 
-            image_registeration_flow.run(static_image_file, moving_image_file,
-                                         transform=transform_type,
-                                         out_dir=temp_out_dir,
-                                         out_moved=out_moved,
-                                         out_affine=out_affine,
-                                         level_iters=[1, 1, 1],
-                                         save_metric=False)
+            image_registration_flow.run(static_image_file, moving_image_file,
+                                        transform=transform_type,
+                                        out_dir=temp_out_dir,
+                                        out_moved=out_moved,
+                                        out_affine=out_affine,
+                                        level_iters=[1, 1, 1],
+                                        save_metric=False)
 
             # Checking for the created moved file.
             assert os.path.exists(out_moved)

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -144,6 +144,46 @@ def test_image_registration():
             npt.assert_almost_equal(dist, -0.6900534794005155, 1)
             check_existence(out_moved, out_affine)
 
+        def test_rigid_isoscaling():
+
+            out_moved = pjoin(temp_out_dir, "rigid_isoscaling_moved.nii.gz")
+            out_affine = pjoin(temp_out_dir, "rigid_isoscaling_affine.txt")
+
+            image_registeration_flow._force_overwrite = True
+            image_registeration_flow.run(static_image_file,
+                                         moving_image_file,
+                                         transform='rigid_isoscaling',
+                                         out_dir=temp_out_dir,
+                                         out_moved=out_moved,
+                                         out_affine=out_affine,
+                                         save_metric=True,
+                                         level_iters=[100, 10, 1],
+                                         out_quality='rigid_isoscaling_q.txt')
+
+            dist = read_distance('rigid_isoscaling_q.txt')
+            npt.assert_almost_equal(dist, -0.6960044668271375, 1)
+            check_existence(out_moved, out_affine)
+
+        def test_rigid_caling():
+
+            out_moved = pjoin(temp_out_dir, "rigid_scaling_moved.nii.gz")
+            out_affine = pjoin(temp_out_dir, "rigid_scaling_affine.txt")
+
+            image_registeration_flow._force_overwrite = True
+            image_registeration_flow.run(static_image_file,
+                                         moving_image_file,
+                                         transform='rigid_scaling',
+                                         out_dir=temp_out_dir,
+                                         out_moved=out_moved,
+                                         out_affine=out_affine,
+                                         save_metric=True,
+                                         level_iters=[100, 10, 1],
+                                         out_quality='rigid_scaling_q.txt')
+
+            dist = read_distance('rigid_scaling_q.txt')
+            npt.assert_almost_equal(dist, -0.698688892993124, 1)
+            check_existence(out_moved, out_affine)
+
         def test_affine():
 
             out_moved = pjoin(temp_out_dir, "affine_moved.nii.gz")
@@ -204,6 +244,12 @@ def test_apply_affine_transform():
             ('TRANSLATION', 3): (2.0, None, np.array([2.3, 4.5, 1.7])),
             ('RIGID', 3): (0.1, None, np.array([0.1, 0.15, -0.11, 2.3, 4.5,
                                                 1.7])),
+            ('RIGIDISOSCALING', 3): (0.1, None, np.array([0.1, 0.15, -0.11,
+                                                         2.3, 4.5, 1.7,
+                                                          0.8])),
+            ('RIGIDSCALING', 3): (0.1, None, np.array([0.1, 0.15, -0.11, 2.3,
+                                                       4.5, 1.7, 0.8, 0.9,
+                                                       1.1])),
             ('AFFINE', 3): (0.1, None, np.array([0.99, -0.05, 0.03, 1.3,
                                                  0.05, 0.99, -0.10, 2.5,
                                                  -0.07, 0.10, 0.99, -1.4]))}
@@ -237,6 +283,10 @@ def test_apply_affine_transform():
 
             if str(i[0]) == "TRANSLATION":
                 transform_type = "trans"
+            elif str(i[0]) == "RIGIDISOSCALING":
+                transform_type = "rigid_isoscaling"
+            elif str(i[0]) == "RIGIDSCALING":
+                transform_type = "rigid_scaling"
             else:
                 transform_type = str(i[0]).lower()
 

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -295,20 +295,21 @@ regtools.overlay_slices(static, transformed, None, 2,
 Now, let's repeat this process with a simplified functional interface:
 """
 
-from dipy.align import (affine_registration, center_of_mass, translation,
-                        rigid, affine, register_dwi_to_template)
+from dipy.align import affine_registration, register_dwi_to_template
 
 """
-This interface constructs a pipeline of operations as a sequence of functions
-that each implement one of the transforms.
+This interface constructs a pipeline of operations from a given list of 
+transformations.
 """
 
-pipeline = [center_of_mass, translation, rigid, affine]
+pipeline = ["center_of_mass", "translation", "rigid", "affine"]
 
 """
-And then applies the functions in the pipeline on the input (from left to
+And then applies the transformations in the pipeline on the input (from left to
 right) with a call to an `affine_registration` function, which takes optional
-settings for things like the iterations, sigmas and factors.
+settings for things like the iterations, sigmas and factors. The pipeline must
+be a list of strings with one or more of the following transformations:
+center_of_mass, translation, rigid, rigid_isoscaling, rigid_scaling and affine.
 """
 
 xformed_img, reg_affine = affine_registration(

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -298,7 +298,7 @@ Now, let's repeat this process with a simplified functional interface:
 from dipy.align import affine_registration, register_dwi_to_template
 
 """
-This interface constructs a pipeline of operations from a given list of 
+This interface constructs a pipeline of operations from a given list of
 transformations.
 """
 


### PR DESCRIPTION
Part of #2276 

### Proposed changes
- Add RigidIsoScaling and RigidScaling options to the align workflow
- Update corresponding tests


By the way, I've noticed that the registration parameters defined [here](https://github.com/dipy/dipy/pull/2390/files#diff-b6bf9b9a51f8dfc421e3896b6ea103012d81d9eae8b07e252e0f5a66a220f42fL204) are not used as the [setup_random_transform ](https://github.com/dipy/dipy/blob/master/dipy/align/tests/test_parzenhist.py#L259)function calculates them randomly.