### PR TITLE
Fix weighted Jacobians, return extra fit data, add adjacency function

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1686,11 +1686,34 @@ class DiffusionKurtosisModel(ReconstModel):
             'sdp': self.sdp,
             }
 
+<<<<<<< HEAD
         params = self.fit_method(self.design_matrix, data_thres,
                                  self.inverse_design_matrix,
                                  weights=self.weights,
                                  min_diffusivity=self.min_diffusivity,
                                  **extra_args)
+=======
+        if self.min_signal is None:
+            min_signal = MIN_POSITIVE_SIGNAL
+        else:
+            min_signal = self.min_signal
+
+        data_in_mask = np.maximum(data_in_mask, min_signal)
+        params_in_mask, extra = self.fit_method(self.design_matrix, data_in_mask,
+                                                *self.args, **self.kwargs)
+
+        if mask is None:
+            out_shape = data.shape[:-1] + (-1, )
+            dki_params = params_in_mask.reshape(out_shape)
+            if extra is not None:
+                self.extra = extra.reshape(data.shape)
+        else:
+            dki_params = np.zeros(data.shape[:-1] + (27,))
+            dki_params[mask, :] = params_in_mask
+            if extra is not None:
+                self.extra = np.zeros(data.shape)
+                self.extra[mask, :] = extra
+>>>>>>> fix for dki_micro
 
         return DiffusionKurtosisFit(self, params)
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -2247,7 +2247,7 @@ def ls_fit_dki(design_matrix, data, inverse_design_matrix, weights=True,
     # Write output
     dki_params = params_to_dki_params(result, min_diffusivity=min_diffusivity)
 
-    return dki_params
+    return dki_params, None
 
 
 def cls_fit_dki(design_matrix, data, inverse_design_matrix, sdp, weights=True,
@@ -2312,7 +2312,7 @@ def cls_fit_dki(design_matrix, data, inverse_design_matrix, sdp, weights=True,
     # Write output
     dki_params = params_to_dki_params(result, min_diffusivity=min_diffusivity)
 
-    return dki_params
+    return dki_params, None
 
 
 def Wrotate(kt, Basis):

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1675,7 +1675,7 @@ class DiffusionKurtosisModel(ReconstModel):
         if self.is_multi_method:
             return self.multi_fit(data_thres, mask=mask)
 
-        params = self.fit_method(self.design_matrix, data_thres,
+        params, extra = self.fit_method(self.design_matrix, data_thres,
                                  *self.args, **self.kwargs)
         return DiffusionKurtosisFit(self, params)
 
@@ -1686,34 +1686,11 @@ class DiffusionKurtosisModel(ReconstModel):
             'sdp': self.sdp,
             }
 
-<<<<<<< HEAD
-        params = self.fit_method(self.design_matrix, data_thres,
+        params, extra = self.fit_method(self.design_matrix, data_thres,
                                  self.inverse_design_matrix,
                                  weights=self.weights,
                                  min_diffusivity=self.min_diffusivity,
                                  **extra_args)
-=======
-        if self.min_signal is None:
-            min_signal = MIN_POSITIVE_SIGNAL
-        else:
-            min_signal = self.min_signal
-
-        data_in_mask = np.maximum(data_in_mask, min_signal)
-        params_in_mask, extra = self.fit_method(self.design_matrix, data_in_mask,
-                                                *self.args, **self.kwargs)
-
-        if mask is None:
-            out_shape = data.shape[:-1] + (-1, )
-            dki_params = params_in_mask.reshape(out_shape)
-            if extra is not None:
-                self.extra = extra.reshape(data.shape)
-        else:
-            dki_params = np.zeros(data.shape[:-1] + (27,))
-            dki_params[mask, :] = params_in_mask
-            if extra is not None:
-                self.extra = np.zeros(data.shape)
-                self.extra[mask, :] = extra
->>>>>>> fix for dki_micro
 
         return DiffusionKurtosisFit(self, params)
 

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -393,9 +393,14 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
         if mask is None:
             out_shape = data.shape[:-1] + (-1,)
             params = params_all_mask.reshape(out_shape)
+            if extra is not None:
+                self.extra = extra.reshape(data.shape)
         else:
             params = np.zeros(data.shape[:-1] + (params_all_mask.shape[-1],))
             params[mask, :] = params_all_mask
+            if extra is not None:
+                self.extra = np.zeros(data.shape)
+                self.extra[mask, :] = extra
 
         return KurtosisMicrostructuralFit(self, params)
 

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -393,14 +393,14 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
         if mask is None:
             out_shape = data.shape[:-1] + (-1,)
             params = params_all_mask.reshape(out_shape)
-            if extra is not None:
-                self.extra = extra.reshape(data.shape)
+            #if extra is not None:
+            #    self.extra = extra.reshape(data.shape)
         else:
             params = np.zeros(data.shape[:-1] + (params_all_mask.shape[-1],))
             params[mask, :] = params_all_mask
-            if extra is not None:
-                self.extra = np.zeros(data.shape)
-                self.extra[mask, :] = extra
+            #if extra is not None:
+            #    self.extra = np.zeros(data.shape)
+            #    self.extra[mask, :] = extra
 
         return KurtosisMicrostructuralFit(self, params)
 

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -708,14 +708,14 @@ def adjacency_calc(img_shape, mask):
             if flat_mask[idx]:
                 cond = dists[idx, :]
                 cond = cond * flat_mask
-                cond = cond[flat_mask]  # so indices will match masked array 
+                cond = cond[flat_mask]  # so indices will match masked array
                 adj.append(np.argwhere(cond).flatten().tolist())
     else:
         for idx in range(dists.shape[0]):
             cond = dists[idx, :]
             adj.append(np.argwhere(cond).flatten().tolist())
 
-    return adj   
+    return adj
 
 
 class TensorModel(ReconstModel):
@@ -814,7 +814,7 @@ class TensorModel(ReconstModel):
             A boolean array used to mark the coordinates in the data that
             should be analyzed that has the shape data.shape[:-1]
 
-        adjacency : bool
+        adjacency : bool, optional
             Boolean to calculate voxel adjacency accounting for mask.
         """
 
@@ -828,7 +828,8 @@ class TensorModel(ReconstModel):
             mask = np.array(mask, dtype=bool, copy=False)
         data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
-        # NOTE: build adjacency list, if required - could make a list somewhere that notes whether this is required for a particular algorithm
+        # build adjacency list, if required
+        # NOTE: could make a list somewhere that notes whether this is required for a particular algorithm
         if adjacency:
             self.kwargs["adjacency"] = adjacency_calc(img_shape, mask)
 
@@ -1382,7 +1383,7 @@ def iter_fit_tensor(step=1e4):
             for i in range(0, size, step):
                 if return_S0_hat:
                     (dtiparams[i:i + step], S0params[i:i + step]),\
-                    extra[i:i + step]\
+                     extra[i:i + step]\
                         = fit_tensor(design_matrix,
                                      data[i:i + step],
                                      return_S0_hat=return_S0_hat,
@@ -1419,7 +1420,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False, adjacency=None):
         dimension should contain the data. It makes no copies of data.
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-    adjacency : list
+    adjacency : list, optional
         Adjacency list matching the flattened and masked array data array.
 
     Returns
@@ -1473,7 +1474,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False, adjacency=None):
 
     # calculate weights
     fit_result, _ = ols_fit_tensor(design_matrix, data,
-                                return_lower_triangular=True)
+                                   return_lower_triangular=True)
     w = np.exp(fit_result @ design_matrix.T)
 
     # the weighted problem design_matrix * w is much larger (differs per voxel)
@@ -1512,7 +1513,7 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
         dimension should contain the data. It makes no copies of data.
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-    adjacency : list
+    adjacency : list, optional
         Adjacency list matching the flattened and masked array data array.
     return_lower_triangular : bool
         Boolean to return (True) or not (False) the coefficients of the fit.
@@ -1771,7 +1772,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
 
-    adjacency : list
+    adjacency : list, optional
         Adjacency list matching the flattened and masked array data array.
 
     fail_is_nan : bool
@@ -1902,7 +1903,7 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
 
-    adjacency : list
+    adjacency : list, optional
         Adjacency list matching the flattened and masked array data array.
 
     fail_is_nan : bool

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1405,7 +1405,7 @@ def iter_fit_tensor(step=1e4):
 
 
 @iter_fit_tensor()
-def wls_fit_tensor(design_matrix, data, return_S0_hat=False, adjacency=None):
+def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     r"""
     Computes weighted least squares (WLS) fit to calculate self-diffusion
     tensor using a linear regression model [1]_.
@@ -1420,8 +1420,6 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False, adjacency=None):
         dimension should contain the data. It makes no copies of data.
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-    adjacency : list, optional
-        Adjacency list matching the flattened and masked array data array.
 
     Returns
     -------
@@ -1498,7 +1496,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False, adjacency=None):
 
 @iter_fit_tensor()
 def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
-                   adjacency=None, return_lower_triangular=False):
+                   return_lower_triangular=False):
     r"""
     Computes ordinary least squares (OLS) fit to calculate self-diffusion
     tensor using a linear regression model [1]_.
@@ -1513,8 +1511,6 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
         dimension should contain the data. It makes no copies of data.
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-    adjacency : list, optional
-        Adjacency list matching the flattened and masked array data array.
     return_lower_triangular : bool
         Boolean to return (True) or not (False) the coefficients of the fit.
 
@@ -1760,7 +1756,7 @@ def _decompose_tensor_nan(tensor, tensor_alternative, min_diffusivity=0):
 
 def nlls_fit_tensor(design_matrix, data, weighting=None,
                     sigma=None, jac=True, return_S0_hat=False,
-                    adjacency=None, fail_is_nan=False):
+                    fail_is_nan=False):
     """
     Fit the cumulant expansion params (e.g. DTI, DKI) using non-linear
     least-squares.
@@ -1792,9 +1788,6 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-
-    adjacency : list, optional
-        Adjacency list matching the flattened and masked array data array.
 
     fail_is_nan : bool
         Boolean to set failed NL fitting to NaN (True) or LS (False, default).
@@ -1895,7 +1888,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
 
 def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
-                       return_S0_hat=False, adjacency=None,
+                       return_S0_hat=False,
                        fail_is_nan=False):
     """
     Use the RESTORE algorithm [1]_ to calculate a robust tensor fit
@@ -1926,9 +1919,6 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
     return_S0_hat : bool
         Boolean to return (True) or not (False) the S0 values for the fit.
-
-    adjacency : list, optional
-        Adjacency list matching the flattened and masked array data array.
 
     fail_is_nan : bool
         Boolean to set failed NL fitting to NaN (True) or LS (False, default).

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1584,114 +1584,6 @@ def _ols_fit_matrix(design_matrix):
     return np.dot(U, U.T)
 
 
-def _nlls_err_func(tensor, design_matrix, data, weighting=None,
-                   sigma=None):
-    r"""
-    Error function for the non-linear least-squares fit of the tensor.
-
-    Parameters
-    ----------
-    tensor : array (3,3)
-        The 3-by-3 tensor matrix
-
-    design_matrix : array
-        The design matrix
-
-    data : array
-        The voxel signal in all gradient directions
-
-    weighting : str (optional).
-         Whether to use the Geman-McClure weighting criterion (see [1]_
-         for details)
-
-    sigma : float or float array (optional)
-        If 'sigma' weighting is used, we will weight the error function
-        according to the background noise estimated either in aggregate over
-        all directions (when a float is provided), or to an estimate of the
-        noise in each diffusion-weighting direction (if an array is
-        provided). If 'gmm', the Geman-Mclure M-estimator is used for
-        weighting (see below).
-
-    Notes
-    -----
-    The Geman-McClure M-estimator is described as follows [1]_ (page 1089):
-    "The scale factor C affects the shape of the GMM
-    [Geman-McClure M-estimator] weighting function and represents the expected
-    spread of the residuals (i.e., the SD of the residuals) due to Gaussian
-    distributed noise. The scale factor C can be estimated by many robust scale
-    estimators. We used the median absolute deviation (MAD) estimator because
-    it is very robust to outliers having a 50% breakdown point (6,7).
-    The explicit formula for C using the MAD estimator is:
-
-    .. math ::
-
-            C = 1.4826 x MAD = 1.4826 x median{|r1-\hat{r}|,... |r_n-\hat{r}|}
-
-    where $\hat{r} = median{r_1, r_2, ..., r_3}$ and n is the number of data
-    points. The multiplicative constant 1.4826 makes this an approximately
-    unbiased estimate of scale when the error model is Gaussian."
-
-
-    References
-    ----------
-    .. [1] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust
-    estimation of tensors by outlier rejection. MRM, 53: 1088-95.
-    """
-    # This is the predicted signal given the params:
-    y = np.exp(np.dot(design_matrix, tensor))
-
-    # Compute the residuals
-    residuals = data - y
-
-    # If we don't want to weight the residuals, we are basically done:
-    if weighting is None:
-        # And we return the SSE:
-        return residuals
-    se = residuals ** 2
-    # If the user provided a sigma (e.g 1.5267 * std(background_noise), as
-    # suggested by Chang et al.) we will use it:
-    if weighting == 'sigma':
-        if sigma is None:
-            e_s = "Must provide sigma value as input to use this weighting"
-            e_s += " method"
-            raise ValueError(e_s)
-        w = 1 / (sigma**2)
-
-    elif weighting == 'gmm':
-        # We use the Geman-McClure M-estimator to compute the weights on the
-        # residuals:
-        C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            w = 1 / (se + C**2)
-            # The weights are normalized to the mean weight (see p. 1089):
-            w = w / np.mean(w)
-
-    # Return the weighted residuals:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return np.sqrt(w * se)
-
-
-def _nlls_jacobian_func(tensor, design_matrix, data, *arg, **kwargs):
-    """The Jacobian is the first derivative of the error function [1]_.
-
-    Notes
-    -----
-    This is an implementation of equation 14 in [1]_.
-
-    References
-    ----------
-    .. [1] Koay, CG, Chang, L-C, Carew, JD, Pierpaoli, C, Basser PJ (2006).
-        A unifying theoretical and algorithmic framework for least squares
-        methods of estimation in diffusion tensor imaging. MRM 182, 115-25.
-
-    """
-    pred = np.exp(np.dot(design_matrix, tensor))
-    # NOTE: minus sign, because derivative of residuals = data - y
-    return -pred[:, None] * design_matrix
-
-
 class _nlls_class():
     r"""Class with member functions to return nlls error and derivative.
     """
@@ -1715,13 +1607,11 @@ class _nlls_class():
              Whether to use the Geman-McClure weighting criterion (see [1]_
              for details)
 
-        sigma : float or float array (optional)
+        sigma : float, array (optional)
             If 'sigma' weighting is used, we will weight the error function
-            according to the background noise estimated either in aggregate over
-            all directions (when a float is provided), or to an estimate of the
-            noise in each diffusion-weighting direction (if an array is
-            provided). If 'gmm', the Geman-Mclure M-estimator is used for
-            weighting (see below).
+            according to 1/sigma^2. If 'gmm', the Geman-Mclure
+            M-estimator is used for weighting, in which case this value
+            should be C (see below).
 
         Notes
         -----
@@ -1764,19 +1654,15 @@ class _nlls_class():
 
         # FIXME: sigma must be an array or None, otherwise no point in providing it
         if weighting == 'sigma':
-            # If the user provided a sigma (e.g 1.5267 * std(background_noise), as
-            # suggested by Chang et al.) we will use it:
-            if sigma is None:
-                e_s = "Must provide sigma value as input to use this weighting"
+            if sigma is None: # or not(np.iterable(sigma)):
+                e_s = "Must provide sigma float / array as input to use this weighting"
                 e_s += " method"
                 raise ValueError(e_s)
-            w = 1 / (sigma**2)  # NOTE: should normalize? Or no need?
+            w = 1 / (sigma**2)  # NOTE: no need to normalize the weights
 
         elif weighting == 'gmm':
             # We use the Geman-McClure M-estimator to compute the weights on the
             # residuals:
-            # NOTE: testing a different approach - if GMM is used, assume 'sigma' is C, then we can test out if the gradients are okay
-            #C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
             if sigma is None:
                 e_s = "Must provide sigma value, used as C in Geman-McClure M-estimator, as input to use this weighting"
                 e_s += " method"
@@ -1784,17 +1670,18 @@ class _nlls_class():
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 #w = 1 / (se + C**2)
-                w = 1 / (residuals**2 + sigma**2)
+                w = 1 / (residuals**2 + sigma**2)  # NOTE: sigma is set to 'C'
                 # The weights are normalized to the mean weight (see p. 1089):
-                #w = w / np.mean(w)  # NOTE: no need to normalize
-
-        self.sqrt_w = np.sqrt(w)  # NOTE: cache the weights for the non-squared RESIDUALS
+                #w = w / np.mean(w)  # NOTE: no need to normalize (makes checking Jacobian 1 data-point at a time more difficult)
 
         # Return the weighted residuals:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            #return np.sqrt(w * se)
-            return self.sqrt_w * residuals  # NOTE: must be this to get the signs correct
+            self.sqrt_w = np.sqrt(w)
+            ans = self.sqrt_w * residuals
+            if np.iterable(w):
+                self.sqrt_w = np.sqrt(w)[:, None]  # NOTE: cache the weights for the *non-squared* residuals
+            return ans
 
 
     #def jacobian_func(self, tensor, design_matrix, data, *arg, **kwargs):                      
@@ -1812,19 +1699,18 @@ class _nlls_class():
             methods of estimation in diffusion tensor imaging. MRM 182, 115-25.
 
         """
-        #pred = np.exp(np.dot(design_matrix, tensor))
-        #return -pred[:, None] * design_matrix
-        # NOTE: minus sign, because derivative of residuals = data - y
-        # NOTE: sqrt(w) because w coresponds to the squared residuals
+        # minus sign, because derivative of residuals = data - y
+        # sqrt(w) because w coresponds to the squared residuals
+
         if weighting is None:
             return -self.y[:, None] * design_matrix
+
         if weighting == 'sigma':
-            return -self.y[:, None] * design_matrix * self.sqrt_w[:, None]
-        if weighting == 'gmm':  # NOTE: this assumes that 'C' is constant
+            return -self.y[:, None] * design_matrix * self.sqrt_w
+
+        if weighting == 'gmm':  # assumes that 'C' is constant
             return -self.y[:, None] * design_matrix * \
-                    (self.sqrt_w[:, None] - self.residuals[:, None]**2 * self.sqrt_w[:, None]**3)
-            #return -self.y[:, None] * design_matrix * self.sqrt_w[:, None] * \
-            #        (1 - self.residuals[:, None]**2 * self.sqrt_w[:, None]**2)
+                    (self.sqrt_w - self.residuals[:, None]**2 * self.sqrt_w**3)
         
 
 def _decompose_tensor_nan(tensor, tensor_alternative, min_diffusivity=0):
@@ -1896,11 +1782,10 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
            squared-error. Default behavior is to use uniform weighting. Other
            options: 'sigma' 'gmm'
 
-    sigma: float
-        If the 'sigma' weighting scheme is used, a value of sigma needs to be
-        provided here. According to [Chang2005]_, a good value to use is
-        1.5267 * std(background_noise), where background_noise is estimated
-        from some part of the image known to contain no signal (only noise).
+    sigma : array (optional)
+        If 'sigma' weighting is used, we will weight the error function
+        according to 1/sigma^2. If 'gmm', the Geman-Mclure
+        M-estimator is used for weighting (see below).
 
     jac : bool
         Use the Jacobian? Default: True
@@ -1963,7 +1848,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
                                                        sigma),
                                                  Dfun=nlls.jacobian_func)
             else:
-                this_param, status = opt.leastsq(_nlls_err_func, start_params,
+                this_param, status = opt.leastsq(nlls.err_func, start_params,
                                                  args=(design_matrix,
                                                        flat_data[vox],
                                                        weighting,
@@ -2086,6 +1971,9 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
     # For warnings
     resort_to_OLS = False
 
+    # Instance of _nlls_class, need for nlls error func and jacobian
+    nlls = _nlls_class()
+
     if return_S0_hat:
         model_S0 = np.empty((flat_data.shape[0], 1))
     for vox in range(flat_data.shape[0]):
@@ -2104,14 +1992,14 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
             # Do nlls using sigma weighting in this voxel:
             if jac:
-                this_param, status = opt.leastsq(_nlls_err_func, start_params,
+                this_param, status = opt.leastsq(nlls.err_func, start_params,
                                                  args=(design_matrix,
                                                        flat_data[vox],
                                                        'sigma',
                                                        sigma_vox),
-                                                 Dfun=_nlls_jacobian_func)
+                                                 Dfun=nlls.jacobian_func)
             else:
-                this_param, status = opt.leastsq(_nlls_err_func, start_params,
+                this_param, status = opt.leastsq(nlls.err_func, start_params,
                                                  args=(design_matrix,
                                                        flat_data[vox],
                                                        'sigma',
@@ -2124,24 +2012,44 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
             # If any of the residuals are outliers (using 3 sigma as a
             # criterion following Chang et al., e.g page 1089):
             if np.any(np.abs(residuals) > 3 * sigma_vox):
-                # Do nlls with GMM-weighting:
-                if jac:
-                    this_param, status = opt.leastsq(_nlls_err_func,
-                                                     start_params,
-                                                     args=(design_matrix,
-                                                           flat_data[vox],
-                                                           'gmm'),
-                                                     Dfun=_nlls_jacobian_func)
-                else:
-                    this_param, status = opt.leastsq(_nlls_err_func,
-                                                     start_params,
-                                                     args=(design_matrix,
-                                                           flat_data[vox],
-                                                           'gmm'))
 
-                # Recalculate residuals given gmm fit
-                pred_sig = np.exp(np.dot(design_matrix, this_param))
-                residuals = flat_data[vox] - pred_sig
+                # 1. robustly estimate C from current residuals
+                # 2. Use NLLS with GMM weighting. Weights are updated during optimization based on residuals at each step in opt.leastsq, using fixed C,
+                #    which means that derivative of the loss function is continuous (not true if C is recalculated at each step).
+                # 3. calculate difference in new vs old parameter estimate, and return to 1 if not converged.
+                # (NOTE: this implementation is in contrast to completely fixing the weights in step 1)
+                rdx = 1
+                while rdx <= 10:  # NOTE: capped at 10 iterations
+                    C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
+
+                    # Do nlls with GMM-weighting:
+                    if jac:
+                        this_param, status = opt.leastsq(nlls.err_func,
+                                                         start_params,
+                                                         args=(design_matrix,
+                                                               flat_data[vox],
+                                                               'gmm',
+                                                               C),
+                                                         Dfun=nlls.jacobian_func)
+                    else:
+                        this_param, status = opt.leastsq(nlls.err_func,
+                                                         start_params,
+                                                         args=(design_matrix,
+                                                               flat_data[vox],
+                                                               'gmm',
+                                                               C))
+
+                    # Recalculate residuals given gmm fit
+                    pred_sig = np.exp(np.dot(design_matrix, this_param))
+                    residuals = flat_data[vox] - pred_sig
+                    perc = 100 * np.linalg.norm(this_param - start_params) / np.linalg.norm(this_param)
+                    start_params = this_param
+                    #print("rdx:", rdx, this_param)
+                    #print("percentage difference:", perc, "%")
+                    #print(status)
+                    if perc < 0.1: break
+                    rdx = rdx + 1
+
                 cond = np.abs(residuals) > 3 * sigma_vox
                 if np.any(cond):
                     # If you still have outliers, refit without those outliers:
@@ -2160,15 +2068,15 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
                         this_sigma = sigma_vox
 
                     if jac:
-                        this_param, status = opt.leastsq(_nlls_err_func,
+                        this_param, status = opt.leastsq(nlls.err_func,
                                                          new_start,
                                                          args=(clean_design,
                                                                clean_data,
                                                                'sigma',
                                                                this_sigma),
-                                                         Dfun=_nlls_jacobian_func)
+                                                         Dfun=nlls.jacobian_func)
                     else:
-                        this_param, status = opt.leastsq(_nlls_err_func,
+                        this_param, status = opt.leastsq(nlls.err_func,
                                                          new_start,
                                                          args=(clean_design,
                                                                clean_data,

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -703,7 +703,11 @@ def adjacency_calc(img_shape, mask=None, distance=1.99):
     XYZ = np.meshgrid(*[range(ds) for ds in img_shape], indexing='ij')
     XYZ = np.column_stack([xyz.ravel() for xyz in XYZ])
     dists = squareform(pdist(XYZ))
-    dists = (dists < distance)  # NOTE: adjaceny list contains currnet voxel
+#    if mask is not None:
+#        import matplotlib.pyplot as plt
+#        plt.imshow(dists[1025].reshape(img_shape), alpha=mask.astype(float))
+#        plt.show()
+    dists = (dists < distance)  # adjacency list contains current voxel
     adj = []
     if mask is not None:
         flat_mask = mask.reshape(-1)
@@ -711,7 +715,10 @@ def adjacency_calc(img_shape, mask=None, distance=1.99):
             if flat_mask[idx]:
                 cond = dists[idx, :]
                 cond = cond * flat_mask
-                cond = cond[flat_mask]  # so indices will match masked array
+#                print(cond)
+#                print("before:", cond.sum())
+                cond = cond[flat_mask == 1]  # so indices will match masked array
+#                print("after:", cond.sum())
                 adj.append(np.argwhere(cond).flatten().tolist())
     else:
         for idx in range(dists.shape[0]):

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -2012,7 +2012,7 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
                 rdx = 1
                 while rdx <= 10:  # NOTE: capped at 10 iterations
                     C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
-                    gmm = C**2 + residuals**2
+                    gmm = C**2 / (C**2 + residuals**2)**2
 
                     # Do nlls with GMM-weighting:
                     if jac:

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -13,7 +13,8 @@ from dipy.reconst.dti import (axial_diffusivity, color_fa,
                               mean_diffusivity, radial_diffusivity,
                               TensorModel, trace, linearity, planarity,
                               sphericity, decompose_tensor,
-                              _decompose_tensor_nan)
+                              _decompose_tensor_nan,
+                              adjacency_calc)
 
 from dipy.io.image import load_nifti_data
 from dipy.data import get_fnames, dsi_voxels, get_sphere
@@ -713,6 +714,38 @@ def test_restore():
                                    return_S0_hat=True, fail_is_nan=True)
     tmf = npt.assert_warns(UserWarning, tensor_model.fit, Y.copy())
     npt.assert_equal(tmf[0].S0_hat, np.nan)
+
+
+def test_adjacency_calc():
+    """
+    Test adjacency_calc function, which calculates indices of adjacent voxels
+    """
+
+    distance = 1.99
+    for img_shape in [(50, 50), (50, 50, 5)]:
+
+        mask = None
+        adj = adjacency_calc(img_shape, mask, distance=distance)
+        # check that adj in the first voxel is correct
+        adj[0].sort()
+        if len(img_shape) == 2:
+            npt.assert_equal(adj[0], [0, 1, 50, 51])
+        if len(img_shape) == 3:
+            npt.assert_equal(adj[0], [0, 1, 5, 6, 250, 251, 255, 256])
+
+        mask = np.zeros(img_shape, dtype=int)
+        if len(img_shape) == 2:
+            mask[10:40, 20:30] = 1
+        if len(img_shape) == 3:
+            mask[10:40, 20:30, :] = 1
+        adj = adjacency_calc(img_shape, mask, distance=distance)
+        # check that adj in the first voxel is correct
+        if len(img_shape) == 2:
+            npt.assert_equal(adj[0], [0, 1, 10, 11])
+        if len(img_shape) == 3:
+            npt.assert_equal(adj[0], [0, 1, 5, 6, 50, 51, 55, 56])
+        # test that adj only corresponds to flattened and masked data
+        npt.assert_equal(len(adj), mask.sum())
 
 
 def test_adc():

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -644,6 +644,15 @@ def test_nlls_fit_tensor():
     tmf = npt.assert_warns(UserWarning, tensor_model.fit, Y_less)
     npt.assert_equal(tmf[0].S0_hat, np.nan)
 
+    # Test sigma with an array
+    sigma = np.ones(Y_less.shape[-1])
+    tensor_model = dti.TensorModel(gtab_less, fit_method='NLLS', weighting='sigma', sigma=sigma)
+
+    # Test sigma with an array of wrong size
+    sigma = np.ones(Y_less.shape[-1] + 10)
+    tensor_model = dti.TensorModel(gtab_less, fit_method='NLLS', weighting='sigma', sigma=sigma)
+    tmf = npt.assert_raises(ValueError, tensor_model.fit, Y_less)
+
 
 def test_restore():
     """

--- a/dipy/utils/tests/test_volume.py
+++ b/dipy/utils/tests/test_volume.py
@@ -1,0 +1,38 @@
+""" Testing volumes """
+
+import numpy as np
+import numpy.testing as npt
+
+from dipy.utils.volume import (adjacency_calc)
+
+def test_adjacency_calc():
+    """
+    Test adjacency_calc function, which calculates indices of adjacent voxels
+    """
+
+    cutoff = 1.99
+    for img_shape in [(50, 50), (50, 50, 5)]:
+
+        mask = None
+        adj = adjacency_calc(img_shape, mask, cutoff=cutoff)
+        # check that adj in the first voxel is correct
+        adj[0].sort()
+        if len(img_shape) == 2:
+            npt.assert_equal(adj[0], [0, 1, 50, 51])
+        if len(img_shape) == 3:
+            npt.assert_equal(adj[0], [0, 1, 5, 6, 250, 251, 255, 256])
+
+        mask = np.zeros(img_shape, dtype=int)
+        if len(img_shape) == 2:
+            mask[10:40, 20:30] = 1
+        if len(img_shape) == 3:
+            mask[10:40, 20:30, :] = 1
+        adj = adjacency_calc(img_shape, mask, cutoff=cutoff)
+        # check that adj in the first voxel is correct
+        if len(img_shape) == 2:
+            npt.assert_equal(adj[0], [0, 1, 10, 11])
+        if len(img_shape) == 3:
+            npt.assert_equal(adj[0], [0, 1, 5, 6, 50, 51, 55, 56])
+        # test that adj only corresponds to flattened and masked data
+        npt.assert_equal(len(adj), mask.sum())
+

--- a/dipy/utils/volume.py
+++ b/dipy/utils/volume.py
@@ -1,0 +1,54 @@
+""" Utilities for calculating voxel adjacencies and neighbourhoods """
+
+import numpy as np
+from scipy.spatial.distance import pdist, squareform
+
+
+def adjacency_calc(img_shape, mask=None, cutoff=1.99):
+    """Create adjacency list for voxels, accounting for the mask.
+
+    Parameters
+    ----------
+
+    img_shape : list
+        Spatial shape of the image data.
+
+    mask : array, optional
+        A boolean array used to mark the coordinates in the data that
+        should be analyzed that should have the same shape as the images.
+
+    cutoff : float, optional
+        Cutoff distance in voxel coordinates for finding adjacent voxels.
+        e.g. cutoff=2 gives a 3x3 patch, cutoff=2.1 gives a 3x3 patch
+        with additional 4 voxels above, below, left, right of this patch.
+
+    Returns
+    -------
+
+    adj : list
+        List, one entry per voxel, giving the indices of adjacent voxels.
+        The list will correspond to the data array once masked and flattened.
+
+    """
+
+    # Image-space coordinates of voxels, flattened
+    XYZ = np.meshgrid(*[range(ds) for ds in img_shape], indexing='ij')
+    XYZ = np.column_stack([xyz.ravel() for xyz in XYZ])
+    dists = squareform(pdist(XYZ))
+    dists = (dists < cutoff)  # adjacency list contains current voxel
+    adj = []
+    if mask is not None:
+        flat_mask = mask.reshape(-1)
+        for idx in range(dists.shape[0]):
+            if flat_mask[idx]:
+                cond = dists[idx, :]
+                cond = cond * flat_mask
+                cond = cond[flat_mask == 1]  # so indices will match masked array
+                adj.append(np.argwhere(cond).flatten().tolist())
+    else:
+        for idx in range(dists.shape[0]):
+            cond = dists[idx, :]
+            adj.append(np.argwhere(cond).flatten().tolist())
+
+    return adj
+


### PR DESCRIPTION
Added the ability to return and store extra information from the fitting functions, in this case applied to retrieving a mask of non-outlier voxels from the RESTORE algorithm, but which could be used to return other data from different functions (for example, the leverages for linear fitting algorithms). This data is stored in TensorFit.model.extra to avoid changing the interface.

I have also added a function to calculate adjacency of voxels, taking account of arbitrary masks. This currently has no use, but it works correctly for a new fitting function I am working on, and will make it possible to include algorithms that utilize multiple voxels for fitting.

The code should work exactly as before as far as the user is concerned. I can add some additional tests, but am currently a little unsure about what they would be, so comments and suggestions are very welcome.

EDIT: following on from #2746, added fixes to get the Jacobian correct for weighted non-linear least squares. This also required modifications to RESTORE to (1) calculate the Jacobian correctly; (2) bring it more in line with the canonical algorithm.