### PR TITLE
[FIX] Allow patch size parameter to be an int on denoise Workflow

### DIFF
--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -218,7 +218,7 @@ class LPCAFlow(Workflow):
 
         """
         io_it = self.get_io_iterator()
-        if len(patch_radius) == 1:
+        if isinstance(patch_radius, list) and len(patch_radius) == 1:
             patch_radius = int(patch_radius[0])
         for dwi, bval, bvec, odenoised in io_it:
             logging.info('Denoising %s', dwi)
@@ -290,7 +290,7 @@ class MPPCAFlow(Workflow):
 
         """
         io_it = self.get_io_iterator()
-        if len(patch_radius) == 1:
+        if isinstance(patch_radius, list) and len(patch_radius) == 1:
             patch_radius = int(patch_radius[0])
 
         for dwi, odenoised, osigma in io_it:

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -218,6 +218,8 @@ class LPCAFlow(Workflow):
 
         """
         io_it = self.get_io_iterator()
+        if len(patch_radius) == 1:
+            patch_radius = int(patch_radius[0])
         for dwi, bval, bvec, odenoised in io_it:
             logging.info('Denoising %s', dwi)
             data, affine, image = load_nifti(dwi, return_img=True)
@@ -288,6 +290,9 @@ class MPPCAFlow(Workflow):
 
         """
         io_it = self.get_io_iterator()
+        if len(patch_radius) == 1:
+            patch_radius = int(patch_radius[0])
+
         for dwi, odenoised, osigma in io_it:
             logging.info('Denoising %s', dwi)
             data, affine, image = load_nifti(dwi, return_img=True)

--- a/doc/interfaces/denoise_flow.rst
+++ b/doc/interfaces/denoise_flow.rst
@@ -96,7 +96,7 @@ will be specifying the patch radius value and the output directory.
 The MMPPCA denoising method is run using the ``dipy_denoise_mppca`` command,
 e.g.::
 
-    dipy_denoise_mppca data/sherbrooke_3shell/HRADI193.nii.gz --patch_radius 10 --out_dir "denoise_mppca_output"
+    dipy_denoise_mppca data/sherbrooke_3shell/HARDI193.nii.gz --patch_radius 10 --out_dir "denoise_mppca_output"
 
 This command will denoise the diffusion image and save it to the specified
 output directory.

--- a/doc/interfaces/denoise_flow.rst
+++ b/doc/interfaces/denoise_flow.rst
@@ -93,7 +93,7 @@ In order to run the MPPCA denoising method, we need to specify the location of
 the diffusion data file, followed by the optional arguments. In this case, we
 will be specifying the patch radius value and the output directory.
 
-The MMPPCA denoising method is run using the ``dipy_denoise_mppca`` command,
+The MPPCA denoising method is run using the ``dipy_denoise_mppca`` command,
 e.g.::
 
     dipy_denoise_mppca data/sherbrooke_3shell/HARDI193.nii.gz --patch_radius 10 --out_dir "denoise_mppca_output"


### PR DESCRIPTION
This PR fixes #2559. It allows providing only one value when we call CLI DIPY denoise methods.  Before this PR, it was generating a `ValueError`. You could also provide 3 values.

It is interesting to see our documentation [here](https://dipy.org/documentation/1.4.1./interfaces/denoise_flow/#denoising-using-marcenko-pastur-pca) was not working as expected. 


