### PR TITLE
fixed pca for features > samples, and fixed pca_noise_estimate

### DIFF
--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -10,6 +10,7 @@ import scipy.special as sps
 from scipy import ndimage
 cimport cython
 cimport numpy as cnp
+from warnings import warn
 
 # Try to get the SVD through direct API to lapack:
 try:
@@ -26,7 +27,7 @@ except ImportError:
 @cython.wraparound(False)
 @cython.cdivision(True)
 def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
-                       smooth=2):
+                       smooth=2, images_as_samples=False):
     """ PCA based local noise estimation.
 
     Parameters
@@ -47,11 +48,24 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
     smooth : int
         Radius of a Gaussian smoothing filter to apply to the noise estimate
         before returning. Default: 2.
+    image_as_samples : bool, optional
+        Whether to use images as rows (samples) for PCA (algorithm in [1]_) or
+        to use images as columns (features).
 
     Returns
     -------
     sigma_corr: 3D array
         The local noise standard deviation estimate.
+
+    Notes
+    -----
+        In [1]_, images are used as samples, so voxels are features, therefore
+        eigenvectors are image-shaped. However, [1]_ is not clear on how to use
+        these eigenvectors to determine the noise level, so here eigenvalues
+        (variance over samples explained by eigenvectors) are used to scale
+        the eigenvectors. Use images_as_samples=True to use this algorithm.
+        Alternatively, voxels can be used as samples using
+        images_as_samples=False. This is not the canonical algorithm of [1]_.
 
     References
     ----------
@@ -71,6 +85,10 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         # if only one b0 value then SIBE noise estimate
         data0 = data[..., ~gtab.b0s_mask]
         sibe = True
+
+    if patch_radius < 1:
+        warn("Minimum patch radius must be 1, setting to 1", UserWarning)
+        patch_radius = 1
 
     data0 = data0.astype(np.float64)
     cdef:
@@ -92,25 +110,42 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
     if (dsm != 1) and (dsm < 2 * patch_radius + 1):
         raise ValueError("Array 'data' is incorrect shape")
 
-    X = data0.reshape(nsamples, n3)
+    if images_as_samples:
+        X = data0.reshape(nsamples, n3).T
+    else:
+        X = data0.reshape(nsamples, n3)
+
     # Demean:
     M = np.mean(X, axis=0)
     X = X - M
     U, S, Vt = svd(X, *svd_args)[:3]
     # Rows of Vt are the eigenvectors, in ascending eigenvalue order:
     W = Vt.T
-    # Project into the data space
-    V = X.dot(W)
 
-    # Grab the column corresponding to the smallest eigen-vector/-value:
-    I = V[:, -1].reshape(n0, n1, n2)
+    if images_as_samples:
+        W = W.astype('double')
+        # #vox(features) >> # img(samples), last eigval zero (X is centered)
+        idx = n3 - 2  # use second-to-last eigvec
+        V = W[:, idx].reshape(n0, n1, n2)
+
+        # ref [1]_ method is ambiguous on how to use image-shaped eigvec
+        # since eigvec is normalized, used eigval=variance for scale
+        I = V * S[idx]
+    else:
+        # Project into the data space
+        V = X.dot(W)
+
+        # Grab the column corresponding to the smallest eigen-vector/-value:
+        # #vox(samples) >> #img(features), last eigenvector is meaningful
+        I = V[:, -1].reshape(n0, n1, n2)
+
     del V, W, X, U, S, Vt
 
     cdef:
-      double[:, :, :] count = np.zeros((n0, n1, n2))
-      double[:, :, :] mean = np.zeros((n0, n1, n2))
-      double[:, :, :] sigma_sq = np.zeros((n0, n1, n2))
-      double[:, :, :, :] data0temp = data0
+        double[:, :, :] count = np.zeros((n0, n1, n2))
+        double[:, :, :] mean = np.zeros((n0, n1, n2))
+        double[:, :, :] sigma_sq = np.zeros((n0, n1, n2))
+        double[:, :, :, :] data0temp = data0
 
     with nogil:
         for i in range(prx, n0 - prx):
@@ -123,37 +158,38 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
                             for k0 in range(-prz, prz + 1):
                                 sum_reg += I[i + i0, j + j0, k + k0] / norm
                                 for l0 in range(n3):
-                                    temp1 += (data0temp[i + i0, j+ j0, k + k0, l0]) / (norm * n3)
+                                    temp1 += (data0temp[i + i0, j + j0, k + k0, l0])\
+                                             / (norm * n3)
 
                     for i0 in range(-prx, prx + 1):
                         for j0 in range(-pry, pry + 1):
                             for k0 in range(-prz, prz + 1):
-                                sigma_sq[i + i0, j +j0, k + k0] += (
+                                sigma_sq[i + i0, j + j0, k + k0] += (
                                     I[i + i0, j + j0, k + k0] - sum_reg) ** 2
                                 mean[i + i0, j + j0, k + k0] += temp1
-                                count[i + i0, j +j0, k + k0] += 1
+                                count[i + i0, j + j0, k + k0] += 1
 
     sigma_sq = np.divide(sigma_sq, count)
 
     # find the SNR and make the correction for bias due to Rician noise:
     if correct_bias:
-      mean = np.divide(mean, count)
-      snr = np.divide(mean, np.sqrt(sigma_sq))
-      snr_sq = (snr ** 2)
-      # xi is practically equal to 1 above 37.4, and we overflow, raising
-      # warnings and creating ot-a-numbers.
-      # Instead, we will replace these values with 1 below
-      with np.errstate(over='ignore', invalid='ignore'):
-          xi = (2 + snr_sq - (np.pi / 8) * np.exp(-snr_sq / 2) *
+        mean = np.divide(mean, count)
+        snr = np.divide(mean, np.sqrt(sigma_sq))
+        snr_sq = (snr ** 2)
+        # xi is practically equal to 1 above 37.4, and we overflow, raising
+        # warnings and creating ot-a-numbers.
+        # Instead, we will replace these values with 1 below
+        with np.errstate(over='ignore', invalid='ignore'):
+            xi = (2 + snr_sq - (np.pi / 8) * np.exp(-snr_sq / 2) *
                   ((2 + snr_sq) * sps.iv(0, snr_sq / 4) +
                   snr_sq * sps.iv(1, snr_sq / 4)) ** 2).astype(float)
-      xi[snr > 37.4] = 1
-      sigma_corr = sigma_sq / xi
-      sigma_corr[np.isnan(sigma_corr)] = 0
+        xi[snr > 37.4] = 1
+        sigma_corr = sigma_sq / xi
+        sigma_corr[np.isnan(sigma_corr)] = 0
     else:
-      sigma_corr = sigma_sq
+        sigma_corr = sigma_sq
 
     if smooth is not None:
-      sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
+        sigma_corr = ndimage.gaussian_filter(sigma_corr, smooth)
 
     return np.sqrt(sigma_corr)

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,13 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.7.0 changes
+------------------
+
+**Denoising**
+
+- Change in ``dipy.denoise.localpca``, function ``genpca`` can use fewer images than patch voxels.
+- Change in ``dipy.denoise.pca_noise_estimate``, function ``pca_noise_estimate`` has new argument ``images_as_samples``
 
 DIPY 1.6.0 changes
 ------------------


### PR DESCRIPTION
Following on from https://github.com/dipy/dipy/discussions/2678 I have attempted to do several things:

1. fix `genpca` to work when the number of samples (voxels) is less than the number of features (images) by modifying `_pca_classifier`
2. fix `pca_noise_estimate` to be able to use the canonical algorithm

This is a new pull request to replace #2707 which became totally corrupted for reasons I don't understand, and I simply could not fix. Sorry about that. But I addressed all comments left at the time.