### PR TITLE
Fix logger in SFT

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -15,8 +15,8 @@ from dipy.io.utils import (get_reference_info,
                            is_reference_info_valid,
                            is_header_compatible)
 
-logging.basicConfig()
 logger = logging.getLogger('StatefulTractogram')
+logger.setLevel(level=logging.INFO)
 
 
 def set_sft_logger_level(log_level):


### PR DESCRIPTION
I don't know what happens, I think I accidentally swap lines.

As of right now, this forces the logging to be the default when importing dipy.io.stateful_tractogram (rather than the SFT logger specifically)

And users cannot reset it using the classic `logging.basicConfig(level=logging.INFO)`, but they could if using `logging.getLogger().setLevel(logging.INFO)`.

Anyway, this is fixed now.