### PR TITLE
NF - Sample PMF for an input position and direction

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -115,7 +115,7 @@ cdef class PmfGenDirectionGetter(BasePmfDirectionGetter):
     """A base class for direction getter using a pmf"""
 
     @classmethod
-    def from_pmf(klass, pmf, max_angle, sphere=default_sphere,
+    def from_pmf(klass, pmf, max_angle, sphere,
                  pmf_threshold=.1, **kwargs):
         """Constructor for making a DirectionGetter from an array of Pmfs
 
@@ -127,7 +127,8 @@ cdef class PmfGenDirectionGetter(BasePmfDirectionGetter):
             The maximum allowed angle between incoming direction and new
             direction.
         sphere : Sphere
-            The set of directions to be used for tracking.
+            The set of directions on which the pmf is sampled and to be used
+            for tracking.
         pmf_threshold : float [0., 1.]
             Used to remove direction from the probability mass function for
             selecting the tracking direction.

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -150,7 +150,7 @@ cdef class PmfGenDirectionGetter(BasePmfDirectionGetter):
                    "points in sphere.")
             raise ValueError(msg)
 
-        pmf_gen = SimplePmfGen(np.asarray(pmf,dtype=float))
+        pmf_gen = SimplePmfGen(np.asarray(pmf,dtype=float), sphere)
         return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
     @classmethod

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -4,9 +4,11 @@ cdef class PmfGen:
     cdef:
         double[:] pmf
         double[:, :, :, :] data
+        object sphere
 
     cpdef double[:] get_pmf(self, double[::1] point)
     cdef double[:] get_pmf_c(self, double* point)
+    cpdef double get_pmf_val(self, double[::1] point, double[::1] xyz)
     cdef void __clear_pmf(self)
     pass
 
@@ -18,9 +20,7 @@ cdef class SimplePmfGen(PmfGen):
 cdef class SHCoeffPmfGen(PmfGen):
     cdef:
         double[:, :] B
-        object sphere
         double[:] coeff
-    cpdef double get_pmf_val(self, double[::1] point, double[::1] xyz)
     pass
 
 
@@ -28,7 +28,6 @@ cdef class BootPmfGen(PmfGen):
     cdef:
         int sh_order
         double[:, :] R
-        object sphere
         object model
         object H
         np.ndarray vox_data

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -34,5 +34,4 @@ cdef class BootPmfGen(PmfGen):
 
 
     cpdef double[:] get_pmf_no_boot(self, double[::1] point)
-    cdef double[:] get_pmf_no_boot_c(self, double* point)
     pass

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -32,6 +32,5 @@ cdef class BootPmfGen(PmfGen):
         np.ndarray vox_data
         np.ndarray dwi_mask
 
-
     cpdef double[:] get_pmf_no_boot(self, double[::1] point)
     pass

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -20,6 +20,7 @@ cdef class SHCoeffPmfGen(PmfGen):
         double[:, :] B
         object sphere
         double[:] coeff
+    cpdef double get_pmf_val(self, double[::1] point, double[::1] xyz)
     pass
 
 

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -50,7 +50,7 @@ cdef class SimplePmfGen(PmfGen):
             raise ValueError("pmf should not have negative values.")
         if not pmf_array.shape[3] == sphere.vertices.shape[0]:
             raise ValueError("pmf should have the same number of values as the"
-                             + "number of vertices on sphere.")
+                             + " number of vertices of sphere.")
 
     cpdef double[:] get_pmf(self, double[::1] point):
         if trilinear_interpolate4d_c(self.data, &point[0], self.pmf) != 0:
@@ -123,7 +123,7 @@ cdef class BootPmfGen(PmfGen):
         r, theta, phi = shm.cart2sphere(x, y, z)
         b_range = (r.max() - r.min()) / r.min()
         if b_range > tol:
-            raise ValueError("BootPmfGen only supports single shell data")
+            raise ValueError("BootPmfGen only supports single shell data.")
         B, _, _ = shm.real_sh_descoteaux(self.sh_order, theta, phi)
         self.H = shm.hat(B)
         self.R = shm.lcr_matrix(self.H)

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -16,7 +16,7 @@ cdef class PmfGen:
 
     def __init__(self,
                  double[:, :, :, :] data,
-                 object sphere=default_sphere):
+                 object sphere):
         self.data = np.asarray(data, dtype=float)
         self.sphere = sphere
 
@@ -43,12 +43,12 @@ cdef class SimplePmfGen(PmfGen):
 
     def __init__(self,
                  double[:, :, :, :] pmf_array,
-                 object sphere=default_sphere):
+                 object sphere):
         PmfGen.__init__(self, pmf_array, sphere)
         self.pmf = np.empty(pmf_array.shape[3])
         if np.min(pmf_array) < 0:
             raise ValueError("pmf should not have negative values.")
-        if pmf_array.shape[-1] != sphere.vertices.shape[0]:
+        if not pmf_array.shape[3] == sphere.vertices.shape[0]:
             raise ValueError("pmf should have the same number of values as the"
                              + "number of vertices on sphere.")
 

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -66,7 +66,14 @@ cdef class SHCoeffPmfGen(PmfGen):
             raise ValueError("%s is not a known basis type." % basis_type)
         self.B, _, _ = basis(sh_order, sphere.theta, sphere.phi)
         self.coeff = np.empty(shcoeff_array.shape[3])
-        self.pmf = np.empty(self.B.shape[0])
+        self.pmf = np.empty(self.B.shape[0])        
+
+    cpdef double get_pmf_val(self, double[::1] point, double[::1] xyz):
+        """
+        Return the pmf value corresponding to the closest vertex to the
+        direction xyz.
+        """
+        return self.get_pmf(point)[self.sphere.find_closest(xyz)]
 
     cdef double[:] get_pmf_c(self, double* point):
         cdef:
@@ -123,7 +130,6 @@ cdef class BootPmfGen(PmfGen):
         self.sphere = sphere
         self.pmf = np.empty(len(sphere.theta))
 
-
     cdef double[:] get_pmf_c(self, double* point):
         """Produces an ODF from a SH bootstrap sample"""
         if trilinear_interpolate4d_c(self.data, point, self.vox_data) != 0:
@@ -134,10 +140,8 @@ cdef class BootPmfGen(PmfGen):
             self.pmf = self.model.fit(self.vox_data).odf(self.sphere)
         return self.pmf
 
-
     cpdef double[:] get_pmf_no_boot(self, double[::1] point):
         return self.get_pmf_no_boot_c(&point[0])
-
 
     cdef double[:] get_pmf_no_boot_c(self, double* point):
         if trilinear_interpolate4d_c(self.data, point, self.vox_data) != 0:

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -140,10 +140,7 @@ cdef class BootPmfGen(PmfGen):
         return self.pmf
 
     cpdef double[:] get_pmf_no_boot(self, double[::1] point):
-        return self.get_pmf_no_boot_c(&point[0])
-
-    cdef double[:] get_pmf_no_boot_c(self, double* point):
-        if trilinear_interpolate4d_c(self.data, point, self.vox_data) != 0:
+        if trilinear_interpolate4d_c(self.data, &point[0], self.vox_data) != 0:
             self.__clear_pmf()
         else:
             self.pmf = self.model.fit(self.vox_data).odf(self.sphere)

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -48,6 +48,9 @@ cdef class SimplePmfGen(PmfGen):
         self.pmf = np.empty(pmf_array.shape[3])
         if np.min(pmf_array) < 0:
             raise ValueError("pmf should not have negative values.")
+        if pmf_array.shape[-1] != sphere.vertices.shape[0]:
+            raise ValueError("pmf should have the same number of values as the"
+                             + "number of vertices on sphere.")
 
     cpdef double[:] get_pmf(self, double[::1] point):
         if trilinear_interpolate4d_c(self.data, &point[0], self.pmf) != 0:

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -14,7 +14,6 @@ cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.direction.peaks import peak_directions, default_sphere
-from dipy.direction.pmf cimport PmfGen, SimplePmfGen, SHCoeffPmfGen
 from dipy.utils.fast_numpy cimport cumsum, where_to_insert
 
 

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -71,7 +71,7 @@ def test_bdg_get_direction():
 
     pmf = np.zeros([1, 1, 1, len(sphere.vertices)])
     pmf[:, :, :, two_neighbors[0]] = 1
-    pmf_gen = SimplePmfGen(pmf)
+    pmf_gen = SimplePmfGen(pmf, sphere)
 
     # test case in which no valid direction is found with default maxdir
     boot_dg = BootDirectionGetter(pmf_gen, angle / 2., sphere=sphere)

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -4,12 +4,28 @@ import numpy.testing as npt
 
 from dipy.core.gradients import gradient_table
 from dipy.core.sphere import HemiSphere, unit_octahedron
+from dipy.data import get_sphere
 from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen, BootPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
 from dipy.sims.voxel import single_tensor
 
 response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
+
+
+
+def test_pmf_val():
+    sphere = sphere = get_sphere('symmetric724')
+    pmfgen = SHCoeffPmfGen(np.random.random([2, 2, 2, 28]), sphere, None)
+    point = np.array([1, 1, 1], dtype='float')
+
+    for idx in [0, 5, 15, -1]:
+        pmf = pmfgen.get_pmf(point)
+        # Create a direction vector close to the vertex idx
+        xyz = sphere.vertices[idx] + np.random.random([3]) / 100
+        pmf_idx = pmfgen.get_pmf_val(point, xyz)
+        # Test that the pmf sampled for the direction xyz is correct
+        npt.assert_array_equal(pmf[idx], pmf_idx)
 
 
 def test_pmf_from_sh():

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -3,8 +3,8 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.core.gradients import gradient_table
-from dipy.core.sphere import HemiSphere, unit_octahedron, default_sphere
-from dipy.data import get_sphere
+from dipy.core.sphere import HemiSphere, unit_octahedron
+from dipy.data import default_sphere, get_sphere
 from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen, BootPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
@@ -59,13 +59,13 @@ def test_pmf_from_array():
     # Test ValueError for negative pmf
     npt.assert_raises(
         ValueError,
-        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1),
-                             sphere)
+        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1,
+                             sphere))
     # Test ValueError for non matching pmf and sphere
     npt.assert_raises(
         ValueError,
-        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])),
-                             default_sphere)
+        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]),
+                             default_sphere))
 
 
 def test_boot_pmf():
@@ -102,7 +102,7 @@ def test_boot_pmf():
         # Tests that additionnal warnings are raised for outdated SH basis
         npt.assert_(len(w) > 1)
 
-    boot_pmf_gen_sh4 = BootPmfGen(data, model=csd_model, sphere=hsph_updated,
+    boot_pmf_gen_sh4 = BootPmfGen(data, sphere=hsph_updated, model=csd_model,
                                   sh_order=4)
     pmf_sh4 = boot_pmf_gen_sh4.get_pmf(point)
     npt.assert_equal(len(hsph_updated.vertices), pmf_sh4.shape[0])

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.core.gradients import gradient_table
-from dipy.core.sphere import HemiSphere, unit_octahedron
+from dipy.core.sphere import HemiSphere, unit_octahedron, default_sphere
 from dipy.data import get_sphere
 from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen, BootPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
@@ -44,7 +44,7 @@ def test_pmf_from_sh():
 
 def test_pmf_from_array():
     sphere = HemiSphere.from_sphere(unit_octahedron)
-    pmfgen = SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]))
+    pmfgen = SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]), sphere)
 
     # Test that the pmf is greater than 0 for a valid point
     pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
@@ -56,9 +56,16 @@ def test_pmf_from_array():
     npt.assert_array_equal(pmfgen.get_pmf(np.array([0, 0, 10], dtype='float')),
                            np.zeros(len(sphere.vertices)))
 
+    # Test ValueError for negative pmf
     npt.assert_raises(
         ValueError,
-        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1))
+        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1),
+                             sphere)
+    # Test ValueError for non matching pmf and sphere
+    npt.assert_raises(
+        ValueError,
+        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])),
+                             default_sphere)
 
 
 def test_boot_pmf():

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -13,7 +13,6 @@ from dipy.sims.voxel import single_tensor
 response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
 
 
-
 def test_pmf_val():
     sphere = sphere = get_sphere('symmetric724')
     pmfgen = SHCoeffPmfGen(np.random.random([2, 2, 2, 28]), sphere, None)

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -12,7 +12,9 @@ DIPY 1.5.0 changes
 **Tracking**
 
 - Change in ``dipy.tracking.pmf``
-    - The class ``SimplePmfGen`` as new mendatory parameter ``sphere``. The sphere vectices corespond to the spherical distribution of the pmf values.
+    - The parent class ``PmfGen`` has new mandatory parameter ``sphere``. The sphere vertices correspond to the spherical distribution of the pmf values.
+    - The parent class ``PmfGen`` has new function ``get_pmf_value(point, xyz)`` which return the pmf value at location ``point`` and orientation ``xyz``.
+
 
 DIPY 1.4.1 changes
 ------------------

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,15 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.5.0 changes
+------------------
+**General**
+
+**Tracking**
+
+- Change in ``dipy.tracking.pmf``
+    - The class ``SimplePmfGen`` as new mendatory parameter ``sphere``. The sphere vectices corespond to the spherical distribution of the pmf values.
+
 DIPY 1.4.1 changes
 ------------------
 


### PR DESCRIPTION
This PR adds a utility function to the `SHCoeffPmfGen` object. 

- It adds the function `get_pmf_val(point, xyz)`, which return the pmf (ODF/FOD) value at the position `point` and orientation `xyz`. 
- The closest vertex of the sphere is used to approximate the value at `xyz`.

In the current implementation, the pmf is computed for all vertices, to return the value for one vertex. This could be further optimized. 

@guaje @skoudoro For the PTT implementation, I think we need to move this function to the parent class `PmfGen`. but it doesn't work with child `class SimplePmfGen(PmfGen)`, since this class doesn't have a sphere object. I think there is a bit of a design flaw, and simply moving/requiring the sphere for `PmfGen` (as for `SHCoeffPmfGen`) might solve this. I can add this commit to clarify what I mean.