### PR TITLE
MAINT: Bump tolerance

### DIFF
--- a/dipy/reconst/tests/test_dki_micro.py
+++ b/dipy/reconst/tests/test_dki_micro.py
@@ -4,7 +4,7 @@ import numpy as np
 import random
 import dipy.reconst.dki_micro as dki_micro
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
-                           assert_, assert_raises)
+                           assert_, assert_raises, assert_allclose)
 from dipy.sims.voxel import (multi_tensor_dki, _check_directions, multi_tensor)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
@@ -118,7 +118,7 @@ def test_single_fiber_model():
     # Test model and fit objects
     wmtiM = dki_micro.KurtosisMicrostructureModel(gtab_2s, fit_method="WLS")
     wmtiF = wmtiM.fit(signal)
-    assert_almost_equal(wmtiF.awf, AWF)
+    assert_allclose(wmtiF.awf, AWF, rtol=1e-6)
     assert_array_almost_equal(wmtiF.hindered_evals,
                               np.array([ADe, RDe, RDe]))
     assert_array_almost_equal(wmtiF.restricted_evals,


### PR DESCRIPTION
Should fix [this error](https://dev.azure.com/dipy/dipy/_build/results?buildId=1238&view=logs&jobId=c4497b2b-649a-591e-539b-0d716883e33e&j=c4497b2b-649a-591e-539b-0d716883e33e&t=315e67fb-8bac-5822-ff35-e6ec3c18835a) that popped up in #2434:
```
        # Test model and fit objects
        wmtiM = dki_micro.KurtosisMicrostructureModel(gtab_2s, fit_method="WLS")
        wmtiF = wmtiM.fit(signal)
>       assert_almost_equal(wmtiF.awf, AWF)
E       AssertionError: 
E       Arrays are not almost equal to 7 decimals
E       
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference: 1.7266712437624676e-07
E       Max relative difference: 3.5238188646389464e-07
E        x: array(0.48999982735824127)
E        y: array(0.49000000002536565)

```