### PR TITLE
[FIX] use tempfile module instead of nibabel for TemporaryDirectory

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -107,14 +107,22 @@ class ParzenJointHistogram(object):
         self.mmin = np.min(moving[mmask != 0])
         self.mmax = np.max(moving[mmask != 0])
 
-        divider = self.nbins - 2 * self.padding
-        self.sdelta = ((self.smax - self.smin) / divider) if divider else 0
-        self.mdelta = ((self.mmax - self.mmin) / divider) if divider else 0
+        numerator = self.smax - self.smin
+        denominator = self.nbins - 2 * self.padding
+        self.sdelta = np.divide(numerator, denominator,
+                                out=np.zeros_like(numerator, dtype=np.float64),
+                                where=denominator!=0)
+        numerator = self.mmax - self.mmin
+        self.mdelta = np.divide(numerator, denominator,
+                                out=np.zeros_like(numerator, dtype=np.float64),
+                                where=denominator!=0)
 
-        divider = self.sdelta - self.padding
-        self.smin = (self.smin / divider) if divider else 0
-        divider = self.mdelta - self.padding
-        self.mmin = (self.mmin / divider) if divider else 0
+        self.smin = np.divide(self.smin, self.sdelta,
+                              out=np.zeros_like(self.smin, dtype=np.float64),
+                              where=self.sdelta!=0) - self.padding
+        self.mmin = np.divide(self.mmin, self.mdelta,
+                              out=np.zeros_like(self.mmin, dtype=np.float64),
+                              where=self.mdelta!=0) - self.padding
 
         self.joint_grad = None
         self.metric_grad = None
@@ -453,6 +461,8 @@ cdef inline double _bin_normalize(double x, double mval, double delta) nogil:
     padding, padding+1, ..., nbins - 1 - padding (i.e., nbins - 2*padding bins)
 
     """
+    if delta == 0:
+        return 0
     return x / delta - mval
 
 

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -107,10 +107,14 @@ class ParzenJointHistogram(object):
         self.mmin = np.min(moving[mmask != 0])
         self.mmax = np.max(moving[mmask != 0])
 
-        self.sdelta = (self.smax - self.smin) / (self.nbins - 2 * self.padding)
-        self.mdelta = (self.mmax - self.mmin) / (self.nbins - 2 * self.padding)
-        self.smin = self.smin / self.sdelta - self.padding
-        self.mmin = self.mmin / self.mdelta - self.padding
+        divider = self.nbins - 2 * self.padding
+        self.sdelta = ((self.smax - self.smin) / divider) if divider else 0
+        self.mdelta = ((self.mmax - self.mmin) / divider) if divider else 0
+
+        divider = self.sdelta - self.padding
+        self.smin = (self.smin / divider) if divider else 0
+        divider = self.mdelta - self.padding
+        self.mmin = (self.mmin / divider) if divider else 0
 
         self.joint_grad = None
         self.metric_grad = None

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -3,7 +3,6 @@ import os.path as op
 import sys
 import os
 import numpy.testing as npt
-from nibabel.tmpdirs import TemporaryDirectory
 import dipy.data.fetcher as fetcher
 from dipy.data import SPHERE_FILES
 from threading import Thread
@@ -29,7 +28,7 @@ def test_check_md5():
 
 def test_make_fetcher():
     symmetric362 = SPHERE_FILES['symmetric362']
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         stored_md5 = fetcher._get_file_md5(symmetric362)
 
         # create local HTTP Server
@@ -73,7 +72,7 @@ def test_make_fetcher():
 
 def test_fetch_data():
     symmetric362 = SPHERE_FILES['symmetric362']
-    with TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         md5 = fetcher._get_file_md5(symmetric362)
         bad_md5 = '8' * len(md5)
 

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -1,5 +1,9 @@
+from packaging.version import Version
 from warnings import warn
+
 import numpy as np
+import scipy
+
 try:
     from scipy.linalg.lapack import dgesvd as svd
     svd_args = [1, 0]
@@ -202,6 +206,8 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
         var = np.zeros(arr.shape[:-1], dtype=calc_dtype)
         thetavar = np.zeros(arr.shape[:-1], dtype=calc_dtype)
 
+    SCIPY_LESS_1_5_0 = Version(scipy.__version__) < Version('1.5.0')
+    kw_eigh = {'turbo': True} if SCIPY_LESS_1_5_0 else {}  # {'driver': 'gvd'}
     # loop around and find the 3D patch for each direction at each pixel
     for k in range(patch_radius[2], arr.shape[2] - patch_radius[2]):
         for j in range(patch_radius[1], arr.shape[1] - patch_radius[1]):
@@ -238,7 +244,7 @@ def genpca(arr, sigma=None, mask=None, patch_radius=2, pca_method='eig',
                     # PCA using an Eigenvalue decomposition
                     C = np.transpose(X).dot(X)
                     C = C / X.shape[0]
-                    [d, W] = eigh(C, turbo=True)
+                    [d, W] = eigh(C, **kw_eigh)
 
                 if sigma is None:
                     # Random matrix theory

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -339,8 +339,9 @@ def patch2self(data, bvals, patch_radius=(0, 0, 0), model='ols',
         denoised_arr.clip(min=0, out=denoised_arr)
 
     elif clip_negative_vals and shift_intensity:
-        warn('Both `clip_negative_vals` and `shift_intensity` cannot be True.')
-        warn('Defaulting to `clip_negative_bvals`...')
+        msg = 'Both `clip_negative_vals` and `shift_intensity` cannot be True.'
+        msg += ' Defaulting to `clip_negative_vals`...'
+        warn(msg)
         denoised_arr.clip(min=0, out=denoised_arr)
 
     return np.array(denoised_arr, dtype=out_dtype)

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from dipy.denoise import patch2self as p2s
 from dipy.testing import (assert_greater, assert_less,
@@ -26,16 +28,21 @@ def test_patch2self_random_noise():
     assert_less_equal(np.round(S0den_shift.mean()), 30)
 
     # clip = True
-    S0den_clip = p2s.patch2self(S0, bvals, model='ols',
-                                clip_negative_vals=True)
+    msg = "Both `clip_negative_vals` and `shift_intensity` .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        S0den_clip = p2s.patch2self(S0, bvals, model='ols',
+                                    clip_negative_vals=True)
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
 
     # both clip and shift = True, and int patch_radius
-    S0den_clip = p2s.patch2self(S0, bvals, patch_radius=0, model='ols',
-                                clip_negative_vals=True,
-                                shift_intensity=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        S0den_clip = p2s.patch2self(S0, bvals, patch_radius=0, model='ols',
+                                    clip_negative_vals=True,
+                                    shift_intensity=True)
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
@@ -47,6 +54,7 @@ def test_patch2self_random_noise():
 
     assert_greater(S0den_clip.min(), S0.min())
     assert_equal(np.round(S0den_clip.mean()), 30)
+
 
 @needs_sklearn
 def test_patch2self_boundary():

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -481,7 +481,7 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
 
     peak_dirs = np.zeros((shape + (npeaks, 3)))
     peak_values = np.zeros((shape + (npeaks,)))
-    peak_indices = np.zeros((shape + (npeaks,)), dtype='int')
+    peak_indices = np.zeros((shape + (npeaks,)), dtype=np.int32)
     peak_indices.fill(-1)
 
     if return_sh:

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -1,4 +1,6 @@
 
+from packaging.version import Version
+
 import nibabel as nib
 import numpy as np
 
@@ -99,6 +101,7 @@ def save_nifti(fname, data, affine, hdr=None, dtype=None):
     None
 
     """
+    NIBABEL_4_0_0_PLUS = Version(nib.__version__) >= Version('4.0.0')
     # See GitHub issues
     #  * https://github.com/nipy/nibabel/issues/1046
     #  * https://github.com/nipy/nibabel/issues/1089
@@ -106,7 +109,8 @@ def save_nifti(fname, data, affine, hdr=None, dtype=None):
     # not support 64-bit integer data, so `set_data_dtype(int64)` would
     # already fail.
     danger_dts = (np.dtype('int64'), np.dtype('uint64'))
-    if hdr is None and dtype is None and data.dtype in danger_dts:
+    if hdr is None and dtype is None and data.dtype in danger_dts and \
+       NIBABEL_4_0_0_PLUS:
         msg = f"Image data has type {data.dtype}, which may cause "
         msg += "incompatibilities with other tools. Indeed, Analyze formats "
         msg += "did not support 64-bit integer data.\n\n"
@@ -117,7 +121,8 @@ def save_nifti(fname, data, affine, hdr=None, dtype=None):
 
         raise ValueError(msg)
 
-    result_img = nib.Nifti1Image(data, affine, header=hdr, dtype=dtype)
+    kwargs = {'dtype': dtype} if NIBABEL_4_0_0_PLUS else {}
+    result_img = nib.Nifti1Image(data, affine, header=hdr, **kwargs)
     result_img.to_filename(fname)
 
 

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -77,7 +77,7 @@ def load_nifti(fname, return_img=False, return_voxsize=False,
     return tuple(ret_val)
 
 
-def save_nifti(fname, data, affine, hdr=None):
+def save_nifti(fname, data, affine, hdr=None, dtype=None):
     """Save a data array into a nifti file.
 
     Parameters
@@ -99,7 +99,25 @@ def save_nifti(fname, data, affine, hdr=None):
     None
 
     """
-    result_img = nib.Nifti1Image(data, affine, header=hdr)
+    # See GitHub issues
+    #  * https://github.com/nipy/nibabel/issues/1046
+    #  * https://github.com/nipy/nibabel/issues/1089
+    # This only applies to NIfTI because the parent Analyze formats did
+    # not support 64-bit integer data, so `set_data_dtype(int64)` would
+    # already fail.
+    danger_dts = (np.dtype('int64'), np.dtype('uint64'))
+    if hdr is None and dtype is None and data.dtype in danger_dts:
+        msg = f"Image data has type {data.dtype}, which may cause "
+        msg += "incompatibilities with other tools. Indeed, Analyze formats "
+        msg += "did not support 64-bit integer data.\n\n"
+        msg += "To silent this, please specify the `header` or `dtype` "
+        msg += "You could also use `np.asarray(data, dtype=np.int32)`. "
+        msg += "This cast will make sure that you data is compatible with "
+        msg += "other software."
+
+        raise ValueError(msg)
+
+    result_img = nib.Nifti1Image(data, affine, header=hdr, dtype=dtype)
     result_img.to_filename(fname)
 
 

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -62,8 +62,12 @@ def setup_module():
     ivim_params_trr[0, 0, 0] = ivim_params_trr[0, 1, 0] = params_trr
     ivim_params_trr[1, 0, 0] = ivim_params_trr[1, 1, 0] = params_trr
 
-    ivim_model_trr = IvimModel(gtab, fit_method='trr')
-    ivim_model_one_stage = IvimModel(gtab, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_trr = IvimModel(gtab, fit_method='trr')
+        ivim_model_one_stage = IvimModel(gtab, fit_method='trr')
+
     ivim_fit_single = ivim_model_trr.fit(data_single)
     ivim_fit_multi = ivim_model_trr.fit(data_multi)
 
@@ -100,7 +104,10 @@ def setup_module():
         1, 0, 0] = noisy_multi[1, 1, 0] = noisy_single
     noisy_multi[0, 0, 0] = data_single
 
-    ivim_model_VP = IvimModel(gtab, fit_method='VarPro')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_VP = IvimModel(gtab, fit_method='VarPro')
     f_VP, D_star_VP, D_VP = 0.13, 0.0088, 0.000921
     # params for a single voxel
     params_VP = np.array([f, D_star, D])
@@ -321,7 +328,11 @@ def test_multiple_b0():
     # Single voxel data
     data_single = signal[0]
 
-    ivim_model_multiple_b0 = IvimModel(gtab_with_multiple_b0, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_model_multiple_b0 = IvimModel(gtab_with_multiple_b0,
+                                           fit_method='trr')
 
     ivim_model_multiple_b0.fit(data_single)
     # Test if all signals are positive
@@ -340,7 +351,11 @@ def test_noisy_fit():
     around 135 and D and D_star values are equal. Hence doing a test based on
     Scipy version.
     """
-    model_one_stage = IvimModel(gtab, fit_method='trr')
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        model_one_stage = IvimModel(gtab, fit_method='trr')
+
     with warnings.catch_warnings(record=True) as w:
         fit_one_stage = model_one_stage.fit(noisy_single)
         assert_equal(len(w), 3)
@@ -423,7 +438,11 @@ def test_fit_one_stage():
     """
     Test to check the results for the one_stage linear fit.
     """
-    model = IvimModel(gtab, two_stage=False)
+    msg = "Bounds for this fit have been set from experiments .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        model = IvimModel(gtab, two_stage=False)
+
     fit = model.fit(data_single)
     linear_fit_params = [9.88834140e+02, 1.19707191e-01, 7.91176970e-03,
                          9.30095210e-04]

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -569,6 +569,12 @@ def test_spherical_l1_increases_sparsity(radial_order=4, time_order=2):
         warnings.filterwarnings(
             "ignore", message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning)
+        warnings.filterwarnings(
+            "ignore", message="cvxpy optimization resulted in .*",
+            category=UserWarning)
+        warnings.filterwarnings(
+            "ignore", message="Solution may be inaccurate..*",
+            category=UserWarning)
         qtdmri_fit_no_l1 = qtdmri_mod_no_l1.fit(S)
         qtdmri_fit_l1 = qtdmri_mod_l1.fit(S)
 

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -24,7 +24,6 @@ from dipy.reconst.shm import descoteaux07_legacy_msg
 def test_rumba():
 
     # Test fODF results from ideal examples.
-
     sphere = default_sphere  # repulsion 724
     sphere2 = get_sphere('symmetric362')
 
@@ -37,8 +36,13 @@ def test_rumba():
                                               fractions=[50, 50], snr=None)
 
     # Testing input validation
-    gtab_broken = gradient_table(
-        bvals[~gtab.b0s_mask], bvecs[~gtab.b0s_mask])
+    msg = "b0_threshold .*"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg,
+                                category=UserWarning)
+        gtab_broken = gradient_table(bvals[~gtab.b0s_mask],
+                                     bvecs[~gtab.b0s_mask])
+
     assert_raises(ValueError, RumbaSDModel, gtab_broken)
 
     with warnings.catch_warnings(record=True) as w:
@@ -186,8 +190,12 @@ def test_mvoxel_rumba():
                              sphere=sphere)
     model_list = [rumba_smf, rumba_sos]
 
+    msg = "There is overlap in clustering of b-value.*"
     for model in model_list:
-        model_fit = model.fit(data)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            model_fit = model.fit(data)
 
         odf = model_fit.odf(sphere)
         f_iso = model_fit.f_iso
@@ -197,10 +205,14 @@ def test_mvoxel_rumba():
         combined = model_fit.combined_odf_iso
 
         # Verify prediction properties
-        pred_sig_1 = model_fit.predict()
-        pred_sig_2 = model_fit.predict(S0=1)
-        pred_sig_3 = model_fit.predict(S0=np.ones(odf.shape[:-1]))
-        pred_sig_4 = model_fit.predict(gtab=gtab)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            pred_sig_1 = model_fit.predict()
+            pred_sig_2 = model_fit.predict(S0=1)
+            pred_sig_3 = model_fit.predict(S0=np.ones(odf.shape[:-1]))
+            pred_sig_4 = model_fit.predict(gtab=gtab)
 
         assert_equal(pred_sig_1, pred_sig_2)
         assert_equal(pred_sig_3, pred_sig_4)
@@ -319,7 +331,11 @@ def test_mvoxel_global_fit():
 
     # Test each model with/without TV regularization
     for model in model_list:
-        model_fit = model.fit(data)
+        msg = "There is overlap in clustering of b-value.*"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            model_fit = model.fit(data)
         odf = model_fit.odf(sphere)
         f_iso = model_fit.f_iso
         f_wm = model_fit.f_wm

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,6 +1,7 @@
 import sys
 import numpy as np
 import pytest
+import warnings
 
 from numpy.testing import assert_equal, assert_almost_equal
 from dipy.data import get_fnames
@@ -43,7 +44,10 @@ def test_rb_check_defaults():
                                          model_clust_thr=5.,
                                          reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -55,7 +59,9 @@ def test_rb_check_defaults():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -73,7 +79,10 @@ def test_rb_disable_slr():
                                          reduction_thr=10,
                                          slr=False)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -85,7 +94,9 @@ def test_rb_disable_slr():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -113,7 +124,11 @@ def test_rb_slr_threads():
                                                      slr=True,
                                                      num_threads=1)
 
-    D = bundles_distances_mam(rec_trans_multi_threads, rec_trans_single_thread)
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(rec_trans_multi_threads,
+                                  rec_trans_single_thread)
 
     # check if the bundle is recognized correctly
     # multi-threading prevent an exact match
@@ -133,7 +148,10 @@ def test_rb_no_verbose_and_mam():
                                          slr=True,
                                          pruning_distance='mam')
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -145,7 +163,9 @@ def test_rb_no_verbose_and_mam():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -164,7 +184,10 @@ def test_rb_clustermap():
                                          model_clust_thr=5.,
                                          reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -176,7 +199,9 @@ def test_rb_clustermap():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:
@@ -233,7 +258,10 @@ def test_rb_reduction_mam():
                                          slr_metric='asymmetric',
                                          pruning_distance='mam')
 
-    D = bundles_distances_mam(f2, f[rec_labels])
+    msg = "Streamlines do not have the same number of points. *"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[rec_labels])
 
     # check if the bundle is recognized correctly
     if len(f2) == len(rec_labels):
@@ -245,7 +273,9 @@ def test_rb_reduction_mam():
                                             model_clust_thr=5.,
                                             reduction_thr=10)
 
-    D = bundles_distances_mam(f2, f[refine_labels])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        D = bundles_distances_mam(f2, f[refine_labels])
 
     # check if the bundle is recognized correctly
     for row in D:

--- a/dipy/utils/tests/test_deprecator.py
+++ b/dipy/utils/tests/test_deprecator.py
@@ -223,11 +223,14 @@ def test_deprecated_argument():
         # One positional, one keyword
         npt.assert_raises(TypeError, method, 1, scale=2)
 
-    with pytest.warns(None) as w_record:
+    with warnings.catch_warnings(record=True) as w_record:
         res = CustomActor().test5(4)
 
-    npt.assert_equal(len(w_record), 0)
-    npt.assert_equal(res, 4)
+        # Select only UserWarning
+        selected_w = [w for w in w_record
+                      if issubclass(w.category, UserWarning)]
+        npt.assert_equal(len(selected_w), 0)
+        npt.assert_equal(res, 4)
 
 
 def test_deprecated_argument_in_kwargs():
@@ -274,10 +277,10 @@ def test_deprecated_argument_multi_deprecation():
     with pytest.warns(ArgsDeprecationWarning) as w:
         npt.assert_equal(test(x=1, y=2, z=3), (1, 2, 3))
         npt.assert_equal(test2(x=1, y=2, z=3), (1, 2, 3))
-    npt.assert_equal(len(w), 6)
+        npt.assert_equal(len(w), 6)
 
-    npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
-    npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
+        npt.assert_raises(TypeError, test, x=1, y=2, z=3, b=3)
+        npt.assert_raises(TypeError, test, x=1, y=2, z=3, a=3)
 
 
 def test_deprecated_argument_not_allowed_use():

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -1,14 +1,16 @@
 import os
 import numpy as np
 import pytest
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
+
 from dipy.tracking.streamline import Streamlines
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.utils import create_nifti_header
 from dipy.testing.decorators import use_xvfb
 from dipy.utils.optpkg import optional_package
 from dipy.data import DATA_DIR
-from nibabel.tmpdirs import TemporaryDirectory
 
 fury, has_fury, setup_module = optional_package('fury')
 

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -609,7 +609,7 @@ class BundleShapeAnalysis(Workflow):
             logging.info("saving BA score matrix")
             np.save(os.path.join(out_dir, bun[:-4]+".npy"), ba_matrix)
 
-            cmap = matplt.cm.get_cmap('Blues')
+            cmap = matplt.colormaps['Blues']
             plt.title(bun[:-4])
             plt.imshow(ba_matrix, cmap=cmap)
             plt.colorbar()

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -1,11 +1,10 @@
 from os.path import join as pjoin
 import os.path
+from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
 import numpy as np
-
 import nibabel as nib
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
 from dipy.align.tests.test_parzenhist import setup_random_transform

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -1,9 +1,11 @@
 import os
+from tempfile import TemporaryDirectory
+
 import pytest
 import numpy as np
 import numpy.testing as npt
 from dipy.utils.optpkg import optional_package
-from nibabel.tmpdirs import TemporaryDirectory
+
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti, load_nifti_data
 

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,8 +1,9 @@
-import numpy.testing as npt
 import sys
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import TemporaryDirectory
+import numpy.testing as npt
+
 from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import (

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -1,13 +1,15 @@
 import logging
 import os
+from tempfile import mkstemp, TemporaryDirectory
+
 import numpy.testing as npt
+
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti
 from dipy.testing import assert_true
 from dipy.data.fetcher import dipy_home
 from dipy.workflows.io import IoInfoFlow, FetchFlow, SplitFlow
-from nibabel.tmpdirs import TemporaryDirectory
-from tempfile import mkstemp
+
 fname_log = mkstemp()[1]
 
 logging.basicConfig(level=logging.INFO,

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -1,7 +1,7 @@
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
 from dipy.testing import assert_false
-
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -1,19 +1,20 @@
+import logging
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 import warnings
 
-import logging
 import numpy as np
-from os.path import join as pjoin
 import numpy.testing as npt
 
 from dipy.io.peaks import load_peaks
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti, load_nifti_data
 from dipy.core.gradients import generate_bvecs
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
 from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
+
 logging.getLogger().setLevel(logging.INFO)
 
 

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -1,6 +1,5 @@
 from os.path import join as pjoin
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -1,6 +1,5 @@
 from os.path import join
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 from numpy.testing import assert_equal

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -1,6 +1,5 @@
 from os.path import join as pjoin
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -1,5 +1,6 @@
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
 
@@ -12,7 +13,6 @@ from dipy.workflows.reconst import ReconstIvimFlow
 
 
 def test_reconst_ivim():
-
     with TemporaryDirectory() as out_dir:
         bvals = np.array([0., 10., 20., 30., 40., 60., 80., 100.,
                           120., 140., 160., 180., 200., 300., 400.,
@@ -40,7 +40,8 @@ def test_reconst_ivim():
         data_multi[0, 0, 0] = data_multi[0, 1, 0] = data_multi[
             1, 0, 0] = data_multi[1, 1, 0] = data_single
         data_path = pjoin(out_dir, 'tmp_data.nii.gz')
-        save_nifti(data_path, data_multi, temp_affine)
+        save_nifti(data_path, data_multi, temp_affine,
+                   dtype=data_multi.dtype)
 
         mask = np.ones_like(data_multi[..., 0], dtype=np.uint8)
         mask_path = pjoin(out_dir, 'tmp_mask.nii.gz')
@@ -50,7 +51,12 @@ def test_reconst_ivim():
 
         args = [data_path, temp_bval_path, temp_bvec_path, mask_path]
 
-        ivim_flow.run(*args, out_dir=out_dir)
+        msg = "Bounds for this fit have been set from experiments and * "
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=msg,
+                category=UserWarning)
+            ivim_flow.run(*args, out_dir=out_dir)
 
         S0_path = ivim_flow.last_generated_outputs['out_S0_predicted']
         S0_data = load_nifti_data(S0_path)

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,16 +1,15 @@
 from os.path import join as pjoin
-
-from nibabel.tmpdirs import TemporaryDirectory
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
 import pytest
-from dipy.reconst import mapmri
 
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
 from dipy.core.gradients import generate_bvecs
+from dipy.reconst import mapmri
 from dipy.workflows.reconst import ReconstMAPMRIFlow
 
 

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,5 +1,6 @@
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -37,10 +38,15 @@ def reconst_mmri_core(flow, lap, pos):
         volume = load_nifti_data(data_path)
 
         mmri_flow = flow()
-        mmri_flow.run(data_files=data_path, bvals_files=bval_path,
-                      bvecs_files=bvec_path, small_delta=0.0129,
-                      big_delta=0.0218, laplacian=lap,
-                      positivity=pos, out_dir=out_dir)
+
+        msg = "Optimization did not find a solution"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=msg,
+                                    category=UserWarning)
+            mmri_flow.run(data_files=data_path, bvals_files=bval_path,
+                          bvecs_files=bvec_path, small_delta=0.0129,
+                          big_delta=0.0218, laplacian=lap,
+                          positivity=pos, out_dir=out_dir)
 
         for out_name in ['out_rtop', 'out_lapnorm', 'out_msd', 'out_qiv',
                          'out_rtap', 'out_rtpp', 'out_ng', 'out_parng',

--- a/dipy/workflows/tests/test_reconst_rumba.py
+++ b/dipy/workflows/tests/test_reconst_rumba.py
@@ -1,18 +1,15 @@
 import logging
-import warnings
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
-import numpy.testing as npt
-from nibabel.tmpdirs import TemporaryDirectory
 
-from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
-from dipy.io.peaks import load_peaks
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti, save_nifti, load_nifti_data
+from dipy.io.image import load_nifti, save_nifti
 from dipy.workflows.reconst import ReconstRUMBAFlow
-from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
+from dipy.reconst.shm import descoteaux07_legacy_msg
+
 logging.getLogger().setLevel(logging.INFO)
 
 

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -1,19 +1,20 @@
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
-from os.path import join
-import nibabel as nib
 import numpy as np
-from nibabel.tmpdirs import TemporaryDirectory
+import nibabel as nib
+
+from dipy.align.streamlinear import BundleMinDistanceMetric
 from dipy.data import get_fnames
 from dipy.segment.mask import median_otsu
 from dipy.tracking.streamline import Streamlines
-from dipy.workflows.segment import MedianOtsuFlow
-from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.image import load_nifti_data
-from os.path import join as pjoin
 from dipy.tracking.streamline import set_number_of_points
-from dipy.align.streamlinear import BundleMinDistanceMetric
+from dipy.workflows.segment import MedianOtsuFlow
+from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
 
 
 def test_median_otsu_flow():
@@ -41,10 +42,10 @@ def test_median_otsu_flow():
                                    numpass=numpass,
                                    autocrop=autocrop, dilate=dilate)
 
-        result_mask_data = load_nifti_data(join(out_dir, mask_name))
+        result_mask_data = load_nifti_data(pjoin(out_dir, mask_name))
         npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
 
-        result_masked = nib.load(join(out_dir, masked_name))
+        result_masked = nib.load(pjoin(out_dir, masked_name))
         result_masked_data = np.asanyarray(result_masked.dataobj)
 
         npt.assert_array_equal(np.round(result_masked_data), masked)

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -2,22 +2,25 @@
 
 import os
 from os.path import join
-from dipy.utils.optpkg import optional_package
+from tempfile import TemporaryDirectory
+
 import numpy.testing as npt
 import pytest
-from nibabel.tmpdirs import TemporaryDirectory
 import numpy as np
-from dipy.tracking.streamline import Streamlines
-from dipy.testing import assert_true
+
+from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.data import get_fnames
+from dipy.testing import assert_true
+from dipy.tracking.streamline import Streamlines
+from dipy.utils.optpkg import optional_package
 from dipy.workflows.stats import SNRinCCFlow
 from dipy.workflows.stats import BundleAnalysisTractometryFlow
 from dipy.workflows.stats import LinearMixedModelsFlow
 from dipy.workflows.stats import BundleShapeAnalysis
 from dipy.workflows.stats import buan_bundle_profiles
+
 pd, have_pandas, _ = optional_package("pandas")
 _, have_statsmodels, _ = optional_package("statsmodels")
 _, have_tables, _ = optional_package("tables")

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -1,12 +1,12 @@
+from os.path import join
+from tempfile import TemporaryDirectory
 import warnings
 
+import nibabel as nib
 import numpy as np
 from numpy.testing import assert_equal
 from dipy.testing import assert_false, assert_true
-from os.path import join
 
-import nibabel as nib
-from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -1,4 +1,9 @@
 import os
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import numpy.testing as npt
+import pytest
 
 from dipy.io.image import save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
@@ -7,10 +12,6 @@ from dipy.io.utils import create_nifti_header
 from dipy.tracking.streamline import Streamlines
 from dipy.testing.decorators import use_xvfb
 from dipy.utils.optpkg import optional_package
-from nibabel.tmpdirs import TemporaryDirectory
-import numpy as np
-import numpy.testing as npt
-import pytest
 
 fury, has_fury, setup_module = optional_package('fury')
 

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -1,13 +1,13 @@
 import os
 import time
 from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import TemporaryDirectory
+import numpy.testing as npt
 
 from dipy.data import get_fnames
 from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.workflow import Workflow
-import numpy.testing as npt
 
 
 def test_force_overwrite():


### PR DESCRIPTION
`TemporaryDirectory` has been deprecated in nibabel. We should use the standard module `tempfile`. This PR fix this issue. Also, some import reshaping