### PR TITLE
Remove python 3.6 from Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,59 +21,59 @@ jobs:
     name: Linux
     vmImage: ubuntu-latest
     matrix:
-      Python36-64bit:
-        python.version: '3.6'
       Python37-64bit:
         python.version: '3.7'
       Python38-64bit:
         python.version: '3.8'
       Python39-64bit:
         python.version: '3.9'
+      Python310-64bit:
+        python.version: '3.10'
       Python37-64bit + MIN_DEPS:
         python.version: '3.7'
         DEPENDS: "cython==0.29 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0 tqdm"
       Python38-64bit + MIN_DEPS:
         python.version: '3.8'
         DEPENDS: "cython==0.29 numpy==1.17.5 scipy==1.3.2 nibabel==3.0.0 h5py==3.0.0 tqdm"
-      Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
+      Python38-64bit + OPTIONAL_DEPS:
+        python.version: '3.8'
         EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
-      Python37-64bit + VIZ + COVERAGE:
+      Python38-64bit + VIZ + COVERAGE:
         TEST_WITH_XVFB: "1"
         COVERAGE: "1"
-        python.version: '3.7'
+        python.version: '3.8'
         MESA_GL_VERSION_OVERRIDE: '3.3'
         LIBGL_ALWAYS_INDIRECT: 'y'
         EXTRA_DEPENDS: "scikit_learn vtk==8.1.2 fury scipy pandas statsmodels tables xvfbwrapper"
-      Python37-64bit + SDIST:
-        python.version: '3.7'
+      Python38-64bit + SDIST:
+        python.version: '3.8'
         INSTALL_TYPE: "sdist"
         EXTRA_DEPENDS: "scipy"
-      Python37-64bit + PIP:
-        python.version: '3.7'
+      Python38-64bit + PIP:
+        python.version: '3.8'
         INSTALL_TYPE: "pip"
         DEPENDS: "" # Dependency checking should get all needed dependencies
-      Python37-64bit + WHEEL:
-        python.version: '3.7'
+      Python38-64bit + WHEEL:
+        python.version: '3.8'
         INSTALL_TYPE: "wheel"
         EXTRA_DEPENDS: "scipy"
-      Python37-64bit + Requirements:
-        python.version: '3.7'
+      Python38-64bit + Requirements:
+        python.version: '3.8'
         INSTALL_TYPE: "requirements"
         DEPENDS: ""
-      CONDA Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
+      CONDA Python38-64bit + OPTIONAL_DEPS:
+        python.version: '3.8'
         EXTRA_DEPENDS: "scikit-learn pandas statsmodels pytables scipy"
         INSTALL_TYPE: "conda"
-      CONDA Python37-64bit:
-        python.version: '3.7'
+      CONDA Python38-64bit:
+        python.version: '3.8'
         INSTALL_TYPE: "conda"
-      CONDA Python36-64bit:
-        python.version: '3.6'
+      CONDA Python310-64bit:
+        python.version: '3.10'
         INSTALL_TYPE: "conda"
-      Python37-64bit - PRE:
+      Python38-64bit - PRE:
         USE_PRE: 1
-        python.version: '3.7'
+        python.version: '3.8'
         EXTRA_DEPENDS: "scikit_learn scipy statsmodels pandas tables"
 
 - template: ci/azure/osx.yml
@@ -81,29 +81,31 @@ jobs:
     name: OSX
     vmImage: macOS-latest
     matrix:
-      Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
-        EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
       Python37-64bit:
         python.version: '3.7'
       Python38-64bit:
         python.version: '3.8'
       Python39-64bit:
         python.version: '3.9'
+      Python310-64bit:
+        python.version: '3.10'
       # Problem with h5py
       # CONDA Python37-64bit + OPTIONAL_DEPS:
       #   python.version: '3.7'
       #   EXTRA_DEPENDS: "scikit-learn pandas statsmodels pytables scipy==1.2"
       #   INSTALL_TYPE: "conda"
-      CONDA Python37-64bit:
-        python.version: '3.7'
+      Python38-64bit + OPTIONAL_DEPS:
+        python.version: '3.8'
+        EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
+      CONDA Python38-64bit:
+        python.version: '3.8'
         INSTALL_TYPE: "conda"
-      CONDA Python36-64bit:
-        python.version: '3.6'
+      CONDA Python310-64bit:
+        python.version: '3.10'
         INSTALL_TYPE: "conda"
-      Python37-64bit + VIZ:
+      Python38-64bit + VIZ:
         TEST_WITH_XVFB: "1"
-        python.version: '3.7'
+        python.version: '3.8'
         MESA_GL_VERSION_OVERRIDE: '3.3'
         LIBGL_ALWAYS_INDIRECT: 'y'
         EXTRA_DEPENDS: "scikit_learn vtk fury scipy xvfbwrapper"
@@ -118,30 +120,30 @@ jobs:
     name: Windows
     vmImage: windows-latest
     matrix:
-      Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
-        EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
       Python39-64bit:
         python.version: '3.9'
       Python38-64bit:
         python.version: '3.8'
       Python37-64bit:
         python.version: '3.7'
-      Python36-64bit:
-        python.version: '3.6'
-      CONDA Python37-64bit + OPTIONAL_DEPS:
-        python.version: '3.7'
+      Python310-64bit:
+        python.version: '3.10'
+      Python38-64bit + OPTIONAL_DEPS:
+        python.version: '3.8'
+        EXTRA_DEPENDS: "scikit_learn pandas statsmodels tables scipy"
+      CONDA Python38-64bit + OPTIONAL_DEPS:
+        python.version: '3.8'
         EXTRA_DEPENDS: "scikit-learn pandas statsmodels pytables scipy"
         INSTALL_TYPE: "conda"
-      CONDA Python37-64bit:
-        python.version: '3.7'
+      CONDA Python38-64bit:
+        python.version: '3.8'
         INSTALL_TYPE: "conda"
-      CONDA Python36-64bit:
-        python.version: '3.6'
+      CONDA Python310-64bit:
+        python.version: '3.10'
         INSTALL_TYPE: "conda"
-      Python37-64bit + VIZ:
+      Python38-64bit + VIZ:
         TEST_WITH_XVFB: "1"
-        python.version: '3.7'
+        python.version: '3.8'
         MESA_GL_VERSION_OVERRIDE: '3.3'
         LIBGL_ALWAYS_INDIRECT: 'y'
         EXTRA_DEPENDS: "scikit_learn vtk fury scipy"

--- a/ci/.travis.yml.old
+++ b/ci/.travis.yml.old
@@ -112,7 +112,7 @@ before_install:
     - virtualenv $VENV_ARGS venv
     - source venv/bin/activate
     - python --version # just to check
-    - $PIPI --upgrade pip "setuptools<50.0"
+    - $PIPI --upgrade pip setuptools wheel
     - $PIPI pytest
     - $PIPI numpy
     - if [ -n "$DEPENDS" ]; then $PIPI $DEPENDS; fi

--- a/ci/azure/install.sh
+++ b/ci/azure/install.sh
@@ -4,11 +4,11 @@ set -ev
 if [ "$INSTALL_TYPE" == "conda" ]; then
 
     conda config --set always_yes yes --set changeps1 no
-    if [ "$AGENT_OS" == "Linux" ]; then
-        # Workaround: https://github.com/conda/conda/issues/9337
-        pip uninstall -y setuptools
-        conda install -yq setuptools
-    fi
+    # if [ "$AGENT_OS" == "Linux" ]; then
+    # Workaround: https://github.com/conda/conda/issues/9337
+    pip uninstall -y setuptools wheel
+    conda install -yq setuptools wheel
+    # fi
     conda update -yq conda
     conda install conda-build anaconda-client
     conda config --add channels conda-forge
@@ -27,9 +27,9 @@ else
     # just to check python version
     python --version
 
-    if [ "$AGENT_OS" == "Linux" ]; then
-        $PIPI --upgrade pip "setuptools<50.0"
-    fi
+    # if [ "$AGENT_OS" == "Linux" ]; then
+    $PIPI --upgrade pip setuptools wheel
+    # fi
 
     $PIPI pytest
     $PIPI numpy


### PR DESCRIPTION
Python3.6 is officially deprecated, so we had to remove it from Azure Pipelines