### PR TITLE
OPT: Initialize `Shape` struct

### DIFF
--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -227,7 +227,7 @@ cdef class CenterOfMassFeature(CythonFeature):
         super(CenterOfMassFeature, self).__init__(is_order_invariant=True)
 
     cdef Shape c_infer_shape(CenterOfMassFeature self, Data2D datum) nogil except *:
-        cdef Shape shape
+        cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
         shape.dims[1] = datum.shape[1]
@@ -262,7 +262,7 @@ cdef class MidpointFeature(CythonFeature):
         super(MidpointFeature, self).__init__(is_order_invariant=False)
 
     cdef Shape c_infer_shape(MidpointFeature self, Data2D datum) nogil except *:
-        cdef Shape shape
+        cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
         shape.dims[1] = datum.shape[1]
@@ -292,7 +292,7 @@ cdef class ArcLengthFeature(CythonFeature):
         super(ArcLengthFeature, self).__init__(is_order_invariant=True)
 
     cdef Shape c_infer_shape(ArcLengthFeature self, Data2D datum) nogil except *:
-        cdef Shape shape
+        cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
         shape.dims[1] = 1
@@ -317,7 +317,7 @@ cdef class VectorOfEndpointsFeature(CythonFeature):
         super(VectorOfEndpointsFeature, self).__init__(is_order_invariant=False)
 
     cdef Shape c_infer_shape(VectorOfEndpointsFeature self, Data2D datum) nogil except *:
-        cdef Shape shape
+        cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
         shape.dims[1] = datum.shape[1]


### PR DESCRIPTION
Initialize `Shape` struct from provided data.

Fixes:
```
building 'dipy.segment.featurespeed' extension
x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Isrc -I/home/local/USHERBROOKE/legj1809/.virtualenvs/dipy/lib/python3.8/site-packages/numpy/core/include -Ibuild -I/home/local/USHERBROOKE/legj1809/.virtualenvs/dipy/include -I/usr/include/python3.8 -c dipy/segment/featurespeed.c -o build/temp.linux-x86_64-3.8/dipy/segment/featurespeed.o -msse2 -mfpmath=sse -fopenmp
dipy/segment/featurespeed.c: In function ‘__pyx_f_4dipy_7segment_12featurespeed_19CenterOfMassFeature_c_infer_shape’:
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[2]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[3]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[4]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[5]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[6]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c: In function ‘__pyx_f_4dipy_7segment_12featurespeed_16ArcLengthFeature_c_infer_shape’:
dipy/segment/featurespeed.c:7656:10: warning: ‘__pyx_v_shape.dims[2]’ is used uninitialized in this function [-Wuninitialized]
 7656 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:7656:10: warning: ‘__pyx_v_shape.dims[3]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:7656:10: warning: ‘__pyx_v_shape.dims[4]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:7656:10: warning: ‘__pyx_v_shape.dims[5]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c:7656:10: warning: ‘__pyx_v_shape.dims[6]’ is used uninitialized in this function [-Wuninitialized]
dipy/segment/featurespeed.c: In function ‘__pyx_f_4dipy_7segment_12featurespeed_24VectorOfEndpointsFeature_c_infer_shape’:
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[2]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[2]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[3]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[3]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[4]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[4]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[5]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[5]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[6]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[6]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c: In function ‘__pyx_f_4dipy_7segment_12featurespeed_15MidpointFeature_c_infer_shape’:
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[2]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[2]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[3]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[3]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[4]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[4]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[5]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[5]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
dipy/segment/featurespeed.c:6543:10: warning: ‘__pyx_v_shape.dims[6]’ is used uninitialized in this function [-Wuninitialized]
 6543 |   return __pyx_r;
      |          ^~~~~~~
dipy/segment/featurespeed.c:6484:53: note: ‘__pyx_v_shape.dims[6]’ was declared here
 6484 |   struct __pyx_t_4dipy_7segment_11cythonutils_Shape __pyx_v_shape;
      |                                                     ^~~~~~~~~~~~~
```