### PR TITLE
Add concurrency + timeout to Github Actions (GHA)

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: '["pip", ]'
+      timeout:
+        description: "Maximum duration of jobs before cancellation"
+        type: number
+        required: false
+        default: 90
       depends:
         description: ""
         type: string
@@ -49,9 +54,14 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ inputs.timeout }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -30,11 +30,11 @@ on:
         type: string
         required: false
         default: '["pip", ]'
-      timeout:
-        description: "Maximum duration of jobs before cancellation"
-        type: number
-        required: false
-        default: 90
+      # timeout:
+      #   description: "Maximum duration of jobs before cancellation"
+      #   type: number
+      #   required: false
+      #   default: 90
       depends:
         description: ""
         type: string
@@ -61,7 +61,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ inputs.timeout }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR adds new attributes to GHA:

- Concurrency:  kill all the remaining jobs on a PR if there is a more recent commit
- Timeout: our test duration is approximately 40-45 min.  I added a hard limit to 90min in case something weird is happening. We should keep the timeout to 6h for the future doc generation matrix.