### PR TITLE
Remove NoseTester

### DIFF
--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -37,12 +37,6 @@ import sys
 from .info import __version__
 from .testing import setup_test
 
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
-del Tester
-
 # Plumb in version etc info stuff
 from .pkg_info import get_pkg_info as _get_pkg_info
 def get_info():

--- a/dipy/core/__init__.py
+++ b/dipy/core/__init__.py
@@ -1,7 +1,2 @@
 # Init for core dipy objects
 """ Core objects """
-
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/core/tests/__init__.py
+++ b/dipy/core/tests/__init__.py
@@ -1,6 +1,1 @@
 # init to make tests into a package
-
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/denoise/__init__.py
+++ b/dipy/denoise/__init__.py
@@ -1,8 +1,1 @@
 #init for denoise aka the denoising module
-
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
-
-del Tester

--- a/dipy/io/tests/__init__.py
+++ b/dipy/io/tests/__init__.py
@@ -1,5 +1,1 @@
 # init to allow relative imports in tests
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/nn/__init__.py
+++ b/dipy/nn/__init__.py
@@ -1,8 +1,2 @@
 # init for nn aka the deep neural network module
 
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
-
-del Tester

--- a/dipy/reconst/__init__.py
+++ b/dipy/reconst/__init__.py
@@ -1,8 +1,1 @@
 # init for reconst aka the reconstruction module
-
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
-
-del Tester

--- a/dipy/sims/tests/__init__.py
+++ b/dipy/sims/tests/__init__.py
@@ -1,4 +1,1 @@
 # Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -3,8 +3,3 @@
 
 from nibabel.streamlines import ArraySequence as Streamlines
 
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-bench = Tester().bench
-del Tester

--- a/dipy/tracking/tests/__init__.py
+++ b/dipy/tracking/tests/__init__.py
@@ -1,4 +1,1 @@
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester
+

--- a/dipy/viz/tests/__init__.py
+++ b/dipy/viz/tests/__init__.py
@@ -1,5 +1,0 @@
-# init to make tests into a package
-# Test callable
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -133,7 +133,9 @@ class FetchFlow(Workflow):
                                for name, func in getmembers(fetcher_module,
                                                             isfunction)
                                if name.lower().startswith("fetch_") and
-                               func is not fetcher_module.fetch_data])
+                               func is not fetcher_module.fetch_data
+                               if name.lower() not in ['fetch_hbn',
+                                                       'fetch_hcp']])
 
         return available_data
 

--- a/dipy/workflows/tests/__init__.py
+++ b/dipy/workflows/tests/__init__.py
@@ -1,3 +1,0 @@
-from numpy.testing import Tester
-test = Tester().test
-del Tester

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -65,8 +65,8 @@ def test_io_fetch_fetcher_datanames():
                      'stanford_labels', 'stanford_pve_maps', 'stanford_t1',
                      'syn_data', 'taiwan_ntu_dsi', 'target_tractogram_hcp',
                      'tissue_data', 'qte_lte_pte', 'resdnn_weights',
-                     'DiB_217_lte_pte_ste', 'DiB_70_lte_pte_ste', 'hcp',
-                     'hbn', 'synb0_weights', 'synb0_test',
+                     'DiB_217_lte_pte_ste', 'DiB_70_lte_pte_ste',
+                     'synb0_weights', 'synb0_test',
                      'evac_weights', 'evac_test', 'ptt_minimal_dataset']
 
     num_expected_fetch_methods = len(dataset_names)


### PR DESCRIPTION
NoseTester is deprecated and removed from Numpy testing on their next release.

To avoid having issue with future Numpy release, this PR remove it from our codebase.

Also, I use the opportunity to fix a small issue with `dipy_fetch`( Not good to do it in the same PR, but emergency)