### PR TITLE
STYLE: Make `sklearn` import warning messages consistent

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -8,8 +8,7 @@ sklearn, has_sklearn, _ = optional_package('sklearn')
 linear_model, _, _ = optional_package('sklearn.linear_model')
 
 if not has_sklearn:
-    w = "Scikit-Learn is required to denoise the data via Patch2Self."
-    warn(w)
+    warn(sklearn._msg)
 
 
 def _vol_split(train, vol_idx):

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -8,8 +8,9 @@ import pytest
 from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import gradient_table, generate_bvecs
 
-needs_sklearn = pytest.mark.skipif(not p2s.has_sklearn,
-                                   reason="Requires Scikit-Learn")
+needs_sklearn = pytest.mark.skipif(
+    not p2s.has_sklearn,
+    reason=p2s.sklearn._msg if not p2s.has_sklearn else "")
 
 
 @needs_sklearn

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -39,7 +39,7 @@ lm, _, _ = optional_package('sklearn.linear_model')
 # If sklearn is unavailable, we can fall back on nnls (but we also warn the
 # user that we are about to do that):
 if not has_sklearn:
-    w = "sklearn is not available, you can use 'nnls' method to fit"
+    w = sklearn._msg + "\nAlternatively, you can use 'nnls' method to fit"
     w += " the SparseFascicleModel"
     warnings.warn(w)
 

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -11,8 +11,9 @@ import dipy.reconst.cross_validation as xval
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
 
-needs_sklearn = pytest.mark.skipif(not sfm.has_sklearn,
-                                   reason="Requires Scikit-Learn")
+needs_sklearn = pytest.mark.skipif(
+    not sfm.has_sklearn,
+    reason=sfm.sklearn._msg if not sfm.has_sklearn else "")
 
 
 def test_design_matrix():

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -13,8 +13,8 @@ from dipy.workflows.denoise import (NLMeansFlow, LPCAFlow, MPPCAFlow,
                                     GibbsRingingFlow, Patch2SelfFlow)
 
 sklearn, has_sklearn, _ = optional_package('sklearn')
-needs_sklearn = pytest.mark.skipif(not has_sklearn,
-                                   reason="Requires Scikit-Learn")
+needs_sklearn = pytest.mark.skipif(
+    not has_sklearn, reason=sklearn._msg if not has_sklearn else "")
 
 
 def test_nlmeans_flow():


### PR DESCRIPTION
Make `sklearn` import warning messages consistent.

Allows to show:
```
UserWarning: We need package sklearn for these functions, but ``import sklearn`` raised an ImportError
  warn(sklearn._msg)
```

and
```
UserWarning: We need package sklearn for these functions, but ``import sklearn`` raised an ImportError
Alternatively, you can use 'nnls' method to fit the SparseFascicleModel
```

instead of
```
UserWarning: Scikit-Learn is required to denoise the data via Patch2Self.
```

and
```
UserWarning: sklearn is not available, you can use 'nnls' method to fit the SparseFascicleModel
```

and
```
"Requires Scikit-Learn"
```