### PR TITLE
TEST: Filter legacy SH bases warnings in tests

### DIFF
--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pickle
 from io import BytesIO
@@ -19,6 +21,7 @@ from dipy.core.gradients import gradient_table, GradientTable
 from dipy.core.sphere_stats import angular_similarity
 from dipy.core.sphere import HemiSphere
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.reconst.shm import descoteaux07_legacy_msg, tournier07_legacy_msg
 
 
 def test_peak_directions_nl():
@@ -453,8 +456,12 @@ def test_peaksFromModel():
         model = SimpleOdfModel(_gtab)
         _odf = (sphere.vertices * [1, 2, 3]).sum(-1)
         odf_argmax = _odf.argmax()
-        pam = peaks_from_model(model, data, sphere, .5, 45,
-                               normalize_peaks=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pam = peaks_from_model(model, data, sphere, .5, 45,
+                                   normalize_peaks=True)
 
         assert_array_equal(pam.gfa, gfa(_odf))
         assert_array_equal(pam.peak_values[:, 0], 1.)
@@ -466,7 +473,12 @@ def test_peaksFromModel():
         assert_array_equal(pam.peak_indices[:, 1:], -1)
 
         # Test that odf array matches and is right shape
-        pam = peaks_from_model(model, data, sphere, .5, 45, return_odf=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pam = peaks_from_model(
+                model, data, sphere, .5, 45, return_odf=True)
         expected_shape = (len(data), len(_odf))
         assert_equal(pam.odf.shape, expected_shape)
         assert_((_odf == pam.odf).all())
@@ -475,8 +487,12 @@ def test_peaksFromModel():
         # Test mask
         mask = (np.arange(10) % 2) == 1
 
-        pam = peaks_from_model(model, data, sphere, .5, 45, mask=mask,
-                               normalize_peaks=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pam = peaks_from_model(model, data, sphere, .5, 45, mask=mask,
+                                   normalize_peaks=True)
         assert_array_equal(pam.gfa[~mask], 0)
         assert_array_equal(pam.qa[~mask], 0)
         assert_array_equal(pam.peak_values[~mask], 0)
@@ -495,10 +511,14 @@ def test_peaksFromModel():
         for normalize_peaks in [True, False]:
             for return_odf in [True, False]:
                 for return_sh in [True, False]:
-                    pam = peaks_from_model(model, data, sphere, .5, 45,
-                                           normalize_peaks=normalize_peaks,
-                                           return_odf=return_odf,
-                                           return_sh=return_sh)
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            "ignore", message=descoteaux07_legacy_msg,
+                            category=PendingDeprecationWarning)
+                        pam = peaks_from_model(model, data, sphere, .5, 45,
+                                               normalize_peaks=normalize_peaks,
+                                               return_odf=return_odf,
+                                               return_sh=return_sh)
 
                     b = BytesIO()
                     pickle.dump(pam, b)
@@ -533,25 +553,30 @@ def test_peaksFromModelParallel():
 
         # test equality with/without multiprocessing
         model = SimpleOdfModel(gtab)
-        pam_multi = peaks_from_model(model, data, sphere, .5, 45,
-                                     normalize_peaks=True, return_odf=True,
-                                     return_sh=True, parallel=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pam_multi = peaks_from_model(model, data, sphere, .5, 45,
+                                         normalize_peaks=True, return_odf=True,
+                                         return_sh=True, parallel=True)
 
-        pam_single = peaks_from_model(model, data, sphere, .5, 45,
-                                      normalize_peaks=True, return_odf=True,
-                                      return_sh=True, parallel=False)
-
-        pam_multi_inv1 = peaks_from_model(model, data, sphere, .5, 45,
+            pam_single = peaks_from_model(model, data, sphere, .5, 45,
                                           normalize_peaks=True,
                                           return_odf=True,
-                                          return_sh=True, parallel=True,
-                                          num_processes=-1)
+                                          return_sh=True, parallel=False)
 
-        pam_multi_inv2 = peaks_from_model(model, data, sphere, .5, 45,
-                                          normalize_peaks=True,
-                                          return_odf=True,
-                                          return_sh=True, parallel=True,
-                                          num_processes=-2)
+            pam_multi_inv1 = peaks_from_model(model, data, sphere, .5, 45,
+                                              normalize_peaks=True,
+                                              return_odf=True,
+                                              return_sh=True, parallel=True,
+                                              num_processes=-1)
+
+            pam_multi_inv2 = peaks_from_model(model, data, sphere, .5, 45,
+                                              normalize_peaks=True,
+                                              return_odf=True,
+                                              return_sh=True, parallel=True,
+                                              num_processes=-2)
 
         for pam in [pam_multi, pam_multi_inv1, pam_multi_inv2]:
             assert_equal(pam.gfa.dtype, pam_single.gfa.dtype)
@@ -608,22 +633,33 @@ def test_peaks_shm_coeff():
 
     from dipy.reconst.shm import CsaOdfModel
 
-    model = CsaOdfModel(gtab, 4)
-
-    pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
-                           return_odf=True, return_sh=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model = CsaOdfModel(gtab, 4)
+        pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
+                               return_odf=True, return_sh=True)
     # Test that spherical harmonic coefficients return back correctly
     odf2 = np.dot(pam.shm_coeff, pam.B)
     assert_array_almost_equal(pam.odf, odf2)
     assert_equal(pam.shm_coeff.shape[-1], 45)
 
-    pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
-                           return_odf=True, return_sh=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
+                               return_odf=True, return_sh=False)
     assert_equal(pam.shm_coeff, None)
 
-    pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
-                           return_odf=True, return_sh=True,
-                           sh_basis_type='tournier07')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=tournier07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pam = peaks_from_model(model, data[None, :], sphere, .5, 45,
+                               return_odf=True, return_sh=True,
+                               sh_basis_type='tournier07')
 
     odf2 = np.dot(pam.shm_coeff, pam.B)
     assert_array_almost_equal(pam.odf, odf2)

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -8,6 +8,7 @@ from dipy.data import default_sphere, get_sphere
 from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen, BootPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.sims.voxel import single_tensor
 
 response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
@@ -15,7 +16,11 @@ response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
 
 def test_pmf_val():
     sphere = get_sphere('symmetric724')
-    pmfgen = SHCoeffPmfGen(np.random.random([2, 2, 2, 28]), sphere, None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pmfgen = SHCoeffPmfGen(np.random.random([2, 2, 2, 28]), sphere, None)
     point = np.array([1, 1, 1], dtype='float')
 
     for idx in [0, 5, 15, -1]:
@@ -29,7 +34,11 @@ def test_pmf_val():
 
 def test_pmf_from_sh():
     sphere = HemiSphere.from_sphere(unit_octahedron)
-    pmfgen = SHCoeffPmfGen(np.ones([2, 2, 2, 28]), sphere, None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pmfgen = SHCoeffPmfGen(np.ones([2, 2, 2, 28]), sphere, None)
 
     # Test that the pmf is greater than 0 for a valid point
     pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
@@ -82,7 +91,12 @@ def test_boot_pmf():
     point = np.array([1., 1., 1.])
     tensor_model = TensorModel(gtab)
 
-    boot_pmf_gen = BootPmfGen(data, model=tensor_model, sphere=hsph_updated)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_pmf_gen = BootPmfGen(
+            data, model=tensor_model, sphere=hsph_updated)
     no_boot_pmf = boot_pmf_gen.get_pmf_no_boot(point)
 
     model_pmf = tensor_model.fit(voxel).odf(hsph_updated)
@@ -93,6 +107,7 @@ def test_boot_pmf():
     # test model spherical harmonic order different than bootstrap order
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
+        warnings.simplefilter("always", category=PendingDeprecationWarning)
         csd_model = ConstrainedSphericalDeconvModel(gtab, response,
                                                     sh_order=6)
         # Tests that the first catched warning comes from
@@ -102,14 +117,22 @@ def test_boot_pmf():
         # Tests that additional warnings are raised for outdated SH basis
         npt.assert_(len(w) > 1)
 
-    boot_pmf_gen_sh4 = BootPmfGen(data, sphere=hsph_updated, model=csd_model,
-                                  sh_order=4)
-    pmf_sh4 = boot_pmf_gen_sh4.get_pmf(point)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_pmf_gen_sh4 = BootPmfGen(data, sphere=hsph_updated,
+                                      model=csd_model, sh_order=4)
+        pmf_sh4 = boot_pmf_gen_sh4.get_pmf(point)
     npt.assert_equal(len(hsph_updated.vertices), pmf_sh4.shape[0])
     npt.assert_(np.sum(pmf_sh4.shape) > 0)
 
-    boot_pmf_gen_sh8 = BootPmfGen(data, model=csd_model, sphere=hsph_updated,
-                                  sh_order=8)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_pmf_gen_sh8 = BootPmfGen(data, model=csd_model,
+                                      sphere=hsph_updated, sh_order=8)
     pmf_sh8 = boot_pmf_gen_sh8.get_pmf(point)
     npt.assert_equal(len(hsph_updated.vertices), pmf_sh8.shape[0])
     npt.assert_(np.sum(pmf_sh8.shape) > 0)

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -115,6 +115,7 @@ class ForecastModel(OdfModel, Cache):
         with respect to the FORECAST and compute the fODF, parallel and
         perpendicular diffusivity.
 
+        >>> import warnings
         >>> from dipy.data import default_sphere, get_3shell_gtab
         >>> gtab = get_3shell_gtab()
         >>> from dipy.sims.voxel import multi_tensor
@@ -128,11 +129,20 @@ class ForecastModel(OdfModel, Cache):
         ...                             fractions=[50, 50],
         ...                             snr=None)
         >>> from dipy.reconst.forecast import ForecastModel
-        >>> fm = ForecastModel(gtab, sh_order=6)
+        >>> from dipy.reconst.shm import descoteaux07_legacy_msg
+        >>> with warnings.catch_warnings():
+        ...     warnings.filterwarnings(
+        ...         "ignore", message=descoteaux07_legacy_msg,
+        ...         category=PendingDeprecationWarning)
+        ...     fm = ForecastModel(gtab, sh_order=6)
         >>> f_fit = fm.fit(data)
         >>> d_par = f_fit.dpar
         >>> d_perp = f_fit.dperp
-        >>> fodf = f_fit.odf(default_sphere)
+        >>> with warnings.catch_warnings():
+        ...     warnings.filterwarnings(
+        ...         "ignore", message=descoteaux07_legacy_msg,
+        ...         category=PendingDeprecationWarning)
+        ...     fodf = f_fit.odf(default_sphere)
         """
         OdfModel.__init__(self, gtab)
 

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -152,8 +152,10 @@ class ShoreModel(Cache):
         with respect to the SHORE basis and compute the real and analytical
         ODF.
 
+        >>> import warnings
         >>> from dipy.data import get_isbi2013_2shell_gtab, default_sphere
         >>> from dipy.sims.voxel import sticks_and_ball
+        >>> from dipy.reconst.shm import descoteaux07_legacy_msg
         >>> from dipy.reconst.shore import ShoreModel
         >>> gtab = get_isbi2013_2shell_gtab()
         >>> data, golden_directions = sticks_and_ball(
@@ -164,8 +166,12 @@ class ShoreModel(Cache):
         >>> zeta = 700
         >>> asm = ShoreModel(gtab, radial_order=radial_order, zeta=zeta,
         ...                  lambdaN=1e-8, lambdaL=1e-8)
-        >>> asmfit = asm.fit(data)
-        >>> odf = asmfit.odf(default_sphere)
+        >>> with warnings.catch_warnings():
+        ...     warnings.filterwarnings(
+        ...         "ignore", message=descoteaux07_legacy_msg,
+        ...         category=PendingDeprecationWarning)
+        ...     asmfit = asm.fit(data)
+        ...     odf = asmfit.odf(default_sphere)
         """
 
         self.bvals = gtab.bvals

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -1,5 +1,7 @@
 """Testing cross-validation analysis."""
 
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 import dipy.reconst.cross_validation as xval
@@ -10,6 +12,7 @@ import dipy.sims.voxel as sims
 import dipy.reconst.csdeconv as csd
 import dipy.reconst.base as base
 from dipy.io.image import load_nifti_data
+from dipy.reconst.shm import descoteaux07_legacy_msg
 
 
 # We'll set these globally:
@@ -74,10 +77,18 @@ def test_csd_xval():
               np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
     S0 = 100
     S = sims.single_tensor(gtab, S0, mevals[0], mevecs[0], snr=None)
-    sm = csd.ConstrainedSphericalDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        sm = csd.ConstrainedSphericalDeconvModel(gtab, response)
     np.random.seed(12345)
     response = ([0.0015, 0.0003, 0.0001], S0)
-    kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2)
     # Because of the regularization, COD is not going to be perfect here:
     cod = xval.coeff_of_determination(S, kf_xval)
     # We'll just test for regressions:
@@ -89,8 +100,12 @@ def test_csd_xval():
     S = np.array([[S, S], [S, S]])
     mask = np.ones(S.shape[:-1], dtype=bool)
     mask[1, 1] = 0
-    kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2,
-                              mask=mask)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2,
+                                  mask=mask)
 
     cod = xval.coeff_of_determination(S, kf_xval)
     npt.assert_array_almost_equal(np.round(cod[0]), csd_cod)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -25,8 +25,14 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    recursive_response)
 from dipy.direction.peaks import peak_directions
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from dipy.reconst.shm import (QballModel, sf_to_sh, sh_to_sf,
-                              real_sh_descoteaux, sph_harm_ind_list)
+from dipy.reconst.shm import (
+    descoteaux07_legacy_msg,
+    QballModel,
+    sf_to_sh,
+    sh_to_sf,
+    real_sh_descoteaux,
+    sph_harm_ind_list
+)
 from dipy.reconst.shm import lazy_index
 from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.io.gradients import read_bvals_bvecs
@@ -99,18 +105,30 @@ def test_recursive_response_calibration():
 
     odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
-    response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.05,
-                                  init_trace=0.0021, iter=8, convergence=0.001,
-                                  parallel=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = recursive_response(gtab, data, mask=None, sh_order=8,
+                                      peak_thr=0.01, init_fa=0.05,
+                                      init_trace=0.0021, iter=8,
+                                      convergence=0.001, parallel=False)
 
-    csd = ConstrainedSphericalDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd = ConstrainedSphericalDeconvModel(gtab, response)
 
     csd_fit = csd.fit(data)
 
     assert_equal(np.all(csd_fit.shm_coeff[:, 0] >= 0), True)
 
-    fodf = csd_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = csd_fit.odf(sphere)
 
     directions_gt_single, _, _ = peak_directions(odf_gt_single, sphere)
     directions_gt_cross, _, _ = peak_directions(odf_gt_cross, sphere)
@@ -132,7 +150,11 @@ def test_recursive_response_calibration():
         npt.assert_equal(len(w), 1)
         npt.assert_(issubclass(w[0].category, UserWarning))
         npt.assert_("Vertices are not on the unit sphere" in str(w[0].message))
-    sf = response.on_sphere(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        sf = response.on_sphere(sphere)
     S = np.concatenate(([response.S0], sf))
 
     tenmodel = TensorModel(gtab, min_signal=0.001)
@@ -233,10 +255,18 @@ def test_csdeconv():
     sphere = get_sphere('symmetric362')
     odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
     response = (np.array([0.0015, 0.0003, 0.0003]), S0)
-    csd = ConstrainedSphericalDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd = ConstrainedSphericalDeconvModel(gtab, response)
     csd_fit = csd.fit(S)
     assert_equal(csd_fit.shm_coeff[0] > 0, True)
-    fodf = csd_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = csd_fit.odf(sphere)
 
     directions, _, _ = peak_directions(odf_gt, sphere)
     directions2, _, _ = peak_directions(fodf, sphere)
@@ -249,12 +279,18 @@ def test_csdeconv():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
         _ = ConstrainedSphericalDeconvModel(gtab, response, sh_order=10)
         assert_greater(len([lw for lw in w if issubclass(lw.category,
                                                          UserWarning)]), 0)
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
         ConstrainedSphericalDeconvModel(gtab, response, sh_order=8)
         assert_equal(len([lw for lw in w if issubclass(lw.category,
                                                        UserWarning)]), 0)
@@ -299,10 +335,18 @@ def test_odfdeconv():
     e2 = 3.0
     ratio = e2 / e1
 
-    csd = ConstrainedSDTModel(gtab, ratio, None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd = ConstrainedSDTModel(gtab, ratio, None)
 
     csd_fit = csd.fit(S)
-    fodf = csd_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = csd_fit.odf(sphere)
 
     directions, _, _ = peak_directions(odf_gt, sphere)
     directions2, _, _ = peak_directions(fodf, sphere)
@@ -315,6 +359,7 @@ def test_odfdeconv():
     assert_equal(directions2.shape[0], 2)
 
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", category=PendingDeprecationWarning)
 
         ConstrainedSDTModel(gtab, ratio, sh_order=10)
         w_count = len(w)
@@ -324,6 +369,7 @@ def test_odfdeconv():
         assert_equal(w_count > 1, True)
 
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", category=PendingDeprecationWarning)
 
         ConstrainedSDTModel(gtab, ratio, sh_order=8)
         # Test that the warning from ConstrainedSDTModel
@@ -355,24 +401,40 @@ def test_odf_sh_to_sharp():
 
     sphere = default_sphere
 
-    qb = QballModel(gtab, sh_order=8, assume_normed=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qb = QballModel(gtab, sh_order=8, assume_normed=True)
 
     qbfit = qb.fit(S)
-    odf_gt = qbfit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf_gt = qbfit.odf(sphere)
 
     Z = np.linalg.norm(odf_gt)
 
     odfs_gt = np.zeros((3, 1, 1, odf_gt.shape[0]))
     odfs_gt[:, :, :] = odf_gt[:]
 
-    odfs_sh = sf_to_sh(odfs_gt, sphere, sh_order=8, basis_type=None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odfs_sh = sf_to_sh(odfs_gt, sphere, sh_order=8, basis_type=None)
 
     odfs_sh /= Z
 
-    fodf_sh = odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15.,
-                              sh_order=8, lambda_=1., tau=0.1)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf_sh = odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15.,
+                                  sh_order=8, lambda_=1., tau=0.1)
 
-    fodf = sh_to_sf(fodf_sh, sphere, sh_order=8, basis_type=None)
+        fodf = sh_to_sf(fodf_sh, sphere, sh_order=8, basis_type=None)
 
     directions2, _, _ = peak_directions(fodf[0, 0, 0], sphere)
 
@@ -418,10 +480,22 @@ def test_r2_term_odf_sharp():
                         fractions=[50, 50], snr=SNR)
 
     odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
-    odfs_sh = sf_to_sh(odf_gt, sphere, sh_order=8, basis_type=None)
-    fodf_sh = odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15.,
-                              sh_order=8, lambda_=1., tau=0.1, r2_term=True)
-    fodf = sh_to_sf(fodf_sh, sphere, sh_order=8, basis_type=None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odfs_sh = sf_to_sh(odf_gt, sphere, sh_order=8, basis_type=None)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf_sh = odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15.,
+                                  sh_order=8, lambda_=1., tau=0.1, r2_term=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = sh_to_sf(fodf_sh, sphere, sh_order=8, basis_type=None)
 
     directions_gt, _, _ = peak_directions(odf_gt, sphere)
     directions, _, _ = peak_directions(fodf, sphere)
@@ -431,9 +505,17 @@ def test_r2_term_odf_sharp():
     assert_equal(directions.shape[0], 2)
 
     # This should pass as well
-    sdt_model = ConstrainedSDTModel(gtab, ratio=3/15., sh_order=8)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        sdt_model = ConstrainedSDTModel(gtab, ratio=3/15., sh_order=8)
     sdt_fit = sdt_model.fit(S)
-    fodf = sdt_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = sdt_fit.odf(sphere)
 
     directions_gt, _, _ = peak_directions(odf_gt, sphere)
     directions, _, _ = peak_directions(fodf, sphere)
@@ -460,19 +542,31 @@ def test_csd_predict():
     multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
     response = (np.array([0.0015, 0.0003, 0.0003]), S0)
 
-    csd = ConstrainedSphericalDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd = ConstrainedSphericalDeconvModel(gtab, response)
     csd_fit = csd.fit(S)
 
     # Predicting from a fit should give the same result as predicting from a
     # model, S0 is 1 by default
     prediction1 = csd_fit.predict()
-    prediction2 = csd.predict(csd_fit.shm_coeff)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        prediction2 = csd.predict(csd_fit.shm_coeff)
     npt.assert_array_equal(prediction1, prediction2)
     npt.assert_array_equal(prediction1[..., gtab.b0s_mask], 1.)
 
     # Same with a different S0
     prediction1 = csd_fit.predict(S0=123.)
-    prediction2 = csd.predict(csd_fit.shm_coeff, S0=123.)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        prediction2 = csd.predict(csd_fit.shm_coeff, S0=123.)
     npt.assert_array_equal(prediction1, prediction2)
     npt.assert_array_equal(prediction1[..., gtab.b0s_mask], 123.)
 
@@ -480,7 +574,11 @@ def test_csd_predict():
     # coefficients from the predicted signal.
     coeff = np.random.random(csd_fit.shm_coeff.shape) - .5
     coeff[..., 0] = 10.
-    S = csd.predict(coeff)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S = csd.predict(coeff)
     csd_fit = csd.fit(S)
     npt.assert_array_almost_equal(coeff, csd_fit.shm_coeff)
 
@@ -489,7 +587,11 @@ def test_csd_predict():
     S_nd[:] = S
     fit = csd.fit(S_nd)
     predict1 = fit.predict()
-    predict2 = csd.predict(fit.shm_coeff)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        predict2 = csd.predict(fit.shm_coeff)
     npt.assert_array_almost_equal(predict1, predict2)
 
 
@@ -503,10 +605,18 @@ def test_csd_predict_multi():
     bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
     gtab = gradient_table(bvals, bvecs)
     response = (np.array([0.0015, 0.0003, 0.0003]), S0)
-    csd = ConstrainedSphericalDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd = ConstrainedSphericalDeconvModel(gtab, response)
     coeff = np.random.random(45) - .5
     coeff[..., 0] = 10.
-    S = csd.predict(coeff, S0=123.)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S = csd.predict(coeff, S0=123.)
     multi_S = np.array([[S, S], [S, S]])
     csd_fit_multi = csd.fit(multi_S)
     S0_multi = np.mean(multi_S[..., gtab.b0s_mask], -1)
@@ -534,10 +644,14 @@ def test_sphere_scaling_csdmodel():
     sphere = hemi.mirror()
 
     response = (np.array([0.0015, 0.0003, 0.0003]), 100)
-    model_full = ConstrainedSphericalDeconvModel(gtab, response,
-                                                 reg_sphere=sphere)
-    model_hemi = ConstrainedSphericalDeconvModel(gtab, response,
-                                                 reg_sphere=hemi)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_full = ConstrainedSphericalDeconvModel(gtab, response,
+                                                     reg_sphere=sphere)
+        model_hemi = ConstrainedSphericalDeconvModel(gtab, response,
+                                                     reg_sphere=hemi)
     csd_fit_full = model_full.fit(S)
     csd_fit_hemi = model_hemi.fit(S)
 
@@ -566,6 +680,7 @@ def test_default_lambda_csdmodel():
                                           expected_lambda.values(),
                                           expected_csdmodel_warnings.values()):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", category=PendingDeprecationWarning)
             model_full = ConstrainedSphericalDeconvModel(gtab, response,
                                                          sh_order=sh_order,
                                                          reg_sphere=sphere)
@@ -576,7 +691,12 @@ def test_default_lambda_csdmodel():
                 npt.assert_("Number of parameters required " in str(w[0].
                                                                     message))
 
-        B_reg, _, _ = real_sh_descoteaux(sh_order, sphere.theta, sphere.phi)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            B_reg, _, _ = real_sh_descoteaux(
+                sh_order, sphere.theta, sphere.phi)
         npt.assert_array_almost_equal(model_full.B_reg, expected * B_reg)
 
 
@@ -594,6 +714,9 @@ def test_csd_superres():
         warnings.filterwarnings(action="always",
                                 message="Number of parameters required.*",
                                 category=UserWarning)
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
         model16 = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
                                                   sh_order=16)
         assert_greater_equal(len(w), 1)
@@ -603,9 +726,13 @@ def test_csd_superres():
 
     sphere = HemiSphere.from_sphere(get_sphere('symmetric724'))
     # print local_maxima(fit16.odf(default_sphere), default_sphere.edges)
-    d, v, ind = peak_directions(fit16.odf(sphere), sphere,
-                                relative_peak_threshold=.2,
-                                min_separation_angle=0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        d, v, ind = peak_directions(fit16.odf(sphere), sphere,
+                                    relative_peak_threshold=.2,
+                                    min_separation_angle=0)
 
     # Check that there are two peaks
     assert_equal(len(d), 2)
@@ -624,9 +751,21 @@ def test_csd_convergence():
     evals = np.array([[1.5, .3, .3]]) * [[1.], [1.]] / 1000.
     S, sticks = multi_tensor(gtab, evals, snr=None, fractions=[55., 45.])
 
-    model_w_conv = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
-                                                   sh_order=8, convergence=50)
-    model_wo_conv = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
-                                                    sh_order=8)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_w_conv = ConstrainedSphericalDeconvModel(
+            gtab,
+            (evals[0], 3.),
+            sh_order=8,
+            convergence=50,
+        )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_wo_conv = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
+                                                        sh_order=8)
 
     assert_equal(model_w_conv.fit(S).shm_coeff, model_wo_conv.fit(S).shm_coeff)

--- a/dipy/reconst/tests/test_eudx_dg.py
+++ b/dipy/reconst/tests/test_eudx_dg.py
@@ -1,7 +1,10 @@
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 
 from dipy.direction.peaks import default_sphere, peaks_from_model
+from dipy.reconst.shm import descoteaux07_legacy_msg
 
 
 def test_EuDXDirectionGetter():
@@ -27,9 +30,13 @@ def test_EuDXDirectionGetter():
         return (state, np.array(newdir))
 
     data = np.random.random((3, 4, 5, 2))
-    peaks = peaks_from_model(SillyModel(), data, default_sphere,
-                             relative_peak_threshold=.5,
-                             min_separation_angle=25)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        peaks = peaks_from_model(SillyModel(), data, default_sphere,
+                                 relative_peak_threshold=.5,
+                                 min_separation_angle=25)
     peaks._initialize()
 
     up = np.zeros(3)
@@ -67,10 +74,14 @@ def test_EuDXDirectionGetter():
                 # It should be a (1, 3) array
                 npt.assert_array_almost_equal(initial_dir, [expected_dir])
 
-    peaks1 = peaks_from_model(SillyModel(), data, default_sphere,
-                              relative_peak_threshold=.5,
-                              min_separation_angle=25,
-                              npeaks=1)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        peaks1 = peaks_from_model(SillyModel(), data, default_sphere,
+                                  relative_peak_threshold=.5,
+                                  min_separation_angle=25,
+                                  npeaks=1)
     peaks1._initialize()
     point = np.array([1, 1, 1], dtype=float)
 

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -1,9 +1,12 @@
 # Tests for FORECAST fitting and metrics
 
+import warnings
+
 import numpy as np
 
 from dipy.data import get_sphere, default_sphere, get_3shell_gtab
 from dipy.reconst.forecast import ForecastModel
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.sims.voxel import multi_tensor
 
 from numpy.testing import assert_almost_equal, assert_equal
@@ -40,15 +43,23 @@ def setup_module():
 
 @needs_cvxpy
 def test_forecast_positive_constrain():
-    fm = ForecastModel(data.gtab,
-                       sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb,
-                       dec_alg='POS',
-                       sphere=data.sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab,
+                           sh_order=data.sh_order,
+                           lambda_lb=data.lambda_lb,
+                           dec_alg='POS',
+                           sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
     sphere = get_sphere('repulsion100')
-    fodf = f_fit.odf(sphere, clip_negative=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere, clip_negative=False)
     assert_almost_equal(fodf[fodf < 0].sum(), 0, 2)
 
     coeff = f_fit.sh_coeff
@@ -58,15 +69,31 @@ def test_forecast_positive_constrain():
 
 def test_forecast_csd():
     sphere = get_sphere('repulsion100')
-    fm = ForecastModel(data.gtab, dec_alg='CSD',
-                       sphere=data.sphere, lambda_csd=data.lambda_csd)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, dec_alg='CSD',
+                           sphere=data.sphere, lambda_csd=data.lambda_csd)
     f_fit = fm.fit(data.S)
-    fodf_csd = f_fit.odf(sphere, clip_negative=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf_csd = f_fit.odf(sphere, clip_negative=False)
 
-    fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, dec_alg='WLS')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=data.sh_order,
+                           lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(data.S)
-    fodf_wls = f_fit.odf(sphere, clip_negative=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf_wls = f_fit.odf(sphere, clip_negative=False)
 
     value = fodf_wls[fodf_wls < 0].sum() < fodf_csd[fodf_csd < 0].sum()
     assert_equal(value, 1)
@@ -74,48 +101,88 @@ def test_forecast_csd():
 
 def test_forecast_odf():
     # check FORECAST fODF at different SH order
-    fm = ForecastModel(data.gtab, sh_order=4,
-                       dec_alg='CSD', sphere=data.sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=4,
+                           dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     sphere = default_sphere
-    fodf = f_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(
         angular_similarity(directions, data.sticks), 2, 1)
 
-    fm = ForecastModel(data.gtab, sh_order=6,
-                       dec_alg='CSD', sphere=data.sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=6,
+                           dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
-    fodf = f_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(
         angular_similarity(directions, data.sticks), 2, 1)
 
-    fm = ForecastModel(data.gtab, sh_order=8,
-                       dec_alg='CSD', sphere=data.sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=8,
+                           dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
-    fodf = f_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(
         angular_similarity(directions, data.sticks), 2, 1)
 
     # stronger regularization is required for high order SH
-    fm = ForecastModel(data.gtab, sh_order=10,
-                       dec_alg='CSD', sphere=sphere.vertices)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=10,
+                           dec_alg='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
-    fodf = f_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(
         angular_similarity(directions, data.sticks), 2, 1)
 
-    fm = ForecastModel(data.gtab, sh_order=12,
-                       dec_alg='CSD', sphere=sphere.vertices)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=12,
+                           dec_alg='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
-    fodf = f_fit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
     assert_equal(len(directions), 2)
     assert_almost_equal(
@@ -124,8 +191,12 @@ def test_forecast_odf():
 
 def test_forecast_indices():
     # check anisotropic tensor
-    fm = ForecastModel(data.gtab, sh_order=2,
-                       lambda_lb=data.lambda_lb, dec_alg='WLS')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=2,
+                           lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(data.S)
 
     d_par = f_fit.dpar
@@ -148,8 +219,12 @@ def test_forecast_indices():
     S, sticks = multi_tensor(data.gtab, mevals, S0=100.0, angles=data.angl,
                              fractions=[50, 50], snr=None)
 
-    fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, dec_alg='WLS')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=data.sh_order,
+                           lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(S)
 
     d_par = f_fit.dpar
@@ -163,11 +238,19 @@ def test_forecast_indices():
 
 def test_forecast_predict():
     # check anisotropic tensor
-    fm = ForecastModel(data.gtab, sh_order=8,
-                       dec_alg='CSD', sphere=data.sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(data.gtab, sh_order=8,
+                           dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
-    S = f_fit.predict(S0=1.0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S = f_fit.predict(S0=1.0)
 
     mse = np.sum((S-data.S/100.0)**2) / len(S)
 
@@ -191,11 +274,19 @@ def test_multivox_forecast():
     S[2, 0, 0], _ = multi_tensor(gtab, mevals, S0=1.0, angles=angl3,
                                  fractions=[50, 50], snr=None)
 
-    fm = ForecastModel(gtab, sh_order=8,
-                       dec_alg='CSD')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        fm = ForecastModel(gtab, sh_order=8,
+                           dec_alg='CSD')
     f_fit = fm.fit(S)
 
-    S_predict = f_fit.predict()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S_predict = f_fit.predict()
 
     assert_equal(S_predict.shape, S.shape)
 

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -19,7 +19,7 @@ from dipy.reconst.mapmri import MapmriModel, mapmri_index_matrix
 from dipy.reconst import dti, mapmri
 from dipy.reconst.odf import gfa
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
-from dipy.reconst.shm import sh_to_sf
+from dipy.reconst.shm import sh_to_sf, descoteaux07_legacy_msg
 from dipy.sims.voxel import (multi_tensor, multi_tensor_pdf, add_noise,
                              single_tensor, cylinders_and_ball_soderman)
 
@@ -174,11 +174,19 @@ def test_mapmri_signal_fitting(radial_order=6):
         assert_almost_equal(nmse_signal, 0.0, 3)
 
     # do the same for isotropic implementation
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_weighting=0.0001,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_weighting=0.0001,
+                           anisotropic_scaling=False)
     mapfit = mapm.fit(S)
-    S_reconst = mapfit.predict(gtab, 1.0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S_reconst = mapfit.predict(gtab, 1.0)
 
     # test the signal reconstruction
     S = S / S[0]
@@ -186,13 +194,21 @@ def test_mapmri_signal_fitting(radial_order=6):
     assert_almost_equal(nmse_signal, 0.0, 3)
 
     # do the same without the positivity constraint:
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_weighting=0.0001,
-                       positivity_constraint=False,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_weighting=0.0001,
+                           positivity_constraint=False,
+                           anisotropic_scaling=False)
 
     mapfit = mapm.fit(S)
-    S_reconst = mapfit.predict(gtab, 1.0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S_reconst = mapfit.predict(gtab, 1.0)
 
     # test the signal reconstruction
     S = S / S[0]
@@ -202,13 +218,21 @@ def test_mapmri_signal_fitting(radial_order=6):
     # Repeat with a gtab with big_delta and small_delta:
     gtab.big_delta = 5
     gtab.small_delta = 3
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_weighting=0.0001,
-                       positivity_constraint=False,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_weighting=0.0001,
+                           positivity_constraint=False,
+                           anisotropic_scaling=False)
 
     mapfit = mapm.fit(S)
-    S_reconst = mapfit.predict(gtab, 1.0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S_reconst = mapfit.predict(gtab, 1.0)
 
     # test the signal reconstruction
     S = S / S[0]
@@ -217,14 +241,22 @@ def test_mapmri_signal_fitting(radial_order=6):
 
     if mapmri.have_cvxpy:
         # Positivity constraint and anisotropic scaling:
-        mapm = MapmriModel(gtab, radial_order=radial_order,
-                           laplacian_weighting=0.0001,
-                           positivity_constraint=True,
-                           anisotropic_scaling=False,
-                           pos_radius=2)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            mapm = MapmriModel(gtab, radial_order=radial_order,
+                               laplacian_weighting=0.0001,
+                               positivity_constraint=True,
+                               anisotropic_scaling=False,
+                               pos_radius=2)
 
         mapfit = mapm.fit(S)
-        S_reconst = mapfit.predict(gtab, 1.0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            S_reconst = mapfit.predict(gtab, 1.0)
 
         # test the signal reconstruction
         S = S / S[0]
@@ -232,14 +264,22 @@ def test_mapmri_signal_fitting(radial_order=6):
         assert_almost_equal(nmse_signal, 0.0, 3)
 
         # Positivity constraint and anisotropic scaling:
-        mapm = MapmriModel(gtab, radial_order=radial_order,
-                           laplacian_weighting=None,
-                           positivity_constraint=True,
-                           anisotropic_scaling=False,
-                           pos_radius=2)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            mapm = MapmriModel(gtab, radial_order=radial_order,
+                               laplacian_weighting=None,
+                               positivity_constraint=True,
+                               anisotropic_scaling=False,
+                               pos_radius=2)
 
         mapfit = mapm.fit(S)
-        S_reconst = mapfit.predict(gtab, 1.0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            S_reconst = mapfit.predict(gtab, 1.0)
 
         # test the signal reconstruction
         S = S / S[0]
@@ -258,19 +298,24 @@ def test_mapmri_isotropic_static_scale_factor(radial_order=6):
     S_array = np.tile(S, (5, 1))
 
     stat_weight = 0.1
-    mapm_scale_stat_reg_stat = MapmriModel(gtab,
-                                           radial_order=radial_order,
-                                           anisotropic_scaling=False,
-                                           dti_scale_estimation=False,
-                                           static_diffusivity=D,
-                                           laplacian_regularization=True,
-                                           laplacian_weighting=stat_weight)
-    mapm_scale_adapt_reg_stat = MapmriModel(gtab,
-                                            radial_order=radial_order,
-                                            anisotropic_scaling=False,
-                                            dti_scale_estimation=True,
-                                            laplacian_regularization=True,
-                                            laplacian_weighting=stat_weight)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm_scale_stat_reg_stat = MapmriModel(gtab,
+                                               radial_order=radial_order,
+                                               anisotropic_scaling=False,
+                                               dti_scale_estimation=False,
+                                               static_diffusivity=D,
+                                               laplacian_regularization=True,
+                                               laplacian_weighting=stat_weight)
+        mapm_scale_adapt_reg_stat = MapmriModel(
+            gtab,
+            radial_order=radial_order,
+            anisotropic_scaling=False,
+            dti_scale_estimation=True,
+            laplacian_regularization=True,
+            laplacian_weighting=stat_weight)
 
     start = time.time()
     mapf_scale_stat_reg_stat = mapm_scale_stat_reg_stat.fit(S_array)
@@ -294,8 +339,12 @@ def test_mapmri_isotropic_static_scale_factor(radial_order=6):
                                          time_scale_adapt_reg_stat))
 
     # check if the fitted signal is the same
-    assert_almost_equal(mapf_scale_stat_reg_stat.fitted_signal(),
-                        mapf_scale_adapt_reg_stat.fitted_signal())
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        assert_almost_equal(mapf_scale_stat_reg_stat.fitted_signal(),
+                            mapf_scale_adapt_reg_stat.fitted_signal())
 
 
 def test_mapmri_signal_fitting_over_radial_order(order_max=8):
@@ -347,18 +396,30 @@ def test_mapmri_pdf_integral_unity(radial_order=6):
     radius_max = 0.04  # 40 microns
     gridsize = 17
     r_points = mapmri.create_rspace(gridsize, radius_max)
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_weighting=0.02,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_weighting=0.02,
+                           anisotropic_scaling=False)
     mapfit = mapm.fit(S)
-    pdf = mapfit.pdf(r_points)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf = mapfit.pdf(r_points)
     pdf[r_points[:, 2] == 0.] /= 2  # for antipodal symmetry on z-plane
 
     point_volume = (radius_max / (gridsize // 2)) ** 3
     integral = pdf.sum() * point_volume * 2
     assert_almost_equal(integral, 1.0, 3)
 
-    odf = mapfit.odf(sphere, s=0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf = mapfit.odf(sphere, s=0)
     odf_sum = odf.sum() / sphere.vertices.shape[0] * (4 * np.pi)
     assert_almost_equal(odf_sum, 1.0, 2)
 
@@ -442,9 +503,13 @@ def test_mapmri_metrics_isotropic(radial_order=6):
 
     # test MAPMRI q-space indices
 
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_regularization=False,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_regularization=False,
+                           anisotropic_scaling=False)
     mapfit = mapm.fit(S)
 
     tau = 1 / (4 * np.pi ** 2)
@@ -462,8 +527,12 @@ def test_mapmri_metrics_isotropic(radial_order=6):
         ((l2 * l3 + l1 * (l2 + l3)) * tau ** 2)
     )
 
-    assert_almost_equal(mapfit.rtap(), rtap_gt, 5)
-    assert_almost_equal(mapfit.rtpp(), rtpp_gt, 5)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        assert_almost_equal(mapfit.rtap(), rtap_gt, 5)
+        assert_almost_equal(mapfit.rtpp(), rtpp_gt, 5)
     assert_almost_equal(mapfit.rtop(), rtop_gt, 4)
     assert_almost_equal(mapfit.msd(), msd_gt, 5)
     assert_almost_equal(mapfit.qiv(), qiv_gt, 5)
@@ -502,9 +571,13 @@ def test_mapmri_laplacian_isotropic(radial_order=6):
     l1, l2, l3 = [0.0003, 0.0003, 0.0003]  # isotropic diffusivities
     S = single_tensor(gtab, evals=np.r_[l1, l2, l3])
 
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_regularization=False,
-                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_regularization=False,
+                           anisotropic_scaling=False)
     mapfit = mapm.fit(S)
     tau = 1 / (4 * np.pi ** 2)
 
@@ -547,8 +620,12 @@ def test_signal_fitting_equality_anisotropic_isotropic(radial_order=6):
     M_aniso = mapmri.mapmri_phi_matrix(radial_order, mu, q)
     K_aniso = mapmri.mapmri_psi_matrix(radial_order, mu, r_points)
 
-    M_iso = mapmri.mapmri_isotropic_phi_matrix(radial_order, u0, q)
-    K_iso = mapmri.mapmri_isotropic_psi_matrix(radial_order, u0, r_points)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        M_iso = mapmri.mapmri_isotropic_phi_matrix(radial_order, u0, q)
+        K_iso = mapmri.mapmri_isotropic_psi_matrix(radial_order, u0, r_points)
 
     coef_aniso = np.dot(np.linalg.pinv(M_aniso), S)
     coef_iso = np.dot(np.linalg.pinv(M_iso), S)
@@ -566,10 +643,14 @@ def test_signal_fitting_equality_anisotropic_isotropic(radial_order=6):
                               np.ones_like(pdf_fitted_aniso), 3)
 
     # test if the implemented version also produces the same result
-    mapm = MapmriModel(gtab, radial_order=radial_order,
-                       laplacian_regularization=False,
-                       anisotropic_scaling=False)
-    s_fitted_implemented_isotropic = mapm.fit(S).fitted_signal()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapm = MapmriModel(gtab, radial_order=radial_order,
+                           laplacian_regularization=False,
+                           anisotropic_scaling=False)
+        s_fitted_implemented_isotropic = mapm.fit(S).fitted_signal()
 
     # normalize non-implemented fitted signal with b0 value
     s_fitted_aniso_norm = s_fitted_aniso / s_fitted_aniso.max()
@@ -597,8 +678,13 @@ def test_mapmri_isotropic_design_matrix_separability(radial_order=6):
     q = gtab.bvecs * qvals[:, None]
     mu = 0.0003  # random value
 
-    M = mapmri.mapmri_isotropic_phi_matrix(radial_order, mu, q)
-    M_independent = mapmri.mapmri_isotropic_M_mu_independent(radial_order, q)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        M = mapmri.mapmri_isotropic_phi_matrix(radial_order, mu, q)
+        M_independent = mapmri.mapmri_isotropic_M_mu_independent(
+            radial_order, q)
     M_dependent = mapmri.mapmri_isotropic_M_mu_dependent(radial_order, mu,
                                                          qvals)
     M_reconstructed = M_independent * M_dependent
@@ -625,12 +711,20 @@ def test_estimate_radius_with_rtap(radius_gt=5e-3):
     # estimate radius using isotropic MAP-MRI.
     # note that the radial order is higher and the precision is lower due to
     # less accurate signal extrapolation.
-    mapmod = mapmri.MapmriModel(gtab, radial_order=8,
-                                laplacian_regularization=True,
-                                laplacian_weighting=0.01,
-                                anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapmod = mapmri.MapmriModel(gtab, radial_order=8,
+                                    laplacian_regularization=True,
+                                    laplacian_weighting=0.01,
+                                    anisotropic_scaling=False)
     mapfit = mapmod.fit(E)
-    radius_estimated = np.sqrt(1 / (np.pi * mapfit.rtap()))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        radius_estimated = np.sqrt(1 / (np.pi * mapfit.rtap()))
     assert_almost_equal(radius_estimated, radius_gt, 4)
 
 
@@ -669,22 +763,34 @@ def test_positivity_constraint(radial_order=6):
                  True)
 
     # the same for isotropic scaling
-    mapmod_no_constraint = MapmriModel(gtab, radial_order=radial_order,
-                                       laplacian_regularization=False,
-                                       positivity_constraint=False,
-                                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapmod_no_constraint = MapmriModel(gtab, radial_order=radial_order,
+                                           laplacian_regularization=False,
+                                           positivity_constraint=False,
+                                           anisotropic_scaling=False)
     mapfit_no_constraint = mapmod_no_constraint.fit(S_noise)
-    pdf = mapfit_no_constraint.pdf(r_grad)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf = mapfit_no_constraint.pdf(r_grad)
     pdf_negative_no_constraint = pdf[pdf < 0].sum()
 
-    mapmod_constraint = MapmriModel(gtab, radial_order=radial_order,
-                                    laplacian_regularization=False,
-                                    positivity_constraint=True,
-                                    anisotropic_scaling=False,
-                                    pos_grid=gridsize,
-                                    pos_radius='adaptive')
-    mapfit_constraint = mapmod_constraint.fit(S_noise)
-    pdf = mapfit_constraint.pdf(r_grad)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapmod_constraint = MapmriModel(gtab, radial_order=radial_order,
+                                        laplacian_regularization=False,
+                                        positivity_constraint=True,
+                                        anisotropic_scaling=False,
+                                        pos_grid=gridsize,
+                                        pos_radius='adaptive')
+        mapfit_constraint = mapmod_constraint.fit(S_noise)
+        pdf = mapfit_constraint.pdf(r_grad)
     pdf_negative_constraint = pdf[pdf < 0].sum()
 
     assert_equal((pdf_negative_constraint / pdf_negative_no_constraint) < 0.1,
@@ -740,18 +846,22 @@ def test_laplacian_regularization(radial_order=6):
     assert_equal(laplacian_norm_laplacian < laplacian_norm_unreg, True)
 
     # the same for isotropic scaling
-    mapmod_unreg = MapmriModel(gtab, radial_order=radial_order,
-                               laplacian_regularization=False,
-                               laplacian_weighting=weight_array,
-                               anisotropic_scaling=False)
-    mapmod_laplacian_array = MapmriModel(gtab, radial_order=radial_order,
-                                         laplacian_regularization=True,
-                                         laplacian_weighting=weight_array,
-                                         anisotropic_scaling=False)
-    mapmod_laplacian_gcv = MapmriModel(gtab, radial_order=radial_order,
-                                       laplacian_regularization=True,
-                                       laplacian_weighting="GCV",
-                                       anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapmod_unreg = MapmriModel(gtab, radial_order=radial_order,
+                                   laplacian_regularization=False,
+                                   laplacian_weighting=weight_array,
+                                   anisotropic_scaling=False)
+        mapmod_laplacian_array = MapmriModel(gtab, radial_order=radial_order,
+                                             laplacian_regularization=True,
+                                             laplacian_weighting=weight_array,
+                                             anisotropic_scaling=False)
+        mapmod_laplacian_gcv = MapmriModel(gtab, radial_order=radial_order,
+                                           laplacian_regularization=True,
+                                           laplacian_weighting="GCV",
+                                           anisotropic_scaling=False)
 
     # test the Generalized Cross Validation
     # test if GCV gives zero if there is no noise
@@ -827,13 +937,25 @@ def test_mapmri_odf(radial_order=6):
 
     # for the isotropic implementation check if the odf spherical harmonics
     # actually represent the discrete sphere function.
-    mapmod = MapmriModel(gtab, radial_order=radial_order,
-                         laplacian_regularization=True,
-                         laplacian_weighting=0.01,
-                         anisotropic_scaling=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        mapmod = MapmriModel(gtab, radial_order=radial_order,
+                             laplacian_regularization=True,
+                             laplacian_weighting=0.01,
+                             anisotropic_scaling=False)
     mapfit = mapmod.fit(data)
-    odf = mapfit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf = mapfit.odf(sphere)
     odf_sh = mapfit.odf_sh()
-    odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None,
-                           legacy=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None,
+                               legacy=True)
     assert_almost_equal(odf, odf_from_sh, 10)

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -58,29 +58,49 @@ def _expand(m, iso, coeff):
 def test_mcsd_model_delta():
     sh_order = 8
     gtab = get_3shell_gtab()
-    response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
-                                          wm_response,
-                                          gm_response,
-                                          csf_response)
-    model = MultiShellDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model = MultiShellDeconvModel(gtab, response)
     iso = response.iso
 
     theta, phi = default_sphere.theta, default_sphere.phi
-    B = shm.real_sh_descoteaux_from_index(
-        response.m, response.n, theta[:, None], phi[:, None])
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        B = shm.real_sh_descoteaux_from_index(
+            response.m, response.n, theta[:, None], phi[:, None])
 
     wm_delta = model.delta.copy()
     # set isotropic components to zero
     wm_delta[:iso] = 0.
     wm_delta = _expand(model.m, iso, wm_delta)
 
-    for i, s in enumerate([0, 1000, 2000, 3500]):
-        g = GradientTable(default_sphere.vertices * s)
-        signal = model.predict(wm_delta, g)
-        expected = np.dot(response.response[i, iso:], B.T)
-        npt.assert_array_almost_equal(signal, expected)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        for i, s in enumerate([0, 1000, 2000, 3500]):
+            g = GradientTable(default_sphere.vertices * s)
+            signal = model.predict(wm_delta, g)
+            expected = np.dot(response.response[i, iso:], B.T)
+            npt.assert_array_almost_equal(signal, expected)
 
-    signal = model.predict(wm_delta, gtab)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        signal = model.predict(wm_delta, gtab)
     fit = model.fit(signal)
     m = model.m
     npt.assert_array_almost_equal(fit.shm_coeff[m != 0], 0., 2)
@@ -91,13 +111,25 @@ def test_MultiShellDeconvModel_response():
     gtab = get_3shell_gtab()
 
     sh_order = 8
-    response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
-                                          wm_response,
-                                          gm_response,
-                                          csf_response)
-    model_1 = MultiShellDeconvModel(gtab, response, sh_order=sh_order)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_1 = MultiShellDeconvModel(gtab, response, sh_order=sh_order)
     responses = np.array([wm_response, gm_response, csf_response])
-    model_2 = MultiShellDeconvModel(gtab, responses, sh_order=sh_order)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_2 = MultiShellDeconvModel(gtab, responses, sh_order=sh_order)
     response_1 = model_1.response.response
     response_2 = model_2.response.response
     npt.assert_array_almost_equal(response_1, response_2, 0)
@@ -121,18 +153,26 @@ def test_MultiShellDeconvModel():
     S_csf = csf_response[0, 3] * np.exp(-gtab.bvals * csf_response[0, 0])
 
     sh_order = 8
-    response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
-                                          wm_response,
-                                          gm_response,
-                                          csf_response)
-    model = MultiShellDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response)
+        model = MultiShellDeconvModel(gtab, response)
     vf = [0.325, 0.2, 0.475]
     signal = sum(i * j for i, j in zip(vf, [S_csf, S_gm, S_wm]))
     fit = model.fit(signal)
 
     # Testing both ways to predict
     S_pred_fit = fit.predict()
-    S_pred_model = model.predict(fit.all_shm_coeff)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        S_pred_model = model.predict(fit.all_shm_coeff)
 
     npt.assert_array_almost_equal(S_pred_fit, S_pred_model, 0)
     npt.assert_array_almost_equal(S_pred_fit, signal, 0)
@@ -151,11 +191,15 @@ def test_MSDeconvFit():
     S_csf = csf_response[0, 3] * np.exp(-gtab.bvals * csf_response[0, 0])
 
     sh_order = 8
-    response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
-                                          wm_response,
-                                          gm_response,
-                                          csf_response)
-    model = MultiShellDeconvModel(gtab, response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response)
+        model = MultiShellDeconvModel(gtab, response)
     vf = [0.325, 0.2, 0.475]
     signal = sum(i * j for i, j in zip(vf, [S_csf, S_gm, S_wm]))
     fit = model.fit(signal)
@@ -167,14 +211,19 @@ def test_MSDeconvFit():
 def test_multi_shell_fiber_response():
 
     sh_order = 8
-    response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
-                                          wm_response,
-                                          gm_response,
-                                          csf_response)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response)
 
     npt.assert_equal(response.response.shape, (4, 7))
 
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", category=PendingDeprecationWarning)
         response = multi_shell_fiber_response(sh_order, [1000, 2000, 3500],
                                               wm_response,
                                               gm_response,

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import scipy.integrate as integrate
 
@@ -10,6 +12,7 @@ import pytest
 from dipy.core.gradients import gradient_table_from_qvals_bvecs
 from dipy.data import get_gtab_taiwan_dsi, get_sphere
 from dipy.reconst import qtdmri, mapmri
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.sims.voxel import multi_tensor, add_noise
 
 needs_cvxpy = pytest.mark.skipif(not qtdmri.have_cvxpy,
@@ -177,17 +180,29 @@ def test_anisotropic_isotropic_equivalence(radial_order=4, time_order=2):
                                         anisotropic_scaling=False)
 
     # both implementations fit the same signal
-    qtdmri_fit_cart = qtdmri_mod_aniso.fit(S)
-    qtdmri_fit_sphere = qtdmri_mod_iso.fit(S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qtdmri_fit_cart = qtdmri_mod_aniso.fit(S)
+        qtdmri_fit_sphere = qtdmri_mod_iso.fit(S)
 
     # same signal fit
-    assert_array_almost_equal(qtdmri_fit_cart.fitted_signal(),
-                              qtdmri_fit_sphere.fitted_signal())
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        assert_array_almost_equal(qtdmri_fit_cart.fitted_signal(),
+                                  qtdmri_fit_sphere.fitted_signal())
 
     # same PDF reconstruction
     rt_grid = qtdmri.create_rt_space_grid(5, 20e-3, 5, 0.02, .05)
     pdf_aniso = qtdmri_fit_cart.pdf(rt_grid)
-    pdf_iso = qtdmri_fit_sphere.pdf(rt_grid)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf_iso = qtdmri_fit_sphere.pdf(rt_grid)
     assert_array_almost_equal(pdf_aniso / pdf_aniso.max(),
                               pdf_iso / pdf_aniso.max())
 
@@ -200,15 +215,25 @@ def test_anisotropic_isotropic_equivalence(radial_order=4, time_order=2):
     # all q-space index is the same for arbitrary tau
     tau = 0.02
     assert_almost_equal(qtdmri_fit_cart.rtop(tau), qtdmri_fit_sphere.rtop(tau))
-    assert_almost_equal(qtdmri_fit_cart.rtap(tau), qtdmri_fit_sphere.rtap(tau))
-    assert_almost_equal(qtdmri_fit_cart.rtpp(tau), qtdmri_fit_sphere.rtpp(tau))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        assert_almost_equal(
+            qtdmri_fit_cart.rtap(tau), qtdmri_fit_sphere.rtap(tau))
+        assert_almost_equal(
+            qtdmri_fit_cart.rtpp(tau), qtdmri_fit_sphere.rtpp(tau))
     assert_almost_equal(qtdmri_fit_cart.msd(tau), qtdmri_fit_sphere.msd(tau))
     assert_almost_equal(qtdmri_fit_cart.qiv(tau), qtdmri_fit_sphere.qiv(tau))
 
     # ODF estimation is the same
     sphere = get_sphere()
-    assert_array_almost_equal(qtdmri_fit_cart.odf(sphere, tau, s=0),
-                              qtdmri_fit_sphere.odf(sphere, tau, s=0))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        assert_array_almost_equal(qtdmri_fit_cart.odf(sphere, tau, s=0),
+                                  qtdmri_fit_sphere.odf(sphere, tau, s=0))
 
 
 def test_cartesian_normalization(radial_order=4, time_order=2):
@@ -254,14 +279,22 @@ def test_spherical_normalization(radial_order=4, time_order=2):
                                                time_order=time_order,
                                                cartesian=False,
                                                normalization=True)
-    qtdmri_fit = qtdmri_mod_aniso.fit(S)
-    qtdmri_fit_norm = qtdmri_mod_aniso_norm.fit(S)
-    assert_array_almost_equal(qtdmri_fit.fitted_signal(),
-                              qtdmri_fit_norm.fitted_signal())
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qtdmri_fit = qtdmri_mod_aniso.fit(S)
+        qtdmri_fit_norm = qtdmri_mod_aniso_norm.fit(S)
+        assert_array_almost_equal(qtdmri_fit.fitted_signal(),
+                                  qtdmri_fit_norm.fitted_signal())
 
     rt_grid = qtdmri.create_rt_space_grid(5, 20e-3, 5, 0.02, .05)
-    pdf = qtdmri_fit.pdf(rt_grid)
-    pdf_norm = qtdmri_fit_norm.pdf(rt_grid)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf = qtdmri_fit.pdf(rt_grid)
+        pdf_norm = qtdmri_fit_norm.pdf(rt_grid)
     assert_array_almost_equal(pdf / pdf.max(),
                               pdf_norm / pdf.max())
 
@@ -393,8 +426,12 @@ def test_q0_constraint_and_unity_of_ODFs(radial_order=6, time_order=2):
         laplacian_regularization=True, laplacian_weighting=1e-4,
         cartesian=False
     )
-    qtdmri_fit_lap = qtdmri_mod_lap.fit(S)
-    fitted_signal = qtdmri_fit_lap.fitted_signal()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qtdmri_fit_lap = qtdmri_mod_lap.fit(S)
+        fitted_signal = qtdmri_fit_lap.fitted_signal()
     E_q0_first_tau = fitted_signal[
         np.all([tau == tau.min(), gtab_4d.b0s_mask], axis=0)
     ]
@@ -453,8 +490,12 @@ def test_spherical_laplacian_reduces_laplacian_norm(radial_order=4,
         laplacian_weighting=1e-4
     )
 
-    qtdmri_fit_no_laplacian = qtdmri_mod_no_laplacian.fit(S)
-    qtdmri_fit_laplacian = qtdmri_mod_laplacian.fit(S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qtdmri_fit_no_laplacian = qtdmri_mod_no_laplacian.fit(S)
+        qtdmri_fit_laplacian = qtdmri_mod_laplacian.fit(S)
 
     laplacian_norm_no_reg = qtdmri_fit_no_laplacian.norm_of_laplacian_signal()
     laplacian_norm_reg = qtdmri_fit_laplacian.norm_of_laplacian_signal()
@@ -524,8 +565,12 @@ def test_spherical_l1_increases_sparsity(radial_order=4, time_order=2):
         l1_weighting=.1
     )
 
-    qtdmri_fit_no_l1 = qtdmri_mod_no_l1.fit(S)
-    qtdmri_fit_l1 = qtdmri_mod_l1.fit(S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        qtdmri_fit_no_l1 = qtdmri_mod_no_l1.fit(S)
+        qtdmri_fit_l1 = qtdmri_mod_l1.fit(S)
 
     sparsity_abs_no_reg = qtdmri_fit_no_l1.sparsity_abs()
     sparsity_abs_reg = qtdmri_fit_l1.sparsity_abs()

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -18,6 +18,7 @@ from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
 from dipy.sims.voxel import sticks_and_ball, multi_tensor, single_tensor
 from dipy.direction.peaks import peak_directions
+from dipy.reconst.shm import descoteaux07_legacy_msg
 
 
 def test_rumba():
@@ -131,7 +132,11 @@ def test_recursive_rumba():
                                                  -16.93940972,
                                                  2.57628738]))
     model = RumbaSDModel(gtab, wm_response, n_iter=20, sphere=sphere)
-    model_fit = model.fit(data)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model_fit = model.fit(data)
 
     # Test peaks
     odf = model_fit.odf(sphere)

--- a/dipy/reconst/tests/test_shore.py
+++ b/dipy/reconst/tests/test_shore.py
@@ -1,4 +1,5 @@
 # Tests for shore fitting
+import warnings
 from math import factorial
 
 import numpy as np
@@ -7,6 +8,7 @@ import numpy.testing as npt
 from scipy.special import genlaguerre, gamma
 
 from dipy.data import get_gtab_taiwan_dsi
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.reconst.shore import ShoreModel
 from dipy.sims.voxel import multi_tensor
 
@@ -56,8 +58,12 @@ def test_shore_positive_constrain():
                      positive_constraint=True,
                      pos_grid=11,
                      pos_radius=20e-03)
-    asmfit = asm.fit(data.S)
-    eap = asmfit.pdf_grid(11, 20e-03)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(data.S)
+        eap = asmfit.pdf_grid(11, 20e-03)
     npt.assert_almost_equal(eap[eap < 0].sum(), 0, 3)
 
 
@@ -65,7 +71,11 @@ def test_shore_fitting_no_constrain_e0():
     asm = ShoreModel(data.gtab, radial_order=data.radial_order,
                      zeta=data.zeta, lambdaN=data.lambdaN,
                      lambdaL=data.lambdaL)
-    asmfit = asm.fit(data.S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(data.S)
     npt.assert_almost_equal(compute_e0(asmfit), 1)
 
 
@@ -75,7 +85,11 @@ def test_shore_fitting_constrain_e0():
                      zeta=data.zeta, lambdaN=data.lambdaN,
                      lambdaL=data.lambdaL,
                      constrain_e0=True)
-    asmfit = asm.fit(data.S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(data.S)
     npt.assert_almost_equal(compute_e0(asmfit), 1)
 
 

--- a/dipy/reconst/tests/test_shore_metrics.py
+++ b/dipy/reconst/tests/test_shore_metrics.py
@@ -1,8 +1,11 @@
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 from scipy.special import genlaguerre
 
 from dipy.data import get_gtab_taiwan_dsi, get_sphere
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.reconst.shore import (ShoreModel,
                                 shore_matrix,
                                 shore_indices,
@@ -46,10 +49,18 @@ def test_shore_metrics():
     lambdaL = 1e-12
     asm = ShoreModel(gtab, radial_order=radial_order,
                      zeta=zeta, lambdaN=lambdaN, lambdaL=lambdaL)
-    asmfit = asm.fit(S)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(S)
     c_shore = asmfit.shore_coeff
 
-    cmat = shore_matrix(radial_order, zeta, gtab)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        cmat = shore_matrix(radial_order, zeta, gtab)
     S_reconst = np.dot(cmat, c_shore)
 
     # test the signal reconstruction
@@ -67,7 +78,11 @@ def test_shore_metrics():
 
     # test if the integral of the pdf calculated on a discrete grid is
     # equal to one
-    pdf_discrete = asmfit.pdf_grid(17, 40e-3)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf_discrete = asmfit.pdf_grid(17, 40e-3)
     integral = pdf_discrete.sum()
     npt.assert_almost_equal(integral, 1.0, 1)
 
@@ -76,7 +91,11 @@ def test_shore_metrics():
     sphere = get_sphere('symmetric724')
     v = sphere.vertices
     radius = 10e-3
-    pdf_shore = asmfit.pdf(v * radius)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        pdf_shore = asmfit.pdf(v * radius)
     pdf_mt = multi_tensor_pdf(v * radius, mevals=mevals,
                               angles=angl, fractions=[50, 50])
 

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -1,8 +1,10 @@
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 from dipy.data import default_sphere, get_isbi2013_2shell_gtab, get_3shell_gtab
 from dipy.reconst.shore import ShoreModel, shore_matrix
-from dipy.reconst.shm import sh_to_sf
+from dipy.reconst.shm import sh_to_sf, descoteaux07_legacy_msg
 from dipy.direction.peaks import peak_directions
 from dipy.reconst.odf import gfa
 from dipy.sims.voxel import sticks_and_ball
@@ -25,14 +27,26 @@ def test_shore_odf():
     asm = ShoreModel(gtab, radial_order=6,
                      zeta=700, lambdaN=1e-8, lambdaL=1e-8)
     # repulsion724
-    asmfit = asm.fit(data)
-    odf = asmfit.odf(sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(data)
+        odf = asmfit.odf(sphere)
     odf_sh = asmfit.odf_sh()
-    odf_from_sh = sh_to_sf(odf_sh, sphere, 6, basis_type=None,
-                           legacy=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf_from_sh = sh_to_sf(odf_sh, sphere, 6, basis_type=None,
+                               legacy=True)
     npt.assert_almost_equal(odf, odf_from_sh, 10)
 
-    expected_phi = shore_matrix(radial_order=6, zeta=700, gtab=gtab)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        expected_phi = shore_matrix(radial_order=6, zeta=700, gtab=gtab)
     npt.assert_array_almost_equal(np.dot(expected_phi, asmfit.shore_coeff),
                                   asmfit.fitted_signal())
 
@@ -42,7 +56,11 @@ def test_shore_odf():
         angular_similarity(directions, golden_directions), 2, 1)
 
     # 5 subdivisions
-    odf = asmfit.odf(sphere2)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        odf = asmfit.odf(sphere2)
     directions, _, _ = peak_directions(odf, sphere2, .35, 25)
     npt.assert_equal(len(directions), 2)
     npt.assert_almost_equal(
@@ -68,7 +86,11 @@ def test_multivox_shore():
     zeta = 700
     asm = ShoreModel(gtab, radial_order=radial_order,
                      zeta=zeta, lambdaN=1e-8, lambdaL=1e-8)
-    asmfit = asm.fit(data)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        asmfit = asm.fit(data)
     c_shore = asmfit.shore_coeff
     npt.assert_equal(c_shore.shape[0:3], data.shape[0:3])
     npt.assert_equal(np.alltrue(np.isreal(c_shore)), True)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -1,3 +1,4 @@
+import warnings
 
 import nibabel as nib
 import numpy as np
@@ -12,6 +13,7 @@ from dipy.direction import (BootDirectionGetter,
                             PeaksAndMetrics,
                             ProbabilisticDirectionGetter)
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.tracking.local_tracking import (LocalTracking,
                                           ParticleFilteringTracking)
 from dipy.tracking.streamline import Streamlines
@@ -572,17 +574,29 @@ def test_bootstap_peak_tracker():
     data[simple_image == 2] = voxel2
 
     response = (np.array(mevals[1]), 1)
-    csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
 
     seeds = [np.array([0., 1., 0.]), np.array([2., 4., 0.])]
 
     sc = BinaryStoppingCriterion((simple_image > 0).astype(float))
     sphere = HemiSphere.from_sphere(get_sphere('symmetric724'))
-    boot_dg = BootDirectionGetter.from_data(data, csd_model, 60,
-                                            sphere=sphere)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_dg = BootDirectionGetter.from_data(data, csd_model, 60,
+                                                sphere=sphere)
 
     streamlines_generator = LocalTracking(boot_dg, sc, seeds, np.eye(4), 1.)
-    streamlines = Streamlines(streamlines_generator)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        streamlines = Streamlines(streamlines_generator)
     expected = [np.array([[0., 1., 0.],
                           [1., 1., 0.],
                           [2., 1., 0.],

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -13,7 +15,7 @@ from dipy.tracking import utils
 from dipy.tracking.stopping_criterion import \
     ThresholdStoppingCriterion
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.reconst.shm import sh_to_sf_matrix
+from dipy.reconst.shm import descoteaux07_legacy_msg, sh_to_sf_matrix
 from dipy.align.tests.test_streamlinear import fornix_streamlines
 from dipy.tracking.streamline import (center_streamlines,
                                       transform_streamlines)
@@ -60,12 +62,16 @@ def test_contour_from_roi():
 
     white_matter = (labels == 1) | (labels == 2)
 
-    csa_model = CsaOdfModel(gtab, sh_order=6)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csa_model = CsaOdfModel(gtab, sh_order=6)
 
-    csa_peaks = peaks_from_model(csa_model, data, default_sphere,
-                                 relative_peak_threshold=.8,
-                                 min_separation_angle=45,
-                                 mask=white_matter)
+        csa_peaks = peaks_from_model(csa_model, data, default_sphere,
+                                     relative_peak_threshold=.8,
+                                     min_separation_angle=45,
+                                     mask=white_matter)
 
     classifier = ThresholdStoppingCriterion(csa_peaks.gfa, .25)
 
@@ -280,7 +286,11 @@ def test_odf_slicer(interactive=False):
         window.show(scene)
 
     # Test that SH coefficients input works
-    B = sh_to_sf_matrix(sphere, sh_order=4, return_inv=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        B = sh_to_sf_matrix(sphere, sh_order=4, return_inv=False)
     odfs = np.zeros((11, 11, 11, B.shape[0]))
     odfs[..., 0] = 1.0
     odf_actor = actor.odf_slicer(odfs, sphere=sphere, B_matrix=B)
@@ -317,7 +327,11 @@ def test_odf_slicer(interactive=False):
 
     # Test that we can change the sphere on an active actor
     new_sphere = get_sphere('symmetric362')
-    new_B = sh_to_sf_matrix(new_sphere, sh_order=4, return_inv=False)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        new_B = sh_to_sf_matrix(new_sphere, sh_order=4, return_inv=False)
     odf_actor.update_sphere(new_sphere.vertices, new_sphere.faces, new_B)
     if interactive:
         window.show(scene)

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -1,3 +1,4 @@
+import warnings
 
 import logging
 import numpy as np
@@ -12,16 +13,24 @@ from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
-from dipy.reconst.shm import sph_harm_ind_list
+from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
 logging.getLogger().setLevel(logging.INFO)
 
 
 def test_reconst_csa():
-    reconst_flow_core(ReconstCSAFlow)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        reconst_flow_core(ReconstCSAFlow)
 
 
 def test_reconst_csd():
-    reconst_flow_core(ReconstCSDFlow)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        reconst_flow_core(ReconstCSDFlow)
 
 
 def reconst_flow_core(flow):

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from numpy.testing import assert_equal
 from dipy.testing import assert_false, assert_true
@@ -9,6 +11,7 @@ from nibabel.tmpdirs import TemporaryDirectory
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti
 from dipy.io.streamline import load_tractogram
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.workflows.mask import MaskFlow
 from dipy.workflows.reconst import ReconstCSDFlow
 from dipy.workflows.tracking import (LocalFiberTrackingPAMFlow,
@@ -71,8 +74,12 @@ def test_particle_filtering_traking_workflows():
 
         # CSD Reconstruction
         reconst_csd_flow = ReconstCSDFlow()
-        reconst_csd_flow.run(dwi_path, bval_path, bvec_path, mask_path,
-                             out_dir=out_dir, extract_pam_values=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            reconst_csd_flow.run(dwi_path, bval_path, bvec_path, mask_path,
+                                 out_dir=out_dir, extract_pam_values=True)
 
         pam_path = reconst_csd_flow.last_generated_outputs['out_pam']
         gfa_path = reconst_csd_flow.last_generated_outputs['out_gfa']
@@ -85,7 +92,11 @@ def test_particle_filtering_traking_workflows():
         # Test tracking
         pf_track_pam = PFTrackingPAMFlow()
         assert_equal(pf_track_pam.get_short_name(), 'track_pft')
-        pf_track_pam.run(pam_path, wm_path, gm_path, csf_path, seeds_path)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pf_track_pam.run(pam_path, wm_path, gm_path, csf_path, seeds_path)
         tractogram_path = \
             pf_track_pam.last_generated_outputs['out_tractogram']
         assert_false(is_tractogram_empty(tractogram_path))
@@ -93,12 +104,16 @@ def test_particle_filtering_traking_workflows():
         # Test that tracking returns seeds
         pf_track_pam = PFTrackingPAMFlow()
         pf_track_pam._force_overwrite = True
-        pf_track_pam.run(pam_path,
-                         wm_path,
-                         gm_path,
-                         csf_path,
-                         seeds_path,
-                         save_seeds=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            pf_track_pam.run(pam_path,
+                             wm_path,
+                             gm_path,
+                             csf_path,
+                             seeds_path,
+                             save_seeds=True)
         tractogram_path = \
             pf_track_pam.last_generated_outputs['out_tractogram']
         assert_true(tractogram_has_seeds(tractogram_path))
@@ -114,8 +129,12 @@ def test_local_fiber_tracking_workflow():
         save_nifti(mask_path, mask, affine)
 
         reconst_csd_flow = ReconstCSDFlow()
-        reconst_csd_flow.run(data_path, bval_path, bvec_path, mask_path,
-                             out_dir=out_dir, extract_pam_values=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            reconst_csd_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                 out_dir=out_dir, extract_pam_values=True)
 
         pam_path = reconst_csd_flow.last_generated_outputs['out_pam']
         gfa_path = reconst_csd_flow.last_generated_outputs['out_gfa']
@@ -160,8 +179,12 @@ def test_local_fiber_tracking_workflow():
         # Test tracking with pam with sh and deterministic getter
         lf_track_pam = LocalFiberTrackingPAMFlow()
         lf_track_pam._force_overwrite = True
-        lf_track_pam.run(pam_path, gfa_path, seeds_path,
-                         tracking_method="deterministic")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            lf_track_pam.run(pam_path, gfa_path, seeds_path,
+                             tracking_method="deterministic")
         tractogram_path = \
             lf_track_pam.last_generated_outputs['out_tractogram']
         assert_false(is_tractogram_empty(tractogram_path))
@@ -169,8 +192,12 @@ def test_local_fiber_tracking_workflow():
         # Test tracking with pam with sh and probabilistic getter
         lf_track_pam = LocalFiberTrackingPAMFlow()
         lf_track_pam._force_overwrite = True
-        lf_track_pam.run(pam_path, gfa_path, seeds_path,
-                         tracking_method="probabilistic")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            lf_track_pam.run(pam_path, gfa_path, seeds_path,
+                             tracking_method="probabilistic")
         tractogram_path = \
             lf_track_pam.last_generated_outputs['out_tractogram']
         assert_false(is_tractogram_empty(tractogram_path))
@@ -178,8 +205,12 @@ def test_local_fiber_tracking_workflow():
         # Test tracking with pam with sh and closest peaks getter
         lf_track_pam = LocalFiberTrackingPAMFlow()
         lf_track_pam._force_overwrite = True
-        lf_track_pam.run(pam_path, gfa_path, seeds_path,
-                         tracking_method="closestpeaks")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            lf_track_pam.run(pam_path, gfa_path, seeds_path,
+                             tracking_method="closestpeaks")
         tractogram_path = \
             lf_track_pam.last_generated_outputs['out_tractogram']
         assert_false(is_tractogram_empty(tractogram_path))
@@ -187,9 +218,13 @@ def test_local_fiber_tracking_workflow():
         # Test that tracking returns seeds
         lf_track_pam = LocalFiberTrackingPAMFlow()
         lf_track_pam._force_overwrite = True
-        lf_track_pam.run(pam_path, gfa_path, seeds_path,
-                         tracking_method="deterministic",
-                         save_seeds=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=descoteaux07_legacy_msg,
+                category=PendingDeprecationWarning)
+            lf_track_pam.run(pam_path, gfa_path, seeds_path,
+                             tracking_method="deterministic",
+                             save_seeds=True)
         tractogram_path = \
             lf_track_pam.last_generated_outputs['out_tractogram']
         assert_true(tractogram_has_seeds(tractogram_path))


### PR DESCRIPTION
Filter legacy SH bases warnings in tests. Warnings are already being
tested, and there is no further need to ensure that these warnings are
raised.

Filtering them avoids having them printed in the standard output, and
thus, unnecessary clutter.

Fixes:
```
workflows/tests/test_tracking.py: 16 warnings
dipy/venv/lib/python3.8/site-packages/dipy/reconst/shm.py:346:
PendingDeprecationWarning:
The legacy descoteaux07 SH basis uses absolute values for negative harmonic degrees.
It is outdated and will be deprecated in a future DIPY release.
Consider using the new descoteaux07 basis by setting the `legacy` parameter to `False`.
    warn(descoteaux07_legacy_msg, category=PendingDeprecationWarning)
```

and
```
direction/tests/test_peaks.py::test_peaks_shm_coeff
dipy/venv/lib/python3.8/site-packages/dipy/reconst/shm.py:302:
PendingDeprecationWarning:
The legacy tournier07 basis is not normalized.
It is outdated and will be deprecated in a future release of DIPY.
Consider using the new tournier07 basis by setting the `legacy` parameter to `False`.
    warn(tournier07_legacy_msg, category=PendingDeprecationWarning)
```

and similar warnings across modules.

Visible, for example, at:
https://github.com/dipy/dipy/runs/5235022769?check_suite_focus=true#step:9:3686

Follow-up of #2482.