### PR TITLE
[DOC] Remove search index

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -15,10 +15,11 @@ Contents:
    coding_style_guideline
    python3
 
-Indices and tables
-==================
+..
+   Indices and tables
+   ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   * :ref:`genindex`
+   * :ref:`modindex`
+   * :ref:`search`
 

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -23,10 +23,11 @@ Contents:
    reference_cmd/index
    api_changes
 
-Indices and tables
-==================
+..
+   Indices and tables
+   ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   * :ref:`genindex`
+   * :ref:`modindex`
+   * :ref:`search`
 


### PR DESCRIPTION
this PR fixes #2564. For now, we disable the search index on our documentation since this functionality is not working with our Django framework. This is something we will have to bring it back when we decide to switch back to a classic static website.