### PR TITLE
Default to False output for null streamlines in streamline_near_roi

### DIFF
--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -360,11 +360,11 @@ def test_near_roi():
     streamlines_null = [np.array([[0., 0., 0.9],
                                  [1.9, 0., 0.],
                                  [3, 2., 2.]]),
-                       np.array([[],
+                        np.array([[],
                                  [],
                                  []]).T,
-                       np.array([]),
-                       []]
+                        np.array([]),
+                        []]
     npt.assert_array_equal(near_roi(streamlines_null, np.eye(4), mask, tol=1),
                            np.array([True, False, False, False]))
     npt.assert_array_equal(near_roi(streamlines_null, np.eye(4), mask),

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -335,29 +335,44 @@ def test_target_line_based_out_of_bounds():
 
 
 def test_near_roi():
-    streamlines = [np.array([[0., 0., 0.9],
-                             [1.9, 0., 0.],
-                             [3, 2., 2.]]),
-                   np.array([[0.1, 0., 0],
-                             [0, 1., 1.],
-                             [0, 2., 2.]]),
-                   np.array([[2, 2, 2],
-                             [3, 3, 3]])]
+    # streamlines = [np.array([[0., 0., 0.9],
+    #                          [1.9, 0., 0.],
+    #                          [3, 2., 2.]]),
+    #                np.array([[0.1, 0., 0],
+    #                          [0, 1., 1.],
+    #                          [0, 2., 2.]]),
+    #                np.array([[2, 2, 2],
+    #                          [3, 3, 3]])]
+
+    streamlines =   [np.array([[],
+                              [],
+                              []]).T,
+                      np.array([]),
+                               [],
+                    np.array([[0., 0., 0.9],
+                              [1.9, 0., 0.],
+                              [3, 2., 2.]]),
+                    np.array([[0.1, 0., 0],
+                              [0, 1., 1.],
+                              [0, 2., 2.]]),
+                    np.array([[2, 2, 2],
+                              [3, 3, 3]])]
+
 
     mask = np.zeros((4, 4, 4), dtype=bool)
     mask[0, 0, 0] = True
     mask[1, 0, 0] = True
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=1),
-                           np.array([True, True, False]))
+                           np.array([False, False, False, True, True, False]))
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask),
-                           np.array([False, True, False]))
+                           np.array([False, False, False, False, True, False]))
 
     # If there is an affine, we need to use it:
     affine = np.eye(4)
     affine[:, 3] = [-1, 100, -20, 1]
     # Transform the streamlines:
-    x_streamlines = [sl + affine[:3, 3] for sl in streamlines]
+    x_streamlines = [sl + affine[:3, 3] for sl in streamlines[-3:]]
     npt.assert_array_equal(near_roi(x_streamlines, affine, mask, tol=1),
                            np.array([True, True, False]))
     npt.assert_array_equal(near_roi(x_streamlines, affine, mask,
@@ -393,17 +408,17 @@ def test_near_roi():
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=0.87,
                                     mode="either_end"),
-                           np.array([True, False, False]))
+                           np.array([False, False, False, True, False, False]))
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=0.87,
                                     mode="both_end"),
-                           np.array([False, False, False]))
+                           np.array([False, False, False, False, False, False]))
 
     mask[0, 0, 0] = True
     mask[0, 2, 2] = True
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask,
                                     mode="both_end"),
-                           np.array([False, True, False]))
+                           np.array([False, False, False, False, True, False]))
 
     # Test with a generator input:
     def generate_sl(streamlines):
@@ -412,7 +427,7 @@ def test_near_roi():
 
     npt.assert_array_equal(near_roi(generate_sl(streamlines), np.eye(4),
                                     mask, mode="both_end"),
-                           np.array([False, True, False]))
+                           np.array([False, False, False, False, True, False]))
 
 
 def test_streamline_mapping():

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -357,7 +357,7 @@ def test_near_roi():
     # test for handling of various forms of null streamlines
     # including a streamline from previous test because near_roi / tol
     # can't handle completely empty streamline collections
-    streamlinesNULL = [np.array([[0., 0., 0.9],
+    streamlines_null = [np.array([[0., 0., 0.9],
                                  [1.9, 0., 0.],
                                  [3, 2., 2.]]),
                        np.array([[],
@@ -365,16 +365,16 @@ def test_near_roi():
                                  []]).T,
                        np.array([]),
                        []]
-    npt.assert_array_equal(near_roi(streamlinesNULL, np.eye(4), mask, tol=1),
+    npt.assert_array_equal(near_roi(streamlines_null, np.eye(4), mask, tol=1),
                            np.array([True, False, False, False]))
-    npt.assert_array_equal(near_roi(streamlinesNULL, np.eye(4), mask),
+    npt.assert_array_equal(near_roi(streamlines_null, np.eye(4), mask),
                            np.array([False, False, False, False]))
 
     # If there is an affine, we need to use it:
     affine = np.eye(4)
     affine[:, 3] = [-1, 100, -20, 1]
     # Transform the streamlines:
-    x_streamlines = [sl + affine[:3, 3] for sl in streamlines[-3:]]
+    x_streamlines = [sl + affine[:3, 3] for sl in streamlines]
     npt.assert_array_equal(near_roi(x_streamlines, affine, mask, tol=1),
                            np.array([True, True, False]))
     npt.assert_array_equal(near_roi(x_streamlines, affine, mask,

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -335,38 +335,40 @@ def test_target_line_based_out_of_bounds():
 
 
 def test_near_roi():
-    # streamlines = [np.array([[0., 0., 0.9],
-    #                          [1.9, 0., 0.],
-    #                          [3, 2., 2.]]),
-    #                np.array([[0.1, 0., 0],
-    #                          [0, 1., 1.],
-    #                          [0, 2., 2.]]),
-    #                np.array([[2, 2, 2],
-    #                          [3, 3, 3]])]
 
-    streamlines =   [np.array([[],
-                              [],
-                              []]).T,
-                      np.array([]),
-                               [],
-                    np.array([[0., 0., 0.9],
-                              [1.9, 0., 0.],
-                              [3, 2., 2.]]),
-                    np.array([[0.1, 0., 0],
-                              [0, 1., 1.],
-                              [0, 2., 2.]]),
-                    np.array([[2, 2, 2],
-                              [3, 3, 3]])]
-
+    streamlines = [np.array([[0., 0., 0.9],
+                             [1.9, 0., 0.],
+                             [3, 2., 2.]]),
+                   np.array([[0.1, 0., 0],
+                             [0, 1., 1.],
+                             [0, 2., 2.]]),
+                   np.array([[2, 2, 2],
+                             [3, 3, 3]])]
 
     mask = np.zeros((4, 4, 4), dtype=bool)
     mask[0, 0, 0] = True
     mask[1, 0, 0] = True
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=1),
-                           np.array([False, False, False, True, True, False]))
+                           np.array([True, True, False]))
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask),
-                           np.array([False, False, False, False, True, False]))
+                           np.array([False, True, False]))
+
+    # test for handling of various forms of null streamlines
+    # including a streamline from previous test because near_roi / tol
+    # can't handle completely empty streamline collections
+    streamlinesNULL = [np.array([[0., 0., 0.9],
+                                 [1.9, 0., 0.],
+                                 [3, 2., 2.]]),
+                       np.array([[],
+                                 [],
+                                 []]).T,
+                       np.array([]),
+                       []]
+    npt.assert_array_equal(near_roi(streamlinesNULL, np.eye(4), mask, tol=1),
+                           np.array([True, False, False, False]))
+    npt.assert_array_equal(near_roi(streamlinesNULL, np.eye(4), mask),
+                           np.array([False, False, False, False]))
 
     # If there is an affine, we need to use it:
     affine = np.eye(4)
@@ -408,17 +410,17 @@ def test_near_roi():
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=0.87,
                                     mode="either_end"),
-                           np.array([False, False, False, True, False, False]))
+                           np.array([True, False, False]))
 
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask, tol=0.87,
                                     mode="both_end"),
-                           np.array([False, False, False, False, False, False]))
+                           np.array([False, False, False]))
 
     mask[0, 0, 0] = True
     mask[0, 2, 2] = True
     npt.assert_array_equal(near_roi(streamlines, np.eye(4), mask,
                                     mode="both_end"),
-                           np.array([False, False, False, False, True, False]))
+                           np.array([False, True, False]))
 
     # Test with a generator input:
     def generate_sl(streamlines):
@@ -427,7 +429,7 @@ def test_near_roi():
 
     npt.assert_array_equal(near_roi(generate_sl(streamlines), np.eye(4),
                                     mask, mode="both_end"),
-                           np.array([False, False, False, False, True, False]))
+                           np.array([False, True, False]))
 
 
 def test_streamline_mapping():

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -703,6 +703,8 @@ def streamline_near_roi(streamline, roi_coords, tol, mode='any'):
     out : boolean
 
     """
+    if not np.any(streamline):
+        return False
     if len(roi_coords) == 0:
         return False
     if mode == "any" or mode == "all":


### PR DESCRIPTION
Per [the discussion on the issue thread](https://github.com/dipy/dipy/issues/2509), I went ahead and cleaned up [the test_utils section where I had created a test for null streamlines](https://github.com/DanNBullock/dipy/blob/01df7ba4042c90f1d7dc3eedac55bb598c21bb31/dipy/tracking/tests/test_utils.py#L357-L371).  It's slightly inelegant, in that I have to append a non-null streamline to the front in order to bypass issues with near_roi and tol/dtc computations, but it works as implemented.

The [streamline_near_roi change itself](https://github.com/DanNBullock/dipy/blob/01df7ba4042c90f1d7dc3eedac55bb598c21bb31/dipy/tracking/utils.py#L706-L707) appears to be effective and well behaved.

Let me know if additional adjustments are suggested/required.  