### PR TITLE
[FIX] option to disable multithreading while multiprocessing

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -17,7 +17,8 @@ from dipy.core.ndindex import ndindex
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.reconst.eudx_direction_getter import EuDXDirectionGetter
 
-from dipy.utils.multiproc import determine_num_processes
+from dipy.utils.multiproc import (determine_num_processes, enable_np_threads,
+                                  disable_np_threads)
 from dipy.utils.deprecator import deprecated_params
 
 
@@ -245,6 +246,7 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         else:
             mask_file_name = None
 
+        disable_np_threads()
         pool = Pool(num_processes)
 
         pam_res = pool.map(_peaks_from_model_parallel_sub,
@@ -334,6 +336,7 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         # Make sure all worker processes have exited before leaving context
         # manager in order to prevent temporary file deletion errors in windows
         pool.join()
+        enable_np_threads()
 
     return pam
 

--- a/dipy/utils/multiproc.py
+++ b/dipy/utils/multiproc.py
@@ -1,5 +1,6 @@
 """Function for determining the effective number of processes to be used."""
 
+import os
 from multiprocessing import cpu_count
 from warnings import warn
 
@@ -40,3 +41,40 @@ def determine_num_processes(num_processes):
         return 1
 
     return num_processes
+
+
+def disable_np_threads():
+    """Reduce OPENBLAS and MKL thread numbers.
+
+    Notes
+    -----
+    The goal of this function is to avoid oversubscription by spawning too
+    many threads when you use multiprocessing module.
+
+    See Also
+    --------
+    ``enable_np_threads``
+    """
+    current_openblas = os.environ.get('OPENBLAS_NUM_THREADS', '')
+    current_mkl = os.environ.get('MKL_NUM_THREADS', '')
+
+    # import ipdb; ipdb.set_trace()
+    os.environ['DIPY_OPENBLAS_NUM_THREADS'] = current_openblas
+    os.environ['DIPY_MKL_NUM_THREADS'] = current_mkl
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
+
+
+def enable_np_threads():
+    """Reactivate OPENBLAS and MKL thread numbers."""
+    if 'DIPY_OPENBLAS_NUM_THREADS' in os.environ:
+        os.environ['OPENBLAS_NUM_THREADS'] = \
+            os.environ.pop('DIPY_OPENBLAS_NUM_THREADS', '')
+        if os.environ['OPENBLAS_NUM_THREADS'] in ['', None]:
+            os.environ.pop('OPENBLAS_NUM_THREADS', '')
+
+    if 'DIPY_MKL_NUM_THREADS' in os.environ:
+        os.environ['MKL_NUM_THREADS'] = \
+            os.environ.pop('DIPY_MKL_NUM_THREADS', '')
+        if os.environ['MKL_NUM_THREADS'] in ['', None]:
+            os.environ.pop('MKL_NUM_THREADS', '')

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -1,7 +1,9 @@
 """ Testing multiproc utilities
 """
+import os
 
-from dipy.utils.multiproc import determine_num_processes
+from dipy.utils.multiproc import (determine_num_processes, disable_np_threads,
+                                  enable_np_threads)
 from numpy.testing import assert_equal, assert_raises
 
 
@@ -30,3 +32,22 @@ def test_determine_num_processs():
     if determine_num_processes(-1) > 1:
         assert_equal(determine_num_processes(-1),
                      determine_num_processes(-2) + 1)
+
+
+def test_np_threads():
+    openblas_num_threads = os.environ.get('OPENBLAS_NUM_THREADS', '')
+    mkl_num_threads = os.environ.get('MKL_NUM_THREADS', '')
+
+    disable_np_threads()
+    assert_equal(os.environ.get('OPENBLAS_NUM_THREADS', ''), '1')
+    assert_equal(os.environ.get('MKL_NUM_THREADS', ''), '1')
+    assert_equal(os.environ.get('DIPY_OPENBLAS_NUM_THREADS', ''),
+                 openblas_num_threads)
+    assert_equal(os.environ.get('DIPY_MKL_NUM_THREADS', ''), mkl_num_threads)
+
+    enable_np_threads()
+    assert_equal(os.environ.get('OPENBLAS_NUM_THREADS', ''),
+                 openblas_num_threads)
+    assert_equal(os.environ.get('MKL_NUM_THREADS', ''), mkl_num_threads)
+
+


### PR DESCRIPTION
This PR fixes #2519. It permits to avoid thread oversubscription. In the close future, we need to improve the design and insert it in the parallel module. Small Notes: the `loky` backend from `joblib` solve this issue. This fix might be useful for the other `joblib` backends