### PR TITLE
BF: QBX and merge clusters should return streamlines

### DIFF
--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -220,15 +220,25 @@ def test_qbx_and_merge():
     bundles = bearing_bundles(4, 2)
     bundles.append(straight_bundle(1))
 
+
     streamlines = Streamlines(list(itertools.chain(*bundles)))
 
     thresholds = [10, 2, 1]
 
     rng = np.random.RandomState(seed=42)
-    qbxm_centroids = qbx_and_merge(streamlines, thresholds, rng=rng).centroids
+    qbxm = qbx_and_merge(streamlines, thresholds, rng=rng)
+
+    qbxm_centroids = qbxm.centroids
+
+    qbxm_clusters = qbxm.clusters
 
     qbx = QuickBundlesX(thresholds)
     tree = qbx.cluster(streamlines)
     qbx_centroids = tree.get_clusters(3).centroids
 
     assert_equal(len(qbx_centroids) > len(qbxm_centroids), True)
+
+    # check that refdata clusters return streamlines in qbx_and_merge    
+    streamline_idx =qbxm_clusters[0].indices[0]
+    assert_array_equal(qbxm_clusters[0][0], streamlines[streamline_idx]) 
+

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -274,7 +274,7 @@ class Horizon(object):
                     scene.add(centroid_actor)
                     self.mem.centroid_actors.append(centroid_actor)
 
-                    cluster_actor = actor.line(clusters[i],
+                    cluster_actor = actor.line(clusters[i][:],
                                                lod=False)
                     cluster_actor.GetProperty().SetRenderLinesAsTubes(1)
                     cluster_actor.GetProperty().SetLineWidth(6)


### PR DESCRIPTION
Thanks to @guaje for reporting a strange issue in ``dipy_horizon`` with the ``--cluster`` option.

```
Traceback (most recent call last):
  File "C:\Users\Eleftherios\Devel\dipy\bin\dipy_horizon", line 7, in <module>
    run_flow(HorizonFlow())
  File "c:\users\eleftherios\devel\dipy\dipy\workflows\flow_runner.py", line 89, in run_flow
    return flow.run(**args)
  File "c:\users\eleftherios\devel\dipy\dipy\workflows\viz.py", line 238, in run
    horizon(tractograms=tractograms, images=images, pams=pams,
  File "c:\users\eleftherios\devel\dipy\dipy\viz\app.py", line 939, in horizon
    scene = hz.build_scene()
  File "c:\users\eleftherios\devel\dipy\dipy\viz\app.py", line 203, in build_scene
    self.add_cluster_actors(scene, self.tractograms,
  File "c:\users\eleftherios\devel\dipy\dipy\viz\app.py", line 277, in add_cluster_actors
    cluster_actor = actor.line(clusters[i],
  File "C:\Users\Eleftherios\Devel\fury\fury\actor.py", line 834, in line
    poly_data, color_is_scalar = lines_to_vtk_polydata(lines, colors)
  File "C:\Users\Eleftherios\Devel\fury\fury\utils.py", line 294, in lines_to_vtk_polydata
    vtk_cell_array = numpy_to_vtk_cells(lines)
  File "C:\Users\Eleftherios\Devel\fury\fury\utils.py", line 138, in numpy_to_vtk_cells
    offsets_dtype = np.dtype(data._offsets.dtype)
AttributeError: 'ClusterCentroid' object has no attribute '_offsets'
```

This PR provides a fix. Interestingly all needed was to add a ``[:]`` in line 277.  Please give it a go @guaje!