### PR TITLE
ENH: Import ABCs from `collections.abc`

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -636,7 +636,7 @@ def register_dwi_series(data, gtab, affine=None, b0_ref=0, pipeline=None):
     pipeline = pipeline or ["center_of_mass", "translation", "rigid", "affine"]
 
     data, affine = read_img_arr_or_path(data, affine=affine)
-    if isinstance(gtab, collections.Sequence):
+    if isinstance(gtab, collections.abc.Sequence):
         gtab = dpg.gradient_table(*gtab)
 
     if np.sum(gtab.b0s_mask) > 1:


### PR DESCRIPTION
Import ABCs from `collections.abc` instead of from `collections`.

Fixes:
```
align/tests/test_api.py::test_register_dwi_series
  /home/vsts/work/1/s/venv/lib/python3.8/site-packages/dipy/align/_public.py:639:
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    if isinstance(gtab, collections.Sequence):
```

being raised consistently, for example, at:
https://dev.azure.com/dipy/dipy/_build/results?buildId=1351&view=logs&j=d9aefae6-c332-51b5-d933-a85009f5a2ac&t=7b3c05b2-26bc-5cc7-178d-37c39b6402cb&l=5184

From the documentation:
```
New in version 3.3: Formerly, this module was part of the collections module.
```

https://docs.python.org/3/library/collections.abc.html

DIPY does not support Python < 3.3 since release 0.11.0.