### PR TITLE
Remove Python 3.7 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      python-version: '["3.8", "3.9", "3.10"]'
+      python-version: '["3.8", "3.9", "3.10", 3.11]'

--- a/.github/workflows/test_compat.yml
+++ b/.github/workflows/test_compat.yml
@@ -7,18 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
-  minimal-py37:
-    uses: ./.github/workflows/test_template.yml
-    with:
-      runs-on: '["ubuntu-latest", ]'
-      python-version: '["3.7", ]'
-      depends: cython==0.29.24 numpy==1.15.0 scipy==1.1 nibabel==3.0.0 h5py==2.8.0 tqdm
   minimal-py38:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", ]'
       python-version: '["3.8", ]'
       depends: cython==0.29.24 numpy==1.17.5 scipy==1.3.2 nibabel==3.0.0 h5py==3.0.0 tqdm
+  minimal-py39:
+    uses: ./.github/workflows/test_template.yml
+    with:
+      runs-on: '["ubuntu-latest", ]'
+      python-version: '["3.9", ]'
+      depends: cython==0.29.24 numpy==1.19.4 scipy==1.5.4 nibabel==3.0.0 h5py==3.1.0 tqdm
   # install-type:
   #   uses: skoudoro/dipy/.github/workflows/test_template.yml@gh-actions
   #   with:

--- a/.github/workflows/test_pre.yml
+++ b/.github/workflows/test_pre.yml
@@ -11,6 +11,6 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", ]'
-      python-version: '["3.10", ]'
+      python-version: '["3.11", ]'
       use-pre: true
       extra-depends: scikit_learn scipy statsmodels pandas tables

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -50,7 +50,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -12,7 +12,7 @@ on:
         description: "Select Python version"
         type: string
         required: false
-        default: '["3.9", ]'
+        default: '["3.10", ]'
       use-pre:
         description: "bal"
         type: boolean


### PR DESCRIPTION
This PR just update our CI  by
- removing python 3.7 (end of life in 3month)
- adding python 3.11
- 3.10 become the reference instead of 3.9