### PR TITLE
BUG: Fix misplaced comma in `warn()` call from `patch2self.py`

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -244,7 +244,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ols',
                          data.shape)
 
     if data.shape[3] < 10:
-        warn("The intput data has less than 10 3D volumes. Patch2Self may not "
+        warn("The input data has less than 10 3D volumes. Patch2Self may not "
              "give denoising performance.")
 
     if out_dtype is None:

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -244,7 +244,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ols',
                          data.shape)
 
     if data.shape[3] < 10:
-        warn("The intput data has less than 10 3D volumes. Patch2Self may not",
+        warn("The intput data has less than 10 3D volumes. Patch2Self may not "
              "give denoising performance.")
 
     if out_dtype is None:


### PR DESCRIPTION
Because of the comma, `"give denoising performance."` gets passed as a second argument  to the `warn()` function, causing this error:

```python
Traceback (most recent call last):
  File "/home/joshua/repos/spinalcordtoolbox/testing/cli/test_cli_sct_dmri_denoise_patch2self.py", line 12, in test_sct_denoising_onlm_no_checks
    '-b', 'sct_testing_data/dmri/bvals.txt', '-v', '2'])
  File "/home/joshua/repos/spinalcordtoolbox/spinalcordtoolbox/scripts/sct_denoise_patch2self.py", line 121, in main
    verbose=True)
  File "/home/joshua/repos/spinalcordtoolbox/python/envs/venv_sct/lib/python3.6/site-packages/dipy/denoise/patch2self.py", line 248, in patch2self
    "give denoising performance.")
TypeError: category must be a Warning subclass, not 'str'
```

(Since this is such a small fix, I skipped creating an issue. Hope that's okay!)