### PR TITLE
BUG: Backward compat support for pipeline

### DIFF
--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -26,12 +26,16 @@ DEBUG : print as much information as possible to isolate the cause of a bug.
 
 from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
                                 write_mapping, read_mapping, resample,
-                                center_of_mass, translation, rigid, affine,
+                                center_of_mass, translation,
+                                rigid_isoscaling, rigid_scaling,
+                                rigid, affine,
                                 affine_registration, register_series,
                                 register_dwi_series, streamline_registration)
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
-           "center_of_mass", "translation", "rigid", "affine",
+           "center_of_mass", "translation",
+           "rigid_isoscaling", "rigid_scaling",
+           "rigid", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -455,12 +455,11 @@ def affine_registration(moving, static,
     # Convert pipeline to sanitized list of str
     pipeline = list(pipeline)
     for fi, func in enumerate(pipeline):
-        if not isinstance(func, str):
-            if callable(func):
-                for key, val in _METHOD_DICT.items():
-                    if func is val[0]:  # if they passed the callable equiv.
-                        pipeline[fi] = func = key
-                        break
+        if callable(func):
+            for key, val in _METHOD_DICT.items():
+                if func is val[0]:  # if they passed the callable equiv.
+                    pipeline[fi] = func = key
+                    break
         if not isinstance(func, str) or func not in _METHOD_DICT:
             raise ValueError(f'pipeline[{fi}] must be one of '
                              f'{list(_METHOD_DICT)}, got {repr(func)}')
@@ -509,11 +508,11 @@ rigid = partial(affine_registration, pipeline=['rigid'])
 rigid.__doc__ = ("Implements a rigid transform. "
                  "Based on `affine_registration()`.")
 
-rigid_isoscaling = partial(affine_registration, pipeline=['rigid'])
+rigid_isoscaling = partial(affine_registration, pipeline=['rigid_isoscaling'])
 rigid_isoscaling.__doc__ = ("Implements a rigid isoscaling transform. "
                             "Based on `affine_registration()`.")
 
-rigid_scaling = partial(affine_registration, pipeline=['rigid'])
+rigid_scaling = partial(affine_registration, pipeline=['rigid_scaling'])
 rigid_scaling.__doc__ = ("Implements a rigid scaling transform. "
                          "Based on `affine_registration()`.")
 

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -37,7 +37,9 @@ from dipy.io.image import load_nifti, save_nifti
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
-           "center_of_mass", "translation", "rigid", "affine",
+           "center_of_mass", "translation",
+           "rigid_isoscaling", "rigid_scaling",
+           "rigid", "affine",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]
 
@@ -368,7 +370,7 @@ def affine_registration(moving, static,
     pipeline : list of str, optional
         Sequence of transforms to use in the gradual fitting. Default: gradual
         fit of the full affine (executed from left to right):
-        `["center_of_mass", "translation", "rigid", "affine"]`
+        ``["center_of_mass", "translation", "rigid", "affine"]``
         Alternatively, any other combination of the following registration
         methods might be used: center_of_mass, translation, rigid,
         rigid_isoscaling, rigid_scaling and affine.
@@ -450,6 +452,19 @@ def affine_registration(moving, static,
                                 sigmas=sigmas,
                                 factors=factors)
 
+    # Convert pipeline to sanitized list of str
+    pipeline = list(pipeline)
+    for fi, func in enumerate(pipeline):
+        if not isinstance(func, str):
+            if callable(func):
+                for key, val in _METHOD_DICT.items():
+                    if func is val[0]:  # if they passed the callable equiv.
+                        pipeline[fi] = func = key
+                        break
+        if not isinstance(func, str) or func not in _METHOD_DICT:
+            raise ValueError(f'pipeline[{fi}] must be one of '
+                             f'{list(_METHOD_DICT)}, got {repr(func)}')
+
     if pipeline == ["center_of_mass"] and ret_metric:
         raise ValueError("center of mass registration cannot return any "
                          "quality metric.")
@@ -461,19 +476,7 @@ def affine_registration(moving, static,
                                                   moving, moving_affine)
             starting_affine = transform.affine
         else:
-            if func == "translation":
-                transform = TranslationTransform3D()
-            elif func == "rigid":
-                transform = RigidTransform3D()
-            elif func == "rigid_isoscaling":
-                transform = RigidIsoScalingTransform3D()
-            elif func == "rigid_scaling":
-                transform = RigidScalingTransform3D()
-            elif func == "affine":
-                transform = AffineTransform3D()
-            else:
-                raise ValueError("Not supported registration method")
-
+            transform = _METHOD_DICT[func][1]()
             xform, xopt, fopt \
                 = affreg.optimize(static, moving, transform, None,
                                   static_affine, moving_affine,
@@ -506,9 +509,26 @@ rigid = partial(affine_registration, pipeline=['rigid'])
 rigid.__doc__ = ("Implements a rigid transform. "
                  "Based on `affine_registration()`.")
 
+rigid_isoscaling = partial(affine_registration, pipeline=['rigid'])
+rigid_isoscaling.__doc__ = ("Implements a rigid isoscaling transform. "
+                            "Based on `affine_registration()`.")
+
+rigid_scaling = partial(affine_registration, pipeline=['rigid'])
+rigid_scaling.__doc__ = ("Implements a rigid scaling transform. "
+                         "Based on `affine_registration()`.")
+
 affine = partial(affine_registration, pipeline=['affine'])
 affine.__doc__ = ("Implements an affine transform. "
                   "Based on `affine_registration()`.")
+
+
+_METHOD_DICT = dict(  # mapping from str key -> (callable, class) tuple
+    center_of_mass=(center_of_mass, None),
+    translation=(translation, TranslationTransform3D),
+    rigid_isoscaling=(rigid_isoscaling, RigidIsoScalingTransform3D),
+    rigid_scaling=(rigid_scaling, RigidScalingTransform3D),
+    rigid=(rigid, RigidTransform3D),
+    affine=(affine, AffineTransform3D))
 
 
 def register_series(series, ref, pipeline=None, series_affine=None,
@@ -604,7 +624,7 @@ def register_dwi_series(data, gtab, affine=None, b0_ref=0, pipeline=None):
 
     pipeline : list of callables, optional.
         The transformations to perform in sequence (from left to right):
-        Default: `[center_of_mass, translation, rigid, affine]`
+        Default: ``[center_of_mass, translation, rigid, affine]``
 
 
     Returns


### PR DESCRIPTION
Prior to #2390 code like this worked:
```
from dipy.align import (affine_registration, center_of_mass,
                        translation, rigid, affine, resample,
                        imwarp, metrics)
moving_zoomed, reg_affine = affine_registration(
    moving_zoomed, static_zoomed, moving_affine, static_affine,
    nbins=32, metric='MI', pipeline=[center_of_mass, translation],
    level_iters=niter[step], sigmas=sigmas, factors=factors)
```
But due to #2390 moving `pipeline` from `list of callable` to `list of str` arguments, this now raises:
```
../../.local/lib/python3.10/site-packages/dipy/align/_public.py:475: in affine_registration
    raise ValueError("Not supported registration method")
E   ValueError: Not supported registration method
```
I saw two ways out:

1. Allow any `callable` and refactor a bunch of code (probably difficult, doubt many people would require this)
2. Check `if step is center_of_mass` etc. and alias to the string equivalent

This PR:

1. Implements option (2) above
2. Adds tests for it
3. Adds `rigid_isoscaling` and `rigid_scaling` callables to the same public namespace as `center_of_mass`, `rigid`, etc. for completeness
4. Fixes some Sphinx/RST errors (single-backticks are for the default Sphinx role, so a couple I changed to double-backticks to be "code mode")

This is just what I inferred to be the right approach here, but if I'm totally on the wrong track feel free to close, or comment and I can revert some of the changes above if they're not wanted!