### PR TITLE
[MNT] Update mininal dependencies version

### DIFF
--- a/dipy/info.py
+++ b/dipy/info.py
@@ -74,11 +74,11 @@ MIT licenses.
 
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
-CYTHON_MIN_VERSION = '0.29'
-NUMPY_MIN_VERSION = '1.12.0'
-SCIPY_MIN_VERSION = '1.0'
+CYTHON_MIN_VERSION = '0.29.24'
+NUMPY_MIN_VERSION = '1.14.5'
+SCIPY_MIN_VERSION = '1.1'
 NIBABEL_MIN_VERSION = '3.0.0'
-H5PY_MIN_VERSION = '2.5.0'
+H5PY_MIN_VERSION = '2.8.0'
 PACKAGING_MIN_VERSION = '19.0'
 TQDM_MIN_VERSION = '4.30.0'
 
@@ -125,13 +125,13 @@ EXTRAS_REQUIRE = {
         "pandas",
         "tables",
         "matplotlib",
-        "fury>=0.6"
+        "fury>=0.8.0"
         "scikit-learn",
         "scikit-image",
         "statsmodels",
     ],
     "viz": [
-        "fury>=0.6",
+        "fury>=0.8.0",
         "matplotlib"
     ],
     "ml": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Check against .travis.yml file and dipy/info.py
-cython>=0.29
-numpy>=1.12.0
-scipy>=1.0
+cython>=0.29.24
+numpy>=1.14.5
+scipy>=1.1
 nibabel>=3.0.0
-h5py>=2.5.0
+h5py>=2.8.0
 packaging>=19.0
 tqdm>=4.30.0


### PR DESCRIPTION
A small update of our minimal dependencies version:

```python
cython>=0.29.24
numpy>=1.14.5
scipy>=1.1
nibabel>=3.0.0
h5py>=2.8.0
packaging>=19.0
tqdm>=4.30.0
```

fixes #2477