### PR TITLE
Limit `peaks_from_model` number of processes in examples

### DIFF
--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -268,7 +268,8 @@ csd_peaks = peaks_from_model(model=csd_model,
                              sphere=default_sphere,
                              relative_peak_threshold=.5,
                              min_separation_angle=25,
-                             parallel=True)
+                             parallel=True,
+                             num_processes=2)
 
 scene.clear()
 fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values)

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -70,11 +70,10 @@ csd_peaks_parallel = peaks_from_model(model=csd_model,
                                       normalize_peaks=True,
                                       npeaks=5,
                                       parallel=True,
-                                      num_processes=None)
+                                      num_processes=2)
 
 time_parallel = time.time() - start_time
-print("peaks_from_model using " + str(multiprocessing.cpu_count())
-      + " process ran in :" + str(time_parallel) + " seconds")
+print(f"peaks_from_model using 2 processes ran in : {time_parallel} seconds")
 
 """
 ``peaks_from_model`` using 8 processes ran in 114.425682068 seconds
@@ -104,7 +103,6 @@ print("peaks_from_model ran in :" + str(time_single) + " seconds")
 print("Speedup factor : " + str(time_single / time_parallel))
 
 """
-Speedup factor : 2.12166099088
 
 In Windows if you get a runtime error about frozen executable please start
 your script by adding your code above in a ``main`` function and use::

--- a/doc/examples/tracking_probabilistic.py
+++ b/doc/examples/tracking_probabilistic.py
@@ -146,7 +146,8 @@ model to the spherical harmonic basis using the ``peaks_from_model`` function.
 from dipy.direction import peaks_from_model
 
 peaks = peaks_from_model(csd_model, data, default_sphere, .5, 25,
-                         mask=white_matter, return_sh=True, parallel=True)
+                         mask=white_matter, return_sh=True, parallel=True,
+                         num_processes=2)
 fod_coeff = peaks.shm_coeff
 
 prob_dg = ProbabilisticDirectionGetter.from_shcoeff(fod_coeff, max_angle=30.,

--- a/doc/examples/tracking_sfm.py
+++ b/doc/examples/tracking_sfm.py
@@ -84,7 +84,8 @@ pnm = peaks_from_model(sf_model, data, sphere,
                        relative_peak_threshold=.5,
                        min_separation_angle=25,
                        mask=white_matter,
-                       parallel=True)
+                       parallel=True,
+                       num_processes=2)
 
 """
 A ThresholdStoppingCriterion object is used to segment the data to track only


### PR DESCRIPTION
Some tutorials use the maximal number of CPUs available in a machine which can cause bad side effects like freezing laptop/desktop, etc....

This PR limits some tutorials. The user can always increase the number of CPUs.