### PR TITLE
Adaptive patch2self

### DIFF
--- a/bin/dipy_denoise_adaptive_patch2self
+++ b/bin/dipy_denoise_adaptive_patch2self
@@ -1,0 +1,8 @@
+#!python
+
+from dipy.workflows.flow_runner import run_flow
+from dipy.workflows.denoise import AdaptivePatch2SelfFlow
+
+
+if __name__ == "__main__":
+    run_flow(AdaptivePatch2SelfFlow())

--- a/dipy/denoise/adaptive_patch2self.py
+++ b/dipy/denoise/adaptive_patch2self.py
@@ -1,0 +1,485 @@
+import numpy as np
+from warnings import warn
+import time
+from dipy.utils.optpkg import optional_package
+import dipy.core.optimize as opt
+try:
+    from scipy.linalg.lapack import dgesvd as svd
+    svd_args = [1, 0]
+    # If you have an older version of scipy, we fall back
+    # on the standard scipy SVD API:
+except ImportError:
+    from scipy.linalg import svd
+    svd_args = [False]
+
+sklearn, has_sklearn, _ = optional_package('sklearn')
+linear_model, _, _ = optional_package('sklearn.linear_model')
+
+if not has_sklearn:
+    w = "Scikit-Learn is required to denoise the data via Patch2Self."
+    warn(w)
+
+
+class LinearlyVaryingRegressor(object):
+    """ Creates a set of regressors that are trained using different neighborhoods
+    of the data, spread out along the n_comps largest principal
+    components. Then when a value is predicted the model coefficients are
+    linearly interpolated from the components of each neighborhood, to estimate
+    a model that had been trained from the neighborhood surrounding the
+    argument (X).
+
+    The result is a "linear" regression where the coefficients linearly vary with
+    the data, so this could also be achieved with a quadratic regression. Unfortunately
+    doing that with sklearn would mean fitting a linear regression with the feature vectors
+    expanded from n_features to n_features**2 / 2, and thus be a huge memory problem.
+    """
+    def __init__(self, data, n_comps=None, dtype=np.float32, model='ols', mod_kwargs={}):
+        """ Calculate the principal components of data and initialize the set of
+        regressors and neighborhood weights.
+
+        Parameters
+        ----------
+        data : 2D array
+            The semi-flattened data, with shape (n_voxels, n_volumes).
+            The regressions will be strictly over the n_volumes axis.
+
+        n_comps : int or None
+            The number of principal components to account for in the variation
+            of the model coefficients. Two Gaussian neighborhoods will be created
+            for each component, centered at +/- 1 on the component axis and with unit
+            standard deviation in each normalized component axis.
+            If None use int(ceil(n_volumes**0.5)).
+
+        dtype : dtype
+            The data type for calculations
+
+        model : string, or initialized linear model object.
+            This will determine the algorithm used to solve the set of linear
+            equations underlying this model. If it is a string it needs to be
+            one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
+            it can be an object that inherits from
+            `dipy.optimize.SKLearnLinearSolver` or an object with a similar
+            interface from Scikit-Learn:
+            `sklearn.linear_model.LinearRegression`,
+            `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
+            and other objects that inherit from `sklearn.base.RegressorMixin`.
+            Default: 'ridge'.
+
+        mod_kwargs : dict
+            Any keyword arguments to pass to the models.
+        """
+        super(LinearlyVaryingRegressor, self).__init__()
+        self.dtype = dtype
+
+        if not n_comps:
+            # Assume the number of voxel types that need distinct regression
+            # coefficients is a slowly growing function of both the number of
+            # voxels and the number of volumes.
+            self.n_comps = int(np.ceil(min(data.shape)**0.5))
+        else:
+            self.n_comps = n_comps
+
+        if mod_kwargs.get('positive'):
+            self.nonnegative = True
+        else:
+            self.nonnegative = False
+        #self.nonnegative = True
+        sup_mod_kwargs = {k: mod_kwargs.pop(k) for k in ['alpha', 'max_iter']
+                          if k in mod_kwargs}
+        self.model = supply_model(model, **sup_mod_kwargs, mod_kwargs=mod_kwargs)
+
+        # Do NOT demean data - that introduces an anticorrelation between the
+        # volumes that makes it easy for the regression to predict any given
+        # volume as -sum(other volumes).
+        self.X = data.astype(self.dtype, copy=True)
+
+        # Calculate the principal components of X in order to place fitting
+        # sites covering different types of voxels.
+        # U is the normalized eigenheads (same shape as data),
+        # S is the vector of eigenvalues in descending order,
+        # and the rows of Vt are the principal components in diffusion space.
+        # This time we use the demeaned data because we want U relative to the centroid.
+        # data = U.dot(S).dot(Vt) + data.mean()
+        U, S, Vt = svd(self.X - self.X.mean(axis=0)[np.newaxis, :], *svd_args)[:3]
+
+        # Trim down to the top n_comps principal components. I wonder if there is a way
+        # to do this as part of svd.
+        if self.n_comps < data.shape[1]:
+            U = U[:, :self.n_comps].astype(self.dtype)
+
+            # For completeness - they are not actually used, but take up relatively little memory.
+            S = S[:self.n_comps].astype(self.dtype)
+            Vt = Vt[:self.n_comps].astype(self.dtype)
+
+        # The weights for each site, arranged by [sample number, site number],
+        # with the central site coming last.
+        self.site_weights = np.zeros((self.X.shape[0], 2 * self.n_comps + 1), dtype=self.dtype)
+        for pca_ind in range(self.n_comps):
+            u = U[:, pca_ind]
+            self.site_weights[u < 0, 2 * pca_ind] = u[u < 0] / u[u < 0].mean()
+            self.site_weights[u > 0, 2 * pca_ind + 1] = u[u > 0] / u[u > 0].mean()
+        self.site_weights[:, -1] = np.exp(-0.5 * self.X.shape[0] * (U**2).sum(axis=1))
+        self.site_weights /= self.site_weights.sum(axis=1)[:, np.newaxis]
+
+    def _select_vol(self, vol_idx):
+        mask = np.zeros(self.X.shape[1:], dtype=bool)
+        mask[vol_idx] = 1
+        self._cur_x = self.X[:, mask == 0]
+        self._y = self.X[:, vol_idx]
+        self._vol_idx = vol_idx
+
+    def _fit(self):
+        self.coef_ = np.zeros_like(self._cur_x)
+        self.intercept_ = np.zeros_like(self._y)
+        for site_ind in range(self.site_weights.shape[-1]):
+            w = self.site_weights[:, site_ind]
+            self.model.fit(self._cur_x[w > 0], self._y[w > 0], w[w > 0])
+            self.coef_[w > 0] += np.outer(w[w > 0], self.model.coef_)
+            self.intercept_[w > 0] += w[w > 0] * self.model.intercept_
+
+    def _predict(self):
+        r"""Return $Y = X^\prime \beta + a$, where
+            $X^\prime$ is self.X without self._vol_idx's column,
+            $\beta$ = self.coef_, and
+            $a$ = self.intercept_
+        """
+        return np.einsum("...j,...j", self._cur_x, self.coef_) + self.intercept_
+
+    def vol_denoise(self, vol_idx):
+        self._select_vol(vol_idx)
+        self._fit()
+        return self._predict()
+
+
+def supply_model(model, alpha=1.0, max_iter=50, copy_X=False, mod_kwargs={}):
+    """ Produce a sklearn.base.RegressorMixin object.
+
+    Parameters
+    ----------
+    model : string, or initialized linear model object.
+            This will determine the algorithm used to solve the set of linear
+            equations underlying this model. If it is a string it needs to be
+            one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
+            it can be an object that inherits from
+            `dipy.optimize.SKLearnLinearSolver` or an object with a similar
+            interface from Scikit-Learn:
+            `sklearn.linear_model.LinearRegression`,
+            `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
+            and other objects that inherit from `sklearn.base.RegressorMixin`.
+            Default: 'ridge'.
+
+    alpha : float, optional
+        Regularization parameter only for ridge and lasso regression models.
+        default: 1.0
+
+    max_iter : int or None
+        Maximum number of iterations for conjugate gradient solver.
+        For 'sparse_cg' and 'lsqr' solvers, the default value is determined
+        by scipy.sparse.linalg. For 'sag' solver, the default value is 1000.
+
+    copy_X : bool
+        If True, X will be copied; else, it may be overwritten.
+
+    mod_kwargs : dict
+        Other keyword arguments to pass to mod.
+
+
+    Returns
+    -------
+    mod : sklearn.base.RegressorMixin object
+    """
+    # To add a new model, use the following API
+    # We adhere to the following options as they are used for comparisons
+    mod_kwargs['copy_X'] = copy_X
+    mod_kwargs['alpha'] = alpha
+
+    if model.lower() == 'ols':
+        mod_kwargs.pop('alpha')
+        model = linear_model.LinearRegression(**mod_kwargs)
+
+    elif model.lower() == 'ridge':
+        mod_kwargs.pop('ridge', None)
+        model = linear_model.Ridge(**mod_kwargs)
+
+    elif model.lower() == 'lasso':
+        mod_kwargs['max_iter'] = max_iter
+        model = linear_model.Lasso(**mod_kwargs)
+
+    elif (isinstance(model, opt.SKLearnLinearSolver) or
+          has_sklearn and isinstance(model, sklearn.base.RegressorMixin)):
+        model = model
+
+    # Both sklearn.linear_model._ridge.Ridge, etc., and opt.SKLearnLinearSolver are abc.ABCMeta.
+    # Using type(opt.SKLearnLinearSolver) avoids having to import abc.
+    elif isinstance(model, type(opt.SKLearnLinearSolver)):
+        model = model(**mod_kwargs)
+
+    else:
+        e_s = "The `solver` key-word argument needs to be: "
+        e_s += "'ols', 'ridge', 'lasso' or a "
+        e_s += "`dipy.optimize.SKLearnLinearSolver` object"
+        raise ValueError(e_s)
+    return model
+
+
+def extract_data(data, mask=None):
+    """Given an n dimensional array, return a 2D copy with the first n-1
+    dimensions flattened out and the last one left as is.
+
+    Parameters
+    ----------
+    data : n dimensional array
+        Typically 4D data
+
+    mask : n-1 dimensional array or None, optional
+        If not None, only use the voxels of each volume where mask is True.
+        Its shape must match data.shape[:-1].
+
+    Returns
+    -------
+    out : 2D array
+        data (or data[mask == True]) rearranged
+
+    See also
+    --------
+    dipy.segment.mask.applymask
+    """
+    if mask is None:
+        rv = data.copy().reshape(np.prod(data.shape[:-1]), data.shape[-1])
+    else:
+        nvols = data.shape[-1]
+        if mask.shape != data.shape[:-1]:
+            raise ValueError("mask's shape must equal data.shape[:-1]")
+        rv = np.empty((len(mask[mask > 0]), nvols), dtype=data.dtype)
+        for v in range(nvols):
+            rv[:, v] = data[mask > 0, v]
+    return rv
+
+
+def replace_data(inp, out, mask=None):
+    """Pour inp into out, accounting for the shape of out and mask.
+
+    Parameters
+    ----------
+    inp : 1D array
+        The input.
+
+    out : nD array
+        The destination.
+
+    mask : None or nD array, optional
+        If not None, only pour inp into voxels where mask is True.
+        (mask.shape must == out.shape and (mask > 0).sum() must == len(inp))
+
+    Returns
+    -------
+    out : nD array
+    """
+    if mask is None:
+        if inp.size != out.size:
+            raise ValueError("shape %s cannot be poured into shape %s without a mask"
+                             % (inp.shape, out.shape))
+        out = inp.reshape(out.shape)
+    else:
+        if mask.shape != out.shape:
+            raise ValueError("the mask and output shapes must match (%s vs %s)"
+                             % (mask.shape, out.shape))
+        nvox = (mask > 0).sum()
+        if nvox != len(inp):
+            e_s = "the number of values in input must match the number of nonzero voxels in mask\n"
+            e_s += "(%d vs %d)" % (len(inp), nvox)
+            raise ValueError(e_s)
+
+        out[mask > 0] = inp
+    return out
+
+
+def denoise_volumes(data, mask, model, verbose, label, calc_dtype):
+    """Return a version of data denoised with a LinearlyVaryingRegressor.
+
+    Parameters
+    ----------
+    data : 4D array
+        Noisy data. Denoising will use patch2self only along the last axis.
+
+    mask : None or 3D array
+        If not None, only denoise voxels where this is True.
+
+    model : string, or initialized linear model object.
+            This will determine the algorithm used to solve the set of linear
+            equations underlying this model. If it is a string it needs to be
+            one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
+            it can be an object that inherits from
+            `dipy.optimize.SKLearnLinearSolver` or an object with a similar
+            interface from Scikit-Learn:
+            `sklearn.linear_model.LinearRegression`,
+            `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
+            and other objects that inherit from `sklearn.base.RegressorMixin`.
+            Default: 'ridge'.
+
+    verbose : bool
+        Iff True, print progress updates
+
+    label : str
+        A label for the kind of volumes being denoised, e.g. "b0" or "DWI".
+        Only used if verbose is True.
+
+    calc_dtype : dtype
+        Data type to use for the calculations and output.
+
+    Returns
+    -------
+    denoised : 4D array
+    """
+    extracted_data = extract_data(data, mask)
+    lvr = LinearlyVaryingRegressor(extracted_data, model=model, dtype=calc_dtype)
+
+    denoised = data.astype(calc_dtype, copy=True)
+    for vol_idx in range(0, data.shape[3]):
+        denoised[..., vol_idx] = replace_data(lvr.vol_denoise(vol_idx),
+                                              denoised[..., vol_idx], mask)
+
+        if verbose:
+            print("Denoised %s volume: %d of %d" % (label, vol_idx + 1, data.shape[3]))
+    return denoised
+
+
+def patch2self(data, bvals, model='ols', mask=None,
+               b0_threshold=50, out_dtype=None, alpha=1.0, verbose=False,
+               b0_denoising=True, clip_negative_vals=True, shift_intensity=False):
+    """ Patch2Self Denoiser
+
+    Parameters
+    ----------
+    data : ndarray
+        The 4D noisy DWI data to be denoised.
+
+    bvals : 1D array
+        Array of the bvals from the DWI acquisition
+
+    model : string, or initialized linear model object.
+            This will determine the algorithm used to solve the set of linear
+            equations underlying this model. If it is a string it needs to be
+            one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
+            it can be an object that inherits from
+            `dipy.optimize.SKLearnLinearSolver` or an object with a similar
+            interface from Scikit-Learn:
+            `sklearn.linear_model.LinearRegression`,
+            `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
+            and other objects that inherit from `sklearn.base.RegressorMixin`.
+            Default: 'ridge'.
+
+    mask : 3D array or None
+           If not None, only denoise where mask is true.
+
+    b0_threshold : int, optional
+        Threshold for considering volumes as b0.
+
+    out_dtype : str or dtype, optional
+        The dtype for the output array. Default: output has the same dtype as
+        the input.
+
+    alpha : float, optional
+        Regularization parameter only for ridge regression model.
+        Default: 1.0
+
+    verbose : bool, optional
+        Show progress of Patch2Self and time taken.
+
+    b0_denoising : bool, optional
+        Skips denoising b0 volumes if set to False.
+        Default: True
+
+    clip_negative_vals : bool, optional
+        Sets negative values after denoising to 0 using `np.clip`.
+        Default: True
+
+    shift_intensity : bool, optional
+        Shifts the distribution of intensities per volume to give
+        non-negative values
+        Default: False
+
+
+    Returns
+    --------
+    denoised array : ndarray
+        This is the denoised array of the same size as that of the input data,
+        clipped to non-negative values.
+
+    References
+    ----------
+    [Fadnavis20] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
+                    Denoising Diffusion MRI with Self-supervised Learning,
+                    Advances in Neural Information Processing Systems 33 (2020)
+    """
+    if not data.ndim == 4:
+        raise ValueError("Patch2Self can only denoise on 4D arrays.",
+                         data.shape)
+
+    if data.shape[3] < 10:
+        warn("The input data has less than 10 3D volumes. Patch2Self may not",
+             "give good denoising performance.")
+
+    if out_dtype is None:
+        out_dtype = data.dtype
+
+    # We retain float64 precision, iff the input is in this precision:
+    if data.dtype == np.float64:
+        calc_dtype = np.float64
+
+    # Otherwise, we'll calculate things in float32 (saving memory)
+    else:
+        calc_dtype = np.float32
+
+    # Segregates volumes by b0 threshold
+    b0_idx = np.argwhere(bvals <= b0_threshold)
+    dwi_idx = np.argwhere(bvals > b0_threshold)
+
+    data_b0s = np.squeeze(np.take(data, b0_idx, axis=3))
+    data_dwi = np.squeeze(np.take(data, dwi_idx, axis=3))
+
+    if verbose is True:
+        t1 = time.time()
+
+    # if only 1 b0 volume, skip denoising it
+    if data_b0s.ndim == 3 or data_b0s.shape[-1] == 0 or not b0_denoising:
+        if verbose:
+            print("b0 denoising skipped...")
+        denoised_b0s = data_b0s
+
+    else:
+        denoised_b0s = denoise_volumes(data_b0s, mask, model, verbose, "b0", calc_dtype)
+
+    # Separate denoising for DWI volumes
+    denoised_dwi = denoise_volumes(data_dwi, mask, model, verbose, "DWI", calc_dtype)
+
+    if verbose is True:
+        t2 = time.time()
+        print('Total time taken for Patch2Self: ', t2-t1, " seconds")
+
+    denoised_arr = np.empty((data.shape), dtype=calc_dtype)
+    if data_b0s.ndim == 3:
+        denoised_arr[:, :, :, b0_idx[0][0]] = denoised_b0s
+    else:
+        for i, idx in enumerate(b0_idx):
+            denoised_arr[:, :, :, idx[0]] = np.squeeze(denoised_b0s[..., i])
+
+    for i, idx in enumerate(dwi_idx):
+        denoised_arr[:, :, :, idx[0]] = np.squeeze(denoised_dwi[..., i])
+
+    # shift intensities per volume to handle for negative intensities
+    if shift_intensity and not clip_negative_vals:
+        for i in range(0, denoised_arr.shape[3]):
+            shift = np.min(data[..., i]) - np.min(denoised_arr[..., i])
+            denoised_arr[..., i] = denoised_arr[..., i] + shift
+
+    # clip out the negative values from the denoised output
+    elif clip_negative_vals and not shift_intensity:
+        denoised_arr.clip(min=0, out=denoised_arr)
+
+    elif clip_negative_vals and shift_intensity:
+        warn('Both `clip_negative_vals` and `shift_intensity` cannot be True.')
+        warn('Defaulting to `clip_negative_bvals`...')
+        denoised_arr.clip(min=0, out=denoised_arr)
+
+    return np.array(denoised_arr, dtype=out_dtype)

--- a/dipy/denoise/adaptive_patch2self.py
+++ b/dipy/denoise/adaptive_patch2self.py
@@ -183,6 +183,33 @@ class AdaptivePatch2Self(object):
         self._fit()
         return self._predict()
 
+    def get_coefs(self, vol_idx, site_inds):
+        """Return the model coefficients for vol_idx and site_inds.
+        This is only needed for displaying the coefficients and how they vary by site.
+
+        Parameters
+        ----------
+        vol_idx : int
+            The index of the volume to be fitted.
+        site_inds : int array-like
+            The site indices to get coefficients for.
+            The site indices for the negative and positive sides of PC index i are 2i and 2i + 1.
+            The central site is -1 or 2 * n_comps + 1.
+
+        Returns
+        -------
+        coefs : (nsites, nvols - 1) float array
+            Each row is the coefficients by non-vol_idx volume index for the corresponding site in
+            site_inds.
+        """
+        self._select_vol(vol_idx)
+        coefs = np.zeros((len(site_inds), self._cur_x.shape[1]))
+        for site_ind in site_inds:
+            w = self.site_weights[:, site_ind]
+            self.model.fit(self._cur_x[w > 0], self._y[w > 0], w[w > 0])
+            coefs[site_ind] = self.model.coef_
+        return coefs
+
 
 def supply_model(model, alpha=1.0, max_iter=50, copy_X=False, mod_kwargs={}):
     """ Produce a sklearn.base.RegressorMixin object.

--- a/dipy/denoise/adaptive_patch2self.py
+++ b/dipy/denoise/adaptive_patch2self.py
@@ -199,7 +199,8 @@ class AdaptivePatch2Self(object):
         #self.nonnegative = True
         sup_mod_kwargs = {k: mod_kwargs.pop(k) for k in ['alpha', 'max_iter']
                           if k in mod_kwargs}
-        self.model = supply_model(model, **sup_mod_kwargs, mod_kwargs=mod_kwargs)
+        sup_mod_kwargs['mod_kwargs'] = mod_kwargs
+        self.model = supply_model(model, **sup_mod_kwargs)
 
         # Do NOT demean data - that introduces an anticorrelation between the
         # volumes that makes it easy for the regression to predict any given

--- a/dipy/denoise/tests/test_adaptive_patch2self.py
+++ b/dipy/denoise/tests/test_adaptive_patch2self.py
@@ -1,0 +1,91 @@
+import numpy as np
+from dipy.denoise import adaptive_patch2self as ap2s
+from dipy.testing import (assert_greater, assert_less,
+                          assert_greater_equal, assert_less_equal)
+from numpy.testing import (assert_array_almost_equal,
+                           assert_raises, assert_equal)
+import pytest
+
+from .test_patch2self import generate_gtab, rfiw_phantom
+
+needs_sklearn = pytest.mark.skipif(not ap2s.has_sklearn,
+                                   reason="Requires Scikit-Learn")
+
+
+@needs_sklearn
+def test_adaptive_patch2self_random_noise():
+    S0 = 30 + 2 * np.random.standard_normal((20, 20, 20, 50))
+
+    bvals = np.repeat(30, 50)
+
+    # shift = True
+    S0den_shift = ap2s.adaptive_patch2self(S0, bvals, model='ols', shift_intensity=True)
+
+    assert_greater_equal(S0den_shift.min(), S0.min())
+    assert_less_equal(np.round(S0den_shift.mean()), 30)
+
+    # clip = True
+    S0den_clip = ap2s.adaptive_patch2self(S0, bvals, model='ols',
+                                          clip_negative_vals=True)
+
+    assert_greater(S0den_clip.min(), S0.min())
+    assert_equal(np.round(S0den_clip.mean()), 30)
+
+    # both clip and shift = True, a mask, and site_weight_beam_arctan
+    mask = np.zeros(S0.shape, dtype=np.bool)
+    mask[1:-1, 2:-2, 3:-3] = True
+    S0den_clip = ap2s.adaptive_patch2self(S0, bvals, patch_radius=0, model='ols',
+                                          clip_negative_vals=True, mask=mask,
+                                          shift_intensity=True,
+                                          site_weight_func=ap2s.site_weight_beam_arctan)
+
+    assert_greater(S0den_clip.min(), S0.min())
+    assert_equal(np.round(S0den_clip.mean()), 30)
+
+    # both clip and shift = False, a mask, and calcSVDU
+    S0den_clip = ap2s.adaptive_patch2self(S0, bvals, model='ols',
+                                          clip_negative_vals=False,
+                                          shift_intensity=False, site_placer=ap2s.calcSVDU)
+
+    assert_greater(S0den_clip.min(), S0.min())
+    assert_equal(np.round(S0den_clip.mean()), 30)
+
+
+@needs_sklearn
+def test_adaptive_patch2self_boundary():
+    # adaptive_patch2self preserves boundaries
+    S0 = 100 + np.zeros((20, 20, 20, 20))
+    noise = 2 * np.random.standard_normal((20, 20, 20, 20))
+    S0 += noise
+    S0[:10, :10, :10, :10] = 300 + noise[:10, :10, :10, :10]
+
+    bvals = np.repeat(100, 20)
+
+    ap2s.adaptive_patch2self(S0, bvals)
+    assert_greater(S0[9, 9, 9, 9], 290)
+    assert_less(S0[10, 10, 10, 10], 110)
+
+
+@needs_sklearn
+def test_phantom():
+    gtab, bvals = generate_gtab()
+
+    dwi, sigma = rfiw_phantom(gtab, snr=10)
+    dwi_den1 = ap2s.adaptive_patch2self(dwi, model='ridge',
+                                        bvals=bvals, alpha=1.0)
+
+    assert_less(np.max(dwi_den1) / sigma, np.max(dwi) / sigma)
+    dwi_den2 = ap2s.adaptive_patch2self(dwi, model='ridge',
+                                        bvals=bvals, alpha=0.7)
+
+    assert_less(np.max(dwi_den2) / sigma, np.max(dwi) / sigma)
+    assert_array_almost_equal(dwi_den1, dwi_den2, decimal=0)
+
+    assert_raises(ValueError, ap2s.adaptive_patch2self, dwi, model='empty',
+                  bvals=bvals)
+
+    # Try this with a sigma volume, instead of a scalar
+    dwi_den = ap2s.adaptive_patch2self(dwi, bvals=bvals,
+                                       model='ols')
+
+    assert_less(np.max(dwi_den) / sigma, np.max(dwi) / sigma)

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -58,9 +58,9 @@ def test_patch2self_boundary():
 
     bvals = np.repeat(100, 20)
 
-    p2s.patch2self(S0, bvals)
-    assert_greater(S0[9, 9, 9, 9], 290)
-    assert_less(S0[10, 10, 10, 10], 110)
+    den = p2s.patch2self(S0, bvals)
+    assert_greater(den[9, 9, 9, 9], 290)
+    assert_less(den[10, 10, 10, 10], 110)
 
 
 def generate_gtab():

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -47,6 +47,7 @@ def test_patch2self_random_noise():
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
 
+
 @needs_sklearn
 def test_patch2self_boundary():
     # patch2self preserves boundaries
@@ -60,6 +61,23 @@ def test_patch2self_boundary():
     p2s.patch2self(S0, bvals)
     assert_greater(S0[9, 9, 9, 9], 290)
     assert_less(S0[10, 10, 10, 10], 110)
+
+
+def generate_gtab():
+    """generate a gradient table for phantom data"""
+    directions8 = generate_bvecs(8)
+    directions30 = generate_bvecs(20)
+    directions60 = generate_bvecs(30)
+    # Create full dataset parameters
+    # (6 b-values = 0, 8 directions for b-value 300, 30 directions for b-value
+    # 1000 and 60 directions for b-value 2000)
+    bvals = np.hstack((np.zeros(6),
+                       300 * np.ones(8),
+                       1000 * np.ones(20),
+                       2000 * np.ones(30)))
+    bvecs = np.vstack((np.zeros((6, 3)),
+                       directions8, directions30, directions60))
+    return gradient_table(bvals, bvecs), bvals
 
 
 def rfiw_phantom(gtab, snr=None):
@@ -128,22 +146,7 @@ def rfiw_phantom(gtab, snr=None):
 
 @needs_sklearn
 def test_phantom():
-
-    # generate a gradient table for phantom data
-    directions8 = generate_bvecs(8)
-    directions30 = generate_bvecs(20)
-    directions60 = generate_bvecs(30)
-    # Create full dataset parameters
-    # (6 b-values = 0, 8 directions for b-value 300, 30 directions for b-value
-    # 1000 and 60 directions for b-value 2000)
-    bvals = np.hstack((np.zeros(6),
-                       300 * np.ones(8),
-                       1000 * np.ones(20),
-                       2000 * np.ones(30)))
-    bvecs = np.vstack((np.zeros((6, 3)),
-                       directions8, directions30, directions60))
-    gtab = gradient_table(bvals, bvecs)
-
+    gtab, bvals = generate_gtab()
     dwi, sigma = rfiw_phantom(gtab, snr=10)
     dwi_den1 = p2s.patch2self(dwi, model='ridge',
                               bvals=bvals, alpha=1.0)

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -7,6 +7,7 @@ from dipy.core.gradients import gradient_table
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
 from dipy.denoise.patch2self import patch2self
+from dipy.denoise.adaptive_patch2self import adaptive_patch2self
 from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.localpca import localpca, mppca
 from dipy.denoise.gibbs import gibbs_removal
@@ -73,6 +74,69 @@ class Patch2SelfFlow(Workflow):
 
                 denoised_data = patch2self(data, bvals, model=model,
                                            verbose=verbose)
+                save_nifti(odenoised, denoised_data, affine, image.header)
+
+                logging.info('Denoised volumes saved as %s', odenoised)
+
+
+class AdaptivePatch2SelfFlow(Workflow):
+    @classmethod
+    def get_short_name(cls):
+        return 'adaptive_patch2self'
+
+    def run(self, input_files, bval_files, model='ols', verbose=False,
+            out_dir='', out_denoised='dwi_ap2s.nii.gz'):
+        """Workflow for the adaptive Patch2Self denoising method.
+
+        It applies adaptive patch2self denoising on each file found by 'globbing'
+        ``input_file`` and ``bval_file``. It saves the results in a directory
+        specified by ``out_dir``.
+
+        Parameters
+        ----------
+        input_files : string
+            Path to the input volumes. This path may contain wildcards to
+            process multiple inputs at once.
+        bval_files : string
+            bval file associated with the diffusion data.
+        model : string, or initialized linear model object.
+            This will determine the algorithm used to solve the set of linear
+            equations underlying this model. If it is a string it needs to be
+            one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
+            it can be an object that inherits from
+            `dipy.optimize.SKLearnLinearSolver` or an object with a similar
+            interface from Scikit-Learn:
+            `sklearn.linear_model.LinearRegression`,
+            `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
+            and other objects that inherit from `sklearn.base.RegressorMixin`.
+            Default: 'ols'.
+        verbose : bool, optional
+            Show progress of Patch2Self and time taken.
+        out_dir : string, optional
+            Output directory (default current directory)
+        out_denoised : string, optional
+            Name of the resulting denoised volume
+            (default: dwi_patch2self.nii.gz)
+
+        References
+        ----------
+        .. [Fadnavis20] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
+                    Denoising Diffusion MRI with Self-supervised Learning,
+                    Advances in Neural Information Processing Systems 33 (2020)
+
+        """
+        io_it = self.get_io_iterator()
+        for fpath, bvalpath, odenoised in io_it:
+            if self._skip:
+                shutil.copy(fpath, odenoised)
+                logging.warning('Denoising skipped for now.')
+            else:
+                logging.info('Denoising %s', fpath)
+                data, affine, image = load_nifti(fpath, return_img=True)
+                bvals = np.loadtxt(bvalpath)
+
+                denoised_data = adaptive_patch2self(data, bvals, model=model,
+                                                    verbose=verbose)
                 save_nifti(odenoised, denoised_data, affine, image.header)
 
                 logging.info('Denoised volumes saved as %s', odenoised)


### PR DESCRIPTION
Hello, this will probably be most interesting to @ShreyasFadnavis .

Shreyas, I think I figured out why p2s is blurring in diffusion space, and mostly fixed it. The problem is that by training the regressor to predict an entire volume it is assuming that all of the voxels have the same "diffusion response function", i.e. it is like saying they have the same diffusion tensor. The result looks better than that, though, because the regressor is free to give more weight to similar volumes, so even though it is using a one-size-fits-all interpolation kernel, it does not have to interpolate from very far away.

My solution is to train different regressors for different types of voxels, and then for any given voxel use a weighted sum of the regressors. The "types of voxels" comes from either Independent Component Analysis or Principal Component Analysis (ICA is slightly better), and the voxel's position in component space also sets the weights for the regressors. Thus each voxel gets a regressor that is appropriate to it, preserving signal without hurting denoising by going to the extreme of giving each voxel a regressor that is exactly tuned to it.

Since the equivalent of a "patch" is now a collection of voxels with similar intensities for each volume, regardless of their spatial location, I took out patch_radius. I now think p2s really is better working only in diffusion space, and the improvement I was seeing before with larger patches was just from the regressor getting more variables to work with. Because the interface changed, I ended up making adaptive_patch2self its own command instead of trying to insert this into p2s.

This will probably make more sense with pictures, but I'll submit the pull request for review now and add images later instead of trying to do everything at once.

Best wishes,

Rob
 