### PR TITLE
[FIX] `c_compress_streamline` discard identical points

### DIFF
--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -468,7 +468,7 @@ cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp prev,
         norm2 += dn*dn
     norm2 = sqrt(norm2)
 
-    return norm1 / norm2
+    return norm1 / norm2 if norm2 else 0
 
 
 cdef double c_segment_length(Streamline streamline,
@@ -519,6 +519,8 @@ cdef cnp.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
 
         # Check that each point is not offset by more than `tol_error` mm.
         for curr in range(prev+1, next):
+            if c_segment_length(streamline, curr, prev) == 0:
+                continue
             dist = c_dist_to_line(streamline, prev, next, curr)
 
             if dpy_isnan(dist) or dist > tol_error:

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -468,7 +468,7 @@ cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp prev,
         norm2 += dn*dn
     norm2 = sqrt(norm2)
 
-    return norm1 / norm2 if norm2 else 0
+    return norm1 / norm2
 
 
 cdef double c_segment_length(Streamline streamline,

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -733,6 +733,25 @@ def test_compress_streamlines():
         assert_array_almost_equal(cspecial_streamline, cstreamline_python)
 
 
+def test_compress_streamlines_identical_points():
+
+    sl_1 = np.array([[1, 1, 1], [1, 1, 1], [2, 2, 2], [3, 3, 3], [3, 3, 3]])
+    sl_2 = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [2, 2, 2]])
+    sl_3 = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1],
+                     [2, 2, 2], [2, 2, 2], [2, 2, 2], [3, 3, 3], [3, 3, 3]])
+    sl_4 = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [2, 2, 2],
+                    [3, 3, 3], [3, 3, 3], [1, 1, 1]])
+    new_sl_1 = compress_streamlines(sl_1)
+    new_sl_2 = compress_streamlines(sl_2)
+    new_sl_3 = compress_streamlines(sl_3)
+    new_sl_4 = compress_streamlines(sl_4)
+    npt.assert_array_equal(new_sl_1, np.array([[1, 1, 1], [3, 3, 3]]))
+    npt.assert_array_equal(new_sl_2, np.array([[1, 1, 1], [2, 2, 2]]))
+    npt.assert_array_equal(new_sl_3, new_sl_1)
+    npt.assert_array_equal(new_sl_4, np.array([[1, 1, 1], [3, 3, 3],
+                                               [1, 1, 1]]))
+
+
 def test_compress_streamlines_memory_leaks():
     # Test some dtypes
     dtypes = [np.float32, np.float64, np.int32, np.int64]


### PR DESCRIPTION
This PR is to fix issue #1805.

The code is removing some points if they are consecutive and identical like [(0,1), (0,1), (0,20)]

However, If you have the following 2D streamline [(0,1), (0,20), (0,1)], we keep it as it is.

You can check the tests for more examples.

It would be good if @jchoude or @MarcCote  could review this PR since it addresses your discussion.

Thank you


