### PR TITLE
Add decomposition

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -648,7 +648,6 @@ def reorient_bvecs(gtab, affines, atol=1e-2):
         # Decompose into rotation and scaling components:
         R, S = polar(aff)
         Rinv = inv(R)
-        
         # Apply the inverse of the rotation to the corresponding gradient
         # direction:
         new_bvecs[i] = np.dot(Rinv, new_bvecs[i])

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -644,13 +644,11 @@ def reorient_bvecs(gtab, affines, atol=1e-2):
         if aff.shape == (4, 4):
             # This must be an affine!
             # Remove the translation component:
-            aff_no_trans = aff[:3, :3]
-            # Decompose into rotation and scaling components:
-            R, S = polar(aff_no_trans)
-        elif aff.shape == (3, 3):
-            # We assume this is a rotation matrix:
-            R = aff
+            aff = aff[:3, :3]
+        # Decompose into rotation and scaling components:
+        R, S = polar(aff_no_trans)
         Rinv = inv(R)
+        
         # Apply the inverse of the rotation to the corresponding gradient
         # direction:
         new_bvecs[i] = np.dot(Rinv, new_bvecs[i])

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -646,7 +646,7 @@ def reorient_bvecs(gtab, affines, atol=1e-2):
             # Remove the translation component:
             aff = aff[:3, :3]
         # Decompose into rotation and scaling components:
-        R, S = polar(aff_no_trans)
+        R, S = polar(aff)
         Rinv = inv(R)
         
         # Apply the inverse of the rotation to the corresponding gradient

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -424,8 +424,7 @@ def test_reorient_bvecs():
     # so that the reorient_bvecs function does not throw an error itself
     new_gt = reorient_bvecs(gt, np.array(shear_affines)[:, :3, :3], atol=1)
     bvecs_close_to_1 = abs(vector_norm(new_gt.bvecs[~gt.b0s_mask]) - 1) <= 0.001
-    npt.assert_equal(bvecs_close_to_1, np.ones(bvecs_close_to_1.shape,
-                                               dtype=bool))
+    npt.assert_(np.all(bvecs_close_to_1)) 
 
 def test_nan_bvecs():
     """

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -14,7 +14,7 @@ from dipy.core.gradients import (gradient_table, GradientTable,
                                  unique_bvals_magnitude,
                                  unique_bvals_tolerance, unique_bvals,
                                  params_to_btens, btens_to_params)
-from dipy.core.geometry import vec2vec_rotmat
+from dipy.core.geometry import vec2vec_rotmat, vector_norm
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.utils.deprecator import ExpiredDeprecationError
 
@@ -412,6 +412,19 @@ def test_reorient_bvecs():
     full_affines.append(np.zeros((4, 4)))
     npt.assert_raises(ValueError, reorient_bvecs, gt_rot, full_affines)
 
+    # Shear components in the matrix need to be decomposed into rotation only,
+    # and should not lead to scaling of the bvecs
+    shear_affines = []
+    for i in np.where(~gt.b0s_mask)[0]:
+        shear_affines.append(np.array([[1, 0, 1, 0],
+                                       [0, 1, 0, 0],
+                                       [0, 0, 1, 0],
+                                       [0, 0, 0, 1]]))
+    # atol is set to 1 here to do the scaling verification here,
+    # so that the reorient_bvecs function does not throw an error itself
+    new_gt = reorient_bvecs(gt, np.array(shear_affines)[:, :3, :3], atol=1)
+    bvecs_close_to_1 = abs(vector_norm(new_gt.bvecs[~gt.b0s_mask]) - 1) <= 0.001
+    npt.assert_equal(bvecs_close_to_1, np.ones(bvecs_close_to_1.shape, dtype=bool))
 
 def test_nan_bvecs():
     """

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -424,7 +424,8 @@ def test_reorient_bvecs():
     # so that the reorient_bvecs function does not throw an error itself
     new_gt = reorient_bvecs(gt, np.array(shear_affines)[:, :3, :3], atol=1)
     bvecs_close_to_1 = abs(vector_norm(new_gt.bvecs[~gt.b0s_mask]) - 1) <= 0.001
-    npt.assert_equal(bvecs_close_to_1, np.ones(bvecs_close_to_1.shape, dtype=bool))
+    npt.assert_equal(bvecs_close_to_1, np.ones(bvecs_close_to_1.shape,
+                                               dtype=bool))
 
 def test_nan_bvecs():
     """


### PR DESCRIPTION
Is there a reason why a 3x3 matrix is assumed to be a rotation-only matrix, but not the 4x4 matrix?
Adding polar decomposition also when the matrix is present in 3x3 form.