### PR TITLE
[FIX] Update `dipy.segment` tutorials

### DIFF
--- a/dipy/segment/metric.py
+++ b/dipy/segment/metric.py
@@ -1,7 +1,14 @@
-from dipy.segment.metricspeed import (SumPointwiseEuclideanMetric,
-                                      MinimumAverageDirectFlipMetric,)
 
-from dipy.segment.metricspeed import dist
+__all__ = ["MinimumAverageDirectFlipMetric", "Metric",
+           "AveragePointwiseEuclideanMetric", "CosineMetric", "dist",
+           "EuclideanMetric", "mdf"]
+
+
+from dipy.segment.metricspeed import (SumPointwiseEuclideanMetric,
+                                      MinimumAverageDirectFlipMetric,
+                                      AveragePointwiseEuclideanMetric,
+                                      CosineMetric, Metric,
+                                      dist)
 
 # Creates aliases
 EuclideanMetric = SumPointwiseEuclideanMetric
@@ -32,4 +39,3 @@ def mdf(s1, s2):
                         vol 6, no 175, 2012.
     """
     return dist(MinimumAverageDirectFlipMetric(), s1, s2)
- 

--- a/doc/examples/reconst_sfm.py
+++ b/doc/examples/reconst_sfm.py
@@ -1,5 +1,5 @@
 """
-.. _sfm-reconst:
+.. _reconst_sfm:
 
 ==============================================
 Reconstruction with the Sparse Fascicle Model
@@ -88,7 +88,7 @@ The ``response`` return value contains two entries. The first is an array with
 the eigenvalues of the response function and the second is the average S0 for
 this response.
 
-It is a very good practice to always validate the result of 
+It is a very good practice to always validate the result of
 ``auto_response_ssst``. For, this purpose we can print it and have a look
 at its values.
 """

--- a/doc/examples/segment_clustering_features.py
+++ b/doc/examples/segment_clustering_features.py
@@ -53,8 +53,8 @@ in the clustering framework.*
 """
 
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import IdentityFeature
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
+from dipy.segment.featurespeed import IdentityFeature
 
 # Get some streamlines.
 streamlines = get_streamlines()  # Previously defined.
@@ -102,7 +102,7 @@ setting the number of points too high will slow down the clustering process.
 """
 
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import ResampleFeature
+from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
 
 # Get some streamlines.
@@ -144,7 +144,7 @@ streamline.
 import numpy as np
 from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import CenterOfMassFeature
+from dipy.segment.featurespeed import CenterOfMassFeature
 from dipy.segment.metric import EuclideanMetric
 
 # Enables/disables interactive visualization
@@ -203,7 +203,7 @@ spatial position of a streamline. This can also be an alternative to the
 import numpy as np
 from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import MidpointFeature
+from dipy.segment.featurespeed import MidpointFeature
 from dipy.segment.metric import EuclideanMetric
 
 # Get some streamlines.
@@ -257,7 +257,7 @@ length of a streamline.
 import numpy as np
 from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import ArcLengthFeature
+from dipy.segment.featurespeed import ArcLengthFeature
 from dipy.segment.metric import EuclideanMetric
 
 # Get some streamlines.
@@ -309,7 +309,7 @@ using this feature.
 import numpy as np
 from dipy.viz import window, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import VectorOfEndpointsFeature
+from dipy.segment.featurespeed import VectorOfEndpointsFeature
 from dipy.segment.metric import CosineMetric
 
 # Get some streamlines.

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -133,7 +133,7 @@ orientation of a streamline.
 import numpy as np
 from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import VectorOfEndpointsFeature
+from dipy.segment.featurespeed import VectorOfEndpointsFeature
 from dipy.segment.metric import CosineMetric
 
 # Enables/disables interactive visualization

--- a/doc/examples/segment_extending_clustering_framework.py
+++ b/doc/examples/segment_extending_clustering_framework.py
@@ -59,17 +59,16 @@ arc length (i.e. the sum of the length of each segment for a given streamline).
 Let's start by importing the necessary modules.
 """
 
-from dipy.segment.featurespeed import Feature
-from dipy.tracking.streamline import length
 import numpy as np
+
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 from dipy.tracking.streamline import Streamlines
 from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metricspeed import (
-    Metric, SumPointwiseEuclideanMetric, VectorOfEndpointsFeature,
-)
+from dipy.segment.featurespeed import Feature, VectorOfEndpointsFeature
+from dipy.segment.metric import Metric, SumPointwiseEuclideanMetric
+from dipy.tracking.streamline import length
 
 """
 We now define the class ``ArcLengthFeature`` that will perform the desired

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -19,6 +19,7 @@
  reconst_mcsd.py
  reconst_qtdmri.py
  reconst_rumba.py
+ reconst_sfm.py
  reconst_sh.py
  reconst_shore.py
  reconst_shore_metrics.py
@@ -31,7 +32,6 @@
  segment_clustering_metrics.py
  snr_in_cc.py
  streamline_formats.py
- sfm_reconst.py
  gradients_spheres.py
  simulate_multi_tensor.py
  simulate_dki.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -138,7 +138,7 @@ DSI with Deconvolution
 Sparse Fascicle Model
 ~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`example_sfm_reconst`
+- :ref:`example_reconst_sfm`
 
 Intravoxel incoherent motion (IVIM)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR fixes some tutorials from `dipy.segment`. Most of them were failing due to some previous code refactoring. 

I also use the opportunity to rename `sfm_reconst` to `reconst_sfm` in order to respect the current convention.