### PR TITLE
BUG: Fix errant warning about starting_affine

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -489,7 +489,7 @@ def affine_registration(moving, static,
 
             if starting_affine is not None and starting_was_supplied:
                 wm = "starting_affine overwritten by center_of_mass transform"
-                warn(wm, UserWarning)
+                warn(wm, UserWarning, stacklevel=2)
 
             # multiply images by masks for transform_centers_of_mass
             static_masked, moving_masked = static, moving

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -451,6 +451,7 @@ def affine_registration(moving, static,
     sigmas = sigmas or [3, 1, 0.0]
     factors = factors or [4, 2, 1]
 
+    starting_was_supplied = starting_affine is not None
     static, static_affine, moving, moving_affine, starting_affine = \
         _handle_pipeline_inputs(moving, static,
                                 moving_affine=moving_affine,
@@ -486,7 +487,7 @@ def affine_registration(moving, static,
     for func in pipeline:
         if func == "center_of_mass":
 
-            if starting_affine is not None:
+            if starting_affine is not None and starting_was_supplied:
                 wm = "starting_affine overwritten by centre_of_mass transform"
                 warn(wm, UserWarning)
 

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -488,7 +488,7 @@ def affine_registration(moving, static,
         if func == "center_of_mass":
 
             if starting_affine is not None and starting_was_supplied:
-                wm = "starting_affine overwritten by centre_of_mass transform"
+                wm = "starting_affine overwritten by center_of_mass transform"
                 warn(wm, UserWarning)
 
             # multiply images by masks for transform_centers_of_mass


### PR DESCRIPTION
Over in MNE-Python we are getting warnigs (that our test suite [turns into errors](https://github.com/mne-tools/mne-python/runs/5470293960?check_suite_focus=true)) of the form:
```
mne/transforms.py:1724: in _compute_volume_registration
    moved_zoomed, reg_affine = affine_registration(
/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/dipy/align/_public.py:491: in affine_registration
    warn(wm, UserWarning)
E   UserWarning: starting_affine overwritten by centre_of_mass transform
```
This is true even though our call passes `starting_affine=None`.

I think this is due to #2512. Not 100% sure this is the right fix, but it seems reasonable. `_handle_pipeline_inputs` returns `np.eye(4)` for `starting_affine`, and it seems more invasive to make that return `None` (which would also avoid the warning at least)...