### PR TITLE
reduce_rois: Force input array type to bool to avoid bitwise or errors

### DIFF
--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -915,9 +915,9 @@ def reduce_rois(rois, include):
 
     for i in range(len(rois)):
         if include[i]:
-            include_roi |= rois[i]
+            include_roi |= rois[i]>0
         else:
-            exclude_roi |= rois[i]
+            exclude_roi |= rois[i]>0
 
     return include_roi, exclude_roi
 


### PR DESCRIPTION
Currently input ROIs arrays are implicitly accepted as non bool.  This results in errors with input arrays of type float and int, as documented in this issue.

https://github.com/dipy/dipy/issues/2446

Using the greater than zero operation should force float and int input arrays to type bool without introducing other troubles.