### PR TITLE
OPT: Prefer using a typed index to get the PMF value

### DIFF
--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -28,7 +28,8 @@ cdef class PmfGen:
         Return the pmf value corresponding to the closest vertex to the
         direction xyz.
         """
-        return self.get_pmf(point)[self.sphere.find_closest(xyz)]
+        cdef int idx = self.sphere.find_closest(xyz)
+        return self.get_pmf(point)[idx]
 
     cdef void __clear_pmf(self):
         cdef:


### PR DESCRIPTION
Prefer using a typed index to get the PMF value from the direction.

Fixes:
```
warning: dipy/direction/pmf.pyx:31:59: Index should be typed for more efficient access
```

Raised for example in
https://dev.azure.com/dipy/dipy/_build/results?buildId=1196&view=logs&j=d9aefae6-c332-51b5-d933-a85009f5a2ac&t=7b3c05b2-26bc-5cc7-178d-37c39b6402cb&l=1670