### PR TITLE
[FIX] incompatible type in numpy array

### DIFF
--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -107,7 +107,7 @@ def test_optional_str():
         npt.assert_equal(args[k], v)
     # Test if **args really fits dummy_flow's arguments
     return_values = dummy_flow.run(**args)
-    npt.assert_array_equal(return_values, all_results + ['default'])
+    npt.assert_equal(return_values, all_results + ['default'])
 
     # Test optional and variable str argument exists and has a value
     sys.argv = [sys.argv[0]]
@@ -124,7 +124,7 @@ def test_optional_str():
         npt.assert_equal(args[k], v)
     # Test if **args really fits dummy_flow's arguments
     return_values = dummy_flow.run(**args)
-    npt.assert_array_equal(return_values, all_results + ['default'])
+    npt.assert_equal(return_values, all_results + ['default'])
 
     # Test optional str empty arguments
     sys.argv = [sys.argv[0]]


### PR DESCRIPTION
Since the last release of Numpy,  array with different type inside should be define as object. e.g ` np.array([1, "test"], dtype=object)`.