### PR TITLE
BF - initial backward orientation of local tracking

### DIFF
--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -15,7 +15,7 @@ cdef class PmfGen:
     def __init__(self,
                  double[:, :, :, :] data,
                  object sphere):
-        self.data = np.asarray(data, dtype=float)
+        self.data = np.asarray(data, dtype=float, order='C')
         self.sphere = sphere
 
     cpdef double[:] get_pmf(self, double[::1] point):

--- a/dipy/direction/probabilistic_direction_getter.pxd
+++ b/dipy/direction/probabilistic_direction_getter.pxd
@@ -5,4 +5,3 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
 
     cdef:
         double[:, :] vertices
-        dict _adj_matrix

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -178,7 +178,6 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
                 (direction[0], direction[1], direction[2])]
         except KeyError:
             # if direction is not a sphere vertex, we find the closest vertex
-            print("oh no!")
             for i in range(3):
                 vertex[i] = direction[i]
             idx = self.sphere.find_closest(vertex)

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -93,14 +93,23 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         cdef:
             cnp.npy_intp i, idx, _len
             double[:] newdir, pmf
+            double vertex[3]
             double last_cdf, random_sample
             cnp.uint8_t[:] bool_array
 
         pmf = self._get_pmf(point)
         _len = pmf.shape[0]
-
-        bool_array = self._adj_matrix[
-            (direction[0], direction[1], direction[2])]
+        try:
+            bool_array = self._adj_matrix[
+                (direction[0], direction[1], direction[2])]
+        except KeyError:
+            # if direction is not a sphere vertex, we find the closest vertex
+            for i in range(3):
+                vertex[i] = direction[i]
+            idx = self.sphere.find_closest(vertex)
+            bool_array = self._adj_matrix[(self.vertices[idx, :][0],
+                                           self.vertices[idx, :][1],
+                                           self.vertices[idx, :][2])]
 
         for i in range(_len):
             if bool_array[i] == 0:
@@ -157,14 +166,25 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
         cdef:
             cnp.npy_intp _len, max_idx
             double[:] newdir, pmf
+            double vertex[3]
             double max_value
             cnp.uint8_t[:] bool_array
 
         pmf = self._get_pmf(point)
         _len = pmf.shape[0]
 
-        bool_array = self._adj_matrix[
-            (direction[0], direction[1], direction[2])]
+        try:
+            bool_array = self._adj_matrix[
+                (direction[0], direction[1], direction[2])]
+        except KeyError:
+            # if direction is not a sphere vertex, we find the closest vertex
+            print("oh no!")
+            for i in range(3):
+                vertex[i] = direction[i]
+            idx = self.sphere.find_closest(vertex)
+            bool_array = self._adj_matrix[(self.vertices[idx, :][0],
+                                           self.vertices[idx, :][1],
+                                           self.vertices[idx, :][2])]
 
         max_idx = 0
         max_value = 0.0

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -6,12 +6,14 @@
 Implementation of a probabilistic direction getter based on sampling from
 discrete distribution (pmf) at each step of the tracking.
 """
+from random import random
+
 import numpy as np
 cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.utils.fast_numpy cimport (copy_point, cumsum, norm, normalize,
-                                    random, where_to_insert)
+                                     where_to_insert)
 
 
 cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
@@ -103,19 +105,19 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
             if last_cdf == 0:
                 return 1
 
-            idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
+        idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
 
-            newdir = self.vertices[idx]
-            # Update direction and return 0 for error
-            if (direction[0] * newdir[0]
-                + direction[1] * newdir[1]
-                + direction[2] * newdir[2] > 0):
-                copy_point(&newdir[0], direction)
-            else:
-                newdir[0] = newdir[0] * -1
-                newdir[1] = newdir[1] * -1
-                newdir[2] = newdir[2] * -1
-                copy_point(&newdir[0], direction)
+        newdir = self.vertices[idx]
+        # Update direction and return 0 for error
+        if (direction[0] * newdir[0]
+            + direction[1] * newdir[1]
+            + direction[2] * newdir[2] > 0):
+            copy_point(&newdir[0], direction)
+        else:
+            newdir[0] = newdir[0] * -1
+            newdir[1] = newdir[1] * -1
+            newdir[2] = newdir[2] * -1
+            copy_point(&newdir[0], direction)
         return 0
 
 

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -6,13 +6,14 @@
 Implementation of a probabilistic direction getter based on sampling from
 discrete distribution (pmf) at each step of the tracking.
 """
+from random import random
 
 import numpy as np
 cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.utils.fast_numpy cimport (copy_point, cumsum, norm, normalize,
-                                    random, where_to_insert)
+                                    where_to_insert)
 
 
 cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
@@ -104,20 +105,20 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
             if last_cdf == 0:
                 return 1
 
-            idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
+        idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
 
-            newdir = self.vertices[idx]
-            # Update direction and return 0 for error
-            if (direction[0] * newdir[0]
-                + direction[1] * newdir[1]
-                + direction[2] * newdir[2] > 0):
-                copy_point(&newdir[0], direction)
-            else:
-                newdir[0] = newdir[0] * -1
-                newdir[1] = newdir[1] * -1
-                newdir[2] = newdir[2] * -1
-                copy_point(&newdir[0], direction)
-            return 0
+        newdir = self.vertices[idx]
+        # Update direction and return 0 for error
+        if (direction[0] * newdir[0]
+            + direction[1] * newdir[1]
+            + direction[2] * newdir[2] > 0):
+            copy_point(&newdir[0], direction)
+        else:
+            newdir[0] = newdir[0] * -1
+            newdir[1] = newdir[1] * -1
+            newdir[2] = newdir[2] * -1
+            copy_point(&newdir[0], direction)
+        return 0
 
 
 cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -85,7 +85,7 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         _len = pmf.shape[0]
 
         if norm(<double[:3]> direction) == 0:
-            return 0
+            return 1
         normalize(<double[:3]> direction)
 
         with nogil:
@@ -154,7 +154,7 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
         max_value = 0.0
 
         if norm(<double[:3]> direction) == 0:
-            return 0
+            return 1
         normalize(<double[:3]> direction)
 
         with nogil:

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -81,7 +81,7 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         cdef:
             cnp.npy_intp i, idx, _len
             double[:] newdir, pmf
-            double last_cdf, cos_sim, dir_norm
+            double last_cdf, cos_sim
 
         pmf = self._get_pmf(point)
         _len = pmf.shape[0]

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -6,14 +6,12 @@
 Implementation of a probabilistic direction getter based on sampling from
 discrete distribution (pmf) at each step of the tracking.
 """
-from random import random
-
 import numpy as np
 cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.utils.fast_numpy cimport (copy_point, cumsum, norm, normalize,
-                                    where_to_insert)
+                                    random, where_to_insert)
 
 
 cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
@@ -105,19 +103,19 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
             if last_cdf == 0:
                 return 1
 
-        idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
+            idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
 
-        newdir = self.vertices[idx]
-        # Update direction and return 0 for error
-        if (direction[0] * newdir[0]
-            + direction[1] * newdir[1]
-            + direction[2] * newdir[2] > 0):
-            copy_point(&newdir[0], direction)
-        else:
-            newdir[0] = newdir[0] * -1
-            newdir[1] = newdir[1] * -1
-            newdir[2] = newdir[2] * -1
-            copy_point(&newdir[0], direction)
+            newdir = self.vertices[idx]
+            # Update direction and return 0 for error
+            if (direction[0] * newdir[0]
+                + direction[1] * newdir[1]
+                + direction[2] * newdir[2] > 0):
+                copy_point(&newdir[0], direction)
+            else:
+                newdir[0] = newdir[0] * -1
+                newdir[1] = newdir[1] * -1
+                newdir[2] = newdir[2] * -1
+                copy_point(&newdir[0], direction)
         return 0
 
 

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -143,7 +143,13 @@ class LocalTracking(object):
                         stream_status == StreamlineStatus.ENDPOINT or
                         stream_status == StreamlineStatus.OUTSIDEIMAGE):
                     continue
-                first_step = -first_step
+                if stepsF > 1:
+                    # Use the opposite of the first selected orientation for
+                    # the backward tracking segment
+                    first_step = F[0] - F[1]
+                    first_step = first_step / np.linalg.norm(first_step)
+                else:
+                    first_step = -first_step
                 stepsB, stream_status = self._tracker(s, first_step, B)
                 if not (self.return_all or
                         stream_status == StreamlineStatus.ENDPOINT or

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -7,6 +7,7 @@ from dipy.tracking.localtrack import local_tracker, pft_tracker
 from dipy.tracking.stopping_criterion import (AnatomicalStoppingCriterion,
                                               StreamlineStatus)
 from dipy.tracking import utils
+from dipy.utils import fast_numpy
 
 
 class LocalTracking(object):
@@ -123,12 +124,13 @@ class LocalTracking(object):
         B = F.copy()
         for s in self.seeds:
             s = np.dot(lin, s) + offset
-            # Set the random seed in numpy and random
+            # Set the random seed in numpy, random and fast_numpy (libc.stdlib)
             if self.random_seed is not None:
                 s_random_seed = hash(np.abs((np.sum(s)) + self.random_seed)) \
                     % (2**32 - 1)
                 random.seed(s_random_seed)
                 np.random.seed(s_random_seed)
+                fast_numpy.seed(s_random_seed)
             directions = self.direction_getter.initial_direction(s)
             if directions.size == 0 and self.return_all:
                 # only the seed position

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -146,8 +146,12 @@ class LocalTracking(object):
                 if stepsF > 1:
                     # Use the opposite of the first selected orientation for
                     # the backward tracking segment
-                    first_step = F[0] - F[1]
-                    first_step = first_step / np.linalg.norm(first_step)
+                    opposite_step = F[0] - F[1]
+                    opposite_step_norm = np.linalg.norm(opposite_step)
+                    if opposite_step_norm > 0:
+                        first_step = opposite_step / opposite_step_norm
+                    else:
+                        first_step = -first_step
                 else:
                     first_step = -first_step
                 stepsB, stream_status = self._tracker(s, first_step, B)

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -56,14 +56,21 @@ def local_tracker(
     cdef:
         cnp.npy_intp i
         StreamlineStatus stream_status
+        double dir[3]
+        double vs[3]
+        double seed[3]
 
     if (seed_pos.shape[0] != 3 or first_step.shape[0] != 3 or
             voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
         raise ValueError('Invalid input parameter dimensions.')
 
+    for i in range(3):
+        dir[i] = first_step[i]
+        vs[i] = voxel_size[i]
+        seed[i] = seed_pos[i]
+
     stream_status = TRACKPOINT
-    i, stream_status = dg.generate_streamline(seed_pos, first_step, voxel_size,
-                                              step_size, sc,
+    i, stream_status = dg.generate_streamline(seed, dir, vs, step_size, sc,
                                               streamline, stream_status,
                                               fixedstep)
     return i, stream_status

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -1,11 +1,13 @@
 
+from random import random
+
 cimport cython
 cimport numpy as cnp
 from .direction_getter cimport DirectionGetter
 from .stopping_criterion cimport(
     StreamlineStatus, StoppingCriterion, AnatomicalStoppingCriterion,
     TRACKPOINT, OUTSIDEIMAGE, INVALIDPOINT, PYERROR)
-from dipy.utils.fast_numpy cimport copy_point, cumsum, random, where_to_insert
+from dipy.utils.fast_numpy cimport copy_point, cumsum, where_to_insert
 
 
 def local_tracker(

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -255,7 +255,8 @@ cdef _pft_tracker(DirectionGetter dg,
             # or an invalid point (PYERROR)
             break
 
-    if stream_status[0] == OUTSIDEIMAGE or stream_status[0] == PYERROR:
+    if ((stream_status[0] == OUTSIDEIMAGE or stream_status[0] == PYERROR)
+        and i > 1):
         i -= 1
     return i
 

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -56,21 +56,21 @@ def local_tracker(
     cdef:
         cnp.npy_intp i
         StreamlineStatus stream_status
-        double dir[3]
-        double vs[3]
-        double seed[3]
+        double input_direction[3]
+        double input_voxel_size[3]
+        double input_seed_pos[3]
 
     if (seed_pos.shape[0] != 3 or first_step.shape[0] != 3 or
             voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
         raise ValueError('Invalid input parameter dimensions.')
 
-    for i in range(3):
-        dir[i] = first_step[i]
-        vs[i] = voxel_size[i]
-        seed[i] = seed_pos[i]
+    copy_point(&first_step[0], input_direction)
+    copy_point(&voxel_size[0], input_voxel_size)
+    copy_point(&seed_pos[0], input_seed_pos)
 
     stream_status = TRACKPOINT
-    i, stream_status = dg.generate_streamline(seed, dir, vs, step_size, sc,
+    i, stream_status = dg.generate_streamline(input_seed_pos, input_direction,
+                                              input_voxel_size, step_size, sc,
                                               streamline, stream_status,
                                               fixedstep)
     return i, stream_status
@@ -153,21 +153,20 @@ def pft_tracker(
     cdef:
         cnp.npy_intp i
         StreamlineStatus stream_status
-        double dir[3]
-        double vs[3]
-        double seed[3]
+        double input_direction[3]
+        double input_voxel_size[3]
+        double input_seed_pos[3]
 
     if (seed_pos.shape[0] != 3 or first_step.shape[0] != 3 or
             voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
         raise ValueError('Invalid input parameter dimensions.')
 
-    for i in range(3):
-        dir[i] = first_step[i]
-        vs[i] = voxel_size[i]
-        seed[i] = seed_pos[i]
+    copy_point(&first_step[0], input_direction)
+    copy_point(&voxel_size[0], input_voxel_size)
+    copy_point(&seed_pos[0], input_seed_pos)
 
-    i = _pft_tracker(dg, sc, seed, dir, vs, streamline,
-                     directions, step_size, &stream_status,
+    i = _pft_tracker(dg, sc, input_seed_pos, input_direction, input_voxel_size,
+                     streamline, directions, step_size, &stream_status,
                      pft_max_nbr_back_steps, pft_max_nbr_front_steps,
                      pft_max_trials, particle_count, particle_paths,
                      particle_dirs, particle_weights, particle_steps,

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -1,13 +1,11 @@
 
-from random import random
-
 cimport cython
 cimport numpy as cnp
 from .direction_getter cimport DirectionGetter
 from .stopping_criterion cimport(
     StreamlineStatus, StoppingCriterion, AnatomicalStoppingCriterion,
     TRACKPOINT, OUTSIDEIMAGE, INVALIDPOINT, PYERROR)
-from dipy.utils.fast_numpy cimport cumsum, where_to_insert, copy_point
+from dipy.utils.fast_numpy cimport copy_point, cumsum, random, where_to_insert
 
 
 def local_tracker(
@@ -196,7 +194,7 @@ cdef _pft_tracker(DirectionGetter dg,
                   cnp.int_t[:, :] particle_steps,
                   cnp.int_t[:, :] particle_stream_statuses):
     cdef:
-        int i, pft_trial, pft_streamline_i, back_steps, front_steps
+        int i, pft_trial, back_steps, front_steps
         int strl_array_len
         double point[3]
         void (*step)(double* , double*, double) nogil
@@ -226,7 +224,7 @@ cdef _pft_tracker(DirectionGetter dg,
             # The tracking continues normally
             continue
         elif stream_status[0] == INVALIDPOINT:
-            if pft_trial < pft_max_trials and i > 1:
+            if pft_trial < pft_max_trials and i > 1 and i < strl_array_len:
                 back_steps = min(i - 1, pft_max_nbr_back_steps)
                 front_steps = min(strl_array_len - i - back_steps - 1,
                                   pft_max_nbr_front_steps)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -546,7 +546,8 @@ def test_maximum_deterministic_tracker():
     mask = (simple_image > 0).astype(float)
     sc = ThresholdStoppingCriterion(mask, .5)
 
-    dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, 90, sphere,
+    dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, max_angle=100,
+                                                      sphere=sphere,
                                                       pmf_threshold=0.1)
     streamlines = LocalTracking(dg, sc, seeds, np.eye(4), 1.)
 

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -437,7 +437,6 @@ def test_particle_filtering_tractography():
                                                     step_size, max_cross=1,
                                                     return_all=True, maxlen=l)
         for s in pft_streamlines:
-            print(s)
             for i in range(len(s) - 1):
                 npt.assert_almost_equal(np.linalg.norm(s[i] - s[i + 1]),
                                         step_size)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -437,6 +437,7 @@ def test_particle_filtering_tractography():
                                                     step_size, max_cross=1,
                                                     return_all=True, maxlen=l)
         for s in pft_streamlines:
+            print(s)
             for i in range(len(s) - 1):
                 npt.assert_almost_equal(np.linalg.norm(s[i] - s[i + 1]),
                                         step_size)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -234,30 +234,33 @@ def test_tracking_max_angle():
                     min_cos_sim = cos_sim
         return min_cos_sim
     np.random.seed(0)  # Random number generator initialization
-    sphere = get_sphere('repulsion100')
-    shape_img = list([5, 5, 5])
-    shape_img.extend([sphere.vertices.shape[0]])
-    mask = np.ones(shape_img[:3])
-    affine = np.eye(4)
-    random_pmf = np.random.random(shape_img)
-    seeds = seeds_from_mask(mask, affine, density=1)
-    sc = ActStoppingCriterion.from_pve(mask,
-                                       np.zeros(shape_img[:3]),
-                                       np.zeros(shape_img[:3]))
-    max_angle = 20
-    step_size = 1
-    dg = ProbabilisticDirectionGetter.from_pmf(random_pmf, max_angle, sphere,
-                                               pmf_threshold=0.1)
-    # local tracking
-    streamlines = Streamlines(LocalTracking(dg, sc, seeds, affine, step_size))
-    min_cos_sim = get_min_cos_similarity(streamlines)
-    npt.assert_(np.arccos(min_cos_sim) <= np.deg2rad(max_angle))
 
-    # PFT tracking
-    streamlines = Streamlines(ParticleFilteringTracking(dg, sc, seeds, affine,
-                                                        1.))
-    min_cos_sim = get_min_cos_similarity(streamlines)
-    npt.assert_(np.arccos(min_cos_sim) <= np.deg2rad(max_angle))
+    for sphere in [get_sphere('repulsion100'),
+                   HemiSphere.from_sphere(get_sphere('repulsion100'))]:
+        shape_img = list([5, 5, 5])
+        shape_img.extend([sphere.vertices.shape[0]])
+        mask = np.ones(shape_img[:3])
+        affine = np.eye(4)
+        random_pmf = np.random.random(shape_img)
+        seeds = seeds_from_mask(mask, affine, density=1)
+        sc = ActStoppingCriterion.from_pve(mask,
+                                           np.zeros(shape_img[:3]),
+                                           np.zeros(shape_img[:3]))
+        max_angle = 20
+        step_size = 1
+        dg = ProbabilisticDirectionGetter.from_pmf(random_pmf, max_angle,
+                                                   sphere, pmf_threshold=0.1)
+        # local tracking
+        streamlines = Streamlines(LocalTracking(
+            dg, sc, seeds, affine, step_size))
+        min_cos_sim = get_min_cos_similarity(streamlines)
+        npt.assert_(np.arccos(min_cos_sim) <= np.deg2rad(max_angle))
+
+        # PFT tracking
+        streamlines = Streamlines(ParticleFilteringTracking(dg, sc, seeds,
+                                                            affine, 1.))
+        min_cos_sim = get_min_cos_similarity(streamlines)
+        npt.assert_(np.arccos(min_cos_sim) <= np.deg2rad(max_angle))
 
 
 def test_probabilistic_odf_weighted_tracker():

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -227,11 +227,12 @@ def test_tracking_max_angle():
     def get_min_cos_similarity(streamlines):
         min_cos_sim = 1
         for sl in streamlines:
-            v = sl[:-1] - sl[1:]  # vectors have norm of 1
-            for i in range(len(v)-1):
-                cos_sim = np.dot(v[i], v[i+1])
-                if cos_sim < min_cos_sim:
-                    min_cos_sim = cos_sim
+            if len(sl) > 1:
+                v = sl[:-1] - sl[1:]  # vectors have norm of 1
+                for i in range(len(v)-1):
+                    cos_sim = np.dot(v[i], v[i+1])
+                    if cos_sim < min_cos_sim:
+                        min_cos_sim = cos_sim
         return min_cos_sim
     np.random.seed(0)  # Random number generator initialization
 
@@ -439,6 +440,7 @@ def test_particle_filtering_tractography():
             for i in range(len(s) - 1):
                 npt.assert_almost_equal(np.linalg.norm(s[i] - s[i + 1]),
                                         step_size)
+
     # Test that all points are within the image volume
     seeds = seeds_from_mask(np.ones(simple_wm.shape), np.eye(4), density=1)
     pft_streamlines_generator = ParticleFilteringTracking(

--- a/dipy/utils/fast_numpy.pxd
+++ b/dipy/utils/fast_numpy.pxd
@@ -4,7 +4,7 @@
 
 cimport numpy as np
 
-from libc.stdlib cimport rand, RAND_MAX
+from libc.stdlib cimport rand, srand, RAND_MAX
 from libc.math cimport sqrt
 
 
@@ -28,6 +28,8 @@ cdef void scalar_muliplication_point(
         double scalar) nogil
 
 cpdef double random() nogil
+
+cpdef void seed(int s) nogil
 
 cpdef double norm(
         double[:] v) nogil

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -53,7 +53,7 @@ cpdef double random() nogil:
     Returns
     -------
     _ : double
-        random number
+        random number.
     """
     return rand() / float(RAND_MAX)
 
@@ -67,7 +67,6 @@ cpdef void seed(int s) nogil:
         random seed.
     """
     srand(s)
-
 
 
 cpdef double norm(double[:] v) nogil:

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -58,6 +58,18 @@ cpdef double random() nogil:
     return rand() / float(RAND_MAX)
 
 
+cpdef void seed(int s) nogil:
+    """Set the random seed of stdlib.
+
+    Parameters
+    ----------
+    s : int
+        random seed.
+    """
+    srand(s)
+
+
+
 cpdef double norm(double[:] v) nogil:
     """Compute the vector norm.
 
@@ -66,10 +78,6 @@ cpdef double norm(double[:] v) nogil:
     v : double[3]
         input vector.
 
-    Returns
-    -------
-    _ : double
-        norm of the input vector.
     """
     return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
 


### PR DESCRIPTION
This address issue #2805.

- Reverts changes in `dipy/tracking/localtrack.pyx` from https://github.com/dipy/dipy/commit/045a1ee5485af33675726675a010c3a6fda5d9b3
- fix a minor infrequent bug in probabilistic tracking where the forward and backward direction could be sample in such a way it is bigger that `max_angle`. This was fixed by changing the initial direction to the true first direction selected in the forward segment, instead of the tentative initial direction obtained from the peaks.