### PR TITLE
Manage Approx_polygon_track with repeated points

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1115,7 +1115,7 @@ def approx_polygon_track(xyz,alpha=0.392):
         float *fvec2
         object characteristic_points
         cnp.npy_intp t_len
-        double angle,tmp
+        double angle,tmp, denom
         float vec0[3]
         float vec1[3]
 
@@ -1135,7 +1135,8 @@ def approx_polygon_track(xyz,alpha=0.392):
         #csub_3vecs(<float *> cnp.PyArray_DATA(fvec1),<float *> cnp.PyArray_DATA(fvec0),vec0)
         csub_3vecs(fvec1,fvec0,vec0)
         csub_3vecs(fvec2,fvec1,vec1)
-        tmp=<double>fabs(acos(cinner_3vecs(vec0,vec1)/(cnorm_3vec(vec0)*cnorm_3vec(vec1))))
+        denom = cnorm_3vec(vec0)*cnorm_3vec(vec1)
+        tmp=<double>fabs(acos(cinner_3vecs(vec0,vec1)/ denom)) if denom else 0
         if dpy_isnan(tmp) :
             angle+=0.
         else:

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -2,8 +2,9 @@
 import warnings
 import numpy as np
 from dipy.testing import assert_true
-from numpy.testing import (assert_array_almost_equal, assert_warns,
-                           assert_equal, assert_almost_equal)
+from numpy.testing import (assert_array_almost_equal,
+                           assert_equal, assert_almost_equal,
+                           assert_array_equal)
 from dipy.tracking import distances as pf
 from dipy.tracking.streamline import set_number_of_points
 from dipy.data import get_fnames
@@ -212,8 +213,14 @@ def test_approx_ei_traj():
     y = 5*np.sin(5*t)
     z = np.zeros(x.shape)
     xyz = np.vstack((x, y, z)).T
+
     xyza = pf.approx_polygon_track(xyz)
     assert_equal(len(xyza), 27)
+
+    # test repeated point
+    track = np.array([[1., 0., 0.], [1., 0., 0.], [3., 0., 0.], [4., 0., 0.]])
+    xyza = pf.approx_polygon_track(track)
+    assert_array_equal(xyza, np.array([[1., 0., 0.], [4., 0., 0.]]))
 
 
 def test_approx_mdl_traj():


### PR DESCRIPTION
This PR should fix #2314. 

It just avoids the division by zero when 2 consecutive repeated points appeared.

It should solve your problem @dulietina, can you test it? 

Thank you