### PR TITLE
transform_streamlines changes dtype to float64

### DIFF
--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -154,11 +154,12 @@ def transform_streamlines(streamlines, mat, in_place=False):
     """
     # using new Streamlines API
     if isinstance(streamlines, Streamlines):
+        old_dtype = streamlines._data.dtype
         if in_place:
-            streamlines._data = apply_affine(mat, streamlines._data)
+            streamlines._data = apply_affine(mat, streamlines._data).astype(old_dtype)
             return streamlines
         new_streamlines = streamlines.copy()
-        new_streamlines._data = apply_affine(mat, new_streamlines._data)
+        new_streamlines._data = apply_affine(mat, new_streamlines._data).astype(old_dtype)
         return new_streamlines
     # supporting old data structure of streamlines
     return [apply_affine(mat, s) for s in streamlines]

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -154,14 +154,17 @@ def transform_streamlines(streamlines, mat, in_place=False):
     """
     # using new Streamlines API
     if isinstance(streamlines, Streamlines):
-        old_dtype = streamlines._data.dtype
+        old_data_dtype = streamlines._data.dtype
+        old_offsets_dtype = streamlines._offsets.dtype
         if in_place:
             streamlines._data = apply_affine(
-                mat, streamlines._data).astype(old_dtype)
+                mat, streamlines._data).astype(old_data_dtype)
             return streamlines
         new_streamlines = streamlines.copy()
+        new_streamlines._offsets = new_streamlines._offsets.astype(
+            old_offsets_dtype)
         new_streamlines._data = apply_affine(
-            mat, new_streamlines._data).astype(old_dtype)
+            mat, new_streamlines._data).astype(old_data_dtype)
         return new_streamlines
     # supporting old data structure of streamlines
     return [apply_affine(mat, s) for s in streamlines]

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -156,10 +156,12 @@ def transform_streamlines(streamlines, mat, in_place=False):
     if isinstance(streamlines, Streamlines):
         old_dtype = streamlines._data.dtype
         if in_place:
-            streamlines._data = apply_affine(mat, streamlines._data).astype(old_dtype)
+            streamlines._data = apply_affine(
+                mat, streamlines._data).astype(old_dtype)
             return streamlines
         new_streamlines = streamlines.copy()
-        new_streamlines._data = apply_affine(mat, new_streamlines._data).astype(old_dtype)
+        new_streamlines._data = apply_affine(
+            mat, new_streamlines._data).astype(old_dtype)
         return new_streamlines
     # supporting old data structure of streamlines
     return [apply_affine(mat, s) for s in streamlines]

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -522,20 +522,24 @@ def test_transform_streamlines_dtype_in_place():
     identity = np.eye(4)
     streamlines = Streamlines([streamline])
     streamlines._data = streamlines._data.astype(np.float16)
-    dtype = streamlines._data.dtype
+    data_dtype = streamlines._data.dtype
+    offsets_dtype = streamlines._offsets.dtype
 
     transform_streamlines(streamlines, identity, in_place=True)
-    assert_equal(dtype, streamlines._data.dtype)
+    assert_equal(data_dtype, streamlines._data.dtype)
+    assert_equal(offsets_dtype, streamlines._offsets.dtype)
 
 
 def test_transform_streamlines_dtype():
     identity = np.eye(4)
     streamlines = Streamlines([streamline])
     streamlines._data = streamlines._data.astype(np.float16)
-    dtype = streamlines._data.dtype
+    data_dtype = streamlines._data.dtype
+    offsets_dtype = streamlines._offsets.dtype
 
     streamlines = transform_streamlines(streamlines, identity, in_place=False)
-    assert_equal(dtype, streamlines._data.dtype)
+    assert_equal(data_dtype, streamlines._data.dtype)
+    assert_equal(offsets_dtype, streamlines._offsets.dtype)
 
 
 def test_deform_streamlines():

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -518,6 +518,26 @@ def test_unlist_relist_streamlines():
         assert_array_equal(streamlines[i], streamlines2[i])
 
 
+def test_transform_streamlines_dtype_in_place():
+    identity = np.eye(4)
+    streamlines = Streamlines([streamline])
+    streamlines._data = streamlines._data.astype(np.float16)
+    dtype = streamlines._data.dtype
+
+    transform_streamlines(streamlines, identity, in_place=True)
+    assert_equal(dtype, streamlines._data.dtype)
+
+
+def test_transform_streamlines_dtype():
+    identity = np.eye(4)
+    streamlines = Streamlines([streamline])
+    streamlines._data = streamlines._data.astype(np.float16)
+    dtype = streamlines._data.dtype
+
+    streamlines = transform_streamlines(streamlines, identity, in_place=False)
+    assert_equal(dtype, streamlines._data.dtype)
+
+
 def test_deform_streamlines():
     # Create Random deformation field
     deformation_field = np.random.randn(200, 200, 200, 3)


### PR DESCRIPTION
Keep the same dtype when using transform_streamlines (with array_sequence)

This problem was identified when saving VTK files, it was always double precision.