### PR TITLE
remove Nibabel InTemporaryDirectory

### DIFF
--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -1,11 +1,11 @@
 import os.path as op
 import pytest
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
 
 import nibabel as nib
-import nibabel.tmpdirs as nbtmp
 
 import dipy.data as dpd
 import dipy.core.gradients as dpg
@@ -45,7 +45,7 @@ def setup_module():
 
 
 def test_syn_registration():
-    with nbtmp.InTemporaryDirectory() as tmpdir:
+    with TemporaryDirectory() as tmpdir:
         warped_moving, mapping = syn_registration(subset_b0,
                                                   subset_t2,
                                                   moving_affine=hardi_affine,
@@ -223,7 +223,7 @@ def test_register_series():
 
 def test_register_dwi_series_and_motion_correction():
     fdata, fbval, fbvec = dpd.get_fnames('small_64D')
-    with nbtmp.InTemporaryDirectory() as tmpdir:
+    with TemporaryDirectory() as tmpdir:
         # Use an abbreviated data-set:
         img = nib.load(fdata)
         data = img.get_fdata()[..., :10]
@@ -261,7 +261,7 @@ def test_streamline_registration():
     base_aff[:3, 3] = np.array([1, 2, 3])
     base_aff[3, 3] = 1
 
-    with nbtmp.InTemporaryDirectory() as tmpdir:
+    with TemporaryDirectory() as tmpdir:
         for use_aff in [None, base_aff]:
             fname1 = op.join(tmpdir, 'sl1.trk')
             fname2 = op.join(tmpdir, 'sl2.trk')

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -1,15 +1,15 @@
-import numpy as np
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import InTemporaryDirectory
+import numpy as np
+import numpy.testing as npt
 
 from dipy.io.dpy import Dpy, Streamlines
 
-import numpy.testing as npt
-
 
 def test_dpy():
-    fname = 'test.bin'
-    with InTemporaryDirectory():
+    with TemporaryDirectory() as tmpdir:
+        fname = pjoin(tmpdir, 'test.bin')
         dpw = Dpy(fname, 'w')
         A = np.ones((5, 3))
         B = 2 * A.copy()

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -1,6 +1,7 @@
 import warnings
 import os.path as osp
-from nibabel.tmpdirs import InTemporaryDirectory
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
@@ -31,50 +32,53 @@ def test_read_bvals_bvecs():
 
     # Test for error raising with incorrect file-contents:
 
-    with InTemporaryDirectory():
+    with TemporaryDirectory() as tmpdir:
         # These bvecs only have two rows/columns:
         new_bvecs1 = bvecs[:, :2]
         # Make a temporary file
-        with open('test_bv_file1.txt', 'wt') as bv_file1:
+        fname = 'test_bv_file1.txt'
+        with open(pjoin(tmpdir, fname), 'wt') as bv_file1:
             # And fill it with these 2-columned bvecs:
             for x in range(new_bvecs1.shape[0]):
                 bv_file1.write('%s %s\n' % (new_bvecs1[x][0],
                                             new_bvecs1[x][1]))
         npt.assert_raises(IOError, read_bvals_bvecs, fbvals,
-                          'test_bv_file1.txt')
+                          fname)
 
         # These bvecs are saved as one long array:
+        fname = 'test_bv_file2.npy'
         new_bvecs2 = np.ravel(bvecs)
-        with open('test_bv_file2.npy', 'w') as bv_file2:
+        with open(pjoin(tmpdir, fname), 'w') as bv_file2:
             np.save(bv_file2.name, new_bvecs2)
         npt.assert_raises(IOError, read_bvals_bvecs, fbvals,
-                          'test_bv_file2.npy')
+                          fname)
 
         # There are less bvecs than bvals:
+        fname = 'test_bv_file3.txt'
         new_bvecs3 = bvecs[:-1, :]
-        with open('test_bv_file3.txt', 'w') as bv_file3:
+        with open(pjoin(tmpdir, fname), 'w') as bv_file3:
             np.savetxt(bv_file3.name, new_bvecs3)
         npt.assert_raises(IOError, read_bvals_bvecs, fbvals,
-                          'test_bv_file3.txt')
+                          fname)
 
         # You entered the bvecs on both sides:
         npt.assert_raises(IOError, read_bvals_bvecs, fbvecs, fbvecs)
 
         # All possible delimiters should work
         bv_file4 = 'test_space.txt'
-        with open(bv_file4, 'w') as f:
+        with open(pjoin(tmpdir, bv_file4), 'w') as f:
             f.write("66 55 33")
-        bvals_1, _ = read_bvals_bvecs(bv_file4, '')
+        bvals_1, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file4), '')
 
         bv_file5 = 'test_coma.txt'
-        with open(bv_file5, 'w') as f:
+        with open(pjoin(tmpdir, bv_file5), 'w') as f:
             f.write("66, 55, 33")
-        bvals_2, _ = read_bvals_bvecs(bv_file5, '')
+        bvals_2, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file5), '')
 
         bv_file6 = 'test_tabs.txt'
-        with open(bv_file6, 'w') as f:
+        with open(pjoin(tmpdir, bv_file6), 'w') as f:
             f.write("66 \t 55 \t 33")
-        bvals_3, _ = read_bvals_bvecs(bv_file6, '')
+        bvals_3, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file6), '')
 
         ans = np.array([66., 55., 33.])
         npt.assert_array_equal(ans, bvals_1)
@@ -82,24 +86,24 @@ def test_read_bvals_bvecs():
         npt.assert_array_equal(ans, bvals_3)
 
         bv_file7 = 'test_space_2.txt'
-        with open(bv_file7, 'w') as f:
+        with open(pjoin(tmpdir, bv_file7), 'w') as f:
             f.write("66 55 33\n45 34 21\n55 32 65\n")
-        _, bvecs_1 = read_bvals_bvecs('', bv_file7)
+        _, bvecs_1 = read_bvals_bvecs('', pjoin(tmpdir, bv_file7))
 
         bv_file8 = 'test_coma_2.txt'
-        with open(bv_file8, 'w') as f:
+        with open(pjoin(tmpdir, bv_file8), 'w') as f:
             f.write("66, 55, 33\n45, 34, 21 \n 55, 32, 65\n")
-        _, bvecs_2 = read_bvals_bvecs('', bv_file8)
+        _, bvecs_2 = read_bvals_bvecs('', pjoin(tmpdir, bv_file8))
 
         bv_file9 = 'test_tabs_2.txt'
-        with open(bv_file9, 'w') as f:
+        with open(pjoin(tmpdir, bv_file9), 'w') as f:
             f.write("66 \t 55 \t 33\n45 \t 34 \t 21\n55 \t 32 \t 65\n")
-        _, bvecs_3 = read_bvals_bvecs('', bv_file9)
+        _, bvecs_3 = read_bvals_bvecs('', pjoin(tmpdir, bv_file9))
 
         bv_file10 = 'test_multiple_space.txt'
-        with open(bv_file10, 'w') as f:
+        with open(pjoin(tmpdir, bv_file10), 'w') as f:
             f.write("66   55   33\n45,   34,   21 \n 55,   32,     65\n")
-        _, bvecs_4 = read_bvals_bvecs('', bv_file10)
+        _, bvecs_4 = read_bvals_bvecs('', pjoin(tmpdir, bv_file10))
 
         ans = np.array([[66., 55., 33.], [45., 34., 21.], [55., 32., 65.]])
         npt.assert_array_equal(ans, bvecs_1)
@@ -108,26 +112,26 @@ def test_read_bvals_bvecs():
         npt.assert_array_equal(ans, bvecs_4)
 
         bv_two_volume = 'bv_two_volume.txt'
-        with open(bv_two_volume, 'w') as f:
+        with open(pjoin(tmpdir, bv_two_volume), 'w') as f:
             f.write("0 0 \n0 0 \n0 0")
         bval_two_volume = 'bval_two_volume.txt'
-        with open(bval_two_volume, 'w') as f:
+        with open(pjoin(tmpdir, bval_two_volume), 'w') as f:
             f.write("0\n0\n")
-        bval_5, bvecs_5 = read_bvals_bvecs(bval_two_volume,
-                                           bv_two_volume)
+        bval_5, bvecs_5 = read_bvals_bvecs(pjoin(tmpdir, bval_two_volume),
+                                           pjoin(tmpdir, bv_two_volume))
         npt.assert_array_equal(bvecs_5, np.zeros((2, 3)))
         npt.assert_array_equal(bval_5, np.zeros(2))
 
         bv_single_volume = 'test_single_volume.txt'
-        with open(bv_single_volume, 'w') as f:
+        with open(pjoin(tmpdir, bv_single_volume), 'w') as f:
             f.write("0 \n0 \n0 ")
         bval_single_volume = 'test_single_volume_2.txt'
-        with open(bval_single_volume, 'w') as f:
+        with open(pjoin(tmpdir, bval_single_volume), 'w') as f:
             f.write("0\n")
 
         with warnings.catch_warnings(record=True) as w:
-            bval_5, bvecs_5 = read_bvals_bvecs(bval_single_volume,
-                                               bv_single_volume)
+            bval_5, bvecs_5 = read_bvals_bvecs(pjoin(tmpdir, bval_single_volume),
+                                               pjoin(tmpdir, bv_single_volume))
             npt.assert_array_equal(bvecs_5, np.zeros((1, 3)))
             npt.assert_array_equal(bval_5, np.zeros(1))
             assert_true(len(w) == 1)

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -1,9 +1,10 @@
 
 import os
+from os.path import join as pjoin
+from tempfile import TemporaryDirectory
+
 import numpy as np
 import numpy.testing as npt
-
-from nibabel.tmpdirs import InTemporaryDirectory
 
 from dipy.direction.peaks import PeaksAndMetrics
 from dipy.data import default_sphere
@@ -11,7 +12,7 @@ from dipy.io.peaks import load_peaks, save_peaks, peaks_to_niftis
 
 
 def test_io_peaks():
-    with InTemporaryDirectory():
+    with TemporaryDirectory() as tmpdir:
         fname = 'test.pam5'
 
         pam = PeaksAndMetrics()
@@ -28,18 +29,18 @@ def test_io_peaks():
         pam.qa = np.zeros((10, 10, 10, 5))
         pam.odf = np.zeros((10, 10, 10, default_sphere.vertices.shape[0]))
 
-        save_peaks(fname, pam)
-        pam2 = load_peaks(fname, verbose=True)
+        save_peaks(pjoin(tmpdir, fname), pam)
+        pam2 = load_peaks(pjoin(tmpdir, fname), verbose=True)
         npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
 
         pam2.affine = None
 
         fname2 = 'test2.pam5'
-        save_peaks(fname2, pam2, np.eye(4))
-        pam2_res = load_peaks(fname2, verbose=True)
+        save_peaks(pjoin(tmpdir, fname2), pam2, np.eye(4))
+        pam2_res = load_peaks(pjoin(tmpdir, fname2), verbose=True)
         npt.assert_array_equal(pam.peak_dirs, pam2_res.peak_dirs)
 
-        pam3 = load_peaks(fname2, verbose=False)
+        pam3 = load_peaks(pjoin(tmpdir, fname2), verbose=False)
 
         for attr in ['peak_dirs', 'peak_values', 'peak_indices',
                      'gfa', 'qa', 'shm_coeff', 'B', 'odf']:
@@ -53,33 +54,34 @@ def test_io_peaks():
 
         fname3 = 'test3.pam5'
         pam4 = PeaksAndMetrics()
-        npt.assert_raises(ValueError, save_peaks, fname3, pam4)
+        npt.assert_raises(AttributeError, save_peaks, pjoin(tmpdir, fname3),
+                          pam4)
 
         fname4 = 'test4.pam5'
         del pam.affine
-        save_peaks(fname4, pam, affine=None)
+        save_peaks(pjoin(tmpdir, fname4), pam, affine=None)
 
         fname5 = 'test5.pkm'
-        npt.assert_raises(IOError, save_peaks, fname5, pam)
+        npt.assert_raises(IOError, save_peaks, pjoin(tmpdir, fname5), pam)
 
         pam.affine = np.eye(4)
         fname6 = 'test6.pam5'
-        save_peaks(fname6, pam, verbose=True)
+        save_peaks(pjoin(tmpdir, fname6), pam, verbose=True)
 
         del pam.shm_coeff
-        save_peaks(fname6, pam, verbose=False)
+        save_peaks(pjoin(tmpdir, fname6), pam, verbose=False)
 
         pam.shm_coeff = np.zeros((10, 10, 10, 45))
         del pam.odf
-        save_peaks(fname6, pam)
-        pam_tmp = load_peaks(fname6, True)
+        save_peaks(pjoin(tmpdir, fname6), pam)
+        pam_tmp = load_peaks(pjoin(tmpdir, fname6), True)
         npt.assert_equal(pam_tmp.odf, None)
 
         fname7 = 'test7.paw'
-        npt.assert_raises(IOError, load_peaks, fname7)
+        npt.assert_raises(IOError, load_peaks, pjoin(tmpdir, fname7))
 
         del pam.shm_coeff
-        save_peaks(fname6, pam, verbose=True)
+        save_peaks(pjoin(tmpdir, fname6), pam, verbose=True)
 
         fname_shm = 'shm.nii.gz'
         fname_dirs = 'dirs.nii.gz'
@@ -99,13 +101,14 @@ def test_io_peaks():
 
 
 def test_io_save_peaks_error():
-    with InTemporaryDirectory():
+    with TemporaryDirectory() as tmpdir:
         fname = 'test.pam5'
 
         pam = PeaksAndMetrics()
 
-        npt.assert_raises(IOError, save_peaks, 'test.pam', pam)
-        npt.assert_raises(ValueError, save_peaks, fname, pam)
+        npt.assert_raises(IOError, save_peaks, pjoin(tmpdir, 'test.pam'), pam)
+        npt.assert_raises(AttributeError, save_peaks, pjoin(tmpdir, fname),
+                          pam)
 
         pam.affine = np.eye(4)
         pam.peak_dirs = np.random.rand(10, 10, 10, 5, 3)

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -54,8 +54,8 @@ def test_io_peaks():
 
         fname3 = 'test3.pam5'
         pam4 = PeaksAndMetrics()
-        npt.assert_raises(AttributeError, save_peaks, pjoin(tmpdir, fname3),
-                          pam4)
+        npt.assert_raises((ValueError, AttributeError), save_peaks,
+                          pjoin(tmpdir, fname3), pam4)
 
         fname4 = 'test4.pam5'
         del pam.affine
@@ -107,8 +107,8 @@ def test_io_save_peaks_error():
         pam = PeaksAndMetrics()
 
         npt.assert_raises(IOError, save_peaks, pjoin(tmpdir, 'test.pam'), pam)
-        npt.assert_raises(AttributeError, save_peaks, pjoin(tmpdir, fname),
-                          pam)
+        npt.assert_raises((ValueError, AttributeError), save_peaks,
+                          pjoin(tmpdir, fname), pam)
 
         pam.affine = np.eye(4)
         pam.peak_dirs = np.random.rand(10, 10, 10, 5, 3)

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -1,8 +1,9 @@
 import json
 import os
+from os.path import join as pjoin
 from copy import deepcopy
+from tempfile import TemporaryDirectory
 
-from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 import numpy.testing as npt
 from numpy.testing import assert_allclose, assert_array_equal, assert_
@@ -231,12 +232,13 @@ def test_to_center_equivalence():
 def test_trk_iterative_saving_loading():
     sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
                           to_space=Space.RASMM)
-    with InTemporaryDirectory():
-        save_tractogram(sft, 'gs_iter.trk')
+    with TemporaryDirectory() as tmpdir:
+        save_tractogram(sft, pjoin(tmpdir, 'gs_iter.trk'))
         tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram('gs_iter.trk', filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmpdir, 'gs_iter.trk'),
+                                       filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -247,17 +249,18 @@ def test_trk_iterative_saving_loading():
 def test_tck_iterative_saving_loading():
     sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'],
                           to_space=Space.RASMM)
-    with InTemporaryDirectory():
-        save_tractogram(sft, 'gs_iter.tck')
+    with TemporaryDirectory() as tmpdir:
+        save_tractogram(sft, pjoin(tmpdir, 'gs_iter.tck'))
         tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram('gs_iter.tck', filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmpdir, 'gs_iter.tck'),
+                                       filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
-            save_tractogram(sft_iter, 'gs_iter.tck')
+            save_tractogram(sft_iter, pjoin(tmpdir, 'gs_iter.tck'))
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -266,33 +269,33 @@ def test_fib_iterative_saving_loading():
         return
     sft = load_tractogram(filepath_dix['gs.fib'], filepath_dix['gs.nii'],
                           to_space=Space.RASMM)
-    with InTemporaryDirectory():
-        save_tractogram(sft, 'gs_iter.fib')
+    with TemporaryDirectory() as tmpdir:
+        save_tractogram(sft, pjoin(tmpdir, 'gs_iter.fib'))
         tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram('gs_iter.fib', filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmpdir, 'gs_iter.fib'), filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
-            save_tractogram(sft_iter, 'gs_iter.fib')
+            save_tractogram(sft_iter, pjoin(tmpdir, 'gs_iter.fib'))
 
 
 def test_dpy_iterative_saving_loading():
     sft = load_tractogram(filepath_dix['gs.dpy'], filepath_dix['gs.nii'],
                           to_space=Space.RASMM)
-    with InTemporaryDirectory():
-        save_tractogram(sft, 'gs_iter.dpy')
+    with TemporaryDirectory() as tmpdir:
+        save_tractogram(sft, pjoin(tmpdir, 'gs_iter.dpy'))
         tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram('gs_iter.dpy', filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmpdir, 'gs_iter.dpy'), filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
                             atol=1e-3, rtol=1e-6)
-            save_tractogram(sft_iter, 'gs_iter.dpy')
+            save_tractogram(sft_iter, pjoin(tmpdir, 'gs_iter.dpy'))
 
 
 def test_iterative_to_vox_transformation():
@@ -447,8 +450,8 @@ def test_random_point_color():
 
     try:
         sft.data_per_point = coloring_dict
-        with InTemporaryDirectory():
-            save_tractogram(sft, 'random_points_color.trk')
+        with TemporaryDirectory() as tmp_dir:
+            save_tractogram(sft, pjoin(tmp_dir, 'random_points_color.trk'))
         assert_(True)
     except (TypeError, ValueError):
         assert_(False)
@@ -467,8 +470,8 @@ def test_random_point_gray():
 
     try:
         sft.data_per_point = coloring_dict
-        with InTemporaryDirectory():
-            save_tractogram(sft, 'random_points_gray.trk')
+        with TemporaryDirectory() as tmpdir:
+            save_tractogram(sft, pjoin(tmpdir, 'random_points_gray.trk'))
         assert_(True)
     except (ValueError):
         assert_(False)
@@ -496,8 +499,8 @@ def test_random_streamline_color():
 
     try:
         sft.data_per_point = coloring_dict
-        with InTemporaryDirectory():
-            save_tractogram(sft, 'random_streamlines_color.trk')
+        with TemporaryDirectory() as tmpdir:
+            save_tractogram(sft, pjoin(tmpdir, 'random_streamlines_color.trk'))
         assert_(True)
     except (TypeError, ValueError):
         assert_(False)
@@ -874,7 +877,6 @@ def test_non_existing_dtype_dict_attributes():
         assert_(False, msg='Fake entries in dtype_dict should not work.')
     except ValueError:
         assert_(True)
-        
 
 
 def test_from_sft_dtype_dict_attributes():

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -9,6 +9,7 @@ Run scripts and check outputs
 import glob
 import os
 import shutil
+from tempfile import TemporaryDirectory
 
 from os.path import (dirname, join as pjoin, abspath)
 
@@ -17,7 +18,6 @@ import numpy.testing as nt
 import pytest
 
 import nibabel as nib
-from nibabel.tmpdirs import InTemporaryDirectory
 
 from dipy.data import get_fnames
 
@@ -67,7 +67,7 @@ def assert_image_shape_affine(filename, shape, affine):
 
 
 def test_dipy_fit_tensor_again():
-    with InTemporaryDirectory():
+    with TemporaryDirectory():
         dwi, bval, bvec = get_fnames("small_25")
         # Copy data to tmp directory
         shutil.copyfile(dwi, "small_25.nii.gz")
@@ -89,7 +89,7 @@ def test_dipy_fit_tensor_again():
         assert_image_shape_affine("small_25_md.nii.gz", shape, affine)
         assert_image_shape_affine("small_25_rd.nii.gz", shape, affine)
 
-    with InTemporaryDirectory():
+    with TemporaryDirectory():
         dwi, bval, bvec = get_fnames("small_25")
         # Copy data to tmp directory
         shutil.copyfile(dwi, "small_25.nii.gz")
@@ -120,7 +120,7 @@ def test_dipy_fit_tensor_again():
 
 @pytest.mark.skipif(no_mpl)
 def test_qb_commandline():
-    with InTemporaryDirectory():
+    with TemporaryDirectory():
         tracks_file = get_fnames('fornix')
         cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
                '--out_file', 'tracks300.trk']
@@ -129,7 +129,7 @@ def test_qb_commandline():
 
 @pytest.mark.skipif(no_mpl)
 def test_qb_commandline_output_path_handling():
-    with InTemporaryDirectory():
+    with TemporaryDirectory():
         # Create temporary subdirectory for input and for output
         os.mkdir('work')
         os.mkdir('output')


### PR DESCRIPTION
`InTemporaryDirectory` or `TemporaryDirectory` is deprecated in Nibabel in favor of the standard package `tempfile`.

So this PR clean a bit our codebase