### PR TITLE
Masking for affine registration

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -43,6 +43,8 @@
 
 """
 
+from warnings import warn
+
 import numpy as np
 import numpy.linalg as npl
 import scipy.ndimage as ndimage
@@ -215,7 +217,7 @@ class AffineMap(object):
         return str(self.affine)
 
     def __repr__(self):
-        """Relodable representation - also relies on ndarray's implementation."""
+        """Reloadable representation - relies on ndarray's implementation."""
 
         return self.affine.__repr__()
 
@@ -506,7 +508,8 @@ class MutualInformationMetric(object):
         self.metric_grad = None
 
     def setup(self, transform, static, moving, static_grid2world=None,
-              moving_grid2world=None, starting_affine=None):
+              moving_grid2world=None, starting_affine=None,
+              static_mask=None, moving_mask=None):
         r"""Prepare the metric to compute intensity densities and gradients.
 
         The histograms will be setup to compute probability densities of
@@ -537,6 +540,12 @@ class MutualInformationMetric(object):
             instead of manually transforming the moving image to reduce
             interpolation artifacts. The default is None, implying no
             pre-alignment is performed.
+        static_mask : array, shape (S, R, C) or (R, C), optional
+            static image mask that defines which pixels in the static image
+            are used to calculate the mutual information.
+        moving_mask : array, shape (S', R', C') or (R', C'), optional
+            moving image mask that defines which pixels in the moving image
+            are used to calculate the mutual information.
 
         """
         n = transform.get_number_of_parameters()
@@ -566,6 +575,28 @@ class MutualInformationMetric(object):
         self.affine_map = AffineMap(P, static.shape, static_grid2world,
                                     moving.shape, moving_grid2world)
 
+        # Masks can only be used with dense sampling
+        if self.sampling_proportion in [None, 1.0]:
+
+            if static_mask is not None:
+                self.static_mask = static_mask.astype(np.int32)
+            else:
+                self.static_mask = None
+
+            if moving_mask is not None:
+                self.moving_mask = moving_mask.astype(np.int32)
+            else:
+                self.moving_mask = None
+
+        else:
+
+            if (static_mask is not None) or (moving_mask is not None):
+                wm = "Masking is not implemented for sampling_proportion < 1, "
+                wm = wm + "setting static_mask = None and moving_mask = None"
+                warn(wm, UserWarning)
+
+            self.static_mask, self.moving_mask = None, None
+
         if self.dim == 2:
             self.interp_method = interpolate_scalar_2d
         else:
@@ -592,7 +623,8 @@ class MutualInformationMetric(object):
             static_p = static_p[..., :self.dim]
             self.static_vals, inside = self.interp_method(static, static_p)
             self.static_vals = np.array(self.static_vals, dtype=np.float64)
-        self.histogram.setup(self.static, self.moving)
+        self.histogram.setup(self.static, self.moving,
+                             self.static_mask, self.moving_mask)
 
     def _update_histogram(self):
         r"""Update the histogram according to the current affine transform.
@@ -622,10 +654,21 @@ class MutualInformationMetric(object):
             results in an image of the same shape as the static image.
 
         """
+        static_mask_values, moving_mask_values = None, None
         if self.sampling_proportion is None:  # Dense case
             static_values = self.static
             moving_values = self.affine_map.transform(self.moving)
-            self.histogram.update_pdfs_dense(static_values, moving_values)
+
+            if self.static_mask is not None:
+                static_mask_values = self.static_mask
+            if self.moving_mask is not None:
+                moving_mask_values =\
+                 self.affine_map.transform(
+                    self.moving_mask, interpolation='nearest').astype(np.int32)
+
+            self.histogram.update_pdfs_dense(
+                static_values, moving_values,
+                self.static_mask, moving_mask_values)
         else:  # Sparse case
             sp_to_moving = self.moving_world2grid.dot(self.affine_map.affine)
             pts = sp_to_moving.dot(self.samples.T).T  # Points on moving grid
@@ -635,7 +678,8 @@ class MutualInformationMetric(object):
             static_values = self.static_vals
             moving_values = self.moving_vals
             self.histogram.update_pdfs_sparse(static_values, moving_values)
-        return static_values, moving_values
+        return static_values, moving_values,\
+            static_mask_values, moving_mask_values
 
     def _update_mutual_information(self, params, update_gradient=True):
         r"""Update marginal and joint distributions and the joint gradient.
@@ -669,7 +713,8 @@ class MutualInformationMetric(object):
         self.affine_map.set_affine(current_affine)
 
         # Update the histogram with the current joint intensities
-        static_values, moving_values = self._update_histogram()
+        static_values, moving_values, static_mask_values, moving_mask_values =\
+            self._update_histogram()
 
         H = self.histogram  # Shortcut to `self.histogram`
         grad = None  # Buffer to write the MI gradient into (if needed)
@@ -693,7 +738,9 @@ class MutualInformationMetric(object):
                     static_values,
                     moving_values,
                     static2prealigned,
-                    mgrad)
+                    mgrad,
+                    static_mask_values,
+                    moving_mask_values)
             else:  # Sparse case
                 # Compute the gradient of moving at the sampling points
                 # which are already given in physical space coordinates
@@ -888,7 +935,8 @@ class AffineRegistration(object):
 
     def _init_optimizer(self, static, moving, transform, params0,
                         static_grid2world, moving_grid2world,
-                        starting_affine):
+                        starting_affine,
+                        static_mask, moving_mask):
         r"""Initialize the registration optimizer.
 
         Initializes the optimizer by computing the scale space of the input
@@ -922,12 +970,37 @@ class AffineRegistration(object):
                 array, shape (dim+1, dim+1)
             If None:
                 Start from identity
+        static_mask : array, shape (S, R, C) or (R, C), optional
+            static image mask that defines which pixels in the static image
+            are used to calculate the mutual information.
+        moving_mask : array, shape (S', R', C') or (R', C'), optional
+            moving image mask that defines which pixels in the moving image
+            are used to calculate the mutual information.
 
         """
         self.dim = len(static.shape)
         self.transform = transform
         n = transform.get_number_of_parameters()
         self.nparams = n
+
+        # ensure that masks are not all zeros
+        if np.all(static_mask == 0):
+            warn("static_mask is all zeros, setting to None (which means \
+                  the entire volume will be used)", UserWarning)
+            static_mask = None
+        if np.all(moving_mask == 0):
+            warn("moving_mask is all zeros, setting to None", UserWarning)
+            moving_mask = None
+
+        # save masks for use elsewhere
+        self.static_mask, self.moving_mask = static_mask, moving_mask
+
+        # multiply images by masks for transform_centers_of_mass
+        static_masked, moving_masked = static, moving
+        if static_mask is not None:
+            static_masked = static*static_mask
+        if moving_mask is not None:
+            moving_masked = moving*moving_mask
 
         if params0 is None:
             params0 = self.transform.get_identity_parameters()
@@ -936,11 +1009,12 @@ class AffineRegistration(object):
             self.starting_affine = np.eye(self.dim + 1)
         elif isinstance(starting_affine, str):
             if starting_affine == 'mass':
-                affine_map = transform_centers_of_mass(static,
+                affine_map = transform_centers_of_mass(static_masked,
                                                        static_grid2world,
-                                                       moving,
+                                                       moving_masked,
                                                        moving_grid2world)
                 self.starting_affine = affine_map.affine
+                print("starting_affine in imaffine:", self.starting_affine)
             elif starting_affine == 'voxel-origin':
                 affine_map = transform_origins(static, static_grid2world,
                                                moving, moving_grid2world)
@@ -958,16 +1032,26 @@ class AffineRegistration(object):
             self.starting_affine = starting_affine
         else:
             raise ValueError('Invalid starting_affine matrix')
+
         # Extract information from affine matrices to create the scale space
         static_direction, static_spacing = \
             get_direction_and_spacings(static_grid2world, self.dim)
         moving_direction, moving_spacing = \
             get_direction_and_spacings(moving_grid2world, self.dim)
 
-        static = ((static.astype(np.float64) - static.min()) /
-                  (static.max() - static.min()))
-        moving = ((moving.astype(np.float64) - moving.min()) /
-                  (moving.max() - moving.min()))
+        # Scale the images by min and max values (where mask == 1)
+        if static_mask is not None:
+            smin = np.min(static[static_mask == 1])
+            smax = np.max(static[static_mask == 1])
+        else:
+            smin, smax = np.min(static), np.max(static)
+        static = (static.astype(np.float64) - smin) / (smax - smin)
+        if moving_mask is not None:
+            mmin = np.min(moving[moving_mask == 1])
+            mmax = np.max(moving[moving_mask == 1])
+        else:
+            mmin, mmax = np.min(moving), np.max(moving)
+        moving = (moving.astype(np.float64) - mmin) / (mmax - mmin)
 
         # Build the scale space of the input images
         if self.use_isotropic:
@@ -980,6 +1064,7 @@ class AffineRegistration(object):
                                                  self.sigmas,
                                                  static_grid2world,
                                                  static_spacing, False)
+
         else:
             self.moving_ss = ScaleSpace(moving, self.levels, moving_grid2world,
                                         moving_spacing, self.ss_sigma_factor,
@@ -991,7 +1076,8 @@ class AffineRegistration(object):
 
     def optimize(self, static, moving, transform, params0,
                  static_grid2world=None, moving_grid2world=None,
-                 starting_affine=None, ret_metric=False):
+                 starting_affine=None, ret_metric=False,
+                 static_mask=None, moving_mask=None):
         r""" Start the optimization process.
 
         Parameters
@@ -1035,6 +1121,12 @@ class AffineRegistration(object):
             similarity between the images (default 'False').
             The metric containing optimal parameters and
             the distance between the images.
+        static_mask : array, shape (S, R, C) or (R, C), optional
+            static image mask that defines which pixels in the static image
+            are used to calculate the mutual information.
+        moving_mask : array, shape (S', R', C') or (R', C'), optional
+            moving image mask that defines which pixels in the moving image
+            are used to calculate the mutual information.
 
         Returns
         -------
@@ -1048,8 +1140,11 @@ class AffineRegistration(object):
         """
         self._init_optimizer(static, moving, transform, params0,
                              static_grid2world, moving_grid2world,
-                             starting_affine)
+                             starting_affine,
+                             static_mask, moving_mask)
         del starting_affine  # Now we must refer to self.starting_affine
+        del static_mask  # Now we must refer to self.static_mask
+        del moving_mask  # Now we must refer to self.moving_mask
 
         # Multi-resolution iterations
         original_static_shape = self.static_ss.get_image(0).shape
@@ -1078,15 +1173,21 @@ class AffineRegistration(object):
                                            original_static_shape,
                                            original_static_grid2world)
             current_static = current_affine_map.transform(smooth_static)
+            current_static_mask = None
+            if self.static_mask is not None:
+                current_static_mask = current_affine_map.transform(
+                    self.static_mask, interpolation="nearest").astype(np.int32)
 
             # The moving image is full resolution
             current_moving_grid2world = original_moving_grid2world
 
             current_moving = self.moving_ss.get_image(level)
+
             # Prepare the metric for iterations at this resolution
             self.metric.setup(transform, current_static, current_moving,
                               current_static_grid2world,
-                              current_moving_grid2world, self.starting_affine)
+                              current_moving_grid2world, self.starting_affine,
+                              current_static_mask, self.moving_mask)
 
             # Optimize this level
             if self.options is None:

--- a/dipy/align/scalespace.py
+++ b/dipy/align/scalespace.py
@@ -51,7 +51,7 @@ class ScaleSpace(object):
             mask = np.asarray(image > 0, dtype=np.int32)
 
         # Normalize input image to [0,1]
-        img = (image - image.min())/(image.max() - image.min())
+        img = (image - np.min(image))/(np.max(image) - np.min(image))
         if mask0:
             img *= mask
 
@@ -97,8 +97,8 @@ class ScaleSpace(object):
 
             # Filter along each direction with the appropriate sigma
             filtered = gaussian_filter(image, sigmas)
-            filtered = ((filtered - filtered.min()) /
-                        (filtered.max() - filtered.min()))
+            filtered = ((filtered - np.min(filtered)) /
+                        (np.max(filtered) - np.min(filtered)))
             if mask0:
                 filtered *= mask
 
@@ -356,8 +356,8 @@ class IsotropicScaleSpace(ScaleSpace):
             mask = np.asarray(image > 0, dtype=np.int32)
 
         # Normalize input image to [0,1]
-        img = ((image.astype(np.float64) - image.min()) /
-               (image.max() - image.min()))
+        img = ((image.astype(np.float64) - np.min(image)) /
+               (np.max(image) - np.min(image)))
         if mask0:
             img *= mask
 
@@ -409,8 +409,8 @@ class IsotropicScaleSpace(ScaleSpace):
 
             # Filter along each direction with the appropriate sigma
             filtered = gaussian_filter(image.astype(np.float64), new_sigmas)
-            filtered = ((filtered.astype(np.float64) - filtered.min()) /
-                        (filtered.max() - filtered.min()))
+            filtered = ((filtered.astype(np.float64) - np.min(filtered)) /
+                        (np.max(filtered) - np.min(filtered)))
             if mask0:
                 filtered *= mask
 

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -6,7 +6,8 @@ from numpy.testing import (assert_array_equal,
                            assert_array_almost_equal,
                            assert_almost_equal,
                            assert_equal,
-                           assert_raises)
+                           assert_raises,
+                           assert_warns)
 from dipy.core import geometry as geometry
 from dipy.viz import regtools as rt
 from dipy.align import floating
@@ -216,8 +217,20 @@ def test_affreg_all_transforms():
                                              None,
                                              options=None)
         x0 = trans.get_identity_parameters()
-        affine_map = affreg.optimize(static, moving, trans, x0,
-                                     static_g2w, moving_g2w)
+
+        # test warning for using masks (even if all ones) with sparse sampling
+        if sampling_pc not in [1.0, None]:
+            affine_map = assert_warns(UserWarning, affreg.optimize,
+                                      static, moving, trans, x0,
+                                      static_g2w, moving_g2w,
+                                      None, None,
+                                      smask, mmask)
+        else:
+            affine_map = affreg.optimize(static, moving, trans, x0,
+                                         static_g2w, moving_g2w,
+                                         None, None,
+                                         smask, mmask)
+
         transformed = affine_map.transform(moving)
         # Sum of absolute differences
         end_sad = np.abs(static - transformed).sum()
@@ -228,6 +241,13 @@ def test_affreg_all_transforms():
     # Verify that exception is raised if level_iters is empty
     metric = imaffine.MutualInformationMetric(32)
     assert_raises(ValueError, imaffine.AffineRegistration, metric, [])
+
+    # Verify that exception is raised if masks are all zeros
+    affine_map = assert_warns(UserWarning, affreg.optimize,
+                              static, moving, trans, x0,
+                              static_g2w, moving_g2w,
+                              None, None,
+                              np.zeros_like(smask), np.zeros_like(mmask))
 
 
 def test_affreg_defaults():
@@ -258,6 +278,8 @@ def test_affreg_defaults():
         level_iters = None
         static_grid2world = None
         moving_grid2world = None
+        smask = None
+        mmask = None
         for ss_sigma_factor in [1.0, None]:
             affreg = imaffine.AffineRegistration(metric,
                                                  level_iters,
@@ -268,7 +290,8 @@ def test_affreg_defaults():
                                                  options=None)
             affine_map = affreg.optimize(static, moving, transform, x0,
                                          static_grid2world, moving_grid2world,
-                                         starting_affine)
+                                         starting_affine, None,
+                                         smask, mmask)
             transformed = affine_map.transform(moving)
             # Sum of absolute differences
             end_sad = np.abs(static - transformed).sum()

--- a/doc/examples/affine_registration_masks.py
+++ b/doc/examples/affine_registration_masks.py
@@ -1,0 +1,361 @@
+"""
+==============================
+Affine Registration with Masks
+==============================
+
+This example explains how to compute a transformation to register two 3D
+volumes by maximization of their Mutual Information [Mattes03]_. The
+optimization strategy is similar to that implemented in ANTS [Avants11]_.
+
+We will use masks to define which pixels are used in the Mutual Information.
+Masking can also be done for registration of 2D images rather than 3D volumes.
+
+Masking for registration is useful in a variety of circumstances. For example,
+in cardiac MRI, where it is usually used to specify a region of interest on a
+2D static image, e.g., the left ventricle in a short axis slice. This
+prioritizes registering the region of interest over other structures that move
+with respect to the heart.
+
+"""
+
+from os.path import join as pjoin
+import numpy as np
+import matplotlib.pyplot as plt
+from dipy.viz import regtools
+from dipy.data import fetch_stanford_hardi
+from dipy.data.fetcher import fetch_syn_data
+from dipy.io.image import load_nifti
+from dipy.align.imaffine import (AffineMap,
+                                 MutualInformationMetric,
+                                 AffineRegistration)
+from dipy.align.transforms import (TranslationTransform3D,
+                                   RigidTransform3D)
+
+from dipy.align import (affine_registration, translation,
+                        rigid, register_series)
+
+
+"""
+Let's fetch a single b0 volume from the Stanford HARDI dataset.
+
+"""
+
+files, folder = fetch_stanford_hardi()
+static_data, static_affine, static_img = load_nifti(
+                                            pjoin(folder, 'HARDI150.nii.gz'),
+                                            return_img=True)
+static = np.squeeze(static_data)[..., 0]
+
+# pad array to help with this example
+pad_by = 10
+static = np.pad(static, [(pad_by, pad_by), (pad_by, pad_by), (0, 0)],
+                mode='constant', constant_values=0)
+
+static_grid2world = static_affine
+
+"""
+Let's create a moving image by transforming the static image.
+
+"""
+
+affmat = np.eye(4)
+affmat[0, -1] = 4
+affmat[1, -1] = 12
+theta = 0.1
+c, s = np.cos(theta), np.sin(theta)
+affmat[0:2, 0:2] = np.array([[c, -s], [s, c]])
+affine_map = AffineMap(affmat,
+                       static.shape, static_grid2world,
+                       static.shape, static_grid2world)
+moving = affine_map.transform(static)
+moving_affine = static_affine.copy()
+moving_grid2world = static_grid2world.copy()
+
+regtools.overlay_slices(static, moving, None, 2,
+                        "Static", "Moving", "deregistered.png")
+
+"""
+.. figure:: deregistered.png
+   :align: center
+
+   Same images but misaligned.
+"""
+
+"""
+Let's make some registration settings.
+"""
+
+nbins = 32
+sampling_prop = None
+metric = MutualInformationMetric(nbins, sampling_prop)
+
+# small number of iterations for this example
+level_iters = [100, 10]
+sigmas = [1.0, 0.0]
+factors = [2, 1]
+
+affreg = AffineRegistration(metric=metric,
+                            level_iters=level_iters,
+                            sigmas=sigmas,
+                            factors=factors)
+
+"""
+Now let's register these volumes together without any masking. For the purposes
+of this example, we will not provide an inital transformation based on centre
+of mass, but this would work fine with masks.
+
+Note that use of masks is not currently implemented for sparse sampling.
+
+"""
+
+transform = TranslationTransform3D()
+transl = affreg.optimize(static, moving, transform, None,
+                         static_grid2world, moving_grid2world,
+                         starting_affine=None,
+                         static_mask=None, moving_mask=None)
+transform = RigidTransform3D()
+transl = affreg.optimize(static, moving, transform, None,
+                         static_grid2world, moving_grid2world,
+                         starting_affine=transl.affine,
+                         static_mask=None, moving_mask=None)
+transformed = transl.transform(moving)
+
+transformed = transl.transform(moving)
+regtools.overlay_slices(static, transformed, None, 2,
+                        "Static", "Transformed", "transformed.png")
+
+
+"""
+.. figure:: transformed.png
+   :align: center
+
+   Registration result.
+"""
+
+"""
+We can also use a pipeline to achieve the same thing. For convenience in this
+tutorial, we will define a function that runs the pipeline and makes a figure.
+
+"""
+
+
+def reg_func(figname, static_mask=None, moving_mask=None):
+    """Convenience function for registration using a pipeline.
+       Uses variables in global scope, except for static_mask and moving_mask.
+    """
+
+    pipeline = [translation, rigid]
+
+    xformed_img, reg_affine = affine_registration(
+        moving,
+        static,
+        moving_affine=moving_affine,
+        static_affine=static_affine,
+        nbins=32,
+        metric='MI',
+        pipeline=pipeline,
+        level_iters=level_iters,
+        sigmas=sigmas,
+        factors=factors,
+        static_mask=static_mask,
+        moving_mask=moving_mask)
+
+    regtools.overlay_slices(static, xformed_img, None, 2,
+                            "Static", "Transformed", figname)
+
+    return
+
+
+"""
+Now we can run this function and hopefully get the same result.
+"""
+
+
+reg_func("transformed_pipeline.png")
+
+
+"""
+.. figure:: transformed_pipeline.png
+   :align: center
+
+   Registration result using pipeline.
+"""
+
+
+"""
+Now let's modify the images in order to test masking. We will place three
+squares in the corners of both images, but in slightly different locations.
+
+We will make masks that cover these regions but with an extra border of pixels.
+This is because the masks need transforming and resampling during optimization,
+and we want to make sure that we are defintely covering the troublesome
+features.
+"""
+
+sz = 15
+pd = 10
+
+# modify images
+val = static.max()/2.0
+
+static[-sz-pd:-pd, -sz-pd:-pd, :] = val
+static[pd:sz+pd, -sz-pd:-pd, :] = val
+static[-sz-pd:-pd, pd:sz+pd, :] = val
+
+moving[pd:sz+pd, pd:sz+pd, :] = val
+moving[pd:sz+pd, -sz-pd:-pd, :] = val
+moving[-sz-pd:-pd, pd:sz+pd, :] = val
+
+# create masks
+squares_st = np.zeros_like(static).astype(np.int32)
+squares_mv = np.zeros_like(static).astype(np.int32)
+
+squares_st[-sz-1-pd:-pd, -sz-1-pd:-pd, :] = 1
+squares_st[pd:sz+1+pd, -sz-1-pd:-pd, :] = 1
+squares_st[-sz-1-pd:-pd, pd:sz+1+pd, :] = 1
+
+squares_mv[pd:sz+1+pd, pd:sz+1+pd, :] = 1
+squares_mv[pd:sz+1+pd, -sz-1-pd:-pd, :] = 1
+squares_mv[-sz-1-pd:-pd, pd:sz+1+pd, :] = 1
+
+
+regtools.overlay_slices(static, moving, None, 2,
+                        "Static", "Moving", "deregistered_squares.png")
+
+"""
+.. figure:: deregistered_squares.png
+   :align: center
+
+   Same images but misaligned, with white squares in the corners.
+"""
+
+static_mask = np.abs(squares_st - 1)
+moving_mask = np.abs(squares_mv - 1)
+
+fig, ax = plt.subplots(1, 2)
+ax[0].imshow(static_mask[:, :, 1].T, cmap="gray", origin="lower")
+ax[0].set_title("static image mask")
+ax[1].imshow(moving_mask[:, :, 1].T, cmap="gray", origin="lower")
+ax[1].set_title("moving image mask")
+plt.savefig("masked_static.png", bbox_inches='tight')
+
+
+"""
+.. figure:: masked_static.png
+   :align: center
+
+   The masks.
+"""
+
+
+"""
+Let's try to register these new images without a mask.
+"""
+
+reg_func("transformed_squares.png")
+
+
+"""
+.. figure:: transformed_squares.png
+   :align: center
+
+   Registration fails to align the images because the squares pin the images.
+"""
+
+"""
+Now we will attempt to register the images using the masks that we defined.
+
+First, use a mask on the static image. Only pixels where the mask is non-zero
+in the static image will contribute to Mutual Information.
+
+"""
+
+reg_func("transformed_squares_mask.png", static_mask=static_mask)
+
+"""
+.. figure:: transformed_squares_mask.png
+   :align: center
+
+   Registration result using a static mask.
+"""
+
+
+"""
+We can also attempt the same thing use a moving image mask.
+
+"""
+
+reg_func("transformed_squares_mask_2.png", moving_mask=moving_mask)
+
+"""
+.. figure:: transformed_squares_mask_2.png
+   :align: center
+
+   Registration result using a moving mask.
+"""
+
+"""
+And finally, we can use both masks at the same time.
+"""
+
+reg_func("transformed_squares_mask_3.png",
+         static_mask=static_mask, moving_mask=moving_mask)
+
+
+"""
+.. figure:: transformed_squares_mask_3.png
+   :align: center
+
+   Registration result using both a static mask and a moving mask.
+"""
+
+"""
+In most use cases, it is likely that only a static mask will be required,
+e.g., to register a series of images to a single static image.
+
+Let's make a series of volumes to demonstrate this idea, and register the
+series to the first image in the series using a static mask:
+
+"""
+
+series = np.stack([static, moving, moving], axis=-1)
+
+pipeline = [translation, rigid]
+xformed, _ = register_series(series, 0, pipeline,
+                             series_affine=moving_affine,
+                             static_mask=static_mask)
+
+regtools.overlay_slices(np.squeeze(xformed[..., 0]),
+                        np.squeeze(xformed[..., -2]),
+                        None, 2, "Static", "Moving 1", "series_mask_1.png")
+
+regtools.overlay_slices(np.squeeze(xformed[..., 0]),
+                        np.squeeze(xformed[..., -1]),
+                        None, 2, "Static", "Moving 2", "series_mask_2.png")
+
+"""
+.. figure:: series_mask_1.png
+   :align: center
+.. figure:: series_mask_2.png
+   :align: center
+
+   Registration of series using a static mask.
+"""
+
+
+"""
+In all of the examples above, different masking choices achieved essentially
+the same result, but in general the results may differ depending on differences
+between the static and moving images.
+
+
+.. [Mattes03] Mattes, D., Haynor, D. R., Vesselle, H., Lewellen, T. K.,
+              Eubank, W. (2003). PET-CT image registration in the chest using
+              free-form deformations. IEEE Transactions on Medical Imaging,
+              22(1), 120-8.
+.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+              Normalization Tools (ANTS), 1-35.
+
+.. include:: ../links_names.inc
+
+"""

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -53,6 +53,7 @@
  tracking_pft.py
  tracking_sfm.py
  affine_registration_3d.py
+ affine_registration_masks.py
  syn_registration_2d.py
  syn_registration_3d.py
  tissue_classification.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -197,6 +197,7 @@ Image-based Registration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_affine_registration_3d`
+- :ref:`example_affine_registration_masks`
 - :ref:`example_syn_registration_2d`
 - :ref:`example_syn_registration_3d`
 - :ref:`example_register_binary_fuzzy`


### PR DESCRIPTION
Implementation of masking for affine registration. It is possible to use a static_mask and moving_mask, and to use the pipeline interface. A new example is included.

See #2508, #2179, and #1969 for related discussions and requests. This implementation finished and expanded the implementation referenced in #2179.
