### PR TITLE
Pin Ray

### DIFF
--- a/.github/workflows/test_parallel.yml
+++ b/.github/workflows/test_parallel.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: dask joblib ray==1.11
+      extra-depends: dask joblib ray protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211

--- a/.github/workflows/test_parallel.yml
+++ b/.github/workflows/test_parallel.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: dask joblib ray
+      extra-depends: dask joblib ray==1.11


### PR DESCRIPTION
Quick PR to pin ray to version 1.11 in order to avoid CI's failure (Version 1.12 fails to be imported for now).