### PR TITLE
[NF] Add Motion correction workflow

### DIFF
--- a/bin/dipy_correct_motion
+++ b/bin/dipy_correct_motion
@@ -1,0 +1,7 @@
+#!python
+
+from dipy.workflows.flow_runner import run_flow
+from dipy.workflows.align import MotionCorrectionFlow
+
+if __name__ == "__main__":
+    run_flow(MotionCorrectionFlow())

--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -28,7 +28,7 @@ from dipy.align._public import (syn_registration, register_dwi_to_template, # no
                                 write_mapping, read_mapping, resample,
                                 center_of_mass, translation,
                                 rigid_isoscaling, rigid_scaling,
-                                rigid, affine,
+                                rigid, affine, motion_correction,
                                 affine_registration, register_series,
                                 register_dwi_series, streamline_registration)
 
@@ -36,6 +36,6 @@ __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
            "center_of_mass", "translation",
            "rigid_isoscaling", "rigid_scaling",
-           "rigid", "affine",
+           "rigid", "affine", "motion_correction",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -670,10 +670,11 @@ def register_dwi_series(data, gtab, affine=None, b0_ref=0, pipeline=None):
 
     return nib.Nifti1Image(data_array, affine), affine_array
 
-motion_correction  = partial(register_dwi_series, pipeline=["center_of_mass",
-                                                            "translation",
-                                                            "rigid", "affine"])
-motion_correction.__doc__ = re.sub('Register.*?volume','Apply a motion '
+
+motion_correction = partial(register_dwi_series, pipeline=["center_of_mass",
+                                                           "translation",
+                                                           "rigid", "affine"])
+motion_correction.__doc__ = re.sub('Register.*?volume', 'Apply a motion '
                                    'correction to a DWI dataset '
                                    '(Between-Volumes Motion correction',
                                    register_dwi_series.__doc__,

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -5,6 +5,7 @@ streamlines.
 
 
 """
+import re
 import collections
 from functools import partial
 import numbers
@@ -39,7 +40,7 @@ __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",
            "center_of_mass", "translation",
            "rigid_isoscaling", "rigid_scaling",
-           "rigid", "affine",
+           "rigid", "affine", "motion_correction",
            "affine_registration", "register_series",
            "register_dwi_series", "streamline_registration"]
 
@@ -668,6 +669,15 @@ def register_dwi_series(data, gtab, affine=None, b0_ref=0, pipeline=None):
     data_array[..., ~gtab.b0s_mask] = xformed
 
     return nib.Nifti1Image(data_array, affine), affine_array
+
+motion_correction  = partial(register_dwi_series, pipeline=["center_of_mass",
+                                                            "translation",
+                                                            "rigid", "affine"])
+motion_correction.__doc__ = re.sub('Register.*?volume','Apply a motion '
+                                   'correction to a DWI dataset '
+                                   '(Between-Volumes Motion correction',
+                                   register_dwi_series.__doc__,
+                                   flags=re.DOTALL)
 
 
 def streamline_registration(moving, static, n_points=100,

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -6,7 +6,7 @@ streamlines.
 
 """
 import re
-import collections
+import collections.abc
 from functools import partial
 import numbers
 import numpy as np
@@ -637,7 +637,7 @@ def register_dwi_series(data, gtab, affine=None, b0_ref=0, pipeline=None):
     pipeline = pipeline or ["center_of_mass", "translation", "rigid", "affine"]
 
     data, affine = read_img_arr_or_path(data, affine=affine)
-    if isinstance(gtab, collections.Sequence):
+    if isinstance(gtab, collections.abc.Sequence):
         gtab = dpg.gradient_table(*gtab)
 
     if np.sum(gtab.b0s_mask) > 1:

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -12,7 +12,7 @@ import dipy.core.gradients as dpg
 
 from dipy.align import (syn_registration, register_series, register_dwi_series,
                         center_of_mass, translation, rigid_isoscaling,
-                        rigid_scaling, rigid, affine,
+                        rigid_scaling, rigid, affine, motion_correction,
                         affine_registration, streamline_registration,
                         write_mapping, read_mapping, register_dwi_to_template)
 
@@ -221,7 +221,7 @@ def test_register_series():
     npt.assert_(np.all(xformed[..., ref_idx] == img.get_fdata()[..., ref_idx]))
 
 
-def test_register_dwi_series():
+def test_register_dwi_series_and_motion_correction():
     fdata, fbval, fbvec = dpd.get_fnames('small_64D')
     with nbtmp.InTemporaryDirectory() as tmpdir:
         # Use an abbreviated data-set:
@@ -237,7 +237,11 @@ def test_register_dwi_series():
         gtab = dpg.gradient_table(op.join(tmpdir, 'bvals.txt'),
                                   op.join(tmpdir, 'bvecs.txt'))
         reg_img, reg_affines = register_dwi_series(data, gtab, img.affine)
+        reg_img_2, reg_affines_2 = motion_correction(data, gtab, img.affine)
         npt.assert_(isinstance(reg_img, nib.Nifti1Image))
+
+        npt.assert_array_equal(reg_img.get_fdata(), reg_img_2.get_fdata())
+        npt.assert_array_equal(reg_affines, reg_affines_2)
 
 
 def test_streamline_registration():

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1,5 +1,6 @@
 
 import logging
+from warnings import warn
 import numpy as np
 import nibabel as nib
 
@@ -8,9 +9,11 @@ from dipy.align.imwarp import (SymmetricDiffeomorphicRegistration,
                                DiffeomorphicMap)
 from dipy.align.metrics import CCMetric, SSDMetric, EMMetric
 from dipy.align.reslice import reslice
-from dipy.align import affine_registration
+from dipy.align import affine_registration, register_dwi_series
 from dipy.align.streamlinear import slr_with_qbx
+from dipy.core.gradients import gradient_table
 from dipy.io.image import save_nifti, load_nifti, save_qa_metric
+from dipy.io.gradients import read_bvals_bvecs
 from dipy.tracking.streamline import transform_streamlines
 from dipy.workflows.workflow import Workflow
 
@@ -704,3 +707,66 @@ class SynRegistrationFlow(Workflow):
             save_nifti(owarped_file, warped_moving, static_grid2world)
             logging.info('Saving Diffeomorphic map {0}'.format(omap_file))
             save_nifti(omap_file, mapping_data, mapping.codomain_world2grid)
+
+
+class MotionCorrectionFlow(Workflow):
+    """
+    The Motion Correction workflow allows the user to use only one type of
+    registration (such as center of mass or rigid body registration only).
+    """
+
+    def run(self, input_files, bvalues_files, bvectors_files, b0_threshold=50,
+            bvecs_tol=0.01, out_dir='', out_moved='moved.nii.gz',
+            out_affine='affine.txt'):
+        """
+        Parameters
+        ----------
+        input_files : string
+            Path to the input volumes. This path may contain wildcards to
+            process multiple inputs at once.
+        bvalues_files : string
+            Path to the bvalues files. This path may contain wildcards to use
+            multiple bvalues files at once.
+        bvectors_files : string
+            Path to the bvectors files. This path may contain wildcards to use
+            multiple bvectors files at once.
+        b0_threshold : float, optional
+            Threshold used to find b0 volumes.
+        bvecs_tol : float, optional
+            Threshold used to check that norm(bvec) = 1 +/- bvecs_tol
+            b-vectors are unit vectors
+        out_dir : string, optional
+            Directory to save the transformed image and the affine matrix
+             (default current directory).
+        out_moved : string, optional
+            Name for the saved transformed image.
+        out_affine : string, optional
+            Name for the saved affine matrix.
+        """
+
+        io_it = self.get_io_iterator()
+        pipeline = ["center_of_mass", "translation", "rigid", "affine"]
+
+        for dwi, bval, bvec, qual_val_file in io_it:
+
+            # Load the data from the input files and store into objects.
+            logging.info('Loading {0}'.format(dwi))
+            data, affine = load_nifti(dwi)
+
+            bvals, bvecs = read_bvals_bvecs(bval, bvec)
+            print(b0_threshold, bvals.min())
+            if b0_threshold < bvals.min():
+                warn("b0_threshold (value: {0}) is too low, increase your "
+                     "b0_threshold. It should be higher than the first b0 value "
+                     "({1}).".format(b0_threshold, bvals.min()))
+            gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
+                                  atol=bvecs_tol)
+
+            reg_img, reg_affines = register_dwi_series(data=data, gtab=gtab,
+                                                      affiine=affine,
+                                                      pipeline=pipeline)
+            """
+            Saving the moved image file and the affine matrix.
+            """
+            save_nifti(moved_file, moved_image, static_grid2world)
+            np.savetxt(affine_matrix_file, affine_matrix)

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -767,7 +767,10 @@ class MotionCorrectionFlow(Workflow):
             """
             Saving the corrected image file and the affine matrix.
             """
-            # TODO: Check Saving
-            # import ipdb; ipdb.set_trace()
             save_nifti(omoved, reg_img.get_fdata(), affine)
-            np.savetxt(oafffine, reg_affines)
+            # Write the array to disk
+            with open(oafffine, 'w') as outfile:
+                outfile.write('# Array shape: {0}\n'.format(reg_affines.shape))
+                for affine_slice in reg_affines:
+                    np.savetxt(outfile, affine_slice, fmt='%-7.2f')
+                    outfile.write('# New slice\n')

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -757,14 +757,14 @@ class MotionCorrectionFlow(Workflow):
             print(b0_threshold, bvals.min())
             if b0_threshold < bvals.min():
                 warn("b0_threshold (value: {0}) is too low, increase your "
-                     "b0_threshold. It should be higher than the first b0 value "
-                     "({1}).".format(b0_threshold, bvals.min()))
+                     "b0_threshold. It should be higher than the first "
+                     "b0 value ({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
                                   atol=bvecs_tol)
 
             reg_img, reg_affines = register_dwi_series(data=data, gtab=gtab,
-                                                      affiine=affine,
-                                                      pipeline=pipeline)
+                                                       affine=affine,
+                                                       pipeline=pipeline)
             """
             Saving the corrected image file and the affine matrix.
             """

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -711,8 +711,8 @@ class SynRegistrationFlow(Workflow):
 
 class MotionCorrectionFlow(Workflow):
     """
-    The Motion Correction workflow allows the user to use only one type of
-    registration (such as center of mass or rigid body registration only).
+    The Motion Correction workflow allows the user to align between-volumes
+    DWI dataset.
     """
 
     def run(self, input_files, bvalues_files, bvectors_files, b0_threshold=50,
@@ -756,7 +756,7 @@ class MotionCorrectionFlow(Workflow):
 
             if b0_threshold < bvals.min():
                 warn("b0_threshold (value: {0}) is too low, increase your "
-                     "b0_threshold. It should be higher than the first "
+                     "b0_threshold. It should be higher than the lowest "
                      "b0 value ({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
                                   atol=bvecs_tol)

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -747,7 +747,7 @@ class MotionCorrectionFlow(Workflow):
         io_it = self.get_io_iterator()
         pipeline = ["center_of_mass", "translation", "rigid", "affine"]
 
-        for dwi, bval, bvec, qual_val_file in io_it:
+        for dwi, bval, bvec in io_it:
 
             # Load the data from the input files and store into objects.
             logging.info('Loading {0}'.format(dwi))
@@ -766,7 +766,7 @@ class MotionCorrectionFlow(Workflow):
                                                       affiine=affine,
                                                       pipeline=pipeline)
             """
-            Saving the moved image file and the affine matrix.
+            Saving the corrected image file and the affine matrix.
             """
-            save_nifti(moved_file, moved_image, static_grid2world)
-            np.savetxt(affine_matrix_file, affine_matrix)
+            save_nifti(out_moved, reg_img, reg_affines)
+            np.savetxt(out_affine, reg_affines)

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -764,11 +764,9 @@ class MotionCorrectionFlow(Workflow):
             reg_img, reg_affines = motion_correction(data=data, gtab=gtab,
                                                      affine=affine)
 
-            """
-            Saving the corrected image file and the affine matrix.
-            """
+            # Saving the corrected image file
             save_nifti(omoved, reg_img.get_fdata(), affine)
-            # Write the array to disk
+            # Write the affine matrix array to disk
             with open(oafffine, 'w') as outfile:
                 outfile.write('# Array shape: {0}\n'.format(reg_affines.shape))
                 for affine_slice in reg_affines:

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -331,7 +331,6 @@ def test_motion_correction():
 
         motion_correction_flow = MotionCorrectionFlow()
 
-        # import ipdb; ipdb.set_trace()
         motion_correction_flow._force_overwrite = True
         motion_correction_flow.run(os.path.join(out_dir, 'data.nii.gz'),
                                    os.path.join(out_dir, 'bvals.txt'),
@@ -340,11 +339,9 @@ def test_motion_correction():
         out_path = motion_correction_flow.last_generated_outputs['out_moved']
         corrected = load_nifti_data(out_path)
 
-        npt.assert_equal(corrected.shape[0] > volume.shape[0], True)
-        npt.assert_equal(corrected.shape[1] > volume.shape[1], True)
-        npt.assert_equal(corrected.shape[2] > volume.shape[2], True)
-        npt.assert_equal(corrected.shape[-1], volume.shape[-1])
-
+        npt.assert_equal(corrected.shape, data.shape)
+        npt.assert_equal(corrected.min(), data.min())
+        npt.assert_equal(corrected.max(), data.max())
 
 
 def test_syn_registration_flow():

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -17,7 +17,7 @@ from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.tracking.streamline import Streamlines
 from dipy.workflows.align import (ImageRegistrationFlow, SynRegistrationFlow,
                                   ApplyTransformFlow, ResliceFlow,
-                                  SlrWithQbxFlow)
+                                  SlrWithQbxFlow, MotionCorrectionFlow)
 
 
 def test_reslice():
@@ -312,6 +312,22 @@ def test_apply_affine_transform():
         # Checking for the transformed file.
         assert os.path.exists(pjoin(temp_out_dir, "transformed.nii.gz"))
 
+def test_motion_correction():
+    with TemporaryDirectory() as temp_out_dir:
+
+        static, moving, static_g2w, moving_g2w, smask, mmask, M\
+            = setup_random_transform(transform=regtransforms[('AFFINE', 3)],
+                                     rfactor=0.1)
+
+        save_nifti(pjoin(temp_out_dir, 'b0.nii.gz'), data=static,
+                   affine=static_g2w)
+        save_nifti(pjoin(temp_out_dir, 't1.nii.gz'), data=moving,
+                   affine=moving_g2w)
+
+        static_image_file = pjoin(temp_out_dir, 'b0.nii.gz')
+        moving_image_file = pjoin(temp_out_dir, 't1.nii.gz')
+
+        motion_correction_flow = MotionCorrectionFlow()
 
 def test_syn_registration_flow():
     moving_data, static_data = get_synthetic_warped_circle(40)

--- a/doc/examples/motion_correction.py
+++ b/doc/examples/motion_correction.py
@@ -1,0 +1,77 @@
+
+"""
+
+=================================================
+Between-volumes Motion Correction on DWI datasets
+=================================================
+
+Overview
+--------
+During a dMRI acquisition, the subject motion inevitable. This motion implies
+a misalignment between N volumes on a dMRI dataset. A common way to solve this
+issue is to perform a registration on each acquired volume to a
+reference b = 0. [JenkinsonSmith01]_
+
+This preprocessing is an highly recommended step that should be executed before
+any dMRI dataset analysis.
+
+
+Let's import some essential functions.
+"""
+
+from dipy.align import motion_correction
+from dipy.core.gradients import gradient_table
+from dipy.data import get_fnames
+from dipy.io.image import load_nifti, save_nifti
+from dipy.io.gradients import read_bvals_bvecs
+
+"""
+We choose one of the data from the datasets in dipy_. However, you can
+replace the following line with the path of your image.
+"""
+
+dwi_fname, dwi_bval_fname, dwi_bvec_fname = get_fnames('sherbrooke_3shell')
+
+"""
+We load the image and the affine of the image. The affine is the transformation
+matrix which maps image coordinates to world (mm) coordinates. We also load the
+b-values and b-vectors.
+"""
+
+data, affine = load_nifti(dwi_fname)
+bvals, bvecs = read_bvals_bvecs(dwi_bval_fname, dwi_bvec_fname)
+
+"""
+This data has 193 volumes. For this demo purpose, we decide to reduce the
+number of volumes to 5. However, we do not recommended to perform a motion
+correction with less than 10 volumes.
+"""
+
+data_small = data[..., 5]
+bvals_small = bvals[5]
+bvecs_small = bvecs[5, ...]
+gtab = gradient_table(bvals, bvecs)
+
+"""
+Start motion correction of our reduced DWI dataset(between-volumes motion
+correction).
+"""
+
+data_corrected, reg_afines = motion_correction(data, gtab, affine)
+
+"""
+Save our DWI dataset corrected to a new Nifti file.
+"""
+
+save_nifti('motion_correction.nii.gz', data_corrected, affine)
+
+"""
+References
+----------
+
+.. [JenkinsonSmith01] Jenkinson, M., Smith, S., 2001. A global optimisation
+   method for robust affine registration of brain images. Med Image Anal 5
+   (2), 143–56.
+
+.. include:: ../links_names.inc
+"""

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -73,3 +73,4 @@
  afq_tract_profiles.py
  bundle_assignment_maps.py
  bundle_shape_similarity.py
+ motion_correction.py

--- a/doc/interfaces/index.rst
+++ b/doc/interfaces/index.rst
@@ -9,6 +9,7 @@ DIPY Workflows Interfaces
     basic_flow.rst
     data_fetch.rst
     denoise_flow.rst
+    motion_flow.rst
     gibbs_unringing_flow.rst
     registration_flow.rst
     reconstruction_flow.rst

--- a/doc/interfaces/motion_flow.rst
+++ b/doc/interfaces/motion_flow.rst
@@ -1,0 +1,54 @@
+.. _motion_correction_flow:
+
+=================================
+Between-Volumes Motion Correction
+=================================
+
+This tutorial walks through the steps to perform Between-Volumes Motion
+Correction using DIPY.
+
+You can try this using your own data; we will be using the data in DIPY.
+You can check how to :ref:`fetch the DIPY data<data_fetch>`.
+
+-----------------
+Motion Correction
+-----------------
+
+During a dMRI acquisition, the subject motion inevitable. This motion implies
+a misalignment between N volumes on a dMRI dataset. A common way to solve this
+issue is to perform a registration on each acquired volume to a
+reference b = 0. [JenkinsonSmith01]_
+
+This preprocessing is an highly recommended step that should be executed before
+any dMRI dataset analysis.
+
+We will use the ``sherbrooke_3shell`` dataset in DIPY to showcase the motion
+correction process. As with any other workflow in DIPY, you can also use your
+own data!
+
+You may want to create an output directory to save the resulting corrected dataset::
+
+    mkdir motion_output
+
+To run the motion correction method, we need to specify the path of the input
+data, b-vectors file and b-values file. This path may contain wildcards to process
+multiple inputs at once. You can also specify the optional arguments. In this case,
+we will be just specifying the output directory (``out_dir``). For more information,
+use the help option (-h) to obtain all optional arguments.
+
+To run the motion correction on the data it suffices to execute the
+``dipy_correct_motion`` command, e.g.::
+
+    dipy_correct_motion data/sherbrooke_3shell/HARDI193.nii.gz  data/sherbrooke_3shell/HARDI193.bval data/sherbrooke_3shell/HARDI193.bvec --out_dir "motion_output"
+
+This command will apply the motion correction procedure to the input MR image
+and write the artefact-free result to the ``motion_output`` directory.
+
+In case no output directory is specified, the corrected output volume
+is saved to the current directory by default.
+
+References
+----------
+.. [JenkinsonSmith01] Jenkinson, M., Smith, S., 2001. A global optimisation
+   method for robust affine registration of brain images. Med Image Anal 5
+   (2), 143–56.


### PR DESCRIPTION
This PR just adds explicitly a new function named `motion_correction` (Between-Volumes Motion correction). It also adds the associated workflow.  This function has been requested many times since the last Workshop.

To use it, you just to do the following import: `from dipy.align import motion_correction`

Todo:
------
- [x] Add tests
- [x] Add tutorial for motion_correction()
- [x] Add tutorial for the workflow