### PR TITLE
Embed parallelization into the multi_voxel_fit decorator.

### DIFF
--- a/.github/workflows/test_optional.yml
+++ b/.github/workflows/test_optional.yml
@@ -15,12 +15,12 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py==3.10.0 nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py==3.11.0 nibabel cvxpy tqdm
       extra-depends: scikit_learn pandas statsmodels tables scipy==1.10.1
   conda:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["macos-latest", "windows-latest"]'
       install-type: '["conda"]'
-      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py==3.10.0 nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py==3.11.0 nibabel cvxpy tqdm
       extra-depends: scikit-learn pandas statsmodels pytables scipy==1.10.1

--- a/.github/workflows/test_optional.yml
+++ b/.github/workflows/test_optional.yml
@@ -15,12 +15,12 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py==3.10.0 nibabel cvxpy tqdm
       extra-depends: scikit_learn pandas statsmodels tables scipy==1.10.1
   conda:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["macos-latest", "windows-latest"]'
       install-type: '["conda"]'
-      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py==3.10.0 nibabel cvxpy tqdm
       extra-depends: scikit-learn pandas statsmodels pytables scipy==1.10.1

--- a/.github/workflows/test_parallel.yml
+++ b/.github/workflows/test_parallel.yml
@@ -15,4 +15,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: dask joblib ray protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211
+      extra-depends: dask joblib ray==1.11.1 protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211

--- a/.github/workflows/test_parallel.yml
+++ b/.github/workflows/test_parallel.yml
@@ -15,4 +15,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: dask joblib ray==1.11.1 protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211
+      extra-depends: dask joblib ray==2.9.3 protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -97,7 +97,7 @@ jobs:
         channels: defaults, conda-forge
         use-only-tar-bz2: true
     - name: Install HDF5 and pytables on macOS
-      if: runner.os == 'macOS'
+      if: ${{ (runner.os == 'macOS')  &&  (env.EXTRA_DEPENDS != '')  &&  (env.INSTALL_TYPE == 'pip') }}
       run: |
         pip install cython
         brew install hdf5

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -96,6 +96,16 @@ jobs:
         python-version: ${{ matrix.python-version }}
         channels: defaults, conda-forge
         use-only-tar-bz2: true
+    - name: Install HDF5 and pytables on macOS
+      if: runner.os == 'macOS'
+      run: |
+        pip install cython
+        brew install hdf5
+        brew install c-blosc
+        export HDF5_DIR=/opt/homebrew/opt/hdf5
+        export BLOSC_DIR=/opt/homebrew/opt/c-blosc
+        pip install tables
+
     - name: Install Dependencies
       run: |
         if [ "${{ inputs.use-pre }}" == "true" ]; then

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -309,7 +309,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         self._P = np.dot(X.T, X)
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         dwi_data = data[self._where_dwi]
         shm_coeff, _ = csdeconv(
             dwi_data,
@@ -449,8 +449,9 @@ class ConstrainedSDTModel(SphHarmModel):
         self.sh_order_max = sh_order_max
 
     @multi_voxel_fit
-    def fit(self, data):
-        s_sh = np.linalg.lstsq(self.B_dwi, data[self._where_dwi], rcond=-1)[0]
+    def fit(self, data, **kwargs):
+        s_sh = np.linalg.lstsq(self.B_dwi, data[self._where_dwi],
+                               rcond=-1)[0]
         # initial ODF estimation
         odf_sh = np.dot(self.P, s_sh)
         qball_odf = np.dot(self.B_reg, odf_sh)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -450,8 +450,7 @@ class ConstrainedSDTModel(SphHarmModel):
 
     @multi_voxel_fit
     def fit(self, data, **kwargs):
-        s_sh = np.linalg.lstsq(self.B_dwi, data[self._where_dwi],
-                               rcond=-1)[0]
+        s_sh = np.linalg.lstsq(self.B_dwi, data[self._where_dwi], rcond=-1)[0]
         # initial ODF estimation
         odf_sh = np.dot(self.P, s_sh)
         qball_odf = np.dot(self.B_reg, odf_sh)

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -128,7 +128,7 @@ class DiffusionSpectrumModel(OdfModel, Cache):
         self.gtab = gtab
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         return DiffusionSpectrumFit(self, data)
 
 
@@ -563,7 +563,7 @@ class DiffusionSpectrumDeconvModel(DiffusionSpectrumModel):
         )
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         return DiffusionSpectrumDeconvFit(self, data)
 
 

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -201,7 +201,7 @@ class ForecastModel(OdfModel, Cache):
         self.fod = rho_matrix(sh_order_max, self.vertices)
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         data_b0 = data[self.b0s_mask].mean()
         data_single_b0 = np.r_[data_b0, data[~self.b0s_mask]] / data_b0
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -150,7 +150,6 @@ class FreeWaterTensorModel(ReconstModel):
             A boolean array used to mark the coordinates in the data that
             should be analyzed that has the shape data.shape[:-1]
         """
-        data = np.squeeze(data)
         S0 = np.mean(data[self.gtab.b0s_mask])
         fwdti_params = self.fit_method(
             self.design_matrix, data, S0, *self.args, **self.kwargs

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -139,8 +139,8 @@ class FreeWaterTensorModel(ReconstModel):
             raise ValueError(mes)
 
     @multi_voxel_fit
-    def fit(self, data, mask=None):
-        """Fit method of the free water elimination DTI model class
+    def fit(self, data, mask=None, **kwargs):
+        """ Fit method of the free water elimination DTI model class
 
         Parameters
         ----------
@@ -150,6 +150,7 @@ class FreeWaterTensorModel(ReconstModel):
             A boolean array used to mark the coordinates in the data that
             should be analyzed that has the shape data.shape[:-1]
         """
+        data = np.squeeze(data)
         S0 = np.mean(data[self.gtab.b0s_mask])
         fwdti_params = self.fit_method(
             self.design_matrix, data, S0, *self.args, **self.kwargs

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -140,7 +140,7 @@ class FreeWaterTensorModel(ReconstModel):
 
     @multi_voxel_fit
     def fit(self, data, mask=None, **kwargs):
-        """ Fit method of the free water elimination DTI model class
+        """Fit method of the free water elimination DTI model class
 
         Parameters
         ----------

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -150,6 +150,7 @@ class FreeWaterTensorModel(ReconstModel):
             A boolean array used to mark the coordinates in the data that
             should be analyzed that has the shape data.shape[:-1]
         """
+        data = np.squeeze(data)
         S0 = np.mean(data[self.gtab.b0s_mask])
         fwdti_params = self.fit_method(
             self.design_matrix, data, S0, *self.args, **self.kwargs

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -77,7 +77,7 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
         self.b_vector = b_vector.T
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         return GeneralizedQSamplingFit(self, data)
 
 

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -575,13 +575,8 @@ class IvimModelVP(ReconstModel):
         self.bounds = bounds or (BOUNDS[0][1:], BOUNDS[1][1:])
 
     @multi_voxel_fit
-<<<<<<< HEAD
-    def fit(self, data, bounds_de=None):
-        r"""Fit method of the IvimModelVP model class
-=======
     def fit(self, data, bounds_de=None, **kwargs):
         r""" Fit method of the IvimModelVP model class
->>>>>>> a608c2a49 (Enable passing parallelization key-word arguments in fit methods.)
 
         MicroLearn framework (VarPro)[1]_.
 

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -298,7 +298,7 @@ class IvimModelTRR(ReconstModel):
 
     @multi_voxel_fit
     def fit(self, data, **kwargs):
-        """ Fit method of the IvimModelTRR class.
+        """Fit method of the IvimModelTRR class.
 
         The fitting takes place in the following steps: Linear fitting for D
         (bvals > `split_b_D` (default: 400)) and store S0_prime. Another linear
@@ -576,7 +576,7 @@ class IvimModelVP(ReconstModel):
 
     @multi_voxel_fit
     def fit(self, data, bounds_de=None, **kwargs):
-        r""" Fit method of the IvimModelVP model class
+        r"""Fit method of the IvimModelVP model class
 
         MicroLearn framework (VarPro)[1]_.
 

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -297,8 +297,8 @@ class IvimModelTRR(ReconstModel):
         self.bounds = bounds or BOUNDS
 
     @multi_voxel_fit
-    def fit(self, data):
-        """Fit method of the IvimModelTRR class.
+    def fit(self, data, **kwargs):
+        """ Fit method of the IvimModelTRR class.
 
         The fitting takes place in the following steps: Linear fitting for D
         (bvals > `split_b_D` (default: 400)) and store S0_prime. Another linear
@@ -575,8 +575,13 @@ class IvimModelVP(ReconstModel):
         self.bounds = bounds or (BOUNDS[0][1:], BOUNDS[1][1:])
 
     @multi_voxel_fit
+<<<<<<< HEAD
     def fit(self, data, bounds_de=None):
         r"""Fit method of the IvimModelVP model class
+=======
+    def fit(self, data, bounds_de=None, **kwargs):
+        r""" Fit method of the IvimModelVP model class
+>>>>>>> a608c2a49 (Enable passing parallelization key-word arguments in fit methods.)
 
         MicroLearn framework (VarPro)[1]_.
 

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -361,7 +361,7 @@ class MapmriModel(ReconstModel, Cache):
                     self.MMt_inv_Mt = np.dot(np.linalg.pinv(MMt), self.M.T)
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         errorcode = 0
         tenfit = self.tenmodel.fit(data[self.cutoff])
         evals = tenfit.evals

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -307,7 +307,7 @@ class MultiShellDeconvModel(shm.SphHarmModel):
         return pred_sig
 
     @multi_voxel_fit
-    def fit(self, data, verbose=True):
+    def fit(self, data, verbose=True, **kwargs):
         """Fits the model to diffusion data and returns the model fit.
 
         Sometimes the solving process of some voxels can end in a SolverError

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -53,14 +53,13 @@ def multi_voxel_fit(single_voxel_fit):
         vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
         chunks = [data_to_fit[ii:ii + vox_per_chunk]
                   for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
-        fit_array[mask] = np.squeeze(
+        fit_array[mask] = np.concatenate((
             paramap(
                 parallel_fit_worker,
                 chunks,
                 func_args=[single_voxel_with_self],
-                out_shape=fit_array[mask].shape,
                 **kwargs)
-                )
+                ))
         return MultiVoxelFit(self, fit_array, mask)
 
     return new_fit

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -11,6 +11,22 @@ from dipy.utils.parallel import paramap
 from functools import partial
 import multiprocessing
 
+def parallel_fit_worker(vox_data, single_voxel_fit, **kwargs):
+    """
+    Each pool process calls this worker.
+    Fit model on chunks
+    Parameters
+    -----------
+    arguments: tuple
+        tuple should contains a model and
+        list of indexes
+    Returns
+    --------
+    result: list of tuple
+        return a list of tuple(voxel index, model fitted instance)
+    """
+    return [single_voxel_fit(data) for data in vox_data]
+
 
 def multi_voxel_fit(single_voxel_fit):
     """Method decorator to turn a single voxel model fit
@@ -24,9 +40,7 @@ def multi_voxel_fit(single_voxel_fit):
 
         # Make a mask if mask is None
         if mask is None:
-            shape = data.shape[:-1]
-            strides = (0,) * len(shape)
-            mask = as_strided(np.array(True), shape=shape, strides=strides)
+            mask = np.ones(data.shape[:-1], bool)
         # Check the shape of the mask if mask is not None
         elif mask.shape != data.shape[:-1]:
             raise ValueError("mask and data shape do not match")
@@ -39,7 +53,13 @@ def multi_voxel_fit(single_voxel_fit):
         vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
         chunks = [data_to_fit[ii:ii + vox_per_chunk]
                   for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
-        fit_array[mask] = paramap(single_voxel_with_self, chunks, **kwargs)
+        fit_array[mask] = np.squeeze(
+            paramap(
+                parallel_fit_worker,
+                chunks,
+                func_args=[single_voxel_with_self],
+                **kwargs)
+                )
         return MultiVoxelFit(self, fit_array, mask)
 
     return new_fit

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -35,7 +35,7 @@ def multi_voxel_fit(single_voxel_fit):
         fit_array = np.empty(data.shape[:-1], dtype=object)
         data_to_fit = data[mask]
         single_voxel_with_self = partial(single_voxel_fit, self)
-        n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() -1)
+        n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
         vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
         chunks = [data_to_fit[ii:ii + vox_per_chunk]
                   for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -3,7 +3,6 @@ from functools import partial
 import multiprocessing
 
 import numpy as np
-from numpy.lib.stride_tricks import as_strided
 from tqdm import tqdm
 
 from dipy.core.ndindex import ndindex
@@ -50,9 +49,10 @@ def multi_voxel_fit(single_voxel_fit):
         # Default to serial execution:
         engine = kwargs.get("engine", "serial")
         if engine == "serial":
-            bar = tqdm(total=np.sum(mask), position=0)
-            bar.set_description(f"Fitting reconstruction model",
-                                 "using serial execution")
+            bar = tqdm(total=np.sum(mask), position=0,
+                       disable=kwargs.get("verbose", True))
+            bar.set_description("Fitting reconstruction model",
+                                "using serial execution")
             for ijk in ndindex(data.shape[:-1]):
                 if mask[ijk]:
                     fit_array[ijk] = single_voxel_fit(self, data[ijk])
@@ -66,7 +66,7 @@ def multi_voxel_fit(single_voxel_fit):
                 "vox_per_chunk",
                 np.max([data_to_fit.shape[0] // n_jobs, 1]))
             chunks = [data_to_fit[ii:ii + vox_per_chunk]
-                    for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
+                      for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
             fit_array[np.where(mask)] = np.concatenate((
                 paramap(
                     _parallel_fit_worker,

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -50,13 +50,15 @@ def multi_voxel_fit(single_voxel_fit):
         engine = kwargs.get("engine", "serial")
         if engine == "serial":
             bar = tqdm(total=np.sum(mask), position=0)
+            bar.set_description(f"Fitting reconstruction model",
+                                 "using serial execution")
             for ijk in ndindex(data.shape[:-1]):
                 if mask[ijk]:
                     fit_array[ijk] = single_voxel_fit(self, data[ijk])
                 bar.update()
             bar.close()
         else:
-            data_to_fit = data[mask]
+            data_to_fit = data[np.where(mask)]
             single_voxel_with_self = partial(single_voxel_fit, self)
             n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
             vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -33,7 +33,7 @@ def multi_voxel_fit(single_voxel_fit):
         fit_array = np.empty(data.shape[:-1], dtype=object)
         data_to_fit = data[mask]
         single_voxel_with_self = partial(single_voxel_fit, self)
-        n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() -1)
+        n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
         vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
         chunks = [data_to_fit[ii:ii + vox_per_chunk]
                   for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -61,7 +61,9 @@ def multi_voxel_fit(single_voxel_fit):
             data_to_fit = data[np.where(mask)]
             single_voxel_with_self = partial(single_voxel_fit, self)
             n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
-            vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
+            vox_per_chunk = kwargs.get(
+                "vox_per_chunk",
+                np.max([data_to_fit.shape[0] // n_jobs, 1])
             chunks = [data_to_fit[ii:ii + vox_per_chunk]
                     for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
             fit_array[mask] = np.concatenate((

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -11,7 +11,7 @@ from dipy.utils.parallel import paramap
 from functools import partial
 import multiprocessing
 
-def parallel_fit_worker(vox_data, single_voxel_fit, **kwargs):
+def parallel_fit_worker(vox_data, single_voxel_fit):
     """
     Each pool process calls this worker.
     Fit model on chunks
@@ -58,6 +58,7 @@ def multi_voxel_fit(single_voxel_fit):
                 parallel_fit_worker,
                 chunks,
                 func_args=[single_voxel_with_self],
+                out_shape=fit_array[mask].shape,
                 **kwargs)
                 )
         return MultiVoxelFit(self, fit_array, mask)

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -11,19 +11,18 @@ from dipy.utils.parallel import paramap
 from functools import partial
 import multiprocessing
 
-def parallel_fit_worker(vox_data, single_voxel_fit):
+def _parallel_fit_worker(vox_data, single_voxel_fit):
     """
-    Each pool process calls this worker.
-    Fit model on chunks
+    Works on a chunk of voxel data to create a list of
+    single voxel fits.
+
     Parameters
-    -----------
-    arguments: tuple
-        tuple should contains a model and
-        list of indexes
-    Returns
-    --------
-    result: list of tuple
-        return a list of tuple(voxel index, model fitted instance)
+    ----------
+    vox_data : ndarray, shape (n_voxels, ...)
+        The data to fit.
+
+    single_voxel_fit : callable
+        The fit function to use on each voxel.
     """
     return [single_voxel_fit(data) for data in vox_data]
 
@@ -47,9 +46,6 @@ def multi_voxel_fit(single_voxel_fit):
 
         # Fit data where mask is True
         fit_array = np.empty(data.shape[:-1], dtype=object)
-        data_to_fit = data[mask]
-        single_voxel_with_self = partial(single_voxel_fit, self)
-        n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
         # Default to serial execution:
         engine = kwargs.get("engine", "serial")
         if engine == "serial":
@@ -60,12 +56,15 @@ def multi_voxel_fit(single_voxel_fit):
                 bar.update()
             bar.close()
         else:
+            data_to_fit = data[mask]
+            single_voxel_with_self = partial(single_voxel_fit, self)
+            n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
             vox_per_chunk = np.max([data_to_fit.shape[0] // n_jobs, 1])
             chunks = [data_to_fit[ii:ii + vox_per_chunk]
                     for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
             fit_array[mask] = np.concatenate((
                 paramap(
-                    parallel_fit_worker,
+                    _parallel_fit_worker,
                     chunks,
                     func_args=[single_voxel_with_self],
                     **kwargs)

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -66,7 +66,7 @@ def multi_voxel_fit(single_voxel_fit):
                 np.max([data_to_fit.shape[0] // n_jobs, 1])
             chunks = [data_to_fit[ii:ii + vox_per_chunk]
                     for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
-            fit_array[mask] = np.concatenate((
+            fit_array[np.where(mask)] = np.concatenate((
                 paramap(
                     _parallel_fit_worker,
                     chunks,

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -11,7 +11,7 @@ from dipy.reconst.base import ReconstFit
 from functools import partial
 import multiprocessing
 
-def parallel_fit_worker(vox_data, single_voxel_fit, **kwargs):
+def parallel_fit_worker(vox_data, single_voxel_fit):
     """
     Each pool process calls this worker.
     Fit model on chunks
@@ -58,6 +58,7 @@ def multi_voxel_fit(single_voxel_fit):
                 parallel_fit_worker,
                 chunks,
                 func_args=[single_voxel_with_self],
+                out_shape=fit_array[mask].shape,
                 **kwargs)
                 )
         return MultiVoxelFit(self, fit_array, mask)

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -54,9 +54,7 @@ def multi_voxel_fit(single_voxel_fit):
             bar = tqdm(
                 total=np.sum(mask), position=0, disable=kwargs.get("verbose", True)
             )
-            bar.set_description(
-                "Fitting reconstruction model", "using serial execution"
-            )
+            bar.set_description("Fitting reconstruction model using serial execution")
             for ijk in ndindex(data.shape[:-1]):
                 if mask[ijk]:
                     fit_array[ijk] = single_voxel_fit(self, data[ijk])

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -63,7 +63,7 @@ def multi_voxel_fit(single_voxel_fit):
             n_jobs = kwargs.get("n_jobs", multiprocessing.cpu_count() - 1)
             vox_per_chunk = kwargs.get(
                 "vox_per_chunk",
-                np.max([data_to_fit.shape[0] // n_jobs, 1])
+                np.max([data_to_fit.shape[0] // n_jobs, 1]))
             chunks = [data_to_fit[ii:ii + vox_per_chunk]
                     for ii in range(0, data_to_fit.shape[0], vox_per_chunk)]
             fit_array[np.where(mask)] = np.concatenate((

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,15 +1,16 @@
 """Tools to easily make multi voxel models"""
+from functools import partial
+import multiprocessing
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 from tqdm import tqdm
 
 from dipy.core.ndindex import ndindex
+from dipy.reconst.base import ReconstFit
 from dipy.reconst.quick_squash import quick_squash as _squash
 from dipy.utils.parallel import paramap
-from dipy.reconst.base import ReconstFit
-from functools import partial
-import multiprocessing
+
 
 def _parallel_fit_worker(vox_data, single_voxel_fit):
     """

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -265,7 +265,7 @@ class QtdmriModel(Cache):
         self.tenmodel = dti.TensorModel(gtab)
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         bval_mask = self.gtab.bvals < self.bval_threshold
         data_norm = data / data[self.gtab.b0s_mask].mean()
         tau = self.gtab.tau

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -482,8 +482,7 @@ class SparseFascicleModel(ReconstModel, Cache):
                 return np.zeros(self.design_matrix.shape[-1])
         return coef
 
-    def fit(self, data, mask=None, num_processes=1,
-            parallel_backend='multiprocessing'):
+    def fit(self, data, mask=None, num_processes=1, parallel_backend="multiprocessing"):
         """
         Fit the SparseFascicleModel object to data.
 

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -482,7 +482,8 @@ class SparseFascicleModel(ReconstModel, Cache):
                 return np.zeros(self.design_matrix.shape[-1])
         return coef
 
-    def fit(self, data, mask=None, num_processes=1, parallel_backend="multiprocessing"):
+    def fit(self, data, mask=None, num_processes=1,
+            parallel_backend='multiprocessing'):
         """
         Fit the SparseFascicleModel object to data.
 

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -209,7 +209,7 @@ class ShoreModel(Cache):
         self.pos_radius = pos_radius
 
     @multi_voxel_fit
-    def fit(self, data):
+    def fit(self, data, **kwargs):
         Lshore = l_shore(self.radial_order)
         Nshore = n_shore(self.radial_order)
         # Generate the SHORE basis

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 from dipy.core.sphere import unit_icosahedron
 from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.optpkg import optional_package
 
 joblib, has_joblib, _ = optional_package('joblib')
 dask, has_dask, _ = optional_package('dask')

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -12,6 +12,10 @@ joblib, has_joblib, _ = optional_package('joblib')
 dask, has_dask, _ = optional_package('dask')
 ray, has_ray, _ = optional_package('ray')
 
+joblib, has_joblib, _ = optional_package('joblib')
+dask, has_dask, _ = optional_package('dask')
+ray, has_ray, _ = optional_package('ray')
+
 
 def test_squash():
     A = np.ones((3, 3), dtype=float)

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -12,10 +12,6 @@ joblib, has_joblib, _ = optional_package('joblib')
 dask, has_dask, _ = optional_package('dask')
 ray, has_ray, _ = optional_package('ray')
 
-joblib, has_joblib, _ = optional_package('joblib')
-dask, has_dask, _ = optional_package('dask')
-ray, has_ray, _ = optional_package('ray')
-
 
 def test_squash():
     A = np.ones((3, 3), dtype=float)

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -8,9 +8,9 @@ from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
-joblib, has_joblib, _ = optional_package('joblib')
-dask, has_dask, _ = optional_package('dask')
-ray, has_ray, _ = optional_package('ray')
+joblib, has_joblib, _ = optional_package("joblib")
+dask, has_dask, _ = optional_package("dask")
+ray, has_ray, _ = optional_package("ray")
 
 
 def test_squash():

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -7,6 +7,10 @@ from dipy.core.sphere import unit_icosahedron
 from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
 from dipy.testing.decorators import set_random_number_generator
 
+joblib, has_joblib, _ = optional_package('joblib')
+dask, has_dask, _ = optional_package('dask')
+ray, has_ray, _ = optional_package('ray')
+
 
 def test_squash():
     A = np.ones((3, 3), dtype=float)
@@ -139,7 +143,7 @@ def test_CallableArray():
 def test_multi_voxel_fit(rng):
     class SillyModel:
         @multi_voxel_fit
-        def fit(self, data, mask=None):
+        def fit(self, data, mask=None, **kwargs):
             return SillyFit(model, data)
 
         def predict(self, S0):
@@ -180,6 +184,22 @@ def test_multi_voxel_fit(rng):
     npt.assert_equal(fit.directions.shape, (2, 3, 4))
     S0 = 100.0
     npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+
+    # Test with parallelization (using the "serial" dummy engine)
+    fit = model.fit(many_voxels, engine="serial")
+
+    # If parallelization engines are installed use them to test:
+    if has_joblib:
+        fit = model.fit(many_voxels, engine="joblib")
+        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+
+    if has_dask:
+        fit = model.fit(many_voxels, engine="dask")
+        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+
+    if has_ray:
+        fit = model.fit(many_voxels, engine="ray")
+        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask
     mask = np.zeros((3, 3, 3)).astype("bool")

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -98,7 +98,7 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
         else:
             raise ValueError(f"{backend} is not a backend for dask")
 
-    if engine == "ray":
+    elif engine == "ray":
         if not has_ray:
             raise ray()
 

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -111,7 +111,7 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
                     )
                 },)
 
-        func = ray.remote(func, **kwargs)
+        func = ray.remote(func)
         results = ray.get([func.remote(ii, *func_args, **func_kwargs)
                           for ii in in_list])
 

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -41,8 +41,8 @@ def paramap(
          The shape of the output array. If not specified, the output shape will
          be `(len(in_list),)`.
     n_jobs : integer, optional
-        The number of jobs to perform in parallel. -1 to use all but one cpu.
-        Default: -1.
+        The number of jobs to perform in parallel.
+        -1 (default) to use all but one cpu.
     engine : str, optional
         {"dask", "joblib", "ray", "serial"}
         The last one is useful for debugging -- runs the code without any
@@ -53,7 +53,6 @@ def paramap(
     clean_spill : bool, optional
         If True, clean up the spill directory after the computation is done.
         Only applies to "ray" engine. Otherwise has no effect.
-        Default: True.
     func_args : list, optional
         Positional arguments to `func`.
     func_kwargs : dict, optional
@@ -61,7 +60,6 @@ def paramap(
     kwargs : dict, optional
         Additional arguments to pass to either joblib.Parallel
         or dask.compute, or ray.remote depending on the engine used.
-        Default: {}
 
     Returns
     -------

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -8,14 +8,23 @@ from tqdm.auto import tqdm
 
 from dipy.utils.optpkg import optional_package
 
-ray, has_ray, _ = optional_package('ray')
-joblib, has_joblib, _ = optional_package('joblib')
-dask, has_dask, _ = optional_package('dask')
+ray, has_ray, _ = optional_package("ray")
+joblib, has_joblib, _ = optional_package("joblib")
+dask, has_dask, _ = optional_package("dask")
 
 
-def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
-            backend=None, func_args=None, clean_spill=True, func_kwargs=None,
-            **kwargs):
+def paramap(
+    func,
+    in_list,
+    out_shape=None,
+    n_jobs=-1,
+    engine="ray",
+    backend=None,
+    func_args=None,
+    clean_spill=True,
+    func_kwargs=None,
+    **kwargs,
+):
     """
     Maps a function to a list of inputs in parallel.
 
@@ -106,16 +115,21 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
             tmp_dir = tempfile.TemporaryDirectory()
 
             if not ray.is_initialized():
-                ray.init(_system_config={
-                    "object_spilling_config": json.dumps(
-                        {"type": "filesystem", "params": {"directory_path":
-                         tmp_dir.name}},
-                    )
-                },)
+                ray.init(
+                    _system_config={
+                        "object_spilling_config": json.dumps(
+                            {
+                                "type": "filesystem",
+                                "params": {"directory_path": tmp_dir.name},
+                            },
+                        )
+                    },
+                )
 
         func = ray.remote(func)
-        results = ray.get([func.remote(ii, *func_args, **func_kwargs)
-                          for ii in in_list])
+        results = ray.get(
+            [func.remote(ii, *func_args, **func_kwargs) for ii in in_list]
+        )
 
         if clean_spill:
             shutil.rmtree(tmp_dir.name)

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -43,10 +43,10 @@ def paramap(
     n_jobs : integer, optional
         The number of jobs to perform in parallel. -1 to use all but one cpu.
         Default: -1.
-    engine : str
+    engine : str, optional
         {"dask", "joblib", "ray", "serial"}
         The last one is useful for debugging -- runs the code without any
-        parallelization. Default: "ray"
+        parallelization.
     backend : str, optional
         What joblib or dask backend to use. For joblib, the default is "loky".
         For dask the default is "threading".

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -1,13 +1,12 @@
-import shutil
-import numpy as np
+import json
 import multiprocessing
+import shutil
+import tempfile
 
+import numpy as np
 from tqdm.auto import tqdm
 
 from dipy.utils.optpkg import optional_package
-import json
-import tempfile
-
 
 ray, has_ray, _ = optional_package('ray')
 joblib, has_joblib, _ = optional_package('joblib')

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -1,10 +1,13 @@
-import os
 import shutil
 import numpy as np
+import multiprocessing
+
+from tqdm.auto import tqdm
+
 from dipy.utils.optpkg import optional_package
 import json
 import tempfile
-import multiprocessing
+
 
 ray, has_ray, _ = optional_package('ray')
 joblib, has_joblib, _ = optional_package('joblib')

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -3,14 +3,16 @@ import shutil
 import numpy as np
 from dipy.utils.optpkg import optional_package
 import json
+import tempfile
+import multiprocessing
 
-joblib, has_joblib, _ = optional_package("joblib")
-dask, has_dask, _ = optional_package("dask")
-ray, has_ray, _ = optional_package("ray")
+ray, has_ray, _ = optional_package('ray')
+joblib, has_joblib, _ = optional_package('joblib')
+dask, has_dask, _ = optional_package('dask')
 
 
 def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
-            backend=None, func_args=None, func_kwargs=None,
+            backend=None, func_args=None, clean_spill=True, func_kwargs=None,
             **kwargs):
     """
     Maps a function to a list of inputs in parallel.
@@ -37,13 +39,17 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
     backend : str, optional
         What joblib or dask backend to use. For joblib, the default is "loky".
         For dask the default is "threading".
+    clean_spill : bool, optional
+        If True, clean up the spill directory after the computation is done.
+        Only applies to "ray" engine. Otherwise has no effect.
+        Default: True.
     func_args : list, optional
         Positional arguments to `func`.
     func_kwargs : dict, optional
         Keyword arguments to `func`.
     kwargs : dict, optional
         Additional arguments to pass to either joblib.Parallel
-        or dask.compute depending on the engine used.
+        or dask.compute, or ray.remote depending on the engine used.
         Default: {}
 
     Returns
@@ -94,29 +100,23 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
         if not has_ray:
             raise ray()
 
-        if not ray.is_initialized():
-            ray.init(_system_config={
-                "object_spilling_config": json.dumps(
-                    {"type": "filesystem", "params": {"directory_path":
-                     "/tmp/spill"}},
-                )
-            },)
+        if clean_spill:
+            tmp_dir = tempfile.TemporaryDirectory()
 
-        func = ray.remote(func)
+            if not ray.is_initialized():
+                ray.init(_system_config={
+                    "object_spilling_config": json.dumps(
+                        {"type": "filesystem", "params": {"directory_path":
+                         tmp_dir.name}},
+                    )
+                },)
+
+        func = ray.remote(func, **kwargs)
         results = ray.get([func.remote(ii, *func_args, **func_kwargs)
                           for ii in in_list])
 
-        clean_spill = kwargs.get('clean_spill', False)
         if clean_spill:
-            for filename in os.listdir("/tmp/spill"):
-                file_path = os.path.join("/tmp/spill", filename)
-                try:
-                    if os.path.isfile(file_path) or os.path.islink(file_path):
-                        os.unlink(file_path)
-                    elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)
-                except Exception as e:
-                    print('Failed to delete %s. Reason: %s' % (file_path, e))
+            shutil.rmtree(tmp_dir.name)
 
     elif engine == "serial":
         results = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dynamic = ['version']
 dependencies = [
-    "numpy>=1.22.4, <2.0",
+    "numpy>=1.22.4",
     "scipy>=1.8",
     "nibabel>=3.0.0",
     "h5py>=3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dynamic = ['version']
 dependencies = [
-    "numpy>=1.22.4",
+    "numpy>=1.22.4, <2.0",
     "scipy>=1.8",
     "nibabel>=3.0.0",
     "h5py>=3.1.0",
@@ -100,7 +100,7 @@ dev = [
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',
-    'numpy>=1.22',
+    'numpy>=1.22, <2.0',
     # Developer UI
     'spin>=0.5',
     'build',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',
-    'numpy>=1.22, <2.0',
+    'numpy~=1.22',
     # Developer UI
     'spin>=0.5',
     'build',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',
-    'numpy~=1.22',
+    'numpy<=2.0.0',
     # Developer UI
     'spin>=0.5',
     'build',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',
-    'numpy<=2.0.0',
+    'numpy>=1.22.4',
     # Developer UI
     'spin>=0.5',
     'build',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     # Also update [build-system] -> requires
     'meson-python>=0.13',
     'wheel',
-    'setuptools==69.5.1',
+    'setuptools~=69.5',
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     # Also update [build-system] -> requires
     'meson-python>=0.13',
     'wheel',
-    'setuptools>=67',
+    'setuptools==69.5.1',
     'packaging>=21',
     'ninja',
     'Cython>=0.29.35',

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -7,7 +7,7 @@ set -ex
 
 echo "Display Python version"
 python -c "import sys; print(sys.version)"
-python -m pip install -U pip setuptools==69.5.1 wheel
+python -m pip install -U pip 'setuptools~=69.5' wheel
 
 
 echo "Install Dependencies"

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -7,7 +7,7 @@ set -ex
 
 echo "Display Python version"
 python -c "import sys; print(sys.version)"
-python -m pip install -U pip setuptools>=30.3.0 wheel
+python -m pip install -U pip setuptools==69.5.1 wheel
 
 
 echo "Install Dependencies"


### PR DESCRIPTION
I've started playing around with the idea that the multi_voxel_fit decorator could use `paramap` instead of iterating over voxels. If we can make this work generally that would be pretty cool. So far, I've only tested this with the fwdti model, and in that case, the change to the additional changes to the code are rather minimal, which gives me hope that we might be able to use this wherever we use this decorator, so in csd, dsi, forecast, fwdti, gqi, ivim, mapmri, mcsd, qtdmri, and shore (!).