### PR TITLE
[ENH] Asymmetric peak_directions

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -112,7 +112,7 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
     min_separation_angle : float in [0, 90]
         The minimum distance between directions. If two peaks are too close
         only the larger of the two is returned.
-    is_symmetric : bool
+    is_symmetric : bool, optional
         If True, v is considered equal to -v.
 
     Returns

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -113,7 +113,7 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
         The minimum distance between directions. If two peaks are too close
         only the larger of the two is returned.
     is_symmetric : bool
-        When True, vertices v and -v are considered the same
+        If True, v is considered equal to -v.
 
     Returns
     -------
@@ -154,7 +154,7 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
     directions, uniq = remove_similar_vertices(directions,
                                                min_separation_angle,
                                                return_index=True,
-                                               is_symmetric=is_symmetric)
+                                               remove_antipodal=is_symmetric)
     values = values[uniq]
     indices = indices[uniq]
     return directions, values, indices

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -90,7 +90,7 @@ def peak_directions_nl(sphere_eval, relative_peak_threshold=.25,
 
 
 def peak_directions(odf, sphere, relative_peak_threshold=.5,
-                    min_separation_angle=25):
+                    min_separation_angle=25, is_symmetric=True):
     """Get the directions of odf peaks.
 
     Peaks are defined as points on the odf that are greater than at least one
@@ -112,6 +112,8 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
     min_separation_angle : float in [0, 90]
         The minimum distance between directions. If two peaks are too close
         only the larger of the two is returned.
+    is_symmetric : bool
+        When True, vertices v and -v are considered the same
 
     Returns
     -------
@@ -151,7 +153,8 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
     # Remove peaks too close together
     directions, uniq = remove_similar_vertices(directions,
                                                min_separation_angle,
-                                               return_index=True)
+                                               return_index=True,
+                                               is_symmetric=is_symmetric)
     values = values[uniq]
     indices = indices[uniq]
     return directions, values, indices

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -320,6 +320,11 @@ def test_peak_directions_thorough():
     directions, values, indices = peak_directions(odf_gt, sphere, 0, 0)
     assert_almost_equal(angular_similarity(directions, sticks), 4, 1)
 
+    # test the asymmetric case
+    directions, values, indices = peak_directions(odf_gt, sphere, 0, 0, False)
+    expected = np.concatenate([sticks, -sticks], axis=0)
+    assert_almost_equal(angular_similarity(directions, expected), 8, 1)
+
     odf_gt, sticks, hsphere = _create_mt_sim(mevals, angles, fractions,
                                              100, None, half_sphere=True)
 

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -38,13 +38,14 @@ def remove_similar_vertices(
     double theta,
     bint return_mapping=False,
     bint return_index=False,
-    bint is_symmetric=True):
+    bint remove_antipodal=True):
     """Remove vertices that are less than `theta` degrees from any other
 
     Returns vertices that are at least theta degrees from any other vertex.
     Vertex v and -v are considered the same so if v and -v are both in
     `vertices` only one is kept. Also if v and w are both in vertices, w must
-    be separated by theta degrees from both v and -v to be unique.
+    be separated by theta degrees from both v and -v to be unique. To disable
+    this, set `remove_antipodal` to False to keep both directions.
 
     Parameters
     ----------
@@ -58,8 +59,8 @@ def remove_similar_vertices(
     return_indices : {False, True}, optional
         If True, return `indices` as well as `vertices` and maybe `mapping`
         (see below).
-    is_symmetric : {False, True}, optional
-        If False, v is considered different from -v.
+    remove_antipodal : {False, True}, optional
+        If True, v and -v are considered equal, and only one will be kept.
 
     Returns
     -------
@@ -111,7 +112,7 @@ def remove_similar_vertices(
             sim = (a * unique_vertices[j, 0] +
                    b * unique_vertices[j, 1] +
                    c * unique_vertices[j, 2])
-            if is_symmetric:
+            if remove_antipodal:
                 sim = fabs(sim)
             if sim > cos_similarity:  # too similar, drop
                 pass_all = 0

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -37,7 +37,8 @@ def remove_similar_vertices(
     cython.floating[:, :] vertices,
     double theta,
     bint return_mapping=False,
-    bint return_index=False):
+    bint return_index=False,
+    bint is_symmetric=True):
     """Remove vertices that are less than `theta` degrees from any other
 
     Returns vertices that are at least theta degrees from any other vertex.
@@ -57,6 +58,8 @@ def remove_similar_vertices(
     return_indices : {False, True}, optional
         If True, return `indices` as well as `vertices` and maybe `mapping`
         (see below).
+    is_symmetric : {False, True}, optional
+        If False, v is considered different from -v.
 
     Returns
     -------
@@ -105,9 +108,11 @@ def remove_similar_vertices(
         c = vertices[i, 2]
         # Check all other accepted vertices for similarity to this one
         for j in range(n_unique):
-            sim = fabs(a * unique_vertices[j, 0] +
-                       b * unique_vertices[j, 1] +
-                       c * unique_vertices[j, 2])
+            sim = (a * unique_vertices[j, 0] +
+                   b * unique_vertices[j, 1] +
+                   c * unique_vertices[j, 2])
+            if is_symmetric:
+                sim = fabs(sim)
             if sim > cos_similarity:  # too similar, drop
                 pass_all = 0
                 if return_mapping:


### PR DESCRIPTION
Hello,

Add a `is_symmetric` flag to `dipy.direction.peaks.peak_directions` to enable peak extraction on asymmetric ODFs. `is_symmetric` is `True` by default, so that the default behaviour does not change. When set to `False`, the sphere directions `v` and `-v` are considered distinct, such that it is possible to find a maxima along `v` but not along `-v`. 

I simply removed the absolute value in `remove_similar_vertices` so that opposite sphere directions are not considered close to each other.

Have a good one!