### PR TITLE
Fix small difference between pdfs dense 2d/3d

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -648,7 +648,7 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
         if total_sum > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= valid_points
+                    joint[i, j] /= total_sum
 
             for i in range(nbins):
                 smarginal[i] /= valid_points


### PR DESCRIPTION
in` _compute_pdfs_3d` it's used `total_sum` to normalize the joint, whereas in` _compute_pdfs_2d` it was used `valid_points`.