### PR TITLE
ENH: Fix `complex` type `NumPy` alias deprecation warnings

### DIFF
--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1112,7 +1112,7 @@ def mapmri_phi_1d(n, q, mu):
 
     qn = 2 * np.pi * mu * q
     H = hermite(n)(qn)
-    i = np.complex(0, 1)
+    i = complex(0, 1)
     f = mfactorial(n)
 
     k = i ** (-n) / np.sqrt(2 ** (n) * f)


### PR DESCRIPTION
Fix `complex` type `NumPy` alias deprecation warnings.

`NumPy` aliases for built-in types are deprecated since release `1.20.0`:
https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations

Fixes:
```
DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`.
To silence this warning, use `complex` by itself.
Doing this will not modify any behavior and is safe.
If you specifically wanted the numpy scalar type, use `np.complex128` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

Consistently reported across CI builds using recent `NumPy` versions, e.g.:
https://dev.azure.com/dipy/dipy/_build/results?buildId=1329&view=logs&j=81eb4d60-76fc-5ac4-a959-9ebb9871bfee&t=0be92317-04dc-59eb-8af8-1d8747db115d&l=5298