### PR TITLE
TEST: Remove legacy `nose`-related dead testing code

### DIFF
--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -1,7 +1,6 @@
 import numpy as np
 import nibabel as nib
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_almost_equal,
                            assert_raises)
@@ -65,8 +64,3 @@ def test_resample():
     # test invalid values of num_threads
     assert_raises(ValueError, reslice, data, affine, zooms, new_zooms,
                   num_processes=0)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
@@ -488,8 +487,3 @@ def test_wrong_num_threads():
 
     slr = StreamlineLinearRegistration(num_threads=0)
     assert_raises(ValueError, slr.optimize, A, B)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/align/tests/test_whole_brain_slr.py
+++ b/dipy/align/tests/test_whole_brain_slr.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (assert_equal, run_module_suite,
-                           assert_array_almost_equal)
+from numpy.testing import assert_equal, assert_array_almost_equal
 
 from dipy.align.streamlinear import (compose_matrix44, decompose_matrix44,
                                      transform_streamlines, whole_brain_slr,
@@ -67,7 +66,3 @@ def test_whole_brain_slr():
     # we can also check the quality by looking at the decomposed transform
 
     assert_array_almost_equal(decompose_matrix44(transform)[3], -15, 2)
-
-if __name__ == '__main__':
-    # run_module_suite()
-    test_whole_brain_slr()

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -23,8 +23,7 @@ from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 is_hemispherical)
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises, assert_almost_equal,
-                           run_module_suite)
+                           assert_equal, assert_raises, assert_almost_equal,)
 
 from dipy.testing.spherepoints import sphere_points
 from dipy.core.sphere_stats import random_uniform_on_sphere
@@ -364,7 +363,3 @@ def test_is_hemispherical():
 
     # Smoke test the ValueError for non unit-vectors
     assert_raises(ValueError, is_hemispherical, xyz * 2.0)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -407,7 +407,3 @@ def test_interp_rbf():
         npt.assert_(len(w) == 1)
         npt.assert_(issubclass(w[-1].category, PendingDeprecationWarning))
         npt.assert_("deprecated" in str(w[-1].message))
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/core/tests/test_optimize.py
+++ b/dipy/core/tests/test_optimize.py
@@ -108,7 +108,3 @@ def test_sparse_nnls():
     # We should be able to get back the right answer for this simple case
     npt.assert_array_almost_equal(beta, beta_hat, decimal=1)
     npt.assert_array_almost_equal(beta, beta_hat_sparse, decimal=1)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -382,7 +382,3 @@ def test_disperse_charges_alt():
     # Verify that the potential of the optimal configuration is smaller than
     # that of the original configuration
     nt.assert_array_less(dispersed_charges_potential, init_charges_potential)
-
-
-if __name__ == "__main__":
-    nt.run_module_suite()

--- a/dipy/denoise/tests/test_ascm.py
+++ b/dipy/denoise/tests/test_ascm.py
@@ -1,8 +1,7 @@
 import numpy as np
 import dipy.data as dpd
 import nibabel as nib
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_array_almost_equal)
 from dipy.denoise.non_local_means import non_local_means
@@ -129,8 +128,3 @@ def test_ascm_accuracy():
                                           den_small, den_large, sigma[0]))
 
     assert_array_almost_equal(S0n, test_ascm_data_ref)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/denoise/tests/test_kernel.py
+++ b/dipy/denoise/tests/test_kernel.py
@@ -116,6 +116,3 @@ def test_kernel_input():
 
     k = EnhancementKernel(D33, D44, t, orientations=0, force_recompute=True)
     npt.assert_equal(k.get_lookup_table().shape, (0, 0, 7, 7, 7))
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -1,7 +1,6 @@
 import numpy as np
 import scipy.special as sps
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_raises,
                            assert_array_almost_equal)
@@ -332,7 +331,3 @@ def test_mppca_returned_sigma():
     rmse_den = np.sum(np.abs(DWIden1 - DWIden0)) / np.sum(np.abs(DWIden0))
     rmse_ref = np.sum(np.abs(DWIden1 - DWIgt)) / np.sum(np.abs(DWIgt))
     assert_(rmse_den < rmse_ref)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_array_almost_equal,
                            assert_raises)
@@ -137,8 +136,3 @@ def test_nlmeans_4d_3dsigma_and_threads():
     if cpu_count() == 2:
 
         assert_equal(duration_2core < duration_1core, True)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (run_module_suite,
-                           assert_,
+from numpy.testing import (assert_,
                            assert_equal,
                            assert_array_almost_equal,
                            assert_raises)
@@ -83,7 +82,3 @@ def test_nlmeans_dtype():
     mask[10:14, 10:14, 10:14] = 1
     S0n = non_local_means(S0, sigma=1, mask=mask, rician=True)
     assert_equal(S0.dtype, S0n.dtype)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -141,7 +141,3 @@ def test_bdg_residual():
     gtab = gradient_table(bvals, bvecs)
     csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
     npt.assert_raises(ValueError, BootPmfGen, data, csd_model, hsph_updated, 6)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -4,8 +4,7 @@ import pickle
 from io import BytesIO
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_almost_equal, run_module_suite,
-                           assert_equal, assert_)
+                           assert_almost_equal, assert_equal, assert_)
 from dipy.reconst.odf import (OdfFit, OdfModel, gfa)
 
 from dipy.direction.peaks import (peaks_from_model,
@@ -648,8 +647,3 @@ def test_reshape_peaks_for_visualization():
     assert_array_equal(data1_reshape.reshape(10, 5, 3), data1)
     assert_array_equal(data2_reshape.reshape(10, 2, 5, 3), data2)
     assert_array_equal(data3_reshape.reshape(10, 2, 12, 5, 3), data3)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -113,7 +113,3 @@ def test_boot_pmf():
     pmf_sh8 = boot_pmf_gen_sh8.get_pmf(point)
     npt.assert_equal(len(hsph_updated.vertices), pmf_sh8.shape[0])
     npt.assert_(np.sum(pmf_sh8.shape) > 0)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -31,7 +31,3 @@ def test_dpy():
         dpr.close()
         npt.assert_array_equal(A, T[0])
         npt.assert_array_equal(C, T[5])
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -119,9 +119,3 @@ def test_io_save_peaks_error():
         pam.gfa = np.zeros((10, 10, 10))
         pam.qa = np.zeros((10, 10, 10, 5))
         pam.odf = np.zeros((10, 10, 10, default_sphere.vertices.shape[0]))
-
-
-if __name__ == '__main__':
-    # npt.run_module_suite()
-    test_io_peaks()
-    test_io_save_peaks_error()

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -914,7 +914,3 @@ def test_create_from_sft():
     sft_1.streamlines = np.arange(6000).reshape((100, 20, 3))
     if np.array_equal(sft_1.streamlines, sft_2.streamlines):
         raise AssertionError()
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -253,7 +253,3 @@ def test_io_trk_save():
                 msg='trk_saver should not be able to save a fib')
     npt.assert_(not trk_saver(filepath_dix['gs.dpy']),
                 msg='trk_saver should not be able to save a dpy')
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/reconst/tests/test_cache.py
+++ b/dipy/reconst/tests/test_cache.py
@@ -1,7 +1,7 @@
 from dipy.reconst.cache import Cache
 from dipy.core.sphere import Sphere
 
-from numpy.testing import assert_, assert_equal, run_module_suite
+from numpy.testing import assert_, assert_equal
 
 
 class DummyModel(Cache):
@@ -22,7 +22,3 @@ def test_basic_cache():
 
     t.cache_clear()
     assert_(t.cache_get("design_matrix", s) is None)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -2,8 +2,7 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
-                           assert_array_almost_equal, run_module_suite,
-                           assert_array_equal)
+                           assert_array_almost_equal, assert_array_equal)
 from dipy.testing import assert_greater, assert_greater_equal
 from dipy.data import get_sphere, get_fnames, default_sphere, small_sphere
 from dipy.sims.voxel import (multi_tensor,
@@ -631,7 +630,3 @@ def test_csd_convergence():
                                                     sh_order=8)
 
     assert_equal(model_w_conv.fit(S).shm_coeff, model_wo_conv.fit(S).shm_coeff)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_dsi.py
+++ b/dipy/reconst/tests/test_dsi.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
-                           run_module_suite,
                            assert_array_equal,
                            assert_raises)
 from dipy.data import get_fnames, dsi_voxels, default_sphere
@@ -116,7 +115,3 @@ def sticks_and_ball_dummies(gtab):
                                 fractions=[0, 0, 0], snr=None)
     sb_dummies['isotropic'] = (S, sticks)
     return sb_dummies
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_dsi_deconv.py
+++ b/dipy/reconst/tests/test_dsi_deconv.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
-                           run_module_suite,
                            assert_array_equal,
                            assert_raises)
 from dipy.data import get_fnames, dsi_deconv_voxels, default_sphere
@@ -67,7 +66,3 @@ def test_multivox_dsi():
     PDF = DSfit.pdf()
     assert_equal(data.shape[:-1] + (35, 35, 35), PDF.shape)
     assert_equal(np.alltrue(np.isreal(PDF)), True)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_dsi_metrics.py
+++ b/dipy/reconst/tests/test_dsi_metrics.py
@@ -2,7 +2,7 @@ import numpy as np
 from dipy.reconst.dsi import DiffusionSpectrumModel
 from dipy.data import get_fnames
 from dipy.core.gradients import gradient_table
-from numpy.testing import assert_almost_equal, run_module_suite
+from numpy.testing import assert_almost_equal
 from dipy.sims.voxel import sticks_and_ball, multi_tensor
 
 
@@ -29,7 +29,3 @@ def test_dsi_metrics():
     MSD_norm_0 = dsmodel.fit(S_0).msd_discrete(normalized=True)
     MSD_norm_1 = dsmodel.fit(S_1).msd_discrete(normalized=True)
     assert_almost_equal(MSD_norm_0, 0.5 * MSD_norm_1, 4)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_eudx_dg.py
+++ b/dipy/reconst/tests/test_eudx_dg.py
@@ -80,7 +80,3 @@ def test_EuDXDirectionGetter():
     # it should have one direction
     npt.assert_array_almost_equal(len(peaks1.initial_direction(point)), 1)
     npt.assert_array_almost_equal(len(peaks.initial_direction(point)), 1)
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -6,9 +6,7 @@ from dipy.data import get_sphere, default_sphere, get_3shell_gtab
 from dipy.reconst.forecast import ForecastModel
 from dipy.sims.voxel import multi_tensor
 
-from numpy.testing import (assert_almost_equal,
-                           assert_equal,
-                           run_module_suite)
+from numpy.testing import assert_almost_equal, assert_equal
 import pytest
 from dipy.direction.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
@@ -209,7 +207,3 @@ def test_multivox_forecast():
 
     mse3 = np.sum((S_predict[2, 0, 0]-S[2, 0, 0])**2) / len(gtab.bvals)
     assert_almost_equal(mse3, 0.0, 3)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_gqi.py
+++ b/dipy/reconst/tests/test_gqi.py
@@ -11,9 +11,7 @@ from dipy.sims.voxel import sticks_and_ball
 from dipy.reconst.odf import gfa
 from dipy.direction.peaks import peak_directions
 
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           run_module_suite)
+from numpy.testing import assert_equal, assert_almost_equal
 
 
 
@@ -74,7 +72,3 @@ def test_mvoxel_gqi():
     odf = all_odfs[-1, -1, -1]
     directions, values, indices = peak_directions(odf, sphere, .35, 25)
     assert_equal(directions.shape[0], 2)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -14,8 +14,8 @@ References
 import warnings
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_array_less, run_module_suite,
-                           assert_, assert_equal)
+                           assert_raises, assert_array_less, assert_,
+                           assert_equal)
 from dipy.testing import assert_greater_equal
 import pytest
 
@@ -505,7 +505,3 @@ def test_D_vp():
     """
     ivim_fit_VP = ivim_model_VP.fit(data_single)
     assert_array_almost_equal(ivim_fit_VP.D, D_VP, decimal=4)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -9,7 +9,6 @@ import numpy as np
 from numpy.testing import (assert_almost_equal,
                            assert_array_almost_equal,
                            assert_equal, assert_,
-                           run_module_suite,
                            assert_raises)
 import pytest
 from dipy.core.sphere_stats import angular_similarity
@@ -838,7 +837,3 @@ def test_mapmri_odf(radial_order=6):
     odf_from_sh = sh_to_sf(odf_sh, sphere, radial_order, basis_type=None,
                            legacy=True)
     assert_almost_equal(odf, odf_from_sh, 10)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_odf.py
+++ b/dipy/reconst/tests/test_odf.py
@@ -1,6 +1,5 @@
 import numpy as np
-from numpy.testing import (run_module_suite, assert_equal, assert_almost_equal,
-                           assert_)
+from numpy.testing import assert_equal, assert_almost_equal, assert_
 from dipy.reconst.odf import (OdfFit, OdfModel, minmax_normalize, gfa)
 
 from dipy.core.subdivide_octahedron import create_unit_hemisphere
@@ -84,8 +83,3 @@ def test_gfa():
     # All-zeros returns a nan with no warning:
     g = gfa(np.zeros(10))
     assert_(np.isnan(g))
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/reconst/tests/test_peak_finding.py
+++ b/dipy/reconst/tests/test_peak_finding.py
@@ -135,7 +135,3 @@ def test_search_descending():
 
     # Test very small array
     npt.assert_equal(search_descending(a[:0], 1.), 0)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -6,8 +6,7 @@ from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_array_equal,
                            assert_allclose,
-                           assert_raises,
-                           run_module_suite)
+                           assert_raises,)
 from numpy.testing import assert_
 
 from dipy.reconst.rumba import RumbaSDModel, generate_kernel
@@ -392,7 +391,3 @@ def test_generate_kernel():
         gtab, sphere, wm_response, gm_response=None, csf_response=None)
     assert_array_equal(kernel[:, -2], np.zeros(len(gtab.bvals)))
     assert_array_equal(kernel[:, -1], np.zeros(len(gtab.bvals)))
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 
 from dipy.testing import assert_true
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises, run_module_suite)
+                           assert_equal, assert_raises,)
 from scipy.special import sph_harm as sph_harm_sp
 
 from dipy.core.sphere import hemi_icosahedron, Sphere
@@ -990,7 +990,3 @@ def test_convert_sh_to_legacy():
 
     assert_array_almost_equal(converted_coeffs, expected_coeffs, 2)
     assert_raises(ValueError, convert_sh_to_legacy, sh_coeffs, '', True)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/dipy/reconst/tests/test_utils.py
+++ b/dipy/reconst/tests/test_utils.py
@@ -50,7 +50,3 @@ def test_mask_from_roi():
     mask_gt[2, 0:5, 0:5] = 1
     roi_mask = _mask_from_roi(data_shape, roi_center, roi_radii)
     npt.assert_array_equal(roi_mask, mask_gt)
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/segment/tests/test_adjustment.py
+++ b/dipy/segment/tests/test_adjustment.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy import zeros
 from dipy.segment.threshold import upper_bound_by_percent, upper_bound_by_rate
-from numpy.testing import assert_equal, run_module_suite
+from numpy.testing import assert_equal
 
 
 def test_adjustment():
@@ -56,6 +56,3 @@ def test_adjustment():
 
     assert_equal(count2_upper, count2_upper_test)
     assert_equal(count1_upper, count1_upper_test)
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -2,9 +2,7 @@ import sys
 import numpy as np
 import pytest
 
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           run_module_suite)
+from numpy.testing import assert_equal, assert_almost_equal
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 from dipy.segment.bundles import RecoBundles
@@ -252,8 +250,3 @@ def test_rb_reduction_mam():
     # check if the bundle is recognized correctly
     for row in D:
         assert_equal(row.min(), 0)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -5,7 +5,7 @@ from dipy.segment.featurespeed import extract
 
 from dipy.testing import assert_true, assert_false
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_equal, run_module_suite)
+                           assert_raises, assert_equal,)
 
 
 dtype = "float32"
@@ -314,7 +314,3 @@ def test_using_python_feature_with_cython_metric():
     features2 = metric.feature.extract(s2)
     d2 = metric.dist(features1, features2)
     assert_equal(d1, d2)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -7,10 +7,7 @@ from scipy.ndimage import median_filter
 from dipy.segment.mask import (otsu, bounding_box, crop, applymask,
                                multi_median, median_otsu)
 
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_raises,
-                           run_module_suite)
+from numpy.testing import assert_equal, assert_almost_equal, assert_raises
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti_data
 
@@ -114,7 +111,3 @@ def test_median_otsu():
 
     # For 4D volumes, can't call without vol_idx input:
     assert_raises(ValueError, median_otsu, data2)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -4,7 +4,7 @@ import itertools
 
 from dipy.testing import (assert_true, assert_false,
                           assert_greater_equal, assert_less_equal)
-from numpy.testing import (assert_array_equal, assert_raises, run_module_suite,
+from numpy.testing import (assert_array_equal, assert_raises,
                            assert_almost_equal, assert_equal)
 
 
@@ -253,7 +253,3 @@ def test_distance_matrix():
             for j in range(len(data2)):
                 assert_equal(D[i, j], dipymetric.dist(metric, data[i],
                                                       data2[j]))
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -410,7 +410,3 @@ def test_classify():
     npt.assert_(seg_final.min() == 0.0)
 
     npt.assert_(imgseg.energies_sum[0] > imgseg.energies_sum[-1])
-
-if __name__ == '__main__':
-
-    npt.run_module_suite()

--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -1,7 +1,6 @@
 import itertools
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_equal, assert_raises,
-                           run_module_suite)
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 from dipy.segment.clustering import QuickBundlesX, QuickBundles, qbx_and_merge
 from dipy.segment.featurespeed import ResampleFeature
@@ -232,7 +231,3 @@ def test_qbx_and_merge():
     qbx_centroids = tree.get_clusters(3).centroids
 
     assert_equal(len(qbx_centroids) > len(qbxm_centroids), True)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -1,8 +1,7 @@
 import numpy as np
 import itertools
 
-from numpy.testing import (assert_array_equal, run_module_suite,
-                           assert_equal, assert_raises)
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 from dipy.testing.memory import get_type_refcount
 from dipy.testing import assert_arrays_equal
 
@@ -203,7 +202,3 @@ def test_quickbundles_memory_leaks():
     qb.cluster(data)
     # At this point, all memoryviews created during clustering should be freed.
     assert_equal(get_type_refcount(type_name_pattern), initial_types_refcount)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/sims/tests/test_phantom.py
+++ b/dipy/sims/tests/test_phantom.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 
-from numpy.testing import (assert_, assert_array_almost_equal, run_module_suite)
+from numpy.testing import assert_, assert_array_almost_equal
 
 from dipy.data import get_fnames
 from dipy.reconst.dti import TensorModel
@@ -77,7 +77,3 @@ def test_add_noise():
         sigma = S0 / snr
 
         assert_(np.abs(np.var(vol_noise - vol) - sigma ** 2) < 1)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/dipy/stats/tests/test_analysis.py
+++ b/dipy/stats/tests/test_analysis.py
@@ -143,7 +143,3 @@ def test_afq_profile():
     # Test for error-handling:
     empty_bundle = Streamlines([])
     npt.assert_raises(ValueError, afq_profile, data, empty_bundle, np.eye(4))
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/tracking/tests/test_propagation.py
+++ b/dipy/tracking/tests/test_propagation.py
@@ -4,7 +4,7 @@ from dipy.data import default_sphere
 from dipy.tracking.propspeed import ndarray_offset, eudx_both_directions
 
 from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_raises, run_module_suite)
+                           assert_raises,)
 
 
 def stepped_1d(arr_1d):
@@ -49,7 +49,3 @@ def test_eudx_both_directions_errors():
     assert_raises(ValueError, eudx_both_directions,
                   seed, 0, qa, ind, sphere.vertices[::2], 0.5, 0.1,
                   1., 1., 2)
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/dipy/tracking/tests/test_stopping_criterion.py
+++ b/dipy/tracking/tests/test_stopping_criterion.py
@@ -204,6 +204,3 @@ def test_cmc_stopping_criterion():
         npt.assert_equal(cmc_tc.get_exclude(pts), 0)
         npt.assert_equal(cmc_tc.get_include(pts), 0)
 
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -821,7 +821,3 @@ def test_affine_transformations():
         npt.assert_(np.allclose(streamlines_inv[0], expected[0], atol=0.3))
         npt.assert_equal(len(streamlines_inv[1]), len(expected[1]))
         npt.assert_(np.allclose(streamlines_inv[1], expected[1], atol=0.3))
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -2,7 +2,7 @@
 """
 
 from dipy.utils.multiproc import determine_num_processes
-from numpy.testing import assert_equal, assert_raises, run_module_suite
+from numpy.testing import assert_equal, assert_raises
 
 
 def test_determine_num_processs():
@@ -30,8 +30,3 @@ def test_determine_num_processs():
     if determine_num_processes(-1) > 1:
         assert_equal(determine_num_processes(-1),
                      determine_num_processes(-2) + 1)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -5,7 +5,7 @@ import os
 from dipy.utils.omp import (cpu_count, thread_count, default_threads,
                             _set_omp_threads, _restore_omp_threads,
                             have_openmp, determine_num_threads)
-from numpy.testing import assert_equal, assert_raises, run_module_suite
+from numpy.testing import assert_equal, assert_raises
 
 
 def test_set_omp_threads():
@@ -60,8 +60,3 @@ def test_determine_num_threads():
     if determine_num_threads(-1) > 1:
         assert_equal(determine_num_threads(-1),
                      determine_num_threads(-2) + 1)
-
-
-if __name__ == '__main__':
-
-    run_module_suite()

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -437,7 +437,3 @@ def test_syn_registration_flow():
         npt.assert_equal(os.path.isfile(warped_path), True)
         warped_map_path = syn_flow.last_generated_outputs['out_field']
         npt.assert_equal(os.path.isfile(warped_map_path), True)
-
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/workflows/tests/test_docstring_parser.py
+++ b/dipy/workflows/tests/test_docstring_parser.py
@@ -510,6 +510,3 @@ class_doc_txt = """
     --------
     For usage examples, see `ode`.
 """
-
-if __name__ == "__main__":
-    npt.run_module_suite()

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -101,7 +101,3 @@ def test_recobundles_flow():
         bmd_value = BMD.distance(x0.tolist())
 
         npt.assert_equal(bmd_value < 1, True)
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -317,7 +317,3 @@ def test_bundle_shape_analysis_flow():
         sm_flow.run(sub, out_dir=out_dir)
 
         assert_true(os.path.exists(os.path.join(out_dir, "temp.npy")))
-
-
-if __name__ == '__main__':
-    npt.run_module_suite()


### PR DESCRIPTION
Remove legacy `nose`-related dead testing code: `run_module_suite` is
a `NumPy` testing method to run a test module that uses the `nose`
testing framework under the hood. DIPY switched to `pytest` as its
testing framework in a series of commits merged on Jan 26, 2019, and
with the 51234a4 merge commit.