### PR TITLE
Temporary skip Cython 0.29.29 

### DIFF
--- a/.github/workflows/test_compat.yml
+++ b/.github/workflows/test_compat.yml
@@ -12,13 +12,13 @@ jobs:
     with:
       runs-on: '["ubuntu-latest", ]'
       python-version: '["3.7", ]'
-      depends: cython==0.29 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0 tqdm
+      depends: cython==0.29.24 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0 tqdm
   minimal-py38:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", ]'
       python-version: '["3.8", ]'
-      depends: cython==0.29 numpy==1.17.5 scipy==1.3.2 nibabel==3.0.0 h5py==3.0.0 tqdm
+      depends: cython==0.29.24 numpy==1.17.5 scipy==1.3.2 nibabel==3.0.0 h5py==3.0.0 tqdm
   # install-type:
   #   uses: skoudoro/dipy/.github/workflows/test_template.yml@gh-actions
   #   with:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -34,7 +34,7 @@ on:
         description: ""
         type: string
         required: false
-        default: cython numpy matplotlib h5py nibabel cvxpy tqdm
+        default: cython!=0.29.29 numpy matplotlib h5py nibabel cvxpy tqdm
       extra-depends:
         description: ""
         type: string

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -74,7 +74,7 @@ MIT licenses.
 
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
-CYTHON_MIN_VERSION = '0.29.24, !=0.29.29'
+CYTHON_MIN_VERSION = '0.29.24'
 NUMPY_MIN_VERSION = '1.14.5'
 SCIPY_MIN_VERSION = '1.1'
 NIBABEL_MIN_VERSION = '3.0.0'

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -74,7 +74,7 @@ MIT licenses.
 
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
-CYTHON_MIN_VERSION = '0.29.24'
+CYTHON_MIN_VERSION = '0.29.24, !=0.29.29'
 NUMPY_MIN_VERSION = '1.14.5'
 SCIPY_MIN_VERSION = '1.1'
 NIBABEL_MIN_VERSION = '3.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Check against .travis.yml file and dipy/info.py
-cython>=0.29.24
+cython>=0.29.24, !=0.29.29
 numpy>=1.14.5
 scipy>=1.1
 nibabel>=3.0.0


### PR DESCRIPTION
We currently have an issue with cython 0.29.29 described in the issue https://github.com/dipy/dipy/issues/2594.

To avoid blocking some PRs, this PR skips this Cython version (0.29.29) until we solve our issue. 