### PR TITLE
STYLE: Fix miscellaneous Python warnings

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -473,18 +473,18 @@ cdef inline cnp.npy_intp _bin_index(double normalized, int nbins,
 
     Returns
     -------
-    bin : int
+    bin_id : int
         index of the bin in which the normalized intensity 'normalized' lies
     """
     cdef:
-        cnp.npy_intp bin
+        cnp.npy_intp bin_id
 
-    bin = <cnp.npy_intp>normalized
-    if bin < padding:
+    bin_id = <cnp.npy_intp>normalized
+    if bin_id < padding:
         return padding
-    if bin > nbins - 1 - padding:
+    if bin_id > nbins - 1 - padding:
         return nbins - 1 - padding
-    return bin
+    return bin_id
 
 
 def cubic_spline(double[:] x):
@@ -619,10 +619,10 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp i, j, r, c
         double rn, cn
-        double val, spline_arg, sum
+        double val, spline_arg, total_sum
 
     joint[...] = 0
-    sum = 0
+    total_sum = 0
     valid_points = 0
     with nogil:
         smarginal[:] = 0
@@ -643,9 +643,9 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
                 for offset in range(-2, 3):
                     val = _cubic_spline(spline_arg)
                     joint[r, c + offset] += val
-                    sum += val
+                    total_sum += val
                     spline_arg += 1.0
-        if sum > 0:
+        if total_sum > 0:
             for i in range(nbins):
                 for j in range(nbins):
                     joint[i, j] /= valid_points
@@ -708,10 +708,10 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp k, i, j, r, c
         double rn, cn
-        double val, spline_arg, sum
+        double val, spline_arg, total_sum
 
     joint[...] = 0
-    sum = 0
+    total_sum = 0
     with nogil:
         valid_points = 0
         smarginal[:] = 0
@@ -733,13 +733,13 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
                     for offset in range(-2, 3):
                         val = _cubic_spline(spline_arg)
                         joint[r, c + offset] += val
-                        sum += val
+                        total_sum += val
                         spline_arg += 1.0
 
-        if sum > 0:
+        if total_sum > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= sum
+                    joint[i, j] /= total_sum
 
             for i in range(nbins):
                 smarginal[i] /= valid_points
@@ -789,10 +789,10 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp i, r, c
         double rn, cn
-        double val, spline_arg, sum
+        double val, spline_arg, total_sum
 
     joint[...] = 0
-    sum = 0
+    total_sum = 0
 
     with nogil:
         valid_points = 0
@@ -809,13 +809,13 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
             for offset in range(-2, 3):
                 val = _cubic_spline(spline_arg)
                 joint[r, c + offset] += val
-                sum += val
+                total_sum += val
                 spline_arg += 1.0
 
-        if sum > 0:
+        if total_sum > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= sum
+                    joint[i, j] /= total_sum
 
             for i in range(nbins):
                 smarginal[i] /= valid_points

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -428,9 +428,9 @@ def test_compute_masked_class_stats_2d():
         [values[labels == i].var() for i in range(2, 10)]
 
     mask = np.ones(shape, dtype=np.int32)
-    means, vars = em.compute_masked_class_stats_2d(mask, values, 10, labels)
+    means, std_dev = em.compute_masked_class_stats_2d(mask, values, 10, labels)
     assert_array_almost_equal(means, expected_means, decimal=4)
-    assert_array_almost_equal(vars, expected_vars, decimal=4)
+    assert_array_almost_equal(std_dev, expected_vars, decimal=4)
 
 
 def test_compute_masked_class_stats_3d():
@@ -456,6 +456,6 @@ def test_compute_masked_class_stats_3d():
         [values[labels == i].var() for i in range(2, 10)]
 
     mask = np.ones(shape, dtype=np.int32)
-    means, vars = em.compute_masked_class_stats_3d(mask, values, 10, labels)
+    means, std_dev = em.compute_masked_class_stats_3d(mask, values, 10, labels)
     assert_array_almost_equal(means, expected_means, decimal=4)
-    assert_array_almost_equal(vars, expected_vars, decimal=4)
+    assert_array_almost_equal(std_dev, expected_vars, decimal=4)

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -95,8 +95,8 @@ def test_diffeomorphic_map_2d():
     # Verify that the transform method accepts different image types (note that
     # the actual image contained integer values, we don't want to test
     # rounding)
-    for type in [floating, np.float64, np.int64, np.int32]:
-        moving_image = moving_image.astype(type)
+    for _type in [floating, np.float64, np.int64, np.int32]:
+        moving_image = moving_image.astype(_type)
 
         # warp using linear interpolation
         warped = diff_map.transform(moving_image, 'linear')
@@ -123,8 +123,8 @@ def test_diffeomorphic_map_2d():
                                        codomain_shape, codomain_grid2world,
                                        domain_shape, domain_grid2world, None)
     diff_map.backward = disp
-    for type in [floating, np.float64, np.int64, np.int32]:
-        moving_image = moving_image.astype(type)
+    for _type in [floating, np.float64, np.int64, np.int32]:
+        moving_image = moving_image.astype(_type)
 
         # warp using linear interpolation
         warped = diff_map.transform_inverse(moving_image, 'linear')
@@ -486,8 +486,9 @@ def test_ssd_2d_gauss_newton():
     optimizer.ITER_END_CALLED = 0
 
     optimizer.verbosity = VerbosityLevels.DEBUG
-    id = np.eye(3)
-    mapping = optimizer.optimize(static, moving, id, id, id)
+    transformation = np.eye(3)
+    mapping = optimizer.optimize(
+        static, moving, transformation, transformation, transformation)
     m = optimizer.get_map()
     assert_equal(mapping, m)
 

--- a/dipy/align/tests/test_parzenhist.py
+++ b/dipy/align/tests/test_parzenhist.py
@@ -368,9 +368,9 @@ def test_joint_pdf_gradients_dense():
         spacing = np.ones(dim, dtype=np.float64)
         mgrad, inside = vf.gradient(moving.astype(np.float32), moving_g2w,
                                     spacing, shape, grid_to_space)
-        id = transform.get_identity_parameters()
+        params = transform.get_identity_parameters()
         parzen_hist.update_gradient_dense(
-            id, transform, static.astype(np.float64),
+            params, transform, static.astype(np.float64),
             moved.astype(np.float64), grid_to_space,
             mgrad, smask, mmask)
         actual = np.copy(parzen_hist.joint_grad)

--- a/dipy/core/benchmarks/bench_sphere.py
+++ b/dipy/core/benchmarks/bench_sphere.py
@@ -27,7 +27,7 @@ class Timer(object):
     def __enter__(self):
         self.__start = time.time()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exception_type, value, traceback):
         # Error handling here
         self.__finish = time.time()
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1047,10 +1047,10 @@ def params_to_btens(bval, bdelta, b_eta):
     if bval < 0:
         raise ValueError("`bval` must be >= 0")
 
-    if not (bdelta >= -0.5 and bdelta <= 1):
+    if not -0.5 <= bdelta <= 1:
         raise ValueError("`delta` must be >= -0.5 and <= 1")
 
-    if not (b_eta >= 0 and b_eta <= 1):
+    if not 0 <= b_eta <= 1:
         raise ValueError("`b_eta` must be >= 0 and <= 1")
 
     m1 = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 2]])

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1074,7 +1074,7 @@ def ornt_mapping(ornt1, ornt2):
     return mapping
 
 
-def reorient_vectors(input, current_ornt, new_ornt, axis=0):
+def reorient_vectors(bvecs, current_ornt, new_ornt, axis=0):
     """Change the orientation of gradients or other vectors.
 
     Moves vectors, storted along axis, from current_ornt to new_ornt. For
@@ -1093,36 +1093,36 @@ def reorient_vectors(input, current_ornt, new_ornt, axis=0):
     if isinstance(new_ornt, str):
         new_ornt = orientation_from_string(new_ornt)
 
-    n = input.shape[axis]
+    n = bvecs.shape[axis]
     if current_ornt.shape != (n, 2) or new_ornt.shape != (n, 2):
         raise ValueError("orientations do not match")
 
-    input = np.asarray(input)
+    bvecs = np.asarray(bvecs)
     mapping = ornt_mapping(current_ornt, new_ornt)
-    output = input.take(mapping[:, 0], axis)
+    output = bvecs.take(mapping[:, 0], axis)
     out_view = np.rollaxis(output, axis, output.ndim)
     out_view *= mapping[:, 1]
     return output
 
 
-def reorient_on_axis(input, current_ornt, new_ornt, axis=0):
+def reorient_on_axis(bvecs, current_ornt, new_ornt, axis=0):
     if isinstance(current_ornt, str):
         current_ornt = orientation_from_string(current_ornt)
     if isinstance(new_ornt, str):
         new_ornt = orientation_from_string(new_ornt)
 
-    n = input.shape[axis]
+    n = bvecs.shape[axis]
     if current_ornt.shape != (n, 2) or new_ornt.shape != (n, 2):
         raise ValueError("orientations do not match")
 
     mapping = ornt_mapping(current_ornt, new_ornt)
-    order = [slice(None)] * input.ndim
+    order = [slice(None)] * bvecs.ndim
     order[axis] = mapping[:, 0]
-    shape = [1] * input.ndim
+    shape = [1] * bvecs.ndim
     shape[axis] = -1
     sign = mapping[:, 1]
     sign.shape = shape
-    output = input[order]
+    output = bvecs[order]
     output *= sign
     return output
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1158,6 +1158,6 @@ def _check_ornt(ornt):
         print(len(uniq))
         return True
     uniq = np.unique(ornt[:, 1])
-    if tuple(uniq) not in set([(-1, 1), (-1,), (1,)]):
+    if tuple(uniq) not in {(-1, 1), (-1,), (1,)}:
         print(tuple(uniq))
         return True

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -59,8 +59,8 @@ from dipy.io.image import load_nifti
 from dipy.tracking.streamline import relist_streamlines
 
 
-def loads_compat(bytes):
-    return pickle.loads(bytes, encoding='latin1')
+def loads_compat(byte_data):
+    return pickle.loads(byte_data, encoding='latin1')
 
 
 DATA_DIR = pjoin(dirname(__file__), 'files')
@@ -318,13 +318,13 @@ def matlab_life_results():
     return matlab_rmse, matlab_weights
 
 
-def load_sdp_constraints(id, order=None):
+def load_sdp_constraints(model_name, order=None):
     """Import semidefinite programming constraint matrices for different models,
     generated as described for example in [1]_.
 
     Parameters
     ----------
-    id : string
+    model_name : string
         A string identifying the model that is to be constrained.
     order : unsigned int, optional
         A non-negative integer that represent the order or instance of the
@@ -348,7 +348,7 @@ def load_sdp_constraints(id, order=None):
 
     """
 
-    file = id + '_constraint'
+    file = model_name + '_constraint'
     if order is not None:
         file += '_' + str(order)
     file += '.npz'

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -119,34 +119,34 @@ def test_peak_directions():
     sphere = fit.model.sphere
 
     # Only one peak
-    dir, val, ind = peak_directions(odf, sphere, .5, 45)
+    direction, val, ind = peak_directions(odf, sphere, .5, 45)
     dir_e = sphere.vertices[[argmax]]
     assert_array_equal(ind, [argmax])
     assert_array_equal(val, odf[ind])
-    assert_array_equal(dir, dir_e)
+    assert_array_equal(direction, dir_e)
 
     odf[0] = mx * .9
     # Two peaks, relative_threshold
-    dir, val, ind = peak_directions(odf, sphere, 1., 0)
+    direction, val, ind = peak_directions(odf, sphere, 1., 0)
     dir_e = sphere.vertices[[argmax]]
-    assert_array_equal(dir, dir_e)
+    assert_array_equal(direction, dir_e)
     assert_array_equal(ind, [argmax])
     assert_array_equal(val, odf[ind])
-    dir, val, ind = peak_directions(odf, sphere, .8, 0)
+    direction, val, ind = peak_directions(odf, sphere, .8, 0)
     dir_e = sphere.vertices[[argmax, 0]]
-    assert_array_equal(dir, dir_e)
+    assert_array_equal(direction, dir_e)
     assert_array_equal(ind, [argmax, 0])
     assert_array_equal(val, odf[ind])
 
     # Two peaks, angle_sep
-    dir, val, ind = peak_directions(odf, sphere, 0., 90)
+    direction, val, ind = peak_directions(odf, sphere, 0., 90)
     dir_e = sphere.vertices[[argmax]]
-    assert_array_equal(dir, dir_e)
+    assert_array_equal(direction, dir_e)
     assert_array_equal(ind, [argmax])
     assert_array_equal(val, odf[ind])
-    dir, val, ind = peak_directions(odf, sphere, 0., 0)
+    direction, val, ind = peak_directions(odf, sphere, 0., 0)
     dir_e = sphere.vertices[[argmax, 0]]
-    assert_array_equal(dir, dir_e)
+    assert_array_equal(direction, dir_e)
     assert_array_equal(ind, [argmax, 0])
     assert_array_equal(val, odf[ind])
 

--- a/dipy/direction/tests/test_prob_direction_getter.py
+++ b/dipy/direction/tests/test_prob_direction_getter.py
@@ -30,7 +30,7 @@ def test_ProbabilisticDirectionGetter():
 
         # Sample point and direction
         point = np.zeros(3)
-        dir = unit_octahedron.vertices[0].copy()
+        direction = unit_octahedron.vertices[0].copy()
 
         # make a dg from a fit
         with warnings.catch_warnings():
@@ -40,14 +40,14 @@ def test_ProbabilisticDirectionGetter():
             dg = ProbabilisticDirectionGetter.from_shcoeff(
                 fit.shm_coeff, 90, unit_octahedron)
 
-        state = dg.get_direction(point, dir)
+        state = dg.get_direction(point, direction)
         npt.assert_equal(state, 1)
 
         # Make a dg from a pmf
         N = unit_octahedron.theta.shape[0]
         pmf = np.zeros((3, 3, 3, N))
         dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, unit_octahedron)
-        state = dg.get_direction(point, dir)
+        state = dg.get_direction(point, direction)
         npt.assert_equal(state, 1)
 
         # pmf shape must match sphere
@@ -82,7 +82,7 @@ def test_ProbabilisticDirectionGetter():
 def test_DeterministicMaximumDirectionGetter():
     # Test the DeterministicMaximumDirectionGetter
 
-    dir = unit_octahedron.vertices[-1].copy()
+    direction = unit_octahedron.vertices[-1].copy()
     point = np.zeros(3)
     N = unit_octahedron.theta.shape[0]
 
@@ -90,7 +90,7 @@ def test_DeterministicMaximumDirectionGetter():
     pmf = np.zeros((3, 3, 3, N))
     dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, 90,
                                                       unit_octahedron)
-    state = dg.get_direction(point, dir)
+    state = dg.get_direction(point, direction)
     npt.assert_equal(state, 1)
 
     # Test BF #1566 - bad condition in DeterministicMaximumDirectionGetter
@@ -98,5 +98,5 @@ def test_DeterministicMaximumDirectionGetter():
     pmf[0, 0, 0, 0] = 1
     dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, 0,
                                                       unit_octahedron)
-    state = dg.get_direction(point, dir)
+    state = dg.get_direction(point, direction)
     npt.assert_equal(state, 1)

--- a/dipy/io/bvectxt.py
+++ b/dipy/io/bvectxt.py
@@ -72,7 +72,7 @@ def ornt_mapping(ornt1, ornt2):
 @deprecate_with_version("dipy.io.bvectxt module is deprecated, "
                         "Please use dipy.core.gradients module instead",
                         since='1.4', until='1.5')
-def reorient_vectors(input, current_ornt, new_ornt, axis=0):
+def reorient_vectors(bvecs, current_ornt, new_ornt, axis=0):
     """Change the orientation of gradients or other vectors.
 
     Moves vectors, storted along axis, from current_ornt to new_ornt. For
@@ -86,15 +86,15 @@ def reorient_vectors(input, current_ornt, new_ornt, axis=0):
     I: Inferior
 
     """
-    return gradients.reorient_vectors(input=input, current_ornt=current_ornt,
+    return gradients.reorient_vectors(bvecs=bvecs, current_ornt=current_ornt,
                                       new_ornt=new_ornt, axis=axis)
 
 
 @deprecate_with_version("dipy.io.bvectxt module is deprecated, "
                         "Please use dipy.core.gradients module instead",
                         since='1.4', until='1.5')
-def reorient_on_axis(input, current_ornt, new_ornt, axis=0):
-    return gradients.reorient_on_axis(input=input, current_ornt=current_ornt,
+def reorient_on_axis(bvecs, current_ornt, new_ornt, axis=0):
+    return gradients.reorient_on_axis(bvecs=bvecs, current_ornt=current_ornt,
                                       new_ornt=new_ornt, axis=axis)
 
 

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -43,16 +43,16 @@ def nifti1_symmat(image_data, *args, **kwargs):
     return image
 
 
-def make5d(input):
+def make5d(data):
     """reshapes the input to have 5 dimensions, adds extra dimensions just
     before the last dimension
     """
-    input = np.asarray(input)
-    if input.ndim > 5:
+    data = np.asarray(data)
+    if data.ndim > 5:
         raise ValueError("input is already more than 5d")
-    shape = input.shape
+    shape = data.shape
     shape = shape[:-1] + (1,)*(5-len(shape)) + shape[-1:]
-    return input.reshape(shape)
+    return data.reshape(shape)
 
 
 def decfa(img_orig, scale=False):

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -150,7 +150,7 @@ class ForecastModel(OdfModel, Cache):
         self.bvals = np.round(gtab.bvals/100) * 100
         self.bvecs = gtab.bvecs
 
-        if sh_order >= 0 and not(bool(sh_order % 2)) and sh_order <= 12:
+        if 0 <= sh_order <= 12 and not bool(sh_order % 2):
             self.sh_order = sh_order
         else:
             msg = "sh_order must be a non-zero even positive number "

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -384,15 +384,15 @@ def sum_on_blocks_1d(cnp.ndarray[double, ndim=1] arr,
     """
     cdef:
         int m,i,j
-        double sum
+        double blocksum
 
     with nogil:
         j=0
         for m in range(outn):
-            sum=0
+            blocksum=0
             for i in range(j,j+blocks[m]):
-                sum+=arr[i]
-            out[m]=sum
+                blocksum+=arr[i]
+            out[m]=blocksum
             j+=blocks[m]
     return
 

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -664,7 +664,7 @@ def _kappa_odf(zeta, n, l):
 
 
 def l_shore(radial_order):
-    "Returns the angular regularisation matrix for SHORE basis"
+    """Returns the angular regularisation matrix for SHORE basis"""
     F = radial_order / 2
     n_c = int(np.round(1 / 6.0 * (F + 1) * (F + 2) * (4 * F + 3)))
     diagL = np.zeros(n_c)
@@ -679,7 +679,7 @@ def l_shore(radial_order):
 
 
 def n_shore(radial_order):
-    "Returns the angular regularisation matrix for SHORE basis"
+    """Returns the angular regularisation matrix for SHORE basis"""
     F = radial_order / 2
     n_c = int(np.round(1 / 6.0 * (F + 1) * (F + 2) * (4 * F + 3)))
     diagN = np.zeros(n_c)

--- a/dipy/reconst/tests/test_eudx_dg.py
+++ b/dipy/reconst/tests/test_eudx_dg.py
@@ -24,8 +24,8 @@ def test_EuDXDirectionGetter():
             odf[r] = 1
             return odf
 
-    def get_direction(dg, point, dir):
-        newdir = dir.copy()
+    def get_direction(dg, point, direction):
+        newdir = direction.copy()
         state = dg.get_direction(point, newdir)
         return state, np.array(newdir)
 

--- a/dipy/reconst/tests/test_qti.py
+++ b/dipy/reconst/tests/test_qti.py
@@ -383,7 +383,7 @@ def test_qti_fit():
             qtimodel = qti.QtiModel(gtab, fit_method)
             data = qtimodel.predict(params)
             npt.assert_raises(ValueError, qtimodel.fit, data,
-                              np.ones((2)))
+                              np.ones(2))
             npt.assert_raises(ValueError, qtimodel.fit, data,
                               np.ones(data.shape))
             for mask in [None, np.ones(data.shape[0:-1])]:
@@ -412,7 +412,7 @@ def test_qti_fit():
             qtimodel = qti.QtiModel(gtab, fit_method)
             data = qtimodel.predict(params)
             npt.assert_raises(ValueError, qtimodel.fit, data,
-                              np.ones((2)))
+                              np.ones(2))
             npt.assert_raises(ValueError, qtimodel.fit, data,
                               np.ones(data.shape))
             for mask in [None, np.ones(data.shape[0:-1])]:

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -22,9 +22,8 @@ from dipy.reconst.shm import descoteaux07_legacy_msg
 
 
 def test_rumba():
-    '''
-    Test fODF results from ideal examples.
-    '''
+
+    # Test fODF results from ideal examples.
 
     sphere = default_sphere  # repulsion 724
     sphere2 = get_sphere('symmetric362')
@@ -91,9 +90,8 @@ def test_rumba():
 
 
 def test_predict():
-    '''
-    Test signal reconstruction on ideal example
-    '''
+
+    # Test signal reconstruction on ideal example
 
     sphere = default_sphere
 
@@ -113,9 +111,9 @@ def test_predict():
 
 
 def test_recursive_rumba():
-    '''
-    Test with recursive data-driven response
-    '''
+
+    # Test with recursive data-driven response
+
     sphere = default_sphere  # repulsion 724
 
     btable = np.loadtxt(get_fnames('dsi515btable'))
@@ -147,9 +145,9 @@ def test_recursive_rumba():
 
 
 def test_multishell_rumba():
-    '''
-    Test with multi-shell response
-    '''
+
+    # Test with multi-shell response
+
     sphere = default_sphere  # repulsion 724
 
     btable = np.loadtxt(get_fnames('dsi515btable'))
@@ -173,9 +171,9 @@ def test_multishell_rumba():
 
 
 def test_mvoxel_rumba():
-    '''
-    Verify form of results in multi-voxel situation.
-    '''
+
+    # Verify form of results in multi-voxel situation.
+
     data, gtab = dsi_voxels()  # multi-voxel data
     sphere = default_sphere  # repulsion 724
 
@@ -227,9 +225,8 @@ def test_mvoxel_rumba():
 
 
 def test_global_fit():
-    '''
-    Test fODF results on ideal examples in global fitting paradigm.
-    '''
+
+    # Test fODF results on ideal examples in global fitting paradigm.
 
     sphere = default_sphere  # repulsion 724
 
@@ -300,9 +297,9 @@ def test_global_fit():
 
 
 def test_mvoxel_global_fit():
-    '''
-    Verify form of results in global fitting paradigm.
-    '''
+
+    # Verify form of results in global fitting paradigm.
+
     data, gtab = dsi_voxels()  # multi-voxel data
     sphere = default_sphere  # repulsion 724
 
@@ -347,9 +344,8 @@ def test_mvoxel_global_fit():
 
 
 def test_generate_kernel():
-    '''
-    Test form and content of kernel generation result.
-    '''
+
+    # Test form and content of kernel generation result.
 
     # load repulsion 724 sphere
     sphere = default_sphere

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -557,10 +557,10 @@ def test_SphHarmFit():
     fit = SphHarmFit(None, coef, mask)
     item = fit[0, 0, 0]
     assert_equal(item.shape, ())
-    slice = fit[0]
-    assert_equal(slice.shape, (4, 5))
-    slice = fit[:, :, 0]
-    assert_equal(slice.shape, (3, 4))
+    data = fit[0]
+    assert_equal(data.shape, (4, 5))
+    data = fit[:, :, 0]
+    assert_equal(data.shape, (3, 4))
 
 
 class TestOpdtModel(TestQballModel):

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -14,12 +14,12 @@ except Exception:
 from scipy.ndimage import binary_dilation, generate_binary_structure
 
 
-def multi_median(input, median_radius, numpass):
+def multi_median(data, median_radius, numpass):
     """ Applies median filter multiple times on input data.
 
     Parameters
     ----------
-    input : ndarray
+    data : ndarray
         The input volume to apply filter on.
     median_radius : int
         Radius (in voxels) of the applied median filter
@@ -28,22 +28,22 @@ def multi_median(input, median_radius, numpass):
 
     Returns
     -------
-    input : ndarray
+    data : ndarray
         Filtered input volume.
     """
     # Array representing the size of the median window in each dimension.
-    medarr = np.ones_like(input.shape) * ((median_radius * 2) + 1)
+    medarr = np.ones_like(data.shape) * ((median_radius * 2) + 1)
 
     if numpass > 1:
         # ensure the input array is not modified
-        input = input.copy()
+        data = data.copy()
 
     # Multi pass
-    output = np.empty_like(input)
+    output = np.empty_like(data)
     for i in range(0, numpass):
-        median_filter(input, medarr, output=output)
-        input, output = output, input
-    return input
+        median_filter(data, medarr, output=output)
+        data, output = output, data
+    return data
 
 
 def applymask(vol, mask):

--- a/dipy/segment/tests/test_adjustment.py
+++ b/dipy/segment/tests/test_adjustment.py
@@ -10,11 +10,11 @@ def test_adjustment():
 
     for y in range(128):
         for x in range(128):
-            if y > 10 and y < 115 and x > 10 and x < 115:
+            if 10 < y < 115 and 10 < x < 115:
                 imga[x, y] = 100
-            if y > 39 and y < 88 and x > 39 and x < 88:
+            if 39 < y < 88 and 39 < x < 88:
                 imga[x, y] = 150
-            if y > 59 and y < 69 and x > 59 and x < 69:
+            if 59 < y < 69 and 59 < x < 69:
                 imga[x, y] = 255
 
     high_1 = upper_bound_by_rate(imga)

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -10,12 +10,12 @@ from numpy.testing import (assert_array_equal, assert_raises,
                            assert_almost_equal, assert_equal)
 
 
-def norm(x, ord=None, axis=None):
+def norm(x, order=None, axis=None):
     if axis is not None:
         return np.apply_along_axis(np.linalg.norm, axis,
-                                   x.astype(np.float64), ord)
+                                   x.astype(np.float64), order)
 
-    return np.linalg.norm(x.astype(np.float64), ord=ord)
+    return np.linalg.norm(x.astype(np.float64), ord=order)
 
 
 dtype = "float32"

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -18,7 +18,8 @@ pd, have_pd, _ = optional_package("pandas")
 _, have_tables, _ = optional_package("tables")
 
 
-def peak_values(bundle, peaks, dt, pname, bname, subject, group_id, ind, dir):
+def peak_values(
+        bundle, peaks, dt, pname, bname, subject, group_id, ind, dir_name):
     """ Peak_values function finds the generalized fractional anisotropy (gfa)
         and quantitative anisotropy (qa) values from peaks object (eg: csa) for
         every point on a streamline used while tracking and saves it in hd5
@@ -42,22 +43,22 @@ def peak_values(bundle, peaks, dt, pname, bname, subject, group_id, ind, dir):
         which group subject belongs to 1 patient and 0 for control
     ind : integer list
         ind tells which disk number a point belong.
-    dir : string
+    dir_name : string
         path of output directory
 
     """
 
     gfa = peaks.gfa
     anatomical_measures(bundle, gfa, dt, pname+'_gfa', bname, subject, group_id,
-                        ind, dir)
+                        ind, dir_name)
 
     qa = peaks.qa[...,0]
     anatomical_measures(bundle, qa, dt, pname+'_qa', bname, subject, group_id,
-                        ind, dir)
+                        ind, dir_name)
 
 
 def anatomical_measures(bundle, metric, dt, pname, bname, subject, group_id,
-                        ind, dir):
+                        ind, dir_name):
     """ Calculates dti measure (eg: FA, MD) per point on streamlines and
         save it in hd5 file.
 
@@ -79,7 +80,7 @@ def anatomical_measures(bundle, metric, dt, pname, bname, subject, group_id,
         which group subject belongs to 1 for patient and 0 control
     ind : integer list
         ind tells which disk number a point belong.
-    dir : string
+    dir_name : string
         path of output directory
 
     """
@@ -104,7 +105,7 @@ def anatomical_measures(bundle, metric, dt, pname, bname, subject, group_id,
 
     file_name = bname + "_" + pname
 
-    save_buan_profiles_hdf5(os.path.join(dir, file_name), dt)
+    save_buan_profiles_hdf5(os.path.join(dir_name, file_name), dt)
 
 
 def assignment_map(target_bundle, model_bundle, no_disks):

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -92,7 +92,7 @@ cdef class DirectionGetter:
     @cython.cdivision(True)
     cpdef tuple generate_streamline(self,
                                     double[::1] seed,
-                                    double[::1] dir,
+                                    double[::1] direction,
                                     double[::1] voxel_size,
                                     double step_size,
                                     StoppingCriterion stopping_criterion,
@@ -117,10 +117,10 @@ cdef class DirectionGetter:
 
        stream_status = TRACKPOINT
        for i in range(1, len_streamlines):
-           if self.get_direction_c(point, &dir[0]):
+           if self.get_direction_c(point, &direction[0]):
                break
            for j in range(3):
-               voxdir[j] = dir[j] / voxel_size[j]
+               voxdir[j] = direction[j] / voxel_size[j]
            step(point, voxdir, step_size)
            copy_point(point, &streamline[i, 0])
            stream_status = stopping_criterion.check_point_c(point)

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -174,7 +174,7 @@ def pft_tracker(
 cdef _pft_tracker(DirectionGetter dg,
                   AnatomicalStoppingCriterion sc,
                   double* seed,
-                  double* dir,
+                  double* direction,
                   double* voxel_size,
                   cnp.float_t[:, :] streamline,
                   cnp.float_t[:, :] directions,
@@ -197,23 +197,23 @@ cdef _pft_tracker(DirectionGetter dg,
 
     copy_point(seed, point)
     copy_point(seed, &streamline[0,0])
-    copy_point(dir, &directions[0, 0])
+    copy_point(direction, &directions[0, 0])
 
     stream_status[0] = TRACKPOINT
     pft_trial = 0
     i = 1
     strl_array_len = streamline.shape[0]
     while i < strl_array_len:
-        if dg.get_direction_c(point, dir):
+        if dg.get_direction_c(point, direction):
             # no valid diffusion direction to follow
             stream_status[0] = INVALIDPOINT
         else:
             for j in range(3):
                 # step forward
-                point[j] += dir[j] / voxel_size[j] * step_size
+                point[j] += direction[j] / voxel_size[j] * step_size
 
             copy_point(point, &streamline[i, 0])
-            copy_point(dir, &directions[i, 0])
+            copy_point(direction, &directions[i, 0])
             stream_status[0] = sc.check_point_c(point)
             i += 1
         if stream_status[0] == TRACKPOINT:
@@ -233,7 +233,7 @@ cdef _pft_tracker(DirectionGetter dg,
                 pft_trial += 1
                 # update the current point with the PFT results
                 copy_point(&streamline[i-1, 0], point)
-                copy_point(&directions[i-1, 0], dir)
+                copy_point(&directions[i-1, 0], direction)
 
                 if stream_status[0] != TRACKPOINT:
                     # The tracking stops. PFT returned a valid stopping point

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -442,8 +442,8 @@ cdef double c_norm_of_cross_product(double bx, double by, double bz,
     return sqrt(ax*ax + ay*ay + az*az)
 
 
-cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp prev,
-                           cnp.npy_intp next, cnp.npy_intp curr) nogil:
+cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp p1,
+                           cnp.npy_intp p2, cnp.npy_intp p0) nogil:
     """ Computes the shortest Euclidean distance between a point `curr` and
         the line passing through `prev` and `next`. """
 
@@ -452,17 +452,17 @@ cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp prev,
         cnp.npy_intp D = streamline.shape[1]
 
     # Compute cross product of next-prev and curr-next
-    norm1 = c_norm_of_cross_product(streamline[next, 0]-streamline[prev, 0],
-                                    streamline[next, 1]-streamline[prev, 1],
-                                    streamline[next, 2]-streamline[prev, 2],
-                                    streamline[curr, 0]-streamline[next, 0],
-                                    streamline[curr, 1]-streamline[next, 1],
-                                    streamline[curr, 2]-streamline[next, 2])
+    norm1 = c_norm_of_cross_product(streamline[p2, 0]-streamline[p1, 0],
+                                    streamline[p2, 1]-streamline[p1, 1],
+                                    streamline[p2, 2]-streamline[p1, 2],
+                                    streamline[p0, 0]-streamline[p2, 0],
+                                    streamline[p0, 1]-streamline[p2, 1],
+                                    streamline[p0, 2]-streamline[p2, 2])
 
     # Norm of next-prev
     norm2 = 0.0
     for d in range(D):
-        dn = streamline[next, d]-streamline[prev, d]
+        dn = streamline[p2, d]-streamline[p1, d]
         norm2 += dn*dn
     norm2 = sqrt(norm2)
 

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -623,12 +623,12 @@ def compress_streamlines_python(streamline, tol_error=0.01,
         return streamline.copy()
 
     # Euclidean distance
-    def segment_length(prev, next):
-        return np.sqrt(((prev-next)**2).sum())
+    def segment_length(p1, p2):
+        return np.sqrt(((p1-p2)**2).sum())
 
     # Projection of a 3D point on a 3D line, minimal distance
-    def dist_to_line(prev, next, curr):
-        return norm(np.cross(next-prev, curr-next)) / norm(next-prev)
+    def dist_to_line(p1, p2, p0):
+        return norm(np.cross(p2-p1, p0-p2)) / norm(p2-p1)
 
     nb_points = 0
     compressed_streamline = np.zeros_like(streamline)
@@ -636,27 +636,26 @@ def compress_streamlines_python(streamline, tol_error=0.01,
     # Copy first point since it is always kept.
     compressed_streamline[0, :] = streamline[0, :]
     nb_points += 1
-    prev = streamline[0]
+    p1 = streamline[0]
     prev_id = 0
 
-    for next_id, next in enumerate(streamline[2:], start=2):
+    for next_id, p2 in enumerate(streamline[2:], start=2):
         # Euclidean distance between last added point and current point.
-        if segment_length(prev, next) > max_segment_length:
+        if segment_length(p1, p2) > max_segment_length:
             compressed_streamline[nb_points, :] = streamline[next_id-1, :]
             nb_points += 1
-            prev = streamline[next_id-1]
+            p1 = streamline[next_id-1]
             prev_id = next_id-1
             continue
 
         # Check that each point is not offset by more than `tol_error` mm.
-        for o, curr in enumerate(streamline[prev_id+1:next_id],
-                                 start=prev_id+1):
-            dist = dist_to_line(prev, next, curr)
+        for o, p0 in enumerate(streamline[prev_id+1:next_id], start=prev_id+1):
+            dist = dist_to_line(p1, p2, p0)
 
             if np.isnan(dist) or dist > tol_error:
                 compressed_streamline[nb_points, :] = streamline[next_id-1, :]
                 nb_points += 1
-                prev = streamline[next_id-1]
+                p1 = streamline[next_id-1]
                 prev_id = next_id-1
                 break
 

--- a/dipy/utils/deprecator.py
+++ b/dipy/utils/deprecator.py
@@ -296,8 +296,8 @@ def deprecated_params(old_name, new_name=None, since='', until='',
         if not isinstance(new_name, (list, tuple)):
             new_name = [new_name] * len(old_name)
 
-        if len(set([len(old_name), len(new_name), len(since),
-                    len(until), len(arg_in_kwargs)])) != 1:
+        if len({len(old_name), len(new_name), len(since), len(until),
+                len(arg_in_kwargs)}) != 1:
             raise ValueError("All parameters should have the same length")
     else:
         # To allow a uniform approach later on, wrap all arguments in lists.

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -23,10 +23,10 @@ cdef void cumsum(
         int N) nogil:
     cdef:
         int i = 0
-        np.float_t sum = 0
+        np.float_t csum = 0
     for i in range(N):
-        sum += arr_in[i]
-        arr_out[i] = sum
+        csum += arr_in[i]
+        arr_out[i] = csum
 
 
 cdef void copy_point(

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -344,7 +344,7 @@ def slicer_panel(scene, iren,
         istyle.force_render()
 
     def left_click_picker_callback(obj, ev):
-        ''' Get the value of the clicked voxel and show it in the panel.'''
+        """Get the value of the clicked voxel and show it in the panel."""
 
         event_pos = iren.GetEventPosition()
 

--- a/dipy/viz/plotting.py
+++ b/dipy/viz/plotting.py
@@ -9,7 +9,7 @@ plt, have_plt, _ = optional_package("matplotlib.pyplot")
 
 
 def compare_maps(fits, maps, transpose=None, fit_labels=None, map_labels=None,
-                 fit_kwargs={}, map_kwargs={}, filename=None):
+                 fit_kwargs=None, map_kwargs=None, filename=None):
     """ Compare one or more scalar maps for different fits or models.
 
     Parameters:
@@ -44,6 +44,9 @@ def compare_maps(fits, maps, transpose=None, fit_labels=None, map_labels=None,
         Filename where the image will be saved.
         Default: None.
     """
+
+    fit_kwargs = fit_kwargs or {}
+    map_kwargs = map_kwargs or {}
 
     if not have_plt:
         raise ValueError('matplotlib package needed for visualization.')
@@ -109,10 +112,10 @@ def compare_maps(fits, maps, transpose=None, fit_labels=None, map_labels=None,
 
 
 def compare_qti_maps(gt, fit1, fit2, mask,
-                     maps=["fa", "ufa"],
-                     fitname=["QTI", "QTI+"],
-                     xlimits=[[0, 1], [0.4, 1.5]],
-                     disprange=[[0, 1], [0, 1]],
+                     maps=("fa", "ufa"),
+                     fitname=("QTI", "QTI+"),
+                     xlimits=([0, 1], [0.4, 1.5]),
+                     disprange=([0, 1], [0, 1]),
                      slice=13):
     """ Compare one or more qti derived maps obtained with
     different fitting routines.
@@ -128,13 +131,13 @@ def compare_qti_maps(gt, fit1, fit2, mask,
     mask : np.ndarray
         Boolean array indicating which voxels to retain for comparing
         the values
-    maps : list, optional
+    maps : array-like, optional
         QTI invariants to be compared
-    fitname : list, optional
+    fitname : array-like, optional
         Names of the used QTI fitting routines
-    xlimits : list, optional
+    xlimits : array-like, optional
         X-Axis limits for the histograms visualization
-    disprange : list, optional
+    disprange : array-like, optional
         Display range for maps
     slice : int, optional
         Axial brain slice to be visualized

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -186,7 +186,7 @@ def test_bundle_analysis_tractometry_flow():
 
         # assert_true(dft.bundle.unique() == "temp")
 
-        assert_true(set(dft.subject.unique()) == set(['10001', '20002']))
+        assert_true(set(dft.subject.unique()) == {'10001', '20002'})
 
 
 @pytest.mark.skipif(not have_pandas or not have_statsmodels or not have_tables

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -53,13 +53,13 @@ def test_missing_file():
 
     class TestMissingFile(Workflow):
 
-        def run(self, input, out_dir=''):
+        def run(self, filename, out_dir=''):
             """Dummy Workflow used to test if input file is absent.
 
             Parameters
             ----------
 
-            input : string, positional
+            filename : string
                 path of the first input file.
             out_dir: string, optional
                 folder path to save the results.

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -215,10 +215,10 @@ class HorizonFlow(Workflow):
                 colors = numpy_support.vtk_to_numpy(vtk_colors)
                 colors = (colors - np.min(colors))/np.ptp(colors)
 
-                for i in range(n):
+                for j in range(n):
 
-                    if pvalues[i] < buan_thr:
-                        colors[ind == i] = buan_highlight
+                    if pvalues[j] < buan_thr:
+                        colors[ind == j] = buan_highlight
 
                 bundle_colors.append(colors)
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ if exists('MANIFEST'):
 # force_setuptools can be set from the setup_egg.py script
 if 'force_setuptools' not in globals():
     # For some commands, always use setuptools
-    if len(set(('develop', 'bdist_egg', 'bdist_rpm', 'bdist', 'bdist_dumb',
-                'bdist_mpkg', 'bdist_wheel', 'install_egg_info', 'egg_info',
-                'easy_install')).intersection(sys.argv)) > 0:
+    if len({'develop', 'bdist_egg', 'bdist_rpm', 'bdist', 'bdist_dumb',
+            'bdist_mpkg', 'bdist_wheel', 'install_egg_info', 'egg_info',
+            'easy_install'}.intersection(sys.argv)) > 0:
         force_setuptools = True
     else:
         force_setuptools = False


### PR DESCRIPTION
- DOC: Use triple double-quoted strings in docstrings
- STYLE: Avoid array-like mutable default argument values
- STYLE: Avoid re-declaring variables in nested for loops
- STYLE: Replace function call with set literal
- STYLE: Simplify chained comparisons
- STYLE: Avoid shadowing built-in names