### PR TITLE
TEST: Fix intermittent RUMBA test check failure

### DIFF
--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -385,7 +385,7 @@ def test_generate_kernel():
     kernel_multi = generate_kernel(
         gtab, sphere, wm_response_multi, gm_response, csf_response)
     assert_equal(kernel.shape, (len(gtab.bvals), len(sphere.vertices) + 2))
-    assert_array_equal(kernel, kernel_multi)
+    assert_almost_equal(kernel, kernel_multi)
 
     # Test optional isotropic compartment; should cause last column of zeroes
     kernel = generate_kernel(


### PR DESCRIPTION
Fix intermittent RUMBA test check failure: allow comparing with
tolerance.

Fixes:
```
>       assert_array_equal(kernel, kernel_multi)
E       AssertionError:
E       Arrays are not equal
E
E       (mismatch 12.812333297770195%)
E        x: array([  1.000000e+00,   1.000000e+00,   1.000000e+00, ...,   1.404835e-05,
E                7.939220e-01,   9.261458e-16])
E        y: array([  1.000000e+00,   1.000000e+00,   1.000000e+00, ...,   1.404835e-05,
E                7.939220e-01,   9.261458e-16])

../venv/lib/python3.7/site-packages/dipy/reconst/tests/test_rumba.py:388: AssertionError
```

raised for example in:
https://github.com/dipy/dipy/runs/5259123098?check_suite_focus=true#step:9:3318