### PR TITLE
MAINT: Fix version

### DIFF
--- a/dipy/info.py
+++ b/dipy/info.py
@@ -9,7 +9,7 @@ docs.  In setup.py in particular, we exec this file, so it cannot import dipy
 _version_major = 1
 _version_minor = 5
 _version_micro = 0
-_version_extra = 'dev'
+_version_extra = 'dev0'
 # _version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"


### PR DESCRIPTION
Just a tiny tweak to become PEP440 compatible and avoid warnings like the following when installing:
``
  /home/larsoner/.local/lib/python3.10/site-packages/setuptools/dist.py:505: UserWarning: Normalizing '1.5.0dev' to '1.5.0.dev0'
```