### PR TITLE
[FIX ] Handle save VTP

### DIFF
--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -67,7 +67,8 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
         nib.streamlines.save(fileobj, filename)
 
     elif extension in ['.vtk', '.vtp', '.fib']:
-        save_vtk_streamlines(sft.streamlines, filename, binary=True)
+        binary = extension in ['.vtk', '.fib']
+        save_vtk_streamlines(sft.streamlines, filename, binary=binary)
     elif extension in ['.dpy']:
         dpy_obj = Dpy(filename, mode='w')
         dpy_obj.write_tracks(sft.streamlines)

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -193,6 +193,11 @@ def test_io_vtk():
     io_tractogram('vtk')
 
 
+@pytest.mark.skipif(not have_fury, reason="Requires FURY")
+def test_io_vtp():
+    io_tractogram('vtp')
+
+
 def test_io_dpy():
     io_tractogram('dpy')
 


### PR DESCRIPTION
This PR fixes #2572. It allows users to save streamlines as VTP