### PR TITLE
deprecate dipy.io.bvectxt module

### DIFF
--- a/dipy/io/bvectxt.py
+++ b/dipy/io/bvectxt.py
@@ -1,8 +1,13 @@
 
-import numpy as np
 from os.path import splitext
+import numpy as np
+
+from dipy.utils.deprecator import deprecate_with_version
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def read_bvec_file(filename, atol=.001):
     """
     Read gradient table information from a pair of files with extentions
@@ -55,6 +60,9 @@ def read_bvec_file(filename, atol=.001):
     return (grad_table, b_values)
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def ornt_mapping(ornt1, ornt2):
     """Calculates the mapping needing to get from orn1 to orn2"""
 
@@ -69,6 +77,9 @@ def ornt_mapping(ornt1, ornt2):
     return mapping
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def reorient_vectors(input, current_ornt, new_ornt, axis=0):
     """Changes the orientation of a gradients or other vectors
 
@@ -118,6 +129,9 @@ def reorient_vectors(input, current_ornt, new_ornt, axis=0):
     return output
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def reorient_on_axis(input, current_ornt, new_ornt, axis=0):
     if isinstance(current_ornt, str):
         current_ornt = orientation_from_string(current_ornt)
@@ -140,6 +154,9 @@ def reorient_on_axis(input, current_ornt, new_ornt, axis=0):
     return output
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def orientation_from_string(string_ornt):
     """Returns an array representation of an ornt string"""
     orientation_dict = dict(r=(0, 1), l=(0, -1), a=(1, 1),
@@ -152,6 +169,9 @@ def orientation_from_string(string_ornt):
     return ornt
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def orientation_to_string(ornt):
     """Returns a string representation of a 3d ornt"""
     if _check_ornt(ornt):
@@ -165,6 +185,9 @@ def orientation_to_string(ornt):
     return ornt_string
 
 
+@deprecate_with_version("dipy.io.bvectxt module is deprecated, "
+                        "Please use dipy.core.gradients module instead",
+                        since='1.4', until='1.5')
 def _check_ornt(ornt):
     uniq = np.unique(ornt[:, 0])
     if len(uniq) != len(ornt):

--- a/dipy/io/tests/test_bvectxt.py
+++ b/dipy/io/tests/test_bvectxt.py
@@ -1,45 +1,51 @@
 import numpy as np
 from numpy.testing import assert_array_equal, assert_raises
 
-from dipy.io.bvectxt import orientation_from_string, reorient_vectors, \
-    orientation_to_string, reorient_vectors
+from dipy.io.bvectxt import (orientation_from_string, reorient_vectors,
+                             orientation_to_string)
+from dipy.testing import clear_and_catch_warnings
 
 
 def test_orientation_from_to_string():
-    ras = np.array(((0, 1), (1, 1), (2, 1)))
-    lps = np.array(((0, -1), (1, -1), (2, 1)))
-    asl = np.array(((1, 1), (2, 1), (0, -1)))
-    assert_array_equal(orientation_from_string('ras'), ras)
-    assert_array_equal(orientation_from_string('lps'), lps)
-    assert_array_equal(orientation_from_string('asl'), asl)
-    assert_raises(ValueError, orientation_from_string, 'aasl')
+    with clear_and_catch_warnings():
+        ras = np.array(((0, 1), (1, 1), (2, 1)))
+        lps = np.array(((0, -1), (1, -1), (2, 1)))
+        asl = np.array(((1, 1), (2, 1), (0, -1)))
+        assert_array_equal(orientation_from_string('ras'), ras)
+        assert_array_equal(orientation_from_string('lps'), lps)
+        assert_array_equal(orientation_from_string('asl'), asl)
+        assert_raises(ValueError, orientation_from_string, 'aasl')
 
-    assert orientation_to_string(ras) == 'ras'
-    assert orientation_to_string(lps) == 'lps'
-    assert orientation_to_string(asl) == 'asl'
+        assert orientation_to_string(ras) == 'ras'
+        assert orientation_to_string(lps) == 'lps'
+        assert orientation_to_string(asl) == 'asl'
 
 
 def test_reorient_vectors():
-    bvec = np.arange(12).reshape((3, 4))
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'ras'), bvec)
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'lpi'), -bvec)
-    result = bvec[[1, 2, 0]]
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'asr'), result)
-    bvec = result
-    result = bvec[[1, 0, 2]] * [[-1], [1], [-1]]
-    assert_array_equal(reorient_vectors(bvec, 'asr', 'ial'), result)
-    result = bvec[[1, 0, 2]] * [[-1], [1], [1]]
-    assert_array_equal(reorient_vectors(bvec, 'asr', 'iar'), result)
-    assert_raises(ValueError, reorient_vectors, bvec, 'ras', 'ra')
+    with clear_and_catch_warnings():
+        bvec = np.arange(12).reshape((3, 4))
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'ras'), bvec)
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'lpi'), -bvec)
+        result = bvec[[1, 2, 0]]
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'asr'), result)
+        bvec = result
+        result = bvec[[1, 0, 2]] * [[-1], [1], [-1]]
+        assert_array_equal(reorient_vectors(bvec, 'asr', 'ial'), result)
+        result = bvec[[1, 0, 2]] * [[-1], [1], [1]]
+        assert_array_equal(reorient_vectors(bvec, 'asr', 'iar'), result)
+        assert_raises(ValueError, reorient_vectors, bvec, 'ras', 'ra')
 
-    bvec = np.arange(12).reshape((3, 4))
-    bvec = bvec.T
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'ras', axis=1), bvec)
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'lpi', axis=1), -bvec)
-    result = bvec[:, [1, 2, 0]]
-    assert_array_equal(reorient_vectors(bvec, 'ras', 'asr', axis=1), result)
-    bvec = result
-    result = bvec[:, [1, 0, 2]] * [-1, 1, -1]
-    assert_array_equal(reorient_vectors(bvec, 'asr', 'ial', axis=1), result)
-    result = bvec[:, [1, 0, 2]] * [-1, 1, 1]
-    assert_array_equal(reorient_vectors(bvec, 'asr', 'iar', axis=1), result)
+        bvec = np.arange(12).reshape((3, 4))
+        bvec = bvec.T
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'ras', axis=1), bvec)
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'lpi', axis=1), -bvec)
+        result = bvec[:, [1, 2, 0]]
+        assert_array_equal(reorient_vectors(bvec, 'ras', 'asr', axis=1),
+                           result)
+        bvec = result
+        result = bvec[:, [1, 0, 2]] * [-1, 1, -1]
+        assert_array_equal(reorient_vectors(bvec, 'asr', 'ial', axis=1),
+                           result)
+        result = bvec[:, [1, 0, 2]] * [-1, 1, 1]
+        assert_array_equal(reorient_vectors(bvec, 'asr', 'iar', axis=1),
+                           result)


### PR DESCRIPTION
The module `dipy.io.bvectxt` is not used in the DIPY codebase. Furthermore, it seems that some functions contain mistakes like `read_bvec_file`, other functions have been duplicated in `dipy.io.gradients` like `reorient_vectors`.

fix #2460 