### PR TITLE
Improve doc (tensor values' order)

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1932,8 +1932,8 @@ _lt_cols = np.array([0, 0, 1, 0, 1, 2])
 
 def lower_triangular(tensor, b0=None):
     """
-    Returns the six lower triangular values of the tensor and a dummy variable
-    if b0 is not None
+    Returns the six lower triangular values of the tensor ordered as
+    (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz) and a dummy variable if b0 is not None.
 
     Parameters
     ----------

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -124,10 +124,10 @@ tenfit = tenmodel.fit(maskdata)
 
 """
 The fit method creates a ``TensorFit`` object which contains the fitting
-parameters and other attributes of the model. You can revover the 6 values 
-of the triangular matrix representing the tensor D. By default, in Dipy, values
-are ordered as (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz). The tensor_val variable defined
-below is a 4D data with last dimension of size 6.
+parameters and other attributes of the model. You can recover the 6 values
+of the triangular matrix representing the tensor D. By default, in DIPY, values
+are ordered as (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz). The ``tensor_vals`` variable
+defined below is a 4D data with last dimension of size 6.
 """
 
 tensor_vals = dti.lower_triangular(tenfit.quadratic_form)

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -124,7 +124,16 @@ tenfit = tenmodel.fit(maskdata)
 
 """
 The fit method creates a ``TensorFit`` object which contains the fitting
-parameters and other attributes of the model. For example we can generate
+parameters and other attributes of the model. You can revover the 6 values 
+of the triangular matrix representing the tensor D. By default, in Dipy, values
+are ordered as (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz). The tensor_val variable defined
+below is a 4D data with last dimension of size 6.
+"""
+
+tensor_vals = dti.lower_triangular(tenfit.quadratic_form)
+
+"""
+You can also recover other metrics from the model. For example we can generate
 fractional anisotropy (FA) from the eigen-values of the tensor. FA is used to
 characterize the degree to which the distribution of diffusion in a voxel is
 directional. That is, whether there is relatively unrestricted diffusion in one

--- a/doc/interfaces/reconstruction_flow.rst
+++ b/doc/interfaces/reconstruction_flow.rst
@@ -147,7 +147,7 @@ e.g.::
 
     dipy_fit_dti data/stanford_hardi/HARDI150.nii.gz data/stanford_hardi/HARDI150.bval data/stanford_hardi/HARDI150.bvec stanford_hardi_mask/brain_mask.nii.gz --save_metrics "md" "mode" "tensor" --out_dir "recons_dti_output" --out_tensor "dti_tensors.nii.gz"
 
-This command will save the DTI metrics to the specified output directory.
+This command will save the DTI metrics to the specified output directory. The tensors will be saved as a 4D data with last dimension representing (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz).
 
 --------------------------------
 Diffusion Kurtosis Imaging (DKI)


### PR DESCRIPTION
This should fix issue https://github.com/dipy/dipy/issues/2673

Adding the information on the order of the tensor values in a few places in both doc and docstrings.