### PR TITLE
ENH: Better error message

### DIFF
--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -243,18 +243,21 @@ class CCMetric(SimilarityMetric):
         re-orienting the gradients in the voxel space using the corresponding
         affine transformations.
         """
+        min_size = self.radius * 2 + 1
 
         def invalid_image_size(image):
-            min_size = self.radius * 2 + 1
-            return any([size < min_size for size in image.shape])
+            return any(size < min_size for size in image.shape)
 
-        msg = ("Each image dimension should be superior to 2 * radius + 1."
-               "Decrease CCMetric radius or increase your image size")
+        msg = ("Each image dimension should be superior to 2 * radius + 1 "
+               f"({min_size}). Decrease CCMetric radius ({self.radius}) or "
+               "increase your image size (shape=%(shape)s).")
 
         if invalid_image_size(self.static_image):
-            raise ValueError("Static image size is too small. " + msg)
+            raise ValueError("Static image size is too small. " +
+                             msg % dict(shape=self.static_image.shape))
         if invalid_image_size(self.moving_image):
-            raise ValueError("Moving image size is too small. " + msg)
+            raise ValueError("Moving image size is too small. " +
+                             msg % dict(shape=self.moving_image.shape))
 
         self.factors = self.precompute_factors(self.static_image,
                                                self.moving_image,


### PR DESCRIPTION
Just a minor update to improve the error message.

Also, are the units of `radius` and `sigma_diff` for CCMetric in voxels (I assume it's this), or mm (i.e., the image's `affine` dims will be factored in to compute the number of voxels)?