### PR TITLE
Random colors fix in horizon

### DIFF
--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -5,9 +5,9 @@ from os.path import join as pjoin
 from nibabel.tmpdirs import TemporaryDirectory
 from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.tests.workflow_tests_utils import DummyFlow, \
-    DummyCombinedWorkflow, DummyWorkflow1, DummyVariableTypeWorkflow, \
-    DummyVariableTypeErrorWorkflow
+from dipy.workflows.tests.workflow_tests_utils import (
+    DummyFlow, DummyCombinedWorkflow, DummyWorkflow1, DummyWorkflowOptionalStr,
+    DummyVariableTypeWorkflow, DummyVariableTypeErrorWorkflow)
 
 
 def test_none_or_dtype():
@@ -89,6 +89,53 @@ def test_iap():
     # Test if **args really fits dummy_flow's arguments
     return_values = dummy_flow.run(**args)
     npt.assert_array_equal(return_values, all_results + [2.0])
+
+
+def test_optional_str():
+    # Test optional and variable str argument exists but does not have a value
+    sys.argv = [sys.argv[0]]
+    inputs = ['--optional_str_1']
+    sys.argv.extend(inputs)
+    parser = IntrospectiveArgumentParser()
+    dummy_flow = DummyWorkflowOptionalStr()
+    parser.add_workflow(dummy_flow)
+    args = parser.get_flow_args()
+    all_keys = ['optional_str_1']
+    all_results = [[]]
+    # Test if types and order are respected
+    for k, v in zip(all_keys, all_results):
+        npt.assert_equal(args[k], v)
+    # Test if **args really fits dummy_flow's arguments
+    return_values = dummy_flow.run(**args)
+    npt.assert_array_equal(return_values, all_results + ['default'])
+
+    # Test optional and variable str argument exists and has a value
+    sys.argv = [sys.argv[0]]
+    inputs = ['--optional_str_1', 'test']
+    sys.argv.extend(inputs)
+    parser = IntrospectiveArgumentParser()
+    dummy_flow = DummyWorkflowOptionalStr()
+    parser.add_workflow(dummy_flow)
+    args = parser.get_flow_args()
+    all_keys = ['optional_str_1']
+    all_results = [['test']]
+    # Test if types and order are respected
+    for k, v in zip(all_keys, all_results):
+        npt.assert_equal(args[k], v)
+    # Test if **args really fits dummy_flow's arguments
+    return_values = dummy_flow.run(**args)
+    npt.assert_array_equal(return_values, all_results + ['default'])
+
+    # Test optional str empty arguments
+    sys.argv = [sys.argv[0]]
+    inputs = ['--optional_str_2']
+    sys.argv.extend(inputs)
+    parser = IntrospectiveArgumentParser()
+    dummy_flow = DummyWorkflowOptionalStr()
+    parser.add_workflow(dummy_flow)
+    with npt.assert_raises(SystemExit) as cm:
+        parser.get_flow_args()
+    npt.assert_equal(cm.exception.code, 2)
 
 
 def test_iap_epilog_and_description():

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -121,6 +121,21 @@ class DummyFlow(Workflow):
                 optional_float_3)
 
 
+class DummyWorkflowOptionalStr(Workflow):
+    def run(self, optional_str_1=None, optional_str_2='default'):
+        """ Workflow used to test optional string parameters in the
+        introspective argument parser.
+
+        Parameters
+        ----------
+        optional_str_1 : variable str, optional
+            optional string argument 1
+        optional_str_2 : str, optional
+            optional string argument 2 (default 'default')
+        """
+        return optional_str_1, optional_str_2
+
+
 class DummyVariableTypeWorkflow(Workflow):
 
     @classmethod

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -47,7 +47,7 @@ class HorizonFlow(Workflow):
             small animal brains you may need to use something smaller such
             as 2.0. The distance is in mm. For this parameter to be active
             ``cluster`` should be enabled.
-        random_colors : str, optional
+        random_colors : variable str, optional
             Given multiple tractograms and/or ROIs then each tractogram and/or
             ROI will be shown with different color. If no value is provided,
             both the tractograms and the ROIs will have a different random


### PR DESCRIPTION
This PR fixes #2429 and restores the `--random_colors` functionality introduced in #2374.

Additionally, a new test is included for cases when optional strings have different configurations.