### PR TITLE
TEST: Remove unnecessary `main` method definition in tests

### DIFF
--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -212,10 +212,3 @@ def test_compute_cc_steps_3d():
         expected[:, :, -radius::, ...] = 0
         actual, energy = cc.compute_cc_backward_step_3d(gradG, factors, radius)
         assert_array_almost_equal(actual, expected)
-
-
-if __name__ == '__main__':
-    test_cc_factors_2d()
-    test_cc_factors_3d()
-    test_compute_cc_steps_2d()
-    test_compute_cc_steps_3d()

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -459,12 +459,3 @@ def test_compute_masked_class_stats_3d():
     means, vars = em.compute_masked_class_stats_3d(mask, values, 10, labels)
     assert_array_almost_equal(means, expected_means, decimal=4)
     assert_array_almost_equal(vars, expected_vars, decimal=4)
-
-
-if __name__ == '__main__':
-    test_compute_em_demons_step_2d()
-    test_compute_em_demons_step_3d()
-    test_quantize_positive_2d()
-    test_quantize_positive_3d()
-    test_compute_masked_class_stats_2d()
-    test_compute_masked_class_stats_3d()

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -246,10 +246,3 @@ def test_em_demons_step_3d():
 
     assert_array_almost_equal(actual_forward, expected_fwd)
     assert_array_almost_equal(actual_backward, expected_bwd)
-
-
-if __name__ == '__main__':
-    test_em_demons_step_2d()
-    test_em_demons_step_3d()
-    test_exceptions()
-    test_EMMetric_image_dynamics()

--- a/dipy/align/tests/test_sumsqdiff.py
+++ b/dipy/align/tests/test_sumsqdiff.py
@@ -742,12 +742,3 @@ def test_compute_ssd_demons_step_3d():
                                        actual)
 
         assert_array_almost_equal(actual, expected)
-
-
-if __name__ == '__main__':
-    test_compute_residual_displacement_field_ssd_2d()
-    test_compute_residual_displacement_field_ssd_3d()
-    test_compute_energy_ssd_2d()
-    test_compute_energy_ssd_3d()
-    test_compute_ssd_demons_step_2d()
-    test_compute_ssd_demons_step_3d()

--- a/dipy/align/tests/test_transforms.py
+++ b/dipy/align/tests/test_transforms.py
@@ -283,12 +283,3 @@ def test_invalid_transform():
 
     actual = transform.get_dim()
     assert_equal(actual, expected)
-
-
-if __name__ == '__main__':
-    test_number_of_parameters()
-    test_jacobian_functions()
-    test_param_to_matrix_2d()
-    test_param_to_matrix_3d()
-    test_identity_parameters()
-    test_invalid_transform()

--- a/dipy/core/tests/test_rng.py
+++ b/dipy/core/tests/test_rng.py
@@ -31,9 +31,3 @@ def test_LEcuyer():
     # that it is uniformly distributed. This is what we want to check here
     npt.assert_almost_equal(pvalue, 1.0)
     npt.assert_raises(ValueError, rng.LEcuyer, s2=0)
-
-
-if __name__ == "__main__":
-    test_LEcuyer()
-    test_wichmann_hill2006()
-    test_wichmann_hill1982()

--- a/dipy/nn/tests/test_tf.py
+++ b/dipy/nn/tests/test_tf.py
@@ -79,10 +79,3 @@ def test_default_mnist_mlp():
     assert_(mlp.loss < 0.4)
     assert_equal(mlp.accuracy, accuracy)
     assert_equal(x_test_prob.shape, (10000, 10))
-
-
-
-if __name__ == "__main__":
-    test_default_mnist_sequential()
-    test_default_mnist_slp()
-    test_default_mnist_mlp()

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -356,8 +356,3 @@ def test_multi_tensor_btens():
                         fractions=[50, 50], snr=None)
 
     assert_array_almost_equal(S, Ssingle)
-
-
-if __name__ == "__main__":
-
-    test_multi_tensor()

--- a/dipy/testing/tests/test_testing.py
+++ b/dipy/testing/tests/test_testing.py
@@ -64,8 +64,3 @@ def test_clear_and_catch_warnings():
         warnings.warn('Another warning')
     assert_warn_len_equal(my_mod, 2)
     warnings.simplefilter("always", category=UserWarning)
-
-
-if __name__ == '__main__':
-    test_clear_and_catch_warnings()
-    test_assert()

--- a/dipy/tracking/tests/test_fbc.py
+++ b/dipy/tracking/tests/test_fbc.py
@@ -43,7 +43,3 @@ def test_fbc():
 
     # check mean RFBC against tested value
     npt.assert_almost_equal(np.mean(rfbc_orig), 1.0500466494329224, decimal=4)
-
-
-if __name__ == '__main__':
-    test_fbc()

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -151,10 +151,3 @@ def test_roi_images():
         npt.assert_equal(os.path.exists(tmp_fname), True)
         ss = load_image(tmp_fname)
         npt.assert_equal(ss[650, 800, :], [147, 0, 0])
-
-
-if __name__ == '__main__':
-
-    test_horizon_events()
-    test_horizon()
-    test_roi_images()

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -117,11 +117,3 @@ def test_gibbs_flow():
         gibbs_flow.run(data_path, out_dir=out_dir)
         assert_true(os.path.isfile(
                 gibbs_flow.last_generated_outputs['out_unring']))
-
-
-if __name__ == '__main__':
-    test_gibbs_flow()
-    test_mppca_flow()
-    test_patch2self_flow()
-    test_lpca_flow()
-    test_nlmeans_flow()

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -143,12 +143,3 @@ def inputs_from_results(results, keys=None, optional=False):
         inputs.append(str(result))
 
     return inputs
-
-
-if __name__ == '__main__':
-    # test_iap()
-    # test_flow_runner()
-    # test_variable_type()
-    # test_iap_epilog_and_description()
-    test_iap()
-    test_none_or_dtype()

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -86,10 +86,3 @@ def test_split_flow():
         split_data, split_affine = load_nifti(split_path)
         npt.assert_equal(split_data.shape, volume[..., 0].shape)
         npt.assert_array_almost_equal(split_affine, affine)
-
-
-if __name__ == '__main__':
-    test_io_fetch()
-    test_io_fetch_fetcher_datanames()
-    test_io_info()
-    test_split_flow()

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -23,7 +23,3 @@ def test_mask():
         mask_data, mask_affine = load_nifti(mask_path)
         npt.assert_equal(mask_data.shape, volume.shape)
         npt.assert_array_almost_equal(mask_affine, affine)
-
-
-if __name__ == '__main__':
-    test_mask()

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -131,8 +131,3 @@ def reconst_flow_core(flow):
             reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
                              out_dir=out_dir,
                              parallel=True, num_processes=2)
-
-
-if __name__ == '__main__':
-    test_reconst_csa()
-    test_reconst_csd()

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -101,7 +101,3 @@ def test_reconst_dki():
         npt.assert_warns(UserWarning, dki_flow.run, data_path,
                          tmp_bval_path, tmp_bvec_path, mask_path,
                          out_dir=out_dir, b0_threshold=0)
-
-
-if __name__ == '__main__':
-    test_reconst_dki()

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -74,7 +74,3 @@ def reconst_flow_core(flow, extra_args=[], extra_kwargs={}):
         evals_data = load_nifti_data(evals_path)
         assert_equal(evals_data.shape[-1], 3)
         assert_equal(evals_data.shape[:-1], volume.shape[:-1])
-
-
-if __name__ == '__main__':
-    test_reconst_dti_nlls()

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -68,7 +68,3 @@ def test_reconst_ivim():
         D_path = ivim_flow.last_generated_outputs['out_D']
         D_data = load_nifti_data(D_path)
         assert_equal(D_data.shape, data_multi.shape[:-1])
-
-
-if __name__ == '__main__':
-    test_reconst_ivim()

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -63,10 +63,3 @@ def reconst_mmri_core(flow, lap, pos):
                              tmp_bval_path, tmp_bvec_path, small_delta=0.0129,
                              big_delta=0.0218, laplacian=lap,
                              positivity=pos, out_dir=out_dir)
-
-
-if __name__ == '__main__':
-    test_reconst_mmri_laplacian()
-    test_reconst_mmri_none()
-    test_reconst_mmri_positivity()
-    test_reconst_mmri_both()

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -225,8 +225,3 @@ def seeds_are_same_space_as_streamlines(tractogram_path):
             return False
 
     return True
-
-
-if __name__ == '__main__':
-    test_local_fiber_tracking_workflow()
-    test_particle_filtering_traking_workflows()

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -134,8 +134,3 @@ def test_horizon_flow():
                     out_dir=out_dir, out_stealth_png='tmp_x.png')
         npt.assert_equal(os.path.exists(os.path.join(out_dir, 'tmp_x.png')),
                          True)
-
-
-if __name__ == '__main__':
-
-    test_horizon_flow()

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -70,10 +70,3 @@ def test_missing_file():
     with TemporaryDirectory() as tempdir:
         npt.assert_raises(IOError, dummyflow.run,
                           pjoin(tempdir, 'dummy_file.txt'))
-
-
-if __name__ == '__main__':
-    test_force_overwrite()
-    test_get_sub_runs()
-    test_run()
-    test_missing_file()


### PR DESCRIPTION
Remove unnecessary `main` method definition in tests: `pytest` collects
any method having the `test` prefix, so for all practical purposes the
`main` method was being disregarded.