### PR TITLE
[MNT] Use windows-latest on azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
 - template: ci/azure/windows.yml
   parameters:
     name: Windows
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
     matrix:
       Python37-64bit + OPTIONAL_DEPS:
         python.version: '3.7'


### PR DESCRIPTION
We are currently using `vs2017-win2016` Image on our Azure pipeline. However, The windows-2016 environment will be deprecated on November 15, 2021, and removed on March 15, 2022. 

So, we Migrate to windows-latest instead (which uses vs2019).

For more details see https://github.com/actions/virtual-environments/issues/4312