### PR TITLE
Fixdenoise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      python-version: '["3.8", "3.9"]'
-  pip-last:
-    uses: ./.github/workflows/test_template.yml
-    with:
-      # "windows-latest" Does not run on window + python 3.10 due to qdldl package compilation issue (no wheels)
-      # https://github.com/osqp/qdldl-python
-      runs-on: '["ubuntu-latest", "macos-latest", ]'
-      python-version: '["3.10"]'
+      python-version: '["3.8", "3.9", "3.10"]'

--- a/.github/workflows/test_pre.yml
+++ b/.github/workflows/test_pre.yml
@@ -11,5 +11,6 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", ]'
+      python-version: '["3.10", ]'
       use-pre: true
       extra-depends: scikit_learn scipy statsmodels pandas tables

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dipy/.idea/
 .pytest_cache/*
 tmp/
 venv
+build-install

--- a/.mailmap
+++ b/.mailmap
@@ -104,6 +104,7 @@ Kevin Sitek <sitek.kevin@gmail.com>
 Ross Lawrence <lawreros@gmail.com> Lawreros <lawreros@gmail.com>
 Ross Lawrence <lawreros@gmail.com>  Ross Lawrence <52179159+Lawreros@users.noreply.github.com>
 Derek Pisner <dpisner@utexas.edu> dPys <dpisner@utexas.edu>
+Derek Pisner <dpisner@utexas.edu> Derek Pisner <16432683+dPys@users.noreply.github.com>
 Pradeep Reddy Raamana <raamana@gmail.com> Pradeep Reddy Raamana <praamana@research.baycrest.org>
 Shreyas Fadnavis <shreyasfadnavis@gmail.com> Shreyas Sanjeev Fadnavis <shfadn@antelope.sice.indiana.edu>
 Shreyas Fadnavis <shreyasfadnavis@gmail.com> Shreyas Fadnavis <shfadn@iu.edu>
@@ -126,6 +127,7 @@ Basile Pinsard <basile.pinsard@gmail.com> basile <basile.pinsard@gmail.com>
 Siddharth Kapoor <16ec142siddharth@nitk.edu.in> sidkapoor97 <16ec142siddharth@nitk.edu.in>
 Areesha Tariq <areeshatariq02@gmail.com> areeshatariq <areeshatariq02@gmail.com>
 David Romero-Bascones <davidrb093g@gmail.com> dombas <davidrb093g@gmail.com>
+David Romero-Bascones <davidrb093g@gmail.com> drombas <davidrb093g@gmail.com>
 John Kruper <jk23@att.net> John K <jk23@att.net>
 Leon Weninger <leon.weninger@lfb.rwth-aachen.de> Leon Weninger <18707626+weningerleon@users.noreply.github.com>
 Leon Weninger <leon.weninger@lfb.rwth-aachen.de> weninger <leon.weninger@lfb.rwth-aachen.de>
@@ -134,3 +136,10 @@ Lucas Da Costa <lcscosta2761@gmail.com> lcscosta <lcscosta2761@gmail.com>
 Lucas Da Costa <lcscosta2761@gmail.com> Lucas da Costa <45444800+lcscosta@users.noreply.github.com>
 Francis Jerome <francis.jerome999@gmail.com> jerryfrancis-97 <francis.jerome999@gmail.com>
 Kenji Marshall <kenji.marshall99@gmail.com>  Kenji Marshall <47823200+kenjimarshall@users.noreply.github.com>
+Tom Dela Haije <tom@di.ku.dk> Tom <tom@di.ku.dk>
+Deneb Boito <deneb.boito@gmail.com> DenebBoito <deneb.boito@gmail.com>
+Deneb Boito <deneb.boito@gmail.com> DenebBoito <45635305+DenebBoito@users.noreply.github.com>
+Julio Villalon <neurobarranquilla@hotmail.com> Julio Villalon <villalonreina@users.noreply.github.com>
+Malinda Dilhara <malinda.dilhara@gmail.com> Malinda <malinda.dilhara@gmail.com>
+Emmanuelle Renauld <emmanuelle.renauld@usherbrooke.ca> EmmaRenauld <emmanuelle.renauld@usherbrooke.ca>
+Chantal Tax <chantaltax88@gmail.com> ChantalTax <chantaltax88@gmail.com>

--- a/AUTHOR
+++ b/AUTHOR
@@ -1,126 +1,137 @@
-Eleftherios Garyfallidis <garyfallidis@gmail.com>
-Ariel Rokem <arokem@gmail.com>
-Serge Koudoro <skab12@gmail.com>
-Matthew Brett <matthew.brett@gmail.com>
-Rafael Neto Henriques <rafaelnh21@gmail.com>
-Bago Amirbekian <mrbago@gmail.com>
-Omar Ocegueda <jomaroceguedag@gmail.com>
-Gabriel Girard <girard.gabriel@gmail.com>
-Samuel St-Jean <Samuel.St-Jean@usherbrooke.ca>
-Shreyas Fadnavis <shreyasfadnavis@gmail.com>
-Bramsh Qamar <bramshq@gmail.com>
-Marc-Alexandre Côté <marc.cote.19@gmail.com>
-Philippe Karan <philippe.karan@usherbrooke.ca>
-Francois Rheault <francois.m.rheault@usherbrooke>
-Rutger Fick <rutger.fick@inria.fr>
-Shahnawaz Ahmed <shahnawaz.ahmed95@gmail.com>
-Ian Nimmo-Smith <iannimmosmith@gmail.com>
-Mauro Zucchelli <mauro.zucchelli88@gmail.com>
-Jon Haitz Legarreta Gorroño <jon.haitz.legarreta@gmail.com>
-Matthieu Dumont <matthieu.dumont@usherbrooke.ca>
-Kesshi Jordan <kesshi.jordan@gmail.com>
-Stefan van der Walt <sjvdwalt@gmail.com>
-Ranveer Aggarwal <ranveeraggarwal@gmail.com>
-Maxime Descoteaux <m.descoteaux@usherbrooke.ca>
-Riddhish Bhalodia <riddhishb@gmail.com>
-Parichit Sharma <parichitsharma08@gmail.com>
-Karan <karan.jkps@gmail.com>
-Bishakh Ghosh <ghoshbishakh@gmail.com>
-Christopher Nguyen <christopher.t.nguyen@gmail.com>
-Ricci Woo <ricciwoo@gmail.com>
-Stephan Meesters <s.p.l.meesters@tue.nl>
-Eric Peterson <globshim@gmail.com>
-Jean-Christophe Houde <jean.christophe.houde@gmail.com>
-Manu Tej Sharma <a.manutej@gmail.com>
-Sourav Singh <souravsingh@users.noreply.github.com>
-Julio Villalon <neurobarranquilla@hotmail.com>
-Etienne St-Onge <stonge.etienne@gmail.com>
-Kumar Ashutosh <kumarashutosh.ee@gmail.com>
-David Reagan <dmreagan@iu.edu>
-Guillaume Theaud <guillaume.theaud@gmail.com>
-Shubham Shaswat <chandragupta4115@gmail.com>
-Aman Arya <aman.arya524@gmail.com>
-Dimitris Rozakis <dimrozakis@gmail.com>
-Fabio Nery <fabiornery@gmail.com>
-Charles Poirier <charlespoirier2112@gmail.com>
-kunal mehta <36035718+kunakl07@users.noreply.github.com>
-Gregory R. Lee <gregory.lee@cchmc.org>
-Areesha Tariq <areeshatariq02@gmail.com>
-Saber Sheybani <sheybani.saber@gmail.com>
-Nil Goyette <nil.goyette@imeka.ca>
-Gregory Lee <grlee77@gmail.com>
-ChantalTax <chantaltax88@gmail.com>
-David Romero-Bascones <davidrb093g@gmail.com>
-Rohan Prinja <rohan.prinja@gmail.com>
-Antonio Ossa <aaossa@uc.cl>
-Jaewon Chung <jaewonc78@gmail.com>
-Demian Wassermann <demian.wassermann@inria.fr>
-Tingyi Wanyan <tiwanyan@iu.edu>
-Shrishti Hore <40817931+ShrishtiHore@users.noreply.github.com>
-Michael Paquette <jotha885@gmail.com>
-Siddharth Kapoor <16ec142siddharth@nitk.edu.in>
-Jiri Borovec <jiri.borovec@fel.cvut.cz>
-Yaroslav Halchenko <debian@onerussian.com>
-Martijn Nagtegaal <m.a.nagtegaal@tudelft.nl>
-Conor Corbin <ccorbin@usc.edu>
-Leevi Kerkela <leevi.kerkela@protonmail.com>
-Enes Albay <albayenes@gmail.com>
-Kimberly Chan <kimberlylchan@gmail.com>
-ArjitJ <32598699+ArjitJ@users.noreply.github.com>
-Erik Ziegler <erik.ziegler@ulg.ac.be>
-Takis Panagopoulos <takhs91@gmail.com>
-Antoine Theberge <antoine.theberge@usherbrooke.ca>
-Scott Trinkle <tscott.trinkle@gmail.com>
-Nasim Anousheh <nasimanousheh@gmail.com>
-Ross Lawrence <lawreros@gmail.com>
-Derek Pisner <dpisner@utexas.edu>
-Kevin Sitek <sitek.kevin@gmail.com>
-David Qixiang Chen <qixiang.chen@gmail.com>
-Pradeep Reddy Raamana <raamana@gmail.com>
-Eric Larson <larson.eric.d@gmail.com>
-Emanuele Olivetti <olivetti@fbk.eu>
-Basile Pinsard <basile.pinsard@gmail.com>
-David Hunt <davhunt@indiana.edu>
-Alexandre Gauvin <gauvinalexandre@gmail.com>
-Adam Richie-Halford <richford@uw.edu>
-Sarath Chandra <sarathknv@gmail.com>
-Matthias Ekman <matthias.ekman@gmail.com>
-Julio Villalon <villalonreina@users.noreply.github.com>
-endolith <endolith@gmail.com>
-Clint Greene <clint@ece.ucsb.edu>
-Yash Sherry <yash14123@iiitd.ac.in>
-Andrew Lawrence <lawrenceajl@gmail.com>
-Felix Liu <felixkat@gmail.com>
-Tom Wright <tom@maladmin.com>
-Oscar Esteban <code@oscaresteban.es>
-Leon Weninger <18707626+weningerleon@users.noreply.github.com>
-Matt Cieslak <mattcieslak@gmail.com>
-svabhishek29 <svabhishek29@gmail.com>
-Emmanuel Caruyer <caruyer@gmail.com>
-Tashrif Billah <tashrifbillah@gmail.com>
-Gonzalo Sanguinetti <gsangui@gmail.com>
-John Kruper <jk23@att.net>
-Naveen Kumarmarri <naveenkumarmarri6014@gmail.com>
-Clément Zotti <clement.zotti@imeka.ca>
-Chandan Gangwar <chandan.gangwar0411@gmail.com>
-Bennet Fauber <bennet@umich.edu>
-Aryansh Omray <aryansh.omray@outlook.com>
-Sylvain Merlet <merlet.sylvain@gmail.com>
-Vatsala Swaroop <smarshy@users.noreply.github.com>
-Vibhatha Abeykoon <Vibhatha Abeykoon>
-Adam Rybinski <adam.rybinski@outlook.com>
-Qiyuan Tian <fdqiyuantian@gmail.com>
-Sven Dorkenwald <sven.dorkenwald@mpimf-heidelberg.mpg.de>
-Yijun Liu <yijunl@usc.edu>
-Derek Pisner <16432683+dPys@users.noreply.github.com>
-Maria Luisa Mandelli <mmandelli@sampras.radiology.ucsf.edu>
-Katrin Leinweber <9948149+katrinleinweber@users.noreply.github.com>
-Javier Guaje <jrguajeg@gmail.com>
-Jirka Borovec <jirka.borovec@seznam.cz>
-Jakob Wasserthal <j.wasserthal@dkfz.de>
-Himanshu Mishra <himanshu2014iit@gmail.com>
-Jon Mendoza <mrfox321@gmail.com>
-Sagun Pai <sagung.pai@gmail.com>
-Bennet Fauber <justbennet@users.noreply.github.com>
-Chris Filo Gorgolewski <krzysztof.gorgolewski@gmail.com>
-Daniel Enrico Cahall <danielenricocahall@gmail.com>
+Eleftherios Garyfallidis
+Ariel Rokem
+Serge Koudoro
+Matthew Brett
+Rafael Neto Henriques
+Bago Amirbekian
+Omar Ocegueda
+Gabriel Girard
+Samuel St-Jean
+Shreyas Fadnavis
+Bramsh Qamar
+Jon Haitz Legarreta Gorroño <jon.haitz
+Marc-Alexandre Côté
+Philippe Karan
+Francois Rheault
+Rutger Fick
+Shahnawaz Ahmed
+Ian Nimmo-Smith
+Mauro Zucchelli
+Matthieu Dumont
+Kesshi Jordan
+Stefan van der Walt
+Ranveer Aggarwal
+Maxime Descoteaux
+Kenji Marshall
+Riddhish Bhalodia
+Parichit Sharma
+Karan <karan
+Bishakh Ghosh
+Christopher Nguyen
+Ricci Woo
+Stephan Meesters
+Leevi Kerkela
+Eric Peterson
+David Romero-Bascones
+Julio Villalon
+Jean-Christophe Houde
+Tom Dela Haije
+Manu Tej Sharma
+Sourav Singh
+Nasim Anousheh
+Etienne St-Onge
+Kumar Ashutosh
+David Reagan
+Guillaume Theaud
+Shubham Shaswat
+Aman Arya
+Charles Poirier
+Deneb Boito <deneb
+Dimitris Rozakis
+Fabio Nery
+kunal mehta
+Gregory R. Lee
+Areesha Tariq
+Saber Sheybani
+Chantal Tax
+Gregory Lee
+Nil Goyette
+Javier Guaje
+Rohan Prinja
+Eric Larson
+Antonio Ossa
+Jaewon Chung
+Demian Wassermann
+Michael Paquette
+Shrishti Hore
+Tingyi Wanyan
+Jiri Borovec
+Siddharth Kapoor
+Leon Weninger
+Malinda Dilhara
+Yaroslav Halchenko
+Conor Corbin
+Dan Bullock
+Derek Pisner
+Martijn Nagtegaal
+ArjitJ
+Enes Albay
+Kimberly Chan
+Erik Ziegler
+Jacob Roberts
+Takis Panagopoulos
+Antoine Theberge
+Ross Lawrence
+Scott Trinkle
+David Qixiang Chen
+Kevin Sitek
+Pradeep Reddy Raamana
+Adam Richie-Halford
+Alexandre Gauvin
+Basile Pinsard
+David Hunt
+Emanuele Olivetti
+Sarath Chandra
+Clint Greene <clint
+Giulia Bertò <giulia.berto
+Lucas Da Costa
+Matthias Ekman <matthias
+Yash Sherry <yash14123
+endolith
+Andrew Lawrence
+Emmanuel Caruyer
+Felix Liu
+Matt Cieslak
+Oscar Esteban
+Tashrif Billah
+Tom Wright
+svabhishek29
+Adam Rybinski
+Aryansh Omray
+Bennet Fauber
+Chandan Gangwar
+Clément Zotti
+Emmanuelle Renauld
+Gonzalo Sanguinetti
+John Kruper
+Joshua Newton
+Naveen Kumarmarri
+Sam Coveney
+Sylvain Merlet
+Vatsala Swaroop
+Vibhatha Abeykoon
+Bennet Fauber
+Chris Filo Gorgolewski
+Daniel Enrico Cahall
+Francis Jerome
+Himanshu Mishra
+Jakob Wasserthal
+Javier Guaje
+Jirka Borovec
+Jon Mendoza
+Katrin Leinweber
+Maria Luisa Mandelli
+Qiyuan Tian
+Sagun Pai <sagung
+Sven Dorkenwald
+Yijun Liu

--- a/Changelog
+++ b/Changelog
@@ -24,6 +24,21 @@ Dipy
 
 The code found in Dipy was created by the people found in the AUTHOR file.
 
+* 1.6.0 (Monday, January 16, 2023)
+
+- NF: Unbiased groupwise linear bundle registration added.
+- NF: MAP+ constraints added.
+- Generalized PCA to less than 3 spatial dims.
+- Add positivity constraints to QTI.
+- Ability to apply Symmetric Diffeomorphic Registration to points/streamlines.
+- New Human Connectome Project (HCP) data fetcher added.
+- New Healthy Brain Network (HBN) data fetcher added.
+- Multiple Workflows updated (DTIFlow, LPCAFlow, MPPCA) and added (RUMBAFlow).
+- Ability to handle VTP files.
+- Large codebase cleaning.
+- Large documentation update.
+- Closed 75 issues and merged 41 pull requests.
+
 * 1.5.0 (Friday, March 11, 2022)
 
 - New reconstruction model added: Q-space Trajectory Imaging (QTI).

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Unless otherwise specified by LICENSE.txt files in individual
 directories, or within individual files or functions, all code is:
 
-Copyright (c) 2008-2022, dipy developers
+Copyright (c) 2008-2023, dipy developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ Current information can always be found from the DIPY website - http://dipy.org
 Mailing Lists
 =============
 
-Please see the developers' list at
-https://mail.python.org/mailman/listinfo/neuroimaging
+Please see the DIPY community list at
+https://mail.python.org/mailman3/lists/dipy.python.org/
 
 Please see the users' forum at
 https://github.com/dipy/dipy/discussions

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -53,7 +53,8 @@ from dipy.data.fetcher import (get_fnames,
                                read_qte_lte_pte,
                                read_DiB_70_lte_pte_ste,
                                read_DiB_217_lte_pte_ste,
-                               read_five_af_bundles)
+                               read_five_af_bundles,
+                               fetch_hbn)
 
 from ..utils.arrfuncs import as_native_array
 from dipy.io.image import load_nifti

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -1858,6 +1858,9 @@ def fetch_hbn(subjects, path=None):
         query = client.list_objects(
             Bucket="fcp-indi",
             Prefix=f"data/Projects/HBN/BIDS_curated/derivatives/qsiprep/sub-{subject}/{ses}/")  # noqa
+        query_content = query.get('Contents', None)
+        if query_content is None:
+            raise ValueError(f"Could not find derivatives data for subject {subject}")
         file_list = [kk["Key"] for kk in query["Contents"]]
         sub_dir = op.join(base_dir, f'sub-{subject}')
         ses_dir = op.join(sub_dir, ses)

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -3,7 +3,6 @@ import os.path as op
 import sys
 import os
 import numpy.testing as npt
-from nibabel.tmpdirs import TemporaryDirectory
 import dipy.data.fetcher as fetcher
 from dipy.data import SPHERE_FILES
 from threading import Thread
@@ -29,7 +28,7 @@ def test_check_md5():
 
 def test_make_fetcher():
     symmetric362 = SPHERE_FILES['symmetric362']
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         stored_md5 = fetcher._get_file_md5(symmetric362)
 
         # create local HTTP Server
@@ -73,7 +72,7 @@ def test_make_fetcher():
 
 def test_fetch_data():
     symmetric362 = SPHERE_FILES['symmetric362']
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         md5 = fetcher._get_file_md5(symmetric362)
         bad_md5 = '8' * len(md5)
 

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -1,5 +1,9 @@
+from packaging.version import Version
 from warnings import warn
+
 import numpy as np
+import scipy
+
 try:
     from scipy.linalg.lapack import dgesvd as svd
     svd_args = [1, 0]
@@ -202,6 +206,8 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
         var = np.zeros(arr.shape[:-1], dtype=calc_dtype)
         thetavar = np.zeros(arr.shape[:-1], dtype=calc_dtype)
 
+    SCIPY_LESS_1_5_0 = Version(scipy.__version__) < Version('1.5.0')
+    kw_eigh = {'turbo': True} if SCIPY_LESS_1_5_0 else {}  # {'driver': 'gvd'}
     # loop around and find the 3D patch for each direction at each pixel
     for k in range(patch_radius[2], arr.shape[2] - patch_radius[2]):
         for j in range(patch_radius[1], arr.shape[1] - patch_radius[1]):
@@ -238,7 +244,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
                     # PCA using an Eigenvalue decomposition
                     C = np.transpose(X).dot(X)
                     C = C / X.shape[0]
-                    [d, W] = eigh(C, turbo=True)
+                    [d, W] = eigh(C, **kw_eigh)
 
                 if sigma is None:
                     # Random matrix theory

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -296,8 +296,9 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
         return denoised_arr.astype(out_dtype)
 
 
-def localpca(arr, sigma, mask=None, patch_radius=2, pca_method='eig',
-             tau_factor=2.3, out_dtype=None, suppress_warning=False):
+def localpca(arr, sigma=None, mask=None, patch_radius=2, patch_radius_sigma=1,
+             pca_method='eig', tau_factor=2.3, return_sigma=False,
+             out_dtype=None, suppress_warning=False):
     r""" Performs local PCA denoising according to Manjon et al. [1]_.
 
     Parameters
@@ -305,8 +306,9 @@ def localpca(arr, sigma, mask=None, patch_radius=2, pca_method='eig',
     arr : 4D array
         Array of data to be denoised. The dimensions are (X, Y, Z, N), where N
         are the diffusion gradient directions.
-    sigma : float or 3D array
-        Standard deviation of the noise estimated from the data.
+    sigma : float or 3D array (optional)
+        Standard deviation of the noise estimated from the data. If not given,
+        calculate using method in [1]_.
     mask : 3D boolean array (optional)
         A mask with voxels that are true inside the brain and false outside of
         it. The function denoises within the true part and returns zeros
@@ -314,6 +316,9 @@ def localpca(arr, sigma, mask=None, patch_radius=2, pca_method='eig',
     patch_radius : int or 1D array (optional)
         The radius of the local patch to be taken around each voxel (in
         voxels). Default: 2 (denoise in blocks of 5x5x5 voxels).
+    patch_radius_sigma : int (optional)
+        The radius of the local patch to be taken around each voxel (in
+        voxels) for estimating sigma. Default: 1 (estimate in blocks of 3x3x3 voxels).
     pca_method : 'eig' or 'svd' (optional)
         Use either eigenvalue decomposition (eig) or singular value
         decomposition (svd) for principal component analysis. The default
@@ -332,6 +337,10 @@ def localpca(arr, sigma, mask=None, patch_radius=2, pca_method='eig',
         set to None, it will be automatically calculated using the
         Marcenko-Pastur distribution [2]_.
         Default: 2.3 (according to [1]_)
+    return_sigma : bool (optional)
+        If true, a noise standard deviation estimate based on the
+        Marcenko-Pastur distribution is returned [2]_.
+        Default: False.
     out_dtype : str or dtype (optional)
         The dtype for the output array. Default: output has the same dtype as
         the input.
@@ -356,9 +365,18 @@ def localpca(arr, sigma, mask=None, patch_radius=2, pca_method='eig',
            theory. Neuroimage 142:394-406.
            doi: 10.1016/j.neuroimage.2016.08.016
     """
+    # calculate sigma 
+    if sigma is None:
+        sigma = pca_noise_estimate(data.astype(dtype), gtab,
+                                   correct_bias=correct_bias,
+                                   patch_radius=patch_radius_sigma,
+                                   images_as_samples=True)
+    else:
+        warn("Canonical lpca algorithm does not require sigma to be provided", UserWarning)
+
     return genpca(arr, sigma=sigma, mask=mask, patch_radius=patch_radius,
                   pca_method=pca_method, tau_factor=tau_factor,
-                  return_sigma=False, out_dtype=out_dtype,
+                  return_sigma=return_sigma, out_dtype=out_dtype,
                   suppress_warning=suppress_warning)
 
 

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -44,14 +44,22 @@ def _pca_classifier(L, nvoxels):
            theory. Neuroimage 142:394-406.
            doi: 10.1016/j.neuroimage.2016.08.016
     """
+
+    # if num_samples - 1 (to correct for mean subtraction) is less than number
+    # of features, discard the zero eigenvalues
+    if L.size > nvoxels - 1:
+        L = L[-(nvoxels - 1):] 
+
     var = np.mean(L)
     c = L.size - 1
-    r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / nvoxels) * var
+    # NOTE: data is centered, at most (nvoxels - 1) non-zero eigenvalues
+    r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / (nvoxels - 1)) * var
     while r > 0:
         var = np.mean(L[:c])
         c = c - 1
-        r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / nvoxels) * var
+        r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / (nvoxels - 1)) * var
     ncomps = c + 1
+
     return var, ncomps
 
 
@@ -166,7 +174,8 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
     if num_samples == 1:
         raise ValueError("Cannot have only 1 sample,\
                           please increase patch_radius.")
-    if num_samples < arr.shape[-1] and not suppress_warning:
+    # NOTE: account for mean substraction by testing #samples - 1
+    if num_samples - 1 < arr.shape[-1] and not suppress_warning:
         tmp = np.sum(patch_size == 1)  # count spatial dimensions with size 1
         if tmp == 0:
             root = np.ceil(arr.shape[-1] ** (1./3))  # 3D
@@ -176,7 +185,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
             root = arr.shape[-1]  # 1D
         root = root + 1 if (root % 2) == 0 else root  # make odd
         spr = int((root - 1) / 2)  # suggested patch_radius
-        e_s = "Number of samples {1} < Dimensionality {0}. "\
+        e_s = "Number of samples {1} - 1 < Dimensionality {0}. "\
               .format(arr.shape[-1], num_samples)
         e_s += "This might have a performance impact. "
         e_s += "Increase patch_radius to {0} to avoid this warning, "\
@@ -197,7 +206,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
 
     dim = arr.shape[-1]
     if tau_factor is None:
-        tau_factor = 1 + np.sqrt(dim / num_samples)
+        tau_factor = 1 + np.sqrt(dim / (num_samples - 1)) # NOTE: account for mean subtraction
 
     theta = np.zeros(arr.shape, dtype=calc_dtype)
     thetax = np.zeros(arr.shape, dtype=calc_dtype)
@@ -224,7 +233,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
 
                 X = arr[ix1:ix2, jx1:jx2, kx1:kx2].reshape(
                                 num_samples, dim)
-                # compute the mean and normalize
+                # compute the mean
                 M = np.mean(X, axis=0)
                 # Upcast the dtype for precision in the SVD
                 X = X - M
@@ -248,7 +257,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
 
                 if sigma is None:
                     # Random matrix theory
-                    this_var, ncomps = _pca_classifier(d, num_samples)
+                    this_var, ncomps = _pca_classifier(d, num_samples)  # NOTE: ncomps not usable as index if num_samples < num_features, but is recalculated below anyway 
                 else:
                     # Predefined variance
                     this_var = var[i, j, k]
@@ -257,7 +266,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
                 tau = tau_factor ** 2 * this_var
 
                 # Update ncomps according to tau_factor
-                ncomps = np.sum(d < tau)
+                ncomps = np.sum(d < tau)  # NOTE: since we recalcuate ncomps based on variance, ncomps now correct for num_samples < num_features
                 W[:, :ncomps] = 0
 
                 # This is equations 1 and 2 in Manjon 2013:
@@ -266,7 +275,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
                                     patch_size[1],
                                     patch_size[2], dim)
                 # This is equation 3 in Manjon 2013:
-                this_theta = 1.0 / (1.0 + dim - ncomps)
+                this_theta = 1.0 / (1.0 + dim - ncomps)  # NOTE: counting number of non-noise components, no correction needed for num_samples < num_features
                 theta[ix1:ix2, jx1:jx2, kx1:kx2] += this_theta
                 thetax[ix1:ix2, jx1:jx2, kx1:kx2] += Xest * this_theta
                 if return_sigma is True and sigma is None:

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -339,8 +339,9 @@ def patch2self(data, bvals, patch_radius=(0, 0, 0), model='ols',
         denoised_arr.clip(min=0, out=denoised_arr)
 
     elif clip_negative_vals and shift_intensity:
-        warn('Both `clip_negative_vals` and `shift_intensity` cannot be True.')
-        warn('Defaulting to `clip_negative_bvals`...')
+        msg = 'Both `clip_negative_vals` and `shift_intensity` cannot be True.'
+        msg += ' Defaulting to `clip_negative_vals`...'
+        warn(msg)
         denoised_arr.clip(min=0, out=denoised_arr)
 
     return np.array(denoised_arr, dtype=out_dtype)

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -27,7 +27,7 @@ except ImportError:
 @cython.wraparound(False)
 @cython.cdivision(True)
 def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
-                       smooth=2, images_as_samples=True):
+                       smooth=2, images_as_samples=False):
     """ PCA based local noise estimation.
 
     Parameters
@@ -50,12 +50,22 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         before returning. Default: 2.
     image_as_samples : bool
         Whether to use images as rows (samples) for PCA (algorithm in [1]_) or
-        to use images as columns (features). Default: True (images as samples).
+        to use images as columns (features).
 
     Returns
     -------
     sigma_corr: 3D array
         The local noise standard deviation estimate.
+
+    Notes
+    -----
+        In [1]_, images are used as samples, so voxels are features, therefore
+        eigenvectors are image-shaped. However, [1]_ is not clear on how to use
+        these eigenvectors to determine the noise level, so here eigenvalues
+        (variance over samples explained by eigenvectors) are used to scale
+        the eigenvectors. Use images_as_samples=True to use this algorithm.
+        Alternatively, voxels can be used as samples using
+        images_as_samples=False. This is not the canonical algorithm of [1]_.
 
     References
     ----------
@@ -113,26 +123,29 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
     W = Vt.T
 
     if images_as_samples:
-        # use second-to-last eigenvector, because of X is centered
         W = W.astype('double')
-        V = W[:, n3-2].reshape(n0, n1, n2)
+        # #vox(features) >> # img(samples), last eigval zero (X is centered)
+        idx = n3 - 2  # use second-to-last eigvec
+        V = W[:, idx].reshape(n0, n1, n2)
 
-        # eigenvalue = variance gives scale (ref [1]_ method is ambigious)
-        I = V * S[n3-2]
+        # ref [1]_ method is ambigious on how to use image-shaped eigvec
+        # since eigvec is normalized, used eigval=variance for scale
+        I = V * S[idx]
     else:
         # Project into the data space
         V = X.dot(W)
-        
+
         # Grab the column corresponding to the smallest eigen-vector/-value:
+        # #vox(samples) >> #img(features), last eigenvector is meaningful
         I = V[:, -1].reshape(n0, n1, n2)
 
     del V, W, X, U, S, Vt
 
     cdef:
-      double[:, :, :] count = np.zeros((n0, n1, n2))
-      double[:, :, :] mean = np.zeros((n0, n1, n2))
-      double[:, :, :] sigma_sq = np.zeros((n0, n1, n2))
-      double[:, :, :, :] data0temp = data0
+        double[:, :, :] count = np.zeros((n0, n1, n2))
+        double[:, :, :] mean = np.zeros((n0, n1, n2))
+        double[:, :, :] sigma_sq = np.zeros((n0, n1, n2))
+        double[:, :, :, :] data0temp = data0
 
     with nogil:
         for i in range(prx, n0 - prx):
@@ -145,38 +158,38 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
                             for k0 in range(-prz, prz + 1):
                                 sum_reg += I[i + i0, j + j0, k + k0] / norm
                                 for l0 in range(n3):
-                                    temp1 += (data0temp[i + i0, j+ j0, k + k0, l0]) / (norm * n3)
+                                    temp1 += (data0temp[i + i0, j + j0, k + k0, l0])\
+                                             / (norm * n3)
 
                     for i0 in range(-prx, prx + 1):
                         for j0 in range(-pry, pry + 1):
                             for k0 in range(-prz, prz + 1):
-                                sigma_sq[i + i0, j +j0, k + k0] += (
+                                sigma_sq[i + i0, j + j0, k + k0] += (
                                     I[i + i0, j + j0, k + k0] - sum_reg) ** 2
                                 mean[i + i0, j + j0, k + k0] += temp1
-                                count[i + i0, j +j0, k + k0] += 1
+                                count[i + i0, j + j0, k + k0] += 1
 
     sigma_sq = np.divide(sigma_sq, count)
 
     # find the SNR and make the correction for bias due to Rician noise:
     if correct_bias:
-      mean = np.divide(mean, count)
-      snr = np.divide(mean, np.sqrt(sigma_sq))
-      snr_sq = (snr ** 2)
-      # xi is practically equal to 1 above 37.4, and we overflow, raising
-      # warnings and creating ot-a-numbers.
-      # Instead, we will replace these values with 1 below
-      with np.errstate(over='ignore', invalid='ignore'):
-          xi = (2 + snr_sq - (np.pi / 8) * np.exp(-snr_sq / 2) *
+        mean = np.divide(mean, count)
+        snr = np.divide(mean, np.sqrt(sigma_sq))
+        snr_sq = (snr ** 2)
+        # xi is practically equal to 1 above 37.4, and we overflow, raising
+        # warnings and creating ot-a-numbers.
+        # Instead, we will replace these values with 1 below
+        with np.errstate(over='ignore', invalid='ignore'):
+            xi = (2 + snr_sq - (np.pi / 8) * np.exp(-snr_sq / 2) *
                   ((2 + snr_sq) * sps.iv(0, snr_sq / 4) +
                   snr_sq * sps.iv(1, snr_sq / 4)) ** 2).astype(float)
-      xi[snr > 37.4] = 1
-      sigma_corr = sigma_sq / xi
-      sigma_corr[np.isnan(sigma_corr)] = 0
+        xi[snr > 37.4] = 1
+        sigma_corr = sigma_sq / xi
+        sigma_corr[np.isnan(sigma_corr)] = 0
     else:
-      sigma_corr = sigma_sq
+        sigma_corr = sigma_sq
 
     if smooth is not None:
-      sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
+        sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
 
     return np.sqrt(sigma_corr)
-

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -27,7 +27,11 @@ except ImportError:
 @cython.wraparound(False)
 @cython.cdivision(True)
 def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
+<<<<<<< HEAD
                        smooth=2, images_as_samples=False):
+=======
+                       smooth=2, images_as_samples=True):
+>>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
     """ PCA based local noise estimation.
 
     Parameters
@@ -50,7 +54,11 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         before returning. Default: 2.
     image_as_samples : bool
         Whether to use images as rows (samples) for PCA (algorithm in [1]_) or
+<<<<<<< HEAD
         to use images as columns (features).
+=======
+        to use images as columns (features). Default: True (images as samples).
+>>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
 
     Returns
     -------
@@ -123,6 +131,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
     W = Vt.T
 
     if images_as_samples:
+<<<<<<< HEAD
         W = W.astype('double')
         # #vox(features) >> # img(samples), last eigval zero (X is centered)
         idx = n3 - 2  # use second-to-last eigvec
@@ -137,6 +146,19 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
 
         # Grab the column corresponding to the smallest eigen-vector/-value:
         # #vox(samples) >> #img(features), last eigenvector is meaningful
+=======
+        # use second-to-last eigenvector, because of X is centered
+        W = W.astype('double')
+        V = W[:, n3-2].reshape(n0, n1, n2)
+
+        # eigenvalue = variance gives scale (ref [1]_ method is ambigious)
+        I = V * S[n3-2]
+    else:
+        # Project into the data space
+        V = X.dot(W)
+        
+        # Grab the column corresponding to the smallest eigen-vector/-value:
+>>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
         I = V[:, -1].reshape(n0, n1, n2)
 
     del V, W, X, U, S, Vt
@@ -193,3 +215,4 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
 
     return np.sqrt(sigma_corr)
+

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -27,11 +27,7 @@ except ImportError:
 @cython.wraparound(False)
 @cython.cdivision(True)
 def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
-<<<<<<< HEAD
                        smooth=2, images_as_samples=False):
-=======
-                       smooth=2, images_as_samples=True):
->>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
     """ PCA based local noise estimation.
 
     Parameters
@@ -54,11 +50,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         before returning. Default: 2.
     image_as_samples : bool
         Whether to use images as rows (samples) for PCA (algorithm in [1]_) or
-<<<<<<< HEAD
         to use images as columns (features).
-=======
-        to use images as columns (features). Default: True (images as samples).
->>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
 
     Returns
     -------
@@ -131,7 +123,6 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
     W = Vt.T
 
     if images_as_samples:
-<<<<<<< HEAD
         W = W.astype('double')
         # #vox(features) >> # img(samples), last eigval zero (X is centered)
         idx = n3 - 2  # use second-to-last eigvec
@@ -146,19 +137,6 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
 
         # Grab the column corresponding to the smallest eigen-vector/-value:
         # #vox(samples) >> #img(features), last eigenvector is meaningful
-=======
-        # use second-to-last eigenvector, because of X is centered
-        W = W.astype('double')
-        V = W[:, n3-2].reshape(n0, n1, n2)
-
-        # eigenvalue = variance gives scale (ref [1]_ method is ambigious)
-        I = V * S[n3-2]
-    else:
-        # Project into the data space
-        V = X.dot(W)
-        
-        # Grab the column corresponding to the smallest eigen-vector/-value:
->>>>>>> 92be877c247c2d33ea7604fe324e0e307ec897d4
         I = V[:, -1].reshape(n0, n1, n2)
 
     del V, W, X, U, S, Vt
@@ -215,4 +193,3 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
 
     return np.sqrt(sigma_corr)
-

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -302,12 +302,16 @@ def test_mppca_in_phantom():
     std_gt = 0.02
     noise = std_gt*np.random.standard_normal(DWIgt.shape)
     DWInoise = DWIgt + noise
-    DWIden = mppca(DWInoise, patch_radius=2)
 
-    # Test if denoised data is closer to ground truth than noisy data
-    rmse_den = np.sum(np.abs(DWIgt - DWIden)) / np.sum(np.abs(DWIgt))
-    rmse_noisy = np.sum(np.abs(DWIgt - DWInoise)) / np.sum(np.abs(DWIgt))
-    assert_(rmse_den < rmse_noisy)
+    # patch radius (2: #samples > #features, 1: #samples < #features)
+    for PR in [2, 1]:
+
+        DWIden = mppca(DWInoise, patch_radius=PR)
+
+        # Test if denoised data is closer to ground truth than noisy data
+        rmse_den = np.sum(np.abs(DWIgt - DWIden)) / np.sum(np.abs(DWIgt))
+        rmse_noisy = np.sum(np.abs(DWIgt - DWInoise)) / np.sum(np.abs(DWIgt))
+        assert_(rmse_den < rmse_noisy)
 
 
 def test_mppca_returned_sigma():
@@ -316,19 +320,29 @@ def test_mppca_returned_sigma():
     noise = std_gt*np.random.standard_normal(DWIgt.shape)
     DWInoise = DWIgt + noise
 
-    # Case that sigma is estimated using mpPCA
-    DWIden0, sigma = mppca(DWInoise, patch_radius=2, return_sigma=True)
-    msigma = np.mean(sigma)
-    std_error = abs(msigma - std_gt)/std_gt * 100
-    assert_(std_error < 5)
+    # patch radius (2: #samples > #features, 1: #samples < #features)
+    for PR in [2, 1]:
 
-    # Case that sigma is inputted (sigma outputted should be the same as the
-    # one inputted)
-    DWIden1, rsigma = genpca(DWInoise, sigma=sigma, tau_factor=None,
-                             patch_radius=2, return_sigma=True)
-    assert_array_almost_equal(rsigma, sigma)
+        # Case that sigma is estimated using mpPCA
+        DWIden0, sigma = mppca(DWInoise, patch_radius=PR, return_sigma=True)
+        msigma = np.mean(sigma)
+        std_error = abs(msigma - std_gt)/std_gt * 100
 
-    # DWIden1 should be very similar to DWIden0
-    rmse_den = np.sum(np.abs(DWIden1 - DWIden0)) / np.sum(np.abs(DWIden0))
-    rmse_ref = np.sum(np.abs(DWIden1 - DWIgt)) / np.sum(np.abs(DWIgt))
-    assert_(rmse_den < rmse_ref)
+        # if #noise_eigenvals >> #signal_eigenvals, variance should be well estimated 
+        # this is more likely achieved if #samples > #features
+        if PR > 1:
+            assert_(std_error < 5)
+        else: # otherwise, variance estimate may be wrong
+            pass
+
+        # Case that sigma is inputted (sigma outputted should be the same as the
+        # one inputted)
+        DWIden1, rsigma = genpca(DWInoise, sigma=sigma, tau_factor=None,
+                                 patch_radius=PR, return_sigma=True)
+        assert_array_almost_equal(rsigma, sigma)
+
+        # DWIden1 should be very similar to DWIden0
+        rmse_den = np.sum(np.abs(DWIden1 - DWIden0)) / np.sum(np.abs(DWIden0))
+        rmse_ref = np.sum(np.abs(DWIden1 - DWIgt)) / np.sum(np.abs(DWIgt))
+        assert_(rmse_den < rmse_ref)
+

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -260,6 +260,11 @@ def test_lpca_sigma_wrong_shape():
     assert_raises(ValueError, localpca, DWI, sigma)
 
 
+def test_lpca_no_gtab_no_sigma():
+    DWI, sigma = rfiw_phantom(gtab, snr=30)
+    assert_raises(ValueError, localpca, DWI, None, None)
+
+
 def test_pca_classifier():
     # Produce small phantom with well aligned single voxels and ground truth
     # snr = 50, i.e signal std = 0.02 (Gaussian noise)

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -350,4 +350,3 @@ def test_mppca_returned_sigma():
         rmse_den = np.sum(np.abs(DWIden1 - DWIden0)) / np.sum(np.abs(DWIden0))
         rmse_ref = np.sum(np.abs(DWIden1 - DWIgt)) / np.sum(np.abs(DWIgt))
         assert_(rmse_den < rmse_ref)
-

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -185,4 +185,3 @@ def test_pca_noise_estimate():
                           images_as_samples=images_as_samples)))
 
         assert_warns(UserWarning, pca_noise_estimate, data, gtab, patch_radius=0)
-

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
-                           assert_array_almost_equal)
+                           assert_array_almost_equal, assert_warns)
 from dipy.denoise.noise_estimate import _inv_nchi_cdf, piesno, estimate_sigma
 from dipy.denoise.noise_estimate import _piesno_3D
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
@@ -152,27 +152,37 @@ def test_pca_noise_estimate():
     bvecs2 = np.concatenate([np.zeros((1, 3)), np.eye(3)])
     gtab2 = dpg.gradient_table(bvals2, bvecs2)
 
-    for patch_radius in [1, 2]:
-        for gtab in [gtab1, gtab2]:
-            for dtype in [np.int16, np.float64]:
-                signal = np.ones((20, 20, 20, gtab.bvals.shape[0]))
-                for correct_bias in [True, False]:
-                    if not correct_bias:
-                        # High signal for no bias correction
-                        signal = signal * 100
+    for images_as_samples in [True, False]:
 
-                    sigma = 1
-                    noise1 = np.random.normal(0, sigma, size=signal.shape)
-                    noise2 = np.random.normal(0, sigma, size=signal.shape)
+        for patch_radius in [1, 2]:
+            for gtab in [gtab1, gtab2]:
+                for dtype in [np.int16, np.float64]:
+                    signal = np.ones((20, 20, 20, gtab.bvals.shape[0]))
+                    for correct_bias in [True, False]:
+                        if not correct_bias:
+                            # High signal for no bias correction
+                            signal = signal * 100
 
-                    # Rician noise:
-                    data = np.sqrt((signal + noise1) ** 2 + noise2 ** 2)
+                        sigma = 1
+                        noise1 = np.random.normal(0, sigma, size=signal.shape)
+                        noise2 = np.random.normal(0, sigma, size=signal.shape)
 
-                    sigma_est = pca_noise_estimate(data.astype(dtype), gtab,
-                                                   correct_bias=correct_bias,
-                                                   patch_radius=patch_radius)
-                    assert_array_almost_equal(np.mean(sigma_est), sigma,
-                                              decimal=1)
+                        # Rician noise:
+                        data = np.sqrt((signal + noise1) ** 2 + noise2 ** 2)
 
-    assert_(np.mean(pca_noise_estimate(data, gtab, correct_bias=True)) >
-            np.mean(pca_noise_estimate(data, gtab, correct_bias=False)))
+                        sigma_est = pca_noise_estimate(data.astype(dtype), gtab,
+                                                       correct_bias=correct_bias,
+                                                       patch_radius=patch_radius,
+                                                       images_as_samples=images_as_samples)
+                        #print("sigma_est:", sigma_est)
+                        assert_array_almost_equal(np.mean(sigma_est), sigma,
+                                                  decimal=1)
+
+        # check that Rician corrects produces larger noise estimate
+        assert_(np.mean(pca_noise_estimate(data, gtab, correct_bias=True,
+                          images_as_samples=images_as_samples)) >
+                np.mean(pca_noise_estimate(data, gtab, correct_bias=False,
+                          images_as_samples=images_as_samples)))
+
+        assert_warns(UserWarning, pca_noise_estimate, data, gtab, patch_radius=0)
+

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from dipy.denoise import patch2self as p2s
 from dipy.testing import (assert_greater, assert_less,
@@ -26,16 +28,21 @@ def test_patch2self_random_noise():
     assert_less_equal(np.round(S0den_shift.mean()), 30)
 
     # clip = True
-    S0den_clip = p2s.patch2self(S0, bvals, model='ols',
-                                clip_negative_vals=True)
+    msg = "Both `clip_negative_vals` and `shift_intensity` .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        S0den_clip = p2s.patch2self(S0, bvals, model='ols',
+                                    clip_negative_vals=True)
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
 
     # both clip and shift = True, and int patch_radius
-    S0den_clip = p2s.patch2self(S0, bvals, patch_radius=0, model='ols',
-                                clip_negative_vals=True,
-                                shift_intensity=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        S0den_clip = p2s.patch2self(S0, bvals, patch_radius=0, model='ols',
+                                    clip_negative_vals=True,
+                                    shift_intensity=True)
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
@@ -47,6 +54,7 @@ def test_patch2self_random_noise():
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
+
 
 @needs_sklearn
 def test_patch2self_boundary():

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -481,7 +481,7 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
 
     peak_dirs = np.zeros((shape + (npeaks, 3)))
     peak_values = np.zeros((shape + (npeaks,)))
-    peak_indices = np.zeros((shape + (npeaks,)), dtype='int')
+    peak_indices = np.zeros((shape + (npeaks,)), dtype=np.int32)
     peak_indices.fill(-1)
 
     if return_sh:

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -7,10 +7,10 @@ docs.  In setup.py in particular, we exec this file, so it cannot import dipy
 # full release.  '.dev' as a _version_extra string means this is a development
 # version
 _version_major = 1
-_version_minor = 6
+_version_minor = 7
 _version_micro = 0
-# _version_extra = 'dev0'
-_version_extra = ''
+_version_extra = 'dev0'
+# _version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -9,8 +9,8 @@ docs.  In setup.py in particular, we exec this file, so it cannot import dipy
 _version_major = 1
 _version_minor = 6
 _version_micro = 0
-_version_extra = 'dev0'
-# _version_extra = ''
+# _version_extra = 'dev0'
+_version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -829,7 +829,7 @@ class TensorModel(ReconstModel):
             dti_params[mask, :] = params_in_mask
             if self.return_S0_hat:
                 S0_params = np.zeros(data.shape[:-1])
-                S0_params[mask] = model_S0
+                S0_params[mask] = model_S0.squeeze()
 
         return TensorFit(self, dti_params, model_S0=S0_params)
 

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """ Classes and functions for fitting tensors """
-
+from packaging.version import Version
 import warnings
 
 import functools
@@ -1410,7 +1410,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     w = np.exp(fit_result @ design_matrix.T)
 
     # the weighted problem design_matrix * w is much larger (differs per voxel)
-    if np.__version__ < '1.14':
+    if Version(np.__version__) < Version('1.14'):
         fit_result = np.einsum('...ij,...j',
                                pinv(design_matrix * w[..., None]),
                                w * log_s)

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -779,6 +779,30 @@ class TensorModel(ReconstModel):
             mask = np.array(mask, dtype=bool, copy=False)
         data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
+        if "sigma" in self.kwargs:
+            sigma = self.kwargs["sigma"]
+
+            if isinstance(sigma, np.ndarray):  # sigma passed as array
+                if sigma.size == 1:  # scalar passed as array
+                    sigma_in_mask = sigma[0]  # to scalar
+                else:
+                    if sigma.ndim > 1:  # spatially varying
+                        sigma_in_mask = np.reshape(sigma[mask], (-1, 1))
+                        if sigma_in_mask.size != data_in_mask.shape[0]:
+                            raise ValueError("ValueError: sigma size must\
+                                              equal number of voxels for\
+                                              spatial variation")
+                    else:  # image varying
+                        sigma_in_mask = sigma
+                        if sigma_in_mask.size != data_in_mask.shape[-1]:
+                            raise ValueError("ValueError: sigma size must\
+                                              equal number of images for\
+                                              image variation")
+            else:  # sigma passed as scalar
+                sigma_in_mask = sigma
+
+            self.kwargs["sigma"] = sigma_in_mask
+
         if self.min_signal is None:
             min_signal = MIN_POSITIVE_SIGNAL
         else:
@@ -1378,12 +1402,23 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     """
     tol = 1e-6
     data = np.asarray(data)
-    ols_fit = _ols_fit_matrix(design_matrix)
     log_s = np.log(data)
-    w = np.exp(np.einsum('...ij,...j', ols_fit, log_s))
-    fit_result = np.einsum('...ij,...j',
-                           pinv(design_matrix * w[..., None]),
-                           w * log_s)
+
+    # calculate weights
+    fit_result = ols_fit_tensor(design_matrix, data,
+                                return_lower_triangular=True)
+    w = np.exp(fit_result @ design_matrix.T)
+
+    # the weighted problem design_matrix * w is much larger (differs per voxel)
+    if np.__version__ < '1.14':
+        fit_result = np.einsum('...ij,...j',
+                               pinv(design_matrix * w[..., None]),
+                               w * log_s)
+    else:
+        fit_result = np.einsum('...ij,...j',
+                               np.linalg.pinv(design_matrix * w[..., None]),
+                               w * log_s)
+
     if return_S0_hat:
         return (eig_from_lo_tri(fit_result,
                                 min_diffusivity=tol / -design_matrix.min()),
@@ -1394,7 +1429,8 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
 
 
 @iter_fit_tensor()
-def ols_fit_tensor(design_matrix, data, return_S0_hat=False):
+def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
+                   return_lower_triangular=False):
     r"""
     Computes ordinary least squares (OLS) fit to calculate self-diffusion
     tensor using a linear regression model [1]_.
@@ -1409,6 +1445,8 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False):
         dimension should contain the data. It makes no copies of data.
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
+    return_lower_triangular : bool
+        Boolean to return (True) or not (False) the coefficients of the fit.
 
     Returns
     -------
@@ -1443,6 +1481,10 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False):
     data = np.asarray(data)
     fit_result = np.einsum('...ij,...j', np.linalg.pinv(design_matrix),
                            np.log(data))
+
+    if return_lower_triangular:
+        return fit_result
+
     if return_S0_hat:
         return (eig_from_lo_tri(fit_result,
                                 min_diffusivity=tol / -design_matrix.min()),
@@ -1625,7 +1667,8 @@ def _decompose_tensor_nan(tensor, tensor_alternative, min_diffusivity=0):
 
 
 def nlls_fit_tensor(design_matrix, data, weighting=None,
-                    sigma=None, jac=True, return_S0_hat=False):
+                    sigma=None, jac=True, return_S0_hat=False,
+                    fail_is_nan=False):
     """
     Fit the cumulant expansion params (e.g. DTI, DKI) using non-linear
     least-squares.
@@ -1659,6 +1702,9 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
 
+    fail_is_nan : bool
+        Boolean to set failed NL fitting to NaN (True) or LS (False, default).
+
     Returns
     -------
     nlls_params: the eigen-values and eigen-vectors of the tensor in each
@@ -1673,16 +1719,18 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
     # Flatten for the iteration over voxels:
     flat_data = data.reshape((-1, data.shape[-1]))
+
     # Use the OLS method parameters as the starting point for the optimization:
-    inv_design = np.linalg.pinv(design_matrix)
-    log_s = np.log(flat_data)
-    D = np.dot(inv_design, log_s.T).T
+    D = ols_fit_tensor(design_matrix, flat_data, return_lower_triangular=True)
 
     # Flatten for the iteration over voxels:
     ols_params = np.reshape(D, (-1, D.shape[-1]))
 
     # Initialize parameter matrix
     params = np.empty((flat_data.shape[0], npa))
+
+    # For warnings
+    resort_to_OLS = False
 
     if return_S0_hat:
         model_S0 = np.empty((flat_data.shape[0], 1))
@@ -1691,23 +1739,25 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
             raise ValueError("The data in this voxel contains only zeros")
 
         start_params = ols_params[vox]
-        # Do the optimization in this voxel:
-        if jac:
-            this_param, status = opt.leastsq(_nlls_err_func, start_params,
-                                             args=(design_matrix,
-                                                   flat_data[vox],
-                                                   weighting,
-                                                   sigma),
-                                             Dfun=_nlls_jacobian_func)
-        else:
-            this_param, status = opt.leastsq(_nlls_err_func, start_params,
-                                             args=(design_matrix,
-                                                   flat_data[vox],
-                                                   weighting,
-                                                   sigma))
 
-        # Convert diffusion tensor parameters to the evals and the evecs:
         try:
+
+            # Do the optimization in this voxel:
+            if jac:
+                this_param, status = opt.leastsq(_nlls_err_func, start_params,
+                                                 args=(design_matrix,
+                                                       flat_data[vox],
+                                                       weighting,
+                                                       sigma),
+                                                 Dfun=_nlls_jacobian_func)
+            else:
+                this_param, status = opt.leastsq(_nlls_err_func, start_params,
+                                                 args=(design_matrix,
+                                                       flat_data[vox],
+                                                       weighting,
+                                                       sigma))
+
+            # Convert diffusion tensor parameters to the evals and the evecs:
             evals, evecs = decompose_tensor(
                 from_lower_triangular(this_param[:6]))
             params[vox, :3] = evals
@@ -1715,18 +1765,29 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
-        except np.linalg.LinAlgError:
-            this_params = start_params
-            evals, evecs = decompose_tensor(
-                from_lower_triangular(this_params[:6]))
-            params[vox, :3] = evals
-            params[vox, 3:12] = evecs.ravel()
+        except (np.linalg.LinAlgError, TypeError) as e:
+            resort_to_OLS = True
+            this_param = start_params
+
+            if not fail_is_nan:
+                # Convert diffusion tensor parameters to evals and evecs
+                evals, evecs = decompose_tensor(
+                    from_lower_triangular(this_param[:6]))
+                params[vox, :3] = evals
+                params[vox, 3:12] = evecs.ravel()
+            else:
+                # Set NaN values
+                this_param[:] = np.nan  # so that S0_hat is NaN
+                params[vox, :] = np.nan
 
         if return_S0_hat:
             model_S0[vox] = np.exp(-this_param[-1])
         if not dti:
             md2 = evals.mean(0) ** 2
             params[vox, 12:] = this_param[6:-1] / md2
+
+    if resort_to_OLS:
+        warnings.warn("Resorted to OLS solution in some voxels", UserWarning)
 
     params.shape = data.shape[:-1] + (npa,)
     if return_S0_hat:
@@ -1737,7 +1798,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
 
 def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
-                       return_S0_hat=False):
+                       return_S0_hat=False, fail_is_nan=False):
     """
     Use the RESTORE algorithm [1]_ to calculate a robust tensor fit
 
@@ -1752,10 +1813,13 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
         Data or response variables holding the data. Note that the last
         dimension should contain the data. It makes no copies of data.
 
-    sigma : float
+    sigma : float, array of shape [n_directions], array of shape [X, Y, Z]
         An estimate of the variance. [1]_ recommend to use
         1.5267 * std(background_noise), where background_noise is estimated
         from some part of the image known to contain no signal (only noise).
+        Array with ndim > 1 corresponds to spatially varying sigma, so if
+        providing spatially-flattened data and spatially-varying sigma,
+        provide array with shape [num_vox, 1].
 
     jac : bool, optional
         Whether to use the Jacobian of the tensor to speed the non-linear
@@ -1765,6 +1829,8 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
 
+    fail_is_nan : bool
+        Boolean to set failed NL fitting to NaN (True) or LS (False, default).
 
     Returns
     -------
@@ -1785,17 +1851,21 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
     # Flatten for the iteration over voxels:
     flat_data = data.reshape((-1, data.shape[-1]))
+    if isinstance(sigma, np.ndarray):
+        if sigma.ndim > 1:  # spatially varying
+            sigma = np.reshape(sigma, (-1, 1))
 
-    # Use the OLS method parameters as the starting point for the optimization:
-    inv_design = np.linalg.pinv(design_matrix)
-    log_s = np.log(flat_data)
-    D = np.dot(inv_design, log_s.T).T
+    # calculate OLS solution
+    D = ols_fit_tensor(design_matrix, flat_data, return_lower_triangular=True)
 
     # Flatten for the iteration over voxels:
     ols_params = np.reshape(D, (-1, D.shape[-1]))
 
     # Initialize parameter matrix
     params = np.empty((flat_data.shape[0], npa))
+
+    # For warnings
+    resort_to_OLS = False
 
     if return_S0_hat:
         model_S0 = np.empty((flat_data.shape[0], 1))
@@ -1804,74 +1874,88 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
             raise ValueError("The data in this voxel contains only zeros")
 
         start_params = ols_params[vox]
-        # Do nlls using sigma weighting in this voxel:
-        if jac:
-            this_param, status = opt.leastsq(_nlls_err_func, start_params,
-                                             args=(design_matrix,
-                                                   flat_data[vox],
-                                                   'sigma',
-                                                   sigma),
-                                             Dfun=_nlls_jacobian_func)
+
+        # set sigma value
+        if np.iterable(sigma):
+            sigma_vox = sigma[vox, 0] if sigma.ndim > 1 else sigma
         else:
-            this_param, status = opt.leastsq(_nlls_err_func, start_params,
-                                             args=(design_matrix,
-                                                   flat_data[vox],
-                                                   'sigma',
-                                                   sigma))
+            sigma_vox = sigma
 
-        # Get the residuals:
-        pred_sig = np.exp(np.dot(design_matrix, this_param))
-        residuals = flat_data[vox] - pred_sig
+        try:
 
-        # If any of the residuals are outliers (using 3 sigma as a criterion
-        # following Chang et al., e.g page 1089):
-        if np.any(np.abs(residuals) > 3 * sigma):
-            # Do nlls with GMM-weighting:
+            # Do nlls using sigma weighting in this voxel:
             if jac:
-                this_param, status = opt.leastsq(_nlls_err_func,
-                                                 start_params,
+                this_param, status = opt.leastsq(_nlls_err_func, start_params,
                                                  args=(design_matrix,
                                                        flat_data[vox],
-                                                       'gmm'),
+                                                       'sigma',
+                                                       sigma_vox),
                                                  Dfun=_nlls_jacobian_func)
             else:
-                this_param, status = opt.leastsq(_nlls_err_func,
-                                                 start_params,
+                this_param, status = opt.leastsq(_nlls_err_func, start_params,
                                                  args=(design_matrix,
                                                        flat_data[vox],
-                                                       'gmm'))
+                                                       'sigma',
+                                                       sigma_vox))
 
-            # How are you doin' on those residuals?
+            # Get the residuals:
             pred_sig = np.exp(np.dot(design_matrix, this_param))
             residuals = flat_data[vox] - pred_sig
-            if np.any(np.abs(residuals) > 3 * sigma):
-                # If you still have outliers, refit without those outliers:
-                non_outlier_idx = np.where(np.abs(residuals) <= 3 * sigma)
-                clean_design = design_matrix[non_outlier_idx]
-                clean_sig = flat_data[vox][non_outlier_idx]
-                if np.iterable(sigma):
-                    this_sigma = sigma[non_outlier_idx]
-                else:
-                    this_sigma = sigma
 
+            # If any of the residuals are outliers (using 3 sigma as a
+            # criterion following Chang et al., e.g page 1089):
+            if np.any(np.abs(residuals) > 3 * sigma_vox):
+                # Do nlls with GMM-weighting:
                 if jac:
                     this_param, status = opt.leastsq(_nlls_err_func,
                                                      start_params,
-                                                     args=(clean_design,
-                                                           clean_sig,
-                                                           'sigma',
-                                                           this_sigma),
+                                                     args=(design_matrix,
+                                                           flat_data[vox],
+                                                           'gmm'),
                                                      Dfun=_nlls_jacobian_func)
                 else:
                     this_param, status = opt.leastsq(_nlls_err_func,
                                                      start_params,
-                                                     args=(clean_design,
-                                                           clean_sig,
-                                                           'sigma',
-                                                           this_sigma))
+                                                     args=(design_matrix,
+                                                           flat_data[vox],
+                                                           'gmm'))
 
-        # Convert diffusion tensor parameters to the evals and the evecs:
-        try:
+                # Recalculate residuals given gmm fit
+                pred_sig = np.exp(np.dot(design_matrix, this_param))
+                residuals = flat_data[vox] - pred_sig
+                if np.any(np.abs(residuals) > 3 * sigma_vox):
+                    # If you still have outliers, refit without those outliers:
+                    non_outlier_idx = np.where(np.abs(residuals) <=
+                                               3 * sigma_vox)
+                    clean_design = design_matrix[non_outlier_idx]
+                    clean_data = flat_data[vox][non_outlier_idx]
+
+                    # recalculate OLS solution with clean data
+                    new_start = ols_fit_tensor(clean_design, clean_data,
+                                               return_lower_triangular=True)
+
+                    if np.iterable(sigma_vox):
+                        this_sigma = sigma_vox[non_outlier_idx]
+                    else:
+                        this_sigma = sigma_vox
+
+                    if jac:
+                        this_param, status = opt.leastsq(_nlls_err_func,
+                                                         new_start,
+                                                         args=(clean_design,
+                                                               clean_data,
+                                                               'sigma',
+                                                               this_sigma),
+                                                         Dfun=_nlls_jacobian_func)
+                    else:
+                        this_param, status = opt.leastsq(_nlls_err_func,
+                                                         new_start,
+                                                         args=(clean_design,
+                                                               clean_data,
+                                                               'sigma',
+                                                               this_sigma))
+
+            # Convert diffusion tensor parameters to the evals and the evecs:
             evals, evecs = decompose_tensor(
                 from_lower_triangular(this_param[:6]))
             params[vox, :3] = evals
@@ -1879,18 +1963,29 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
-        except np.linalg.LinAlgError:
-            this_params = start_params
-            evals, evecs = decompose_tensor(
-                from_lower_triangular(this_params[:6]))
-            params[vox, :3] = evals
-            params[vox, 3:12] = evecs.ravel()
+        except (np.linalg.LinAlgError, TypeError) as e:
+            resort_to_OLS = True
+            this_param = start_params
+
+            if not fail_is_nan:
+                # Convert diffusion tensor parameters to evals and evecs:
+                evals, evecs = decompose_tensor(
+                    from_lower_triangular(this_param[:6]))
+                params[vox, :3] = evals
+                params[vox, 3:12] = evecs.ravel()
+            else:
+                # Set NaN values
+                this_param[:] = np.nan  # so that S0_hat is NaN
+                params[vox, :] = np.nan
 
         if return_S0_hat:
             model_S0[vox] = np.exp(-this_param[-1])
         if not dti:
             md2 = evals.mean(0) ** 2
             params[vox, 12:] = this_param[6:-1] / md2
+
+    if resort_to_OLS:
+        warnings.warn("Resorted to OLS solution in some voxels", UserWarning)
 
     params.shape = data.shape[:-1] + (npa,)
     if return_S0_hat:

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -163,12 +163,13 @@ def search_descending(cython.floating[::1] a, double relative_threshold):
     Examples
     --------
     >>> a = np.arange(10, 0, -1, dtype=float)
-    >>> a
-    array([ 10.,   9.,   8.,   7.,   6.,   5.,   4.,   3.,   2.,   1.])
+    >>> np.allclose(a, np.array([10., 9., 8., 7., 6., 5., 4., 3., 2., 1.]))
+    True
     >>> search_descending(a, 0.5)
     6
-    >>> a < 10 * 0.5
-    array([False, False, False, False, False, False,  True,  True,  True,  True], dtype=bool)
+    >>> np.allclose(a < 10 * 0.5, np.array([False, False, False, False, False,
+    ... False,  True,  True,  True,  True]))
+    True
     >>> search_descending(a, 1)
     1
     >>> search_descending(a, 2)

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -474,27 +474,10 @@ def test_all_zeros():
 
 def test_mask():
     data, gtab = dsi_voxels()
-    dm = dti.TensorModel(gtab, 'LS')
-    mask = np.zeros(data.shape[:-1], dtype=bool)
-    mask[0, 0, 0] = True
-    dtifit = dm.fit(data)
-    dtifit_w_mask = dm.fit(data, mask=mask)
-    # Without a mask it has some value
-    assert not np.isnan(dtifit.fa[0, 0, 0])
-    # Where mask is False, evals, evecs and fa should all be 0
-    npt.assert_array_equal(dtifit_w_mask.evals[~mask], 0)
-    npt.assert_array_equal(dtifit_w_mask.evecs[~mask], 0)
-    npt.assert_array_equal(dtifit_w_mask.fa[~mask], 0)
-    # Except for the one voxel that was selected by the mask:
-    npt.assert_almost_equal(dtifit_w_mask.fa[0, 0, 0], dtifit.fa[0, 0, 0])
-
-    # Test with returning S0_hat
-    dm = dti.TensorModel(gtab, 'LS', return_S0_hat=True)
-    mask = np.zeros(data.shape[:-1], dtype=bool)
-    mask[0, 0, 0] = True
-    for mask_more in [True, False]:
-        if mask_more:
-            mask[0, 0, 1] = True
+    for fit_type in ['LS', 'NLLS']:
+        dm = dti.TensorModel(gtab, fit_type)
+        mask = np.zeros(data.shape[:-1], dtype=bool)
+        mask[0, 0, 0] = True
         dtifit = dm.fit(data)
         dtifit_w_mask = dm.fit(data, mask=mask)
         # Without a mask it has some value
@@ -503,11 +486,29 @@ def test_mask():
         npt.assert_array_equal(dtifit_w_mask.evals[~mask], 0)
         npt.assert_array_equal(dtifit_w_mask.evecs[~mask], 0)
         npt.assert_array_equal(dtifit_w_mask.fa[~mask], 0)
-        npt.assert_array_equal(dtifit_w_mask.S0_hat[~mask], 0)
         # Except for the one voxel that was selected by the mask:
         npt.assert_almost_equal(dtifit_w_mask.fa[0, 0, 0], dtifit.fa[0, 0, 0])
-        npt.assert_almost_equal(dtifit_w_mask.S0_hat[0, 0, 0],
-                                dtifit.S0_hat[0, 0, 0])
+
+        # Test with returning S0_hat
+        dm = dti.TensorModel(gtab, fit_type, return_S0_hat=True)
+        mask = np.zeros(data.shape[:-1], dtype=bool)
+        mask[0, 0, 0] = True
+        for mask_more in [True, False]:
+            if mask_more:
+                mask[0, 0, 1] = True
+            dtifit = dm.fit(data)
+            dtifit_w_mask = dm.fit(data, mask=mask)
+            # Without a mask it has some value
+            assert not np.isnan(dtifit.fa[0, 0, 0])
+            # Where mask is False, evals, evecs and fa should all be 0
+            npt.assert_array_equal(dtifit_w_mask.evals[~mask], 0)
+            npt.assert_array_equal(dtifit_w_mask.evecs[~mask], 0)
+            npt.assert_array_equal(dtifit_w_mask.fa[~mask], 0)
+            npt.assert_array_equal(dtifit_w_mask.S0_hat[~mask], 0)
+            # Except for the one voxel that was selected by the mask:
+            npt.assert_almost_equal(dtifit_w_mask.fa[0, 0, 0], dtifit.fa[0, 0, 0])
+            npt.assert_almost_equal(dtifit_w_mask.S0_hat[0, 0, 0],
+                                    dtifit.S0_hat[0, 0, 0])
 
 
 def test_nnls_jacobian_fucn():

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -62,8 +62,12 @@ def setup_module():
     ivim_params_trr[0, 0, 0] = ivim_params_trr[0, 1, 0] = params_trr
     ivim_params_trr[1, 0, 0] = ivim_params_trr[1, 1, 0] = params_trr
 
-    ivim_model_trr = IvimModel(gtab, fit_method='trr')
-    ivim_model_one_stage = IvimModel(gtab, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_trr = IvimModel(gtab, fit_method='trr')
+        ivim_model_one_stage = IvimModel(gtab, fit_method='trr')
+
     ivim_fit_single = ivim_model_trr.fit(data_single)
     ivim_fit_multi = ivim_model_trr.fit(data_multi)
 
@@ -100,7 +104,10 @@ def setup_module():
         1, 0, 0] = noisy_multi[1, 1, 0] = noisy_single
     noisy_multi[0, 0, 0] = data_single
 
-    ivim_model_VP = IvimModel(gtab, fit_method='VarPro')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_VP = IvimModel(gtab, fit_method='VarPro')
     f_VP, D_star_VP, D_VP = 0.13, 0.0088, 0.000921
     # params for a single voxel
     params_VP = np.array([f, D_star, D])
@@ -321,7 +328,11 @@ def test_multiple_b0():
     # Single voxel data
     data_single = signal[0]
 
-    ivim_model_multiple_b0 = IvimModel(gtab_with_multiple_b0, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_multiple_b0 = IvimModel(gtab_with_multiple_b0,
+                                           fit_method='trr')
 
     ivim_model_multiple_b0.fit(data_single)
     # Test if all signals are positive
@@ -340,7 +351,11 @@ def test_noisy_fit():
     around 135 and D and D_star values are equal. Hence doing a test based on
     Scipy version.
     """
-    model_one_stage = IvimModel(gtab, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        model_one_stage = IvimModel(gtab, fit_method='trr')
+
     with warnings.catch_warnings(record=True) as w:
         fit_one_stage = model_one_stage.fit(noisy_single)
         assert_equal(len(w), 3)
@@ -423,7 +438,11 @@ def test_fit_one_stage():
     """
     Test to check the results for the one_stage linear fit.
     """
-    model = IvimModel(gtab, two_stage=False)
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        model = IvimModel(gtab, two_stage=False)
+
     fit = model.fit(data_single)
     linear_fit_params = [9.88834140e+02, 1.19707191e-01, 7.91176970e-03,
                          9.30095210e-04]

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -569,6 +569,12 @@ def test_spherical_l1_increases_sparsity(radial_order=4, time_order=2):
         warnings.filterwarnings(
             "ignore", message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning)
+        warnings.filterwarnings(
+            "ignore", message="cvxpy optimization resulted in .*",
+            category=UserWarning)
+        warnings.filterwarnings(
+            "ignore", message="Solution may be inaccurate..*",
+            category=UserWarning)
         qtdmri_fit_no_l1 = qtdmri_mod_no_l1.fit(S)
         qtdmri_fit_l1 = qtdmri_mod_l1.fit(S)
 

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -24,7 +24,6 @@ from dipy.reconst.shm import descoteaux07_legacy_msg
 def test_rumba():
 
     # Test fODF results from ideal examples.
-
     sphere = default_sphere  # repulsion 724
     sphere2 = get_sphere('symmetric362')
 
@@ -37,8 +36,13 @@ def test_rumba():
                                               fractions=[50, 50], snr=None)
 
     # Testing input validation
-    gtab_broken = gradient_table(
-        bvals[~gtab.b0s_mask], bvecs[~gtab.b0s_mask])
+    msg = "b0_threshold .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg,
+                                category=UserWarning)
+        gtab_broken = gradient_table(bvals[~gtab.b0s_mask],
+                                     bvecs[~gtab.b0s_mask])
+
     assert_raises(ValueError, RumbaSDModel, gtab_broken)
 
     with warnings.catch_warnings(record=True) as w:
@@ -186,8 +190,12 @@ def test_mvoxel_rumba():
                              sphere=sphere)
     model_list = [rumba_smf, rumba_sos]
 
+    msg = "There is overlap in clustering of b-value.*"
     for model in model_list:
-        model_fit = model.fit(data)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            model_fit = model.fit(data)
 
         odf = model_fit.odf(sphere)
         f_iso = model_fit.f_iso
@@ -197,10 +205,14 @@ def test_mvoxel_rumba():
         combined = model_fit.combined_odf_iso
 
         # Verify prediction properties
-        pred_sig_1 = model_fit.predict()
-        pred_sig_2 = model_fit.predict(S0=1)
-        pred_sig_3 = model_fit.predict(S0=np.ones(odf.shape[:-1]))
-        pred_sig_4 = model_fit.predict(gtab=gtab)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            pred_sig_1 = model_fit.predict()
+            pred_sig_2 = model_fit.predict(S0=1)
+            pred_sig_3 = model_fit.predict(S0=np.ones(odf.shape[:-1]))
+            pred_sig_4 = model_fit.predict(gtab=gtab)
 
         assert_equal(pred_sig_1, pred_sig_2)
         assert_equal(pred_sig_3, pred_sig_4)
@@ -319,7 +331,11 @@ def test_mvoxel_global_fit():
 
     # Test each model with/without TV regularization
     for model in model_list:
-        model_fit = model.fit(data)
+        msg = "There is overlap in clustering of b-value.*"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            model_fit = model.fit(data)
         odf = model_fit.odf(sphere)
         f_iso = model_fit.f_iso
         f_wm = model_fit.f_wm

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,6 +1,7 @@
 import sys
 import numpy as np
 import pytest
+import warnings
 
 from numpy.testing import assert_equal, assert_almost_equal
 from dipy.data import get_fnames
@@ -43,7 +44,10 @@ def test_rb_check_defaults():
                                          model_clust_thr=5.,
                                          reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -55,7 +59,9 @@ def test_rb_check_defaults():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -73,7 +79,10 @@ def test_rb_disable_slr():
                                          reduction_thr=10,
                                          slr=False)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -85,7 +94,9 @@ def test_rb_disable_slr():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -113,7 +124,11 @@ def test_rb_slr_threads():
                                                      slr=True,
                                                      num_threads=1)
 
-    D = bundles_distances_mam(rec_trans_multi_threads, rec_trans_single_thread)
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(rec_trans_multi_threads,
+                                  rec_trans_single_thread)
 
     # check if the bundle is recognized correctly
     # multi-threading prevent an exact match
@@ -133,7 +148,10 @@ def test_rb_no_verbose_and_mam():
                                          slr=True,
                                          pruning_distance='mam')
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -145,7 +163,9 @@ def test_rb_no_verbose_and_mam():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -164,7 +184,10 @@ def test_rb_clustermap():
                                          model_clust_thr=5.,
                                          reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -176,7 +199,9 @@ def test_rb_clustermap():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -233,7 +258,10 @@ def test_rb_reduction_mam():
                                          slr_metric='asymmetric',
                                          pruning_distance='mam')
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -245,7 +273,9 @@ def test_rb_reduction_mam():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -216,10 +216,11 @@ def cut_plane(tracks, ref):
     >>> res = cut_plane(bundlex,refx)
     >>> len(res)
     2
-    >>> print(res[0])
-    [[ 1.          1.5         0.          0.70710683  0.        ]]
-    >>> print(res[1])
-    [[ 2.          2.5         0.          0.70710677  0.        ]]
+    >>> np.allclose(res[0], np.array([[1., 1.5, 0., 0.70710683, 0. ]]))
+    True
+    >>> np.allclose(res[1], np.array([[2., 2.5, 0., 0.70710677, 0. ]]))
+    True
+
     """
     cdef:
         cnp.npy_intp n_hits, hit_no, max_hit_len

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -161,8 +161,9 @@ def transform_streamlines(streamlines, mat, in_place=False):
         new_streamlines = streamlines.copy()
         new_streamlines._offsets = new_streamlines._offsets.astype(
             old_offsets_dtype)
-        new_streamlines._data = apply_affine(
-            mat, new_streamlines._data).astype(old_data_dtype)
+        if new_streamlines._data.size:
+            new_streamlines._data = apply_affine(
+                mat, new_streamlines._data).astype(old_data_dtype)
         return new_streamlines
     # supporting old data structure of streamlines
     return [apply_affine(mat, s) for s in streamlines]

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -574,7 +574,7 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
 
     Examples
     --------
-    >>> from dipy.tracking.streamline import compress_streamlines
+    >>> from dipy.tracking.streamlinespeed import compress_streamlines
     >>> import numpy as np
     >>> # One streamline: a wiggling line
     >>> rng = np.random.RandomState(42)

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -542,6 +542,14 @@ def test_transform_streamlines_dtype():
     assert_equal(offsets_dtype, streamlines._offsets.dtype)
 
 
+def test_transform_empty_streamlines():
+    identity = np.eye(4)
+    streamlines = Streamlines([])
+
+    streamlines = transform_streamlines(streamlines, identity, in_place=False)
+    assert_equal(len(streamlines), 0)
+
+
 def test_deform_streamlines():
     # Create Random deformation field
     deformation_field = np.random.randn(200, 200, 200, 3)

--- a/dipy/utils/tests/test_deprecator.py
+++ b/dipy/utils/tests/test_deprecator.py
@@ -223,11 +223,14 @@ def test_deprecated_argument():
         # One positional, one keyword
         npt.assert_raises(TypeError, method, 1, scale=2)
 
-    with pytest.warns(None) as w_record:
+    with warnings.catch_warnings(record=True) as w_record:
         res = CustomActor().test5(4)
 
-    npt.assert_equal(len(w_record), 0)
-    npt.assert_equal(res, 4)
+        # Select only UserWarning
+        selected_w = [w for w in w_record
+                      if issubclass(w.category, UserWarning)]
+        npt.assert_equal(len(selected_w), 0)
+        npt.assert_equal(res, 4)
 
 
 def test_deprecated_argument_in_kwargs():
@@ -274,10 +277,10 @@ def test_deprecated_argument_multi_deprecation():
     with pytest.warns(ArgsDeprecationWarning) as w:
         npt.assert_equal(test(x=1, y=2, z=3), (1, 2, 3))
         npt.assert_equal(test2(x=1, y=2, z=3), (1, 2, 3))
-    npt.assert_equal(len(w), 6)
+        npt.assert_equal(len(w), 6)
 
-    npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
-    npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
+        npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
+        npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
 
 
 def test_deprecated_argument_not_allowed_use():

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -1,14 +1,16 @@
 import os
 import numpy as np
 import pytest
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
+
 from dipy.tracking.streamline import Streamlines
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.utils import create_nifti_header
 from dipy.testing.decorators import use_xvfb
 from dipy.utils.optpkg import optional_package
 from dipy.data import DATA_DIR
-from nibabel.tmpdirs import TemporaryDirectory
 
 fury, has_fury, setup_module = optional_package('fury')
 

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -609,7 +609,7 @@ class BundleShapeAnalysis(Workflow):
             logging.info("saving BA score matrix")
             np.save(os.path.join(out_dir, bun[:-4]+".npy"), ba_matrix)
 
-            cmap = matplt.cm.get_cmap('Blues')
+            cmap = matplt.colormaps['Blues']
             plt.title(bun[:-4])
             plt.imshow(ba_matrix, cmap=cmap)
             plt.colorbar()

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -1,11 +1,10 @@
 from os.path import join as pjoin
 import os.path
+from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
 import numpy as np
-
 import nibabel as nib
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
 from dipy.align.tests.test_parzenhist import setup_random_transform

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -1,9 +1,11 @@
 import os
+from tempfile import TemporaryDirectory
+
 import pytest
 import numpy as np
 import numpy.testing as npt
 from dipy.utils.optpkg import optional_package
-from nibabel.tmpdirs import TemporaryDirectory
+
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti, load_nifti_data
 

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,8 +1,9 @@
-import numpy.testing as npt
 import sys
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import TemporaryDirectory
+import numpy.testing as npt
+
 from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import (

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -1,13 +1,15 @@
 import logging
 import os
+from tempfile import mkstemp, TemporaryDirectory
+
 import numpy.testing as npt
+
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti
 from dipy.testing import assert_true
 from dipy.data.fetcher import dipy_home
 from dipy.workflows.io import IoInfoFlow, FetchFlow, SplitFlow
-from nibabel.tmpdirs import TemporaryDirectory
-from tempfile import mkstemp
+
 fname_log = mkstemp()[1]
 
 logging.basicConfig(level=logging.INFO,

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -65,7 +65,8 @@ def test_io_fetch_fetcher_datanames():
                      'stanford_labels', 'stanford_pve_maps', 'stanford_t1',
                      'syn_data', 'taiwan_ntu_dsi', 'target_tractogram_hcp',
                      'tissue_data', 'qte_lte_pte', 'resdnn_weights',
-                     'DiB_217_lte_pte_ste', 'DiB_70_lte_pte_ste', "hcp"]
+                     'DiB_217_lte_pte_ste', 'DiB_70_lte_pte_ste', "hcp",
+                     "hbn"]
 
     num_expected_fetch_methods = len(dataset_names)
     npt.assert_equal(len(available_data), num_expected_fetch_methods)

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -1,7 +1,7 @@
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
 from dipy.testing import assert_false
-
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -1,19 +1,20 @@
+import logging
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 import warnings
 
-import logging
 import numpy as np
-from os.path import join as pjoin
 import numpy.testing as npt
 
 from dipy.io.peaks import load_peaks
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti, load_nifti_data
 from dipy.core.gradients import generate_bvecs
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
 from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
+
 logging.getLogger().setLevel(logging.INFO)
 
 

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -1,6 +1,5 @@
 from os.path import join as pjoin
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -1,6 +1,5 @@
 from os.path import join
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 from numpy.testing import assert_equal

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,16 +1,16 @@
 from os.path import join as pjoin
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
 import numpy.testing as npt
 import pytest
-from dipy.reconst import mapmri
 
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
 from dipy.core.gradients import generate_bvecs
+from dipy.reconst import mapmri
 from dipy.workflows.reconst import ReconstMAPMRIFlow
 
 
@@ -38,10 +38,15 @@ def reconst_mmri_core(flow, lap, pos):
         volume = load_nifti_data(data_path)
 
         mmri_flow = flow()
-        mmri_flow.run(data_files=data_path, bvals_files=bval_path,
-                      bvecs_files=bvec_path, small_delta=0.0129,
-                      big_delta=0.0218, laplacian=lap,
-                      positivity=pos, out_dir=out_dir)
+
+        msg = "Optimization did not find a solution"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            mmri_flow.run(data_files=data_path, bvals_files=bval_path,
+                          bvecs_files=bvec_path, small_delta=0.0129,
+                          big_delta=0.0218, laplacian=lap,
+                          positivity=pos, out_dir=out_dir)
 
         for out_name in ['out_rtop', 'out_lapnorm', 'out_msd', 'out_qiv',
                          'out_rtap', 'out_rtpp', 'out_ng', 'out_parng',

--- a/dipy/workflows/tests/test_reconst_rumba.py
+++ b/dipy/workflows/tests/test_reconst_rumba.py
@@ -1,18 +1,15 @@
 import logging
-import warnings
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
-import numpy.testing as npt
-from nibabel.tmpdirs import TemporaryDirectory
 
-from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
-from dipy.io.peaks import load_peaks
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti, save_nifti, load_nifti_data
+from dipy.io.image import load_nifti, save_nifti
 from dipy.workflows.reconst import ReconstRUMBAFlow
-from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
+from dipy.reconst.shm import descoteaux07_legacy_msg
+
 logging.getLogger().setLevel(logging.INFO)
 
 

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -1,19 +1,20 @@
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
-from os.path import join
-import nibabel as nib
 import numpy as np
-from nibabel.tmpdirs import TemporaryDirectory
+import nibabel as nib
+
+from dipy.align.streamlinear import BundleMinDistanceMetric
 from dipy.data import get_fnames
 from dipy.segment.mask import median_otsu
 from dipy.tracking.streamline import Streamlines
-from dipy.workflows.segment import MedianOtsuFlow
-from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.image import load_nifti_data
-from os.path import join as pjoin
 from dipy.tracking.streamline import set_number_of_points
-from dipy.align.streamlinear import BundleMinDistanceMetric
+from dipy.workflows.segment import MedianOtsuFlow
+from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
 
 
 def test_median_otsu_flow():
@@ -41,10 +42,10 @@ def test_median_otsu_flow():
                                    numpass=numpass,
                                    autocrop=autocrop, dilate=dilate)
 
-        result_mask_data = load_nifti_data(join(out_dir, mask_name))
+        result_mask_data = load_nifti_data(pjoin(out_dir, mask_name))
         npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
 
-        result_masked = nib.load(join(out_dir, masked_name))
+        result_masked = nib.load(pjoin(out_dir, masked_name))
         result_masked_data = np.asanyarray(result_masked.dataobj)
 
         npt.assert_array_equal(np.round(result_masked_data), masked)

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -2,22 +2,25 @@
 
 import os
 from os.path import join
-from dipy.utils.optpkg import optional_package
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
 import pytest
-from nibabel.tmpdirs import TemporaryDirectory
 import numpy as np
-from dipy.tracking.streamline import Streamlines
-from dipy.testing import assert_true
+
+from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.data import get_fnames
+from dipy.testing import assert_true
+from dipy.tracking.streamline import Streamlines
+from dipy.utils.optpkg import optional_package
 from dipy.workflows.stats import SNRinCCFlow
 from dipy.workflows.stats import BundleAnalysisTractometryFlow
 from dipy.workflows.stats import LinearMixedModelsFlow
 from dipy.workflows.stats import BundleShapeAnalysis
 from dipy.workflows.stats import buan_bundle_profiles
+
 pd, have_pandas, _ = optional_package("pandas")
 _, have_statsmodels, _ = optional_package("statsmodels")
 _, have_tables, _ = optional_package("tables")

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -1,12 +1,12 @@
+from os.path import join
+from tempfile import TemporaryDirectory
 import warnings
 
+import nibabel as nib
 import numpy as np
 from numpy.testing import assert_equal
 from dipy.testing import assert_false, assert_true
-from os.path import join
 
-import nibabel as nib
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -1,4 +1,9 @@
 import os
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import numpy.testing as npt
+import pytest
 
 from dipy.io.image import save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
@@ -7,10 +12,6 @@ from dipy.io.utils import create_nifti_header
 from dipy.tracking.streamline import Streamlines
 from dipy.testing.decorators import use_xvfb
 from dipy.utils.optpkg import optional_package
-from nibabel.tmpdirs import TemporaryDirectory
-import numpy as np
-import numpy.testing as npt
-import pytest
 
 fury, has_fury, setup_module = optional_package('fury')
 

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -1,13 +1,13 @@
 import os
 import time
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import TemporaryDirectory
+import numpy.testing as npt
 
 from dipy.data import get_fnames
 from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.workflow import Workflow
-import numpy.testing as npt
 
 
 def test_force_overwrite():

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,11 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+
+DIPY 1.6.0 changes
+------------------
+
+
 DIPY 1.5.0 changes
 ------------------
 **General**
@@ -22,6 +27,10 @@ DIPY 1.5.0 changes
 - Change in ``dipy.tracking.pmf``
     - The parent class ``PmfGen`` has new mandatory parameter ``sphere``. The sphere vertices correspond to the spherical distribution of the pmf values.
     - The parent class ``PmfGen`` has new function ``get_pmf_value(point, xyz)`` which return the pmf value at location ``point`` and orientation ``xyz``.
+
+**Segment**
+
+- The deprecated ``from dipy.segment.metric import ResampleFeature`` was removed and replaced by ``from dipy.segment.featurespeed import ResampleFeature``.
 
 
 DIPY 1.4.1 changes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -70,7 +70,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'dipy'
-copyright = u'2008-2022, %(AUTHOR)s <%(AUTHOR_EMAIL)s>' % rel
+copyright = u'2008-2023, %(AUTHOR)s <%(AUTHOR_EMAIL)s>' % rel
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -235,7 +235,7 @@ from dipy.viz import window, actor
 scene = window.Scene()
 
 # Original lines colored by LFBC
-lineactor = actor.line(fbc_sl_orig, clrs_orig, linewidth=0.2)
+lineactor = actor.line(fbc_sl_orig, np.vstack(clrs_orig), linewidth=0.2)
 scene.add(lineactor)
 
 # Horizontal (axial) slice of T1 data
@@ -258,7 +258,7 @@ if interactive:
 
 # Show thresholded fibers
 scene.rm(lineactor)
-scene.add(actor.line(fbc_sl_thres, clrs_thres, linewidth=0.2))
+scene.add(actor.line(fbc_sl_thres, np.vstack(clrs_thres), linewidth=0.2))
 window.record(scene, n_frames=1, out_path='OR_after.png', size=(900, 900))
 if interactive:
     window.show(scene)

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -186,7 +186,7 @@ optimized group of streamlines:
 
 """
 
-optimized_sl = list(np.array(candidate_sl)[np.where(fiber_fit.beta > 0)[0]])
+optimized_sl = [np.row_stack(candidate_sl)[np.where(fiber_fit.beta > 0)[0]]]
 scene = window.Scene()
 scene.add(actor.streamtube(optimized_sl, cmap.line_colors(optimized_sl)))
 scene.add(cc_ROI_actor)

--- a/doc/examples/reconst_dsi.py
+++ b/doc/examples/reconst_dsi.py
@@ -116,7 +116,7 @@ import matplotlib.pyplot as plt
 fig_hist, ax = plt.subplots(1)
 ax.set_axis_off()
 plt.imshow(GFA.T)
-plt.savefig('dsi_gfa.png', bbox_inches='tight', origin='lower', cmap='gray')
+plt.savefig('dsi_gfa.png', bbox_inches='tight')
 
 """
 .. figure:: dsi_gfa.png

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -110,12 +110,7 @@ fname_fa = os.path.join(os.path.expanduser('~'), '.dipy',
 
 fa = load_nifti_data(fname_fa)
 
-"""
-Notice here how the scale range is (0, 255) and not (0, 1) which is the usual
-range of FA values.
-"""
-
-lut = actor.colormap_lookup_table(scale_range=(0, 255),
+lut = actor.colormap_lookup_table(scale_range=(fa.min(), fa.max()*0.8),
                                   hue_range=(0.4, 1.),
                                   saturation_range=(1, 1.),
                                   value_range=(0., 1.))

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -39,10 +39,12 @@ Basic SNR estimation
 
 - :ref:`example_snr_in_cc`
 
-Reslice
-~~~~~~~
+Reslice & Motion Correction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reslice_datasets`
+- :ref:`example_motion_correction`
+
 
 ---------
 Denoising

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,31 +16,30 @@ perfusion and structural imaging.
 Highlights
 **********
 
-**DIPY 1.5.0** is now available. New features include:
+**DIPY 1.6.0** is now available. New features include:
 
-- New reconstruction model added: Q-space Trajectory Imaging (QTI).
-- New reconstruction model added: Robust and Unbiased Model-BAsed Spherical Deconvolution (RUMBA-SD).
-- New reconstruction model added: Residual block Deep Neural Network (ResDNN).
-- Masking management in Affine Registration added.
-- Multiple Workflows updated (DTIFlow, DKIFlow, ImageRegistrationFlow) and added (MotionCorrectionFlow).
-- Compatibility with Python 3.10 added.
-- Migrations from Azure Pipeline to Github Actions.
+- NF: Unbiased groupwise linear bundle registration added.
+- NF: MAP+ constraints added.
+- Generalized PCA to less than 3 spatial dims.
+- Add positivity constraints to QTI.
+- Ability to apply Symmetric Diffeomorphic Registration to points/streamlines.
+- New Human Connectome Project (HCP) data fetcher added.
+- New Healthy Brain Network (HBN) data fetcher added.
+- Multiple Workflows updated (DTIFlow, LPCAFlow, MPPCA) and added (RUMBAFlow).
+- Ability to handle VTP files.
 - Large codebase cleaning.
-- New parallelisation module added.
-- ``dipy.io.bvectxt`` module deprecated.
-- New DIPY Horizon features (ROI Visualizer, random colors flag).
 - Large documentation update.
-- Closed 129 issues and merged 72 pull requests.
-
+- Closed 75 issues and merged 41 pull requests.
 
 See :ref:`Older Highlights <old_highlights>`.
 
 *************
 Announcements
 *************
+- :doc:`DIPY 1.6.0 <release_notes/release1.6>` released January 16, 2023.
 - :doc:`DIPY 1.5.0 <release_notes/release1.5>` released March 11, 2022.
 - :doc:`DIPY 1.4.1 <release_notes/release1.4.1>` released May 6, 2021.
-- :doc:`DIPY 1.4.0 <release_notes/release1.4>` released March 13, 2021.
+
 
 
 

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -4,6 +4,22 @@
 Older Highlights
 ****************
 
+**DIPY 1.5.0** is now available. New features include:
+
+- New reconstruction model added: Q-space Trajectory Imaging (QTI).
+- New reconstruction model added: Robust and Unbiased Model-BAsed Spherical Deconvolution (RUMBA-SD).
+- New reconstruction model added: Residual block Deep Neural Network (ResDNN).
+- Masking management in Affine Registration added.
+- Multiple Workflows updated (DTIFlow, DKIFlow, ImageRegistrationFlow) and added (MotionCorrectionFlow).
+- Compatibility with Python 3.10 added.
+- Migrations from Azure Pipeline to Github Actions.
+- Large codebase cleaning.
+- New parallelisation module added.
+- ``dipy.io.bvectxt`` module deprecated.
+- New DIPY Horizon features (ROI Visualizer, random colors flag).
+- Large documentation update.
+- Closed 129 issues and merged 72 pull requests.
+
 **DIPY 1.4.1** is now available. New features include:
 
 - Patch2Self and its documentation updated.

--- a/doc/old_news.rst
+++ b/doc/old_news.rst
@@ -5,6 +5,7 @@
 Past Announcements
 **********************
 
+- :doc:`DIPY 1.4.0 <release_notes/release1.4>` released March 13, 2021.
 - :doc:`DIPY 1.3.0 <release_notes/release1.3>` released November 3, 2020.
 - :doc:`DIPY 1.2.0 <release_notes/release1.2>` released September 9, 2020.
 - :doc:`DIPY 1.1.1 <release_notes/release1.1>` released January 10, 2020.

--- a/doc/release_notes/release1.6.rst
+++ b/doc/release_notes/release1.6.rst
@@ -1,0 +1,154 @@
+.. _release1.6:
+
+====================================
+ Release notes for DIPY version 1.6
+====================================
+
+GitHub stats for 2022/03/11 - 2023/01/12 (tag: 1.5.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 15 authors contributed 242 commits.
+
+* Ariel Rokem
+* David Romero-Bascones
+* Deneb Boito
+* Eleftherios Garyfallidis
+* Emmanuelle Renauld
+* Eric Larson
+* Francois Rheault
+* Jacob Roberts
+* Jon Haitz Legarreta Gorroño
+* Malinda Dilhara
+* Omar Ocegueda
+* Sam Coveney
+* Serge Koudoro
+* Shreyas Fadnavis
+* Tom Dela Haije
+
+
+We closed a total of 116 issues, 41 pull requests and 75 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (41):
+
+* :ghpull:`2710`: small fixes for tutorials
+* :ghpull:`2711`: [FIX] use tempfile module instead of nibabel for TemporaryDirectory
+* :ghpull:`2702`: One more small fix to the hcp fetcher.
+* :ghpull:`2704`: MAINT: Fixes for 3.11 and sdist
+* :ghpull:`2701`: FIX: Don't print a progbar for downloading unless you need to.
+* :ghpull:`2700`: [FIX] incompatible type in numpy array
+* :ghpull:`2694`: NF: Add RUMBA-SD reconstruction workflow
+* :ghpull:`2697`: NF: Adds a fetcher for HCP data.
+* :ghpull:`2692`: RF: Improve multi-shell RUMBA test WM response parameterization
+* :ghpull:`2693`: TEST: Fix `Node.js` warnings linked to GitHub actions
+* :ghpull:`2687`: DOC: Fix typos in SH theory documentation page
+* :ghpull:`2690`: STYLE: Remove unnecessary b-val print in CSD reconstruction flow
+* :ghpull:`2688`: DOC: Document Dirac delta generation method missing member
+* :ghpull:`2683`: DOC: Adds missing documentation for a kwarg.
+* :ghpull:`2668`: ENH: Make the DTI fit CLI metric saving message accurate
+* :ghpull:`2674`: Improve doc (tensor values' order)
+* :ghpull:`2670`: ENH: Allow non-default parameters to `Patch2Self` CLI
+* :ghpull:`2672`: DOC: Miscellaneous docstring fixes
+* :ghpull:`2669`: DOC: Remove inaccurate `patch2self` docstring default values
+* :ghpull:`2664`: DOC: Fix DTI fit CLI docstring
+* :ghpull:`2553`: NF: Unbiased groupwise linear bundle registration
+* :ghpull:`2369`: Transform points with DiffeormorphicMap
+* :ghpull:`2631`: [FIX] Allow patch size parameter to be an int on denoise Workflow
+* :ghpull:`2630`: [DOC] Remove search index
+* :ghpull:`2629`: [FIX ] Handle save VTP
+* :ghpull:`2618`: Use np.linalg.multi_dot instead of multiple np.dot routines
+* :ghpull:`2606`: STYLE: Fix miscellaneous Python warnings
+* :ghpull:`2600`: Pin Ray
+* :ghpull:`2531`: NF: MAP+ constraints
+* :ghpull:`2589`: Switch from using nibabel InTemporaryDirectory to standard library tmpfile module
+* :ghpull:`2577`: Add positivity constraints to QTI
+* :ghpull:`2595`: Temporary skip Cython 0.29.29
+* :ghpull:`2591`: STYLE: Avoid array-like mutable default argument values
+* :ghpull:`2592`: STYLE: Fix miscellaneous Python warnings
+* :ghpull:`2579`: Generalized PCA to less than 3 spatial dims
+* :ghpull:`2584`: transform_streamlines changes dtype to float64
+* :ghpull:`2566`: [FIX] Update tests for the deprecated `dipy.io.bvectxt` module
+* :ghpull:`2581`: Fix logger in SFT
+* :ghpull:`2580`: DOC: Fix typos and grammar
+* :ghpull:`2576`: DOC: Documentation fixes
+* :ghpull:`2568`: DOC: Fix the docstring of `write_mapping`
+
+Issues (75):
+
+* :ghissue:`2710`: small fixes for tutorials
+* :ghissue:`2711`: [FIX] use tempfile module instead of nibabel for TemporaryDirectory
+* :ghissue:`2709`: DiffeomorphicMap object on github not the same as recent release
+* :ghissue:`2708`: Provide the dataset of this code
+* :ghissue:`2699`: WIP: Single shell/noreg redux
+* :ghissue:`2702`: One more small fix to the hcp fetcher.
+* :ghissue:`2704`: MAINT: Fixes for 3.11 and sdist
+* :ghissue:`2701`: FIX: Don't print a progbar for downloading unless you need to.
+* :ghissue:`2700`: [FIX] incompatible type in numpy array
+* :ghissue:`2694`: NF: Add RUMBA-SD reconstruction workflow
+* :ghissue:`2696`: Port HCP fetcher from pyAFQ into here
+* :ghissue:`2697`: NF: Adds a fetcher for HCP data.
+* :ghissue:`2692`: RF: Improve multi-shell RUMBA test WM response parameterization
+* :ghissue:`2693`: TEST: Fix `Node.js` warnings linked to GitHub actions
+* :ghissue:`1418`: Adding parallel_voxel_fit decorator
+* :ghissue:`2687`: DOC: Fix typos in SH theory documentation page
+* :ghissue:`2690`: STYLE: Remove unnecessary b-val print in CSD reconstruction flow
+* :ghissue:`2688`: DOC: Document Dirac delta generation method missing member
+* :ghissue:`2683`: DOC: Adds missing documentation for a kwarg.
+* :ghissue:`2679`: Problems with a .nii.gz file when loading and floating
+* :ghissue:`2676`: Does ```convert_sh_to_legacy``` work as intended ?
+* :ghissue:`2668`: ENH: Make the DTI fit CLI metric saving message accurate
+* :ghissue:`2674`: Improve doc (tensor values' order)
+* :ghissue:`2670`: ENH: Allow non-default parameters to `Patch2Self` CLI
+* :ghissue:`2673`: ENH: Doc: DTI format
+* :ghissue:`2667`: Defaults for Patch2Self
+* :ghissue:`2672`: DOC: Miscellaneous docstring fixes
+* :ghissue:`2669`: DOC: Remove inaccurate `patch2self` docstring default values
+* :ghissue:`2662`: Update cmd_line dipy_fit_dti
+* :ghissue:`2664`: DOC: Fix DTI fit CLI docstring
+* :ghissue:`2658`: Any chance of arm64 wheels for Mac / Python 3.10?
+* :ghissue:`2659`: Angle var
+* :ghissue:`2649`: IVIM VarPro fitting running error
+* :ghissue:`2553`: NF: Unbiased groupwise linear bundle registration
+* :ghissue:`2424`: Transforming individual points with SDR
+* :ghissue:`2327`: Diffeomorphic transformation of coordinates
+* :ghissue:`2313`: deform_streamlines for wholebrain tractogram doesn't function properly
+* :ghissue:`936`: WIP: coordinate mapping with DiffeomorphicMap
+* :ghissue:`2369`: Transform points with DiffeormorphicMap
+* :ghissue:`2616`: dti TensorModel fitting issue
+* :ghissue:`2627`: Free-Water Analysis Gradient Table Error
+* :ghissue:`2635`: get_flexi_tvis_affine(tvis_hdr, nii_aff)
+* :ghissue:`2634`: Fix small difference between pdfs dense 2d/3d
+* :ghissue:`2559`: CLI denoise patch_size error
+* :ghissue:`2631`: [FIX] Allow patch size parameter to be an int on denoise Workflow
+* :ghissue:`2564`: Search, index, module links not working in the doc
+* :ghissue:`2630`: [DOC] Remove search index
+* :ghissue:`2572`: Saving vtp file error
+* :ghissue:`2629`: [FIX ] Handle save VTP
+* :ghissue:`2622`: Error with Illustrating Electrostatic Repulsion
+* :ghissue:`2618`: Use np.linalg.multi_dot instead of multiple np.dot routines
+* :ghissue:`2617`: DKI model fit shape broadcast error
+* :ghissue:`2606`: STYLE: Fix miscellaneous Python warnings
+* :ghissue:`2602`: Dear experts, how can I set different number of fiber tracks before generating streamlines?
+* :ghissue:`2603`: Dear experts, how to save dti_peaks?
+* :ghissue:`2600`: Pin Ray
+* :ghissue:`2531`: NF: MAP+ constraints
+* :ghissue:`2587`: Thread safety concerns with reliance on `nibabel.tmpdirs.InTemporaryDirectory`
+* :ghissue:`2589`: Switch from using nibabel InTemporaryDirectory to standard library tmpfile module
+* :ghissue:`2577`: Add positivity constraints to QTI
+* :ghissue:`2450`: [NF] New tracking Algorithm:  Parallel Transport Tractography (PTT)
+* :ghissue:`2594`: DIPY compilation fails with the last release of cython (0.29.29)
+* :ghissue:`2595`: Temporary skip Cython 0.29.29
+* :ghissue:`2591`: STYLE: Avoid array-like mutable default argument values
+* :ghissue:`2592`: STYLE: Fix miscellaneous Python warnings
+* :ghissue:`2579`: Generalized PCA to less than 3 spatial dims
+* :ghissue:`2584`: transform_streamlines changes dtype to float64
+* :ghissue:`2566`: [FIX] Update tests for the deprecated `dipy.io.bvectxt` module
+* :ghissue:`2581`: Fix logger in SFT
+* :ghissue:`2580`: DOC: Fix typos and grammar
+* :ghissue:`2576`: DOC: Documentation fixes
+* :ghissue:`2573`: Cannot Import "Feature" From "dipy.segment.metric"
+* :ghissue:`2568`: DOC: Fix the docstring of `write_mapping`
+* :ghissue:`2567`: This should be a `1`
+* :ghissue:`2565`: compress_streamlines() not available anymore

--- a/doc/stateoftheart.rst
+++ b/doc/stateoftheart.rst
@@ -28,6 +28,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/release1.6
    release_notes/release1.5
    release_notes/release1.4.1
    release_notes/release1.4

--- a/tools/ci/activate_env.sh
+++ b/tools/ci/activate_env.sh
@@ -1,7 +1,7 @@
 if [ -e venv/bin/activate ]; then
     source venv/bin/activate
 elif [ -e venv/Scripts/activate ]; then
-    source virtenv/Scripts/activate
+    source venv/Scripts/activate
 elif [ "$INSTALL_TYPE" == "conda" ]; then
     conda init bash
     source $CONDA/etc/profile.d/conda.sh

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -7,7 +7,7 @@ set -ex
 
 PIPI="pip install --timeout=60"
 
-if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" = true ]; then
+if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" == true ]; then
     PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
 fi
 

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -16,7 +16,7 @@ if [ "$INSTALL_TYPE" == "conda" ]; then
 else
     PIPI="pip install --timeout=60 "
 
-    if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" = true ]; then
+    if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" == true ]; then
         PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
     fi
 

--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -14,7 +14,7 @@ cd for_testing
 cp ../setup.cfg .
 # No figure windows for mpl; quote to hide : from travis-ci yaml parsing
 echo "backend : agg" > matplotlibrc
-if [ "$COVERAGE" == "1" ] || [ "$COVERAGE" = true ]; then
+if [ "$COVERAGE" == "1" ] || [ "$COVERAGE" == true ]; then
     cp ../.coveragerc .;
     cp ../.codecov.yml .;
     # Run the tests and check for test coverage.

--- a/tools/doctest_extmods.py
+++ b/tools/doctest_extmods.py
@@ -12,7 +12,7 @@ Examples
 
 import sys
 import os
-from os.path import dirname, relpath, sep, join as pjoin, splitext, abspath
+from os.path import dirname, relpath, sep, join as pjoin, abspath
 
 from distutils.sysconfig import get_config_vars
 
@@ -32,12 +32,12 @@ def get_ext_modules(pkg_name):
         if reldir == '.':
             reldir = ''
         for filename in filenames:
-            froot, ext = splitext(filename)
-            if ext == EXT_EXT:
+            if filename.endswith(EXT_EXT):
+                froot = filename[:-len(EXT_EXT)]
                 mod_path = pjoin(reldir, froot)
                 mod_uri = pkg_name + '.' + mod_path.replace(sep, '.')
-                # fromlist=[''] results in submodule being returned, rather than the
-                # top level module.  See help(__import__)
+                # fromlist=[''] results in submodule being returned, rather
+                # than the top level module.  See help(__import__)
                 mod = __import__(mod_uri, fromlist=[''])
                 ext_modules.append(mod)
     return ext_modules
@@ -54,7 +54,7 @@ def main():
     mods = get_ext_modules(mod_name)
     for mod in mods:
         print("Testing module: " + mod.__name__)
-        doctest.testmod(mod)
+        doctest.testmod(mod, optionflags=doctest.NORMALIZE_WHITESPACE)
 
 
 if __name__ == '__main__':

--- a/tools/ex2rst
+++ b/tools/ex2rst
@@ -96,7 +96,8 @@ def exfile2rst(filename):
 
         # if we have something that should go into the text
         if indocs \
-           or (cleanline.startswith('"""') or cleanline.startswith("'''")):
+           or (cleanline.startswith('"""') or cleanline.startswith("'''") or
+               cleanline.startswith('r"""') or cleanline.startswith("r'''")):
             # handle doc start
             if not indocs:
                 # guarenteed to start with """


### PR DESCRIPTION
Following on from #2678 I have attempted to do several things:
1) fix `genpca` to work when the number of samples (voxels) is less than the number of features (images) by modifying `_pca_classifier`
2) fix `pca_noise_estimate` to use the canonical algorithm (which was that specified in the function docs), although I have left the original DiPy method available
3) modified `localpca` to use the `pca_noise_estimate` (which would make this function canonical) and to raise a warning if an estimate of sigma is provided to this function

Comments and thoughts welcome. _Especially_ where I have made some modifications of estimated values that attempt to take account of the centering of the data matrix used for PCA (there are some NOTEs left in the code highlighting areas that may need looking at, I can always change things back).