### PR TITLE
TEST: Fix `Node.js` warnings linked to GitHub actions

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -75,10 +75,10 @@ jobs:
       TEST_WITH_XVFB: ${{ inputs.enable-viz-tests }}
       PRE_WHEELS: "https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ matrix.install-type != 'conda' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up Virtualenv


### PR DESCRIPTION
Fix `Node.js` warnings linked to GitHub actions: transition to `actions/checkout@v3` and `actions/setup-python@v3`.

Fixes:
```
pip / build (3.8, ubuntu-latest, pip)
Node.js 12 actions are deprecated.
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
actions/checkout@v2, actions/setup-python@v2
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/3665144550