### PR TITLE
Move evac+ to new module `nn`

### DIFF
--- a/bin/dipy_evac_plus
+++ b/bin/dipy_evac_plus
@@ -1,7 +1,7 @@
 #!python
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.segment import EVACPlusFlow
+from dipy.workflows.nn import EVACPlusFlow
 
 if __name__ == "__main__":
     run_flow(EVACPlusFlow())

--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -1,0 +1,69 @@
+import logging
+
+import numpy as np
+
+from dipy.io.image import save_nifti, load_nifti
+from dipy.nn.evac import EVACPlus
+from dipy.workflows.workflow import Workflow
+
+
+class EVACPlusFlow(Workflow):
+    @classmethod
+    def get_short_name(cls):
+        return 'evacplus'
+
+    def run(self, input_files, save_masked=False, out_dir='',
+            out_mask='brain_mask.nii.gz', out_masked='dwi_masked.nii.gz'):
+        """Extract brain using EVAC+.
+
+        Parameters
+        ----------
+        input_files : string
+            Path to the input volumes. This path may contain wildcards to
+            process multiple inputs at once.
+        save_masked : bool, optional
+            Save mask.
+        out_dir : string, optional
+            Output directory. (default current directory)
+        out_mask : string, optional
+            Name of the mask volume to be saved.
+        out_masked : string, optional
+            Name of the masked volume to be saved.
+
+        References
+        ----------
+        ..  [Park2022] Park, J.S., Fadnavis, S., & Garyfallidis, E. (2022).
+        EVAC+: Multi-scale V-net with Deep Feature
+        CRF Layers for Brain Extraction.
+
+        """
+        io_it = self.get_io_iterator()
+        empty_flag = True
+
+        for fpath, mask_out_path, masked_out_path in io_it:
+            logging.info('Applying evac+ brain extraction on {0}'.
+                         format(fpath))
+
+            data, affine, img, voxsize = load_nifti(fpath, return_img=True,
+                                                    return_voxsize=True)
+            evac = EVACPlus()
+            mask_volume = evac.predict(data, affine, voxsize)
+            masked_volume = mask_volume * data
+
+            save_nifti(mask_out_path, mask_volume.astype(np.float64), affine)
+
+            logging.info('Mask saved as {0}'.format(mask_out_path))
+
+            if save_masked:
+                save_nifti(masked_out_path, masked_volume, affine,
+                           img.header)
+
+                logging.info('Masked volume saved as {0}'.
+                             format(masked_out_path))
+            empty_flag = False
+        if empty_flag:
+            raise ValueError("All output paths exists."
+                             " If you want to overwrite "
+                             "please use the --force option.")
+
+        return io_it

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -1,15 +1,15 @@
-import os
 import logging
-from dipy.workflows.workflow import Workflow
-from dipy.io.image import save_nifti, load_nifti
-import numpy as np
 from time import time
+
+import numpy as np
+
+from dipy.io.image import save_nifti, load_nifti
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.tracking import Streamlines
 from dipy.segment.mask import median_otsu
 from dipy.segment.bundles import RecoBundles
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.nn.evac import EVACPlus
+from dipy.workflows.workflow import Workflow
 
 
 class MedianOtsuFlow(Workflow):
@@ -335,66 +335,3 @@ class LabelsBundlesFlow(Workflow):
             new_sft = StatefulTractogram(bundle, sft, Space.RASMM)
             save_tractogram(new_sft, out_bundle, bbox_valid_check=False)
             logging.info(out_bundle)
-
-
-class EVACPlusFlow(Workflow):
-    @classmethod
-    def get_short_name(cls):
-        return 'evacplus'
-
-    def run(self, input_files, save_masked=False, out_dir='',
-            out_mask='brain_mask.nii.gz', out_masked='dwi_masked.nii.gz'):
-        """ Extract brain using EVAC+
-
-        Parameters
-        ----------
-        input_files : string
-            Path to the input volumes. This path may contain wildcards to
-            process multiple inputs at once.
-        save_masked : bool, optional
-            Save mask.
-        out_dir : string, optional
-            Output directory. (default current directory)
-        out_mask : string, optional
-            Name of the mask volume to be saved.
-        out_masked : string, optional
-            Name of the masked volume to be saved.
-
-        References
-        ----------
-        ..  [Park2022] Park, J.S., Fadnavis, S., & Garyfallidis, E. (2022).
-        EVAC+: Multi-scale V-net with Deep Feature
-        CRF Layers for Brain Extraction.  
-
-        """
-        
-        io_it = self.get_io_iterator()
-        empty_flag = True
-
-        for fpath, mask_out_path, masked_out_path in io_it:
-            logging.info('Applying evac+ brain extraction on {0}'.
-                         format(fpath))
-
-            data, affine, img, voxsize = load_nifti(fpath, return_img=True,
-                                                    return_voxsize=True)
-            evac = EVACPlus()
-            mask_volume = evac.predict(data, affine, voxsize)
-            masked_volume = mask_volume * data
-
-            save_nifti(mask_out_path, mask_volume.astype(np.float64), affine)
-
-            logging.info('Mask saved as {0}'.format(mask_out_path))
-
-            if save_masked:
-                save_nifti(masked_out_path, masked_volume, affine,
-                           img.header)
-
-                logging.info('Masked volume saved as {0}'.
-                             format(masked_out_path))
-            empty_flag = False
-        if empty_flag:
-            raise ValueError("All output paths exists."
-                             " If you want to overwrite "
-                             "please use the --force option.")
-
-        return io_it

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -1,0 +1,50 @@
+from os.path import join as pjoin
+from packaging.version import Version
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from dipy.data import get_fnames
+from dipy.io.image import load_nifti_data, save_nifti
+from dipy.nn.evac import EVACPlus
+from dipy.utils.optpkg import optional_package
+from dipy.workflows.nn import EVACPlusFlow
+
+
+tf, have_tf, _ = optional_package('tensorflow')
+
+if have_tf:
+    from dipy.nn.evac import EVACPlus
+    if Version(tf.__version__) < Version('2.0.0'):
+        raise ImportError('Please upgrade to TensorFlow 2+')
+
+
+@pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
+def test_evac_plus_flow():
+    with TemporaryDirectory() as out_dir:
+        file_path = get_fnames('evac_test_data')
+
+        volume = np.load(file_path)['input'][0]
+        temp_affine = np.eye(4)
+        temp_path = pjoin(out_dir, 'temp.nii.gz')
+        save_nifti(temp_path, volume, temp_affine)
+        save_masked = True
+
+        evac_flow = EVACPlusFlow()
+        evac_flow.run(temp_path, out_dir=out_dir, save_masked=save_masked)
+
+        mask_name = evac_flow.last_generated_outputs['out_mask']
+        masked_name = evac_flow.last_generated_outputs['out_masked']
+
+        evac = EVACPlus()
+        mask = evac.predict(volume, temp_affine)
+        masked = volume * mask
+
+        result_mask_data = load_nifti_data(pjoin(out_dir, mask_name))
+        npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
+
+        result_masked_data = load_nifti_data(pjoin(out_dir, masked_name))
+
+        npt.assert_array_equal(result_masked_data, masked)

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -1,7 +1,5 @@
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
-from packaging.version import Version
-import pytest
 
 import numpy.testing as npt
 import numpy as np
@@ -15,17 +13,9 @@ from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.image import load_nifti_data, save_nifti
 from dipy.tracking.streamline import set_number_of_points
-from dipy.workflows.segment import MedianOtsuFlow, EVACPlusFlow
+from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
-from dipy.nn.evac import EVACPlus
-from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package('tensorflow')
-
-if have_tf:
-    from dipy.nn.evac import EVACPlus
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 
 def test_median_otsu_flow():
     with TemporaryDirectory() as out_dir:
@@ -112,32 +102,3 @@ def test_recobundles_flow():
         bmd_value = BMD.distance(x0.tolist())
 
         npt.assert_equal(bmd_value < 1, True)
-
-
-@pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
-def test_evac_plus_flow():
-    with TemporaryDirectory() as out_dir:
-        file_path = get_fnames('evac_test_data')
-
-        volume = np.load(file_path)['input'][0]
-        temp_affine = np.eye(4)
-        temp_path = pjoin(out_dir, 'temp.nii.gz') 
-        save_nifti(temp_path, volume, temp_affine)
-        save_masked = True
-
-        evac_flow = EVACPlusFlow()
-        evac_flow.run(temp_path, out_dir=out_dir, save_masked=save_masked)
-
-        mask_name = evac_flow.last_generated_outputs['out_mask']
-        masked_name = evac_flow.last_generated_outputs['out_masked']
-
-        evac = EVACPlus()
-        mask = evac.predict(volume, temp_affine)
-        masked = volume * mask
-
-        result_mask_data = load_nifti_data(pjoin(out_dir, mask_name))
-        npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
-
-        result_masked_data = load_nifti_data(pjoin(out_dir, masked_name))
-
-        npt.assert_array_equal(result_masked_data, masked)


### PR DESCRIPTION
During the workshop, we realize that the workflow `evacs+` needs to leave the `segment` module and go to its own module named `nn` due to tensorflow dependency. 

All algorithms depending on tensorflow will go to this `nn` module. 

Tensorflow have some installation issue and bring confusion when you use a not related workflow. (like recobundle here).

