### PR TITLE
[DOC] introducing sphinxcontrib-Bibtex to improve reference management

### DIFF
--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -340,8 +340,8 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
         """Given a CTI model fit, predict the signal on the vertices of a
         gradient table
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         params: numpy.ndarray (...,43)
                 All parameters estimated from the correlation tensor model.
                 Parameters are ordered as follows:

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -423,8 +423,10 @@ def _F2m(a, b, c):
 
 
 def directional_diffusion(dt, V, min_diffusivity=0):
-    r"""Calculate the apparent diffusion coefficient (ADC) in each direction
-    of a sphere for a single voxel [1]_
+    r"""Compute apparent diffusion coefficient (adc).
+
+    Calculate the apparent diffusion coefficient (adc) in each direction of
+    a sphere for a single voxel :footcite:t:`NetoHenriques2015`.
 
     Parameters
     ----------
@@ -446,18 +448,8 @@ def directional_diffusion(dt, V, min_diffusivity=0):
 
     References
     ----------
-    .. [1] Jensen JH, Helpern JA, Ramani A, Lu H, Kaczynski K, (2005).
-           Diffusional kurtosis imaging: The quantification of non-gaussian
-           water diffusion by means of magnetic resonance imaging. Magnetic
-           Resonance in Medicine 53(6): 1432-1440
-    .. [2] Henriques RN, Correia MM, Marrale M, Huber E, Kruper J, Koudoro S,
-           Yeatman JD, Garyfallidis E, Rokem A (2021). Diffusional Kurtosis
-           Imaging in the Diffusion Imaging in Python Project. Frontiers in
-           Human Neuroscience 15: 675433.
-    .. [3] Neto Henriques R, Correia MM, Nunes RG, Ferreira HA (2015).
-           Exploring the 3D geometry of the diffusion kurtosis tensor -
-           Impact on the development of robust tractography procedures and
-           novel biomarkers, NeuroImage 111: 85-99
+    .. footbibliography::
+
     """
     adc = (
         V[:, 0] * V[:, 0] * dt[0]

--- a/doc/cite.rst
+++ b/doc/cite.rst
@@ -45,3 +45,9 @@ A note on citing our work
 * If you are using Generalized Q-sampling please also cite [7].
 
 * If you are using Diffusional Kurtosis Imaging, please also cite [13]
+
+
+Citing other algorithms
+-----------------------
+
+Depending on your research topic, it may also be appropriate to cite related method papers, some of which are listed in the documentation strings of the relevant functions or methods. All references cited in the DIPY codebase and documentation are collected in the :ref:`general_bibliography`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,23 +31,31 @@ sys.path.append(os.path.abspath("sphinxext"))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.todo",
-    "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
     "sphinx.ext.ifconfig",
-    "sphinx.ext.autosummary",
-    "prepare_gallery",
+    # "sphinx.ext.napoleon",
     "math_dollar",  # has to go before numpydoc
-    "sphinx_gallery.gen_gallery",
     # 'numpydoc',
+    "prepare_gallery",
+    "sphinx_gallery.gen_gallery",
+    "sphinxcontrib.bibtex",
     "github",
     "sphinx_design",
 ]
 
 numpydoc_show_class_members = True
 numpydoc_class_members_toctree = False
+
+# Sphinx extension for BibTeX style citations.
+# https://github.com/mcmtroffaes/sphinxcontrib-bibtex
+bibtex_bibfiles = ["references.bib"]
+# bibtex_default_style = 'plain'
 
 # ghissue config
 github_project_url = "https://github.com/dipy/dipy"

--- a/doc/devel/bibliography.rst
+++ b/doc/devel/bibliography.rst
@@ -34,4 +34,4 @@ The following conventions are used in that file.
 Whenever this file needs to be edited (e.g. changed or a new entry added), the
 above conventions must need to be followed.
 
-.. include:: links_names.inc
+.. include:: ../links_names.inc

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -20,3 +20,4 @@ Jinja2
 sphinx-design>=0.5.0
 boto3
 tensorflow
+sphinxcontrib-bibtex>=2.5.0

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -19,7 +19,7 @@ For both shells let's say that we want a specific number of gradients (64) and
 we want to have the points on the sphere evenly distributed.
 
 This is possible using the ``disperse_charges`` which is an implementation of
-electrostatic repulsion [Jones1999]_.
+electrostatic repulsion :footcite:t:`Jones1999` .
 
 Let's start by importing the necessary modules.
 """
@@ -145,6 +145,6 @@ if interactive:
 # References
 # ----------
 #
-# .. [Jones1999] Jones, DK. et al. Optimal strategies for measuring diffusion
-#    in anisotropic systems by magnetic resonance imaging, Magnetic Resonance
-#    in Medicine, vol 42, no 3, 515-525, 1999.
+# .. footbibliography::
+#
+# .. include:: ../../links_names.inc

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -114,7 +114,7 @@
   number    = {3},
   pages     = {209-219},
   year      = {1996},
-  url       = {10.1006/jmrb.1996.0086},
+  doi       = {10.1006/jmrb.1996.0086},
   url       = {https://doi.org/10.1006/jmrb.1996.0086}
 }
 
@@ -346,7 +346,7 @@
   number    = {5},
   pages     = {1051-1058},
   year      = {2007},
-  url       = {10.1002/jmri.20905},
+  doi       = {10.1002/jmri.20905},
   url       = {https://doi.org/10.1002/jmri.20905}
 }
 
@@ -706,7 +706,7 @@
 }
 
 @article{Hansen2016b,
-  author    = {Brian Hansen and Noam Shemesh and Sune N\o{}rh\o{}j Jespersen}
+  author    = {Brian Hansen and Noam Shemesh and Sune N\o{}rh\o{}j Jespersen},
   title     = {{Fast imaging of mean, axial and radial diffusion kurtosis}},
   journal   = {NeuroImage},
   volume    = {142},
@@ -776,7 +776,7 @@
 }
 
 @article{Hui2008,
-  author    = {Edward S. Hui and Matthew M. Cheung and Liqun Qi and Ed X. Wu}
+  author    = {Edward S. Hui and Matthew M. Cheung and Liqun Qi and Ed X. Wu},
   title     = {{Towards better MR characterization of neural tissues using directional diffusion kurtosis analysis}},
   journal   = {NeuroImage},
   volume    = {42},
@@ -796,7 +796,7 @@
   pages     = {1432-1440},
   year      = {2005},
   doi       = {https://doi.org/10.1002/mrm.20508},
-  doi       = {https://onlinelibrary.wiley.com/doi/abs/10.1002/mrm.20508}
+  url       = {https://onlinelibrary.wiley.com/doi/abs/10.1002/mrm.20508}
 }
 
 @article{Jeurissen2014,
@@ -821,6 +821,18 @@
   year      = {2011},
   doi       = {10.1002/hbm.21032},
   url       = {https://doi.org/10.1002/hbm.21032}
+}
+
+@article{Jones1999,
+  author    = {Derek K. Jones and Mark A. Horsfield and Andrew Simmons},
+  title     = {{Optimal strategies for measuring diffusion in anisotropic systems by magnetic resonance imaging}},
+  journal   = {Magnetic Resonance in Medicine},
+  volume    = {42},
+  number    = {3},
+  pages     = {515--25},
+  year      = {1999},
+  doi       = {10.1002/(SICI)1522-2594(199909)42:3<515::AID-MRM14>3.0.CO;2-Q},
+  url       = {http://www.ncbi.nlm.nih.gov/pubmed/10467296}
 }
 
 @article{Jones2013,
@@ -910,7 +922,7 @@
 }
 
 @article{Koay2009a,
-  author    = {Cheng Guan Koay and Evren {\"O}zarslan and Peter J. Basser}
+  author    = {Cheng Guan Koay and Evren {\"O}zarslan and Peter J. Basser},
   title     = {{A signal transformational framework for breaking the noise floor and its applications in MRI}},
   journal   = {Journal of Magnetic Resonance},
   volume    = {197},
@@ -1002,7 +1014,7 @@
   journal   = {IEEE Transactions on Medical Imaging},
   volume    = {22},
   number    = {1},
-  year      = {120-128},
+  pages     = {120-128},
   year      = {2003},
   doi       = {10.1109/TMI.2003.809072}
 }
@@ -1059,7 +1071,7 @@
   journal   = {Magnetic Resonance in Medicine},
   volume    = {81},
   number    = {5},
-  year      = {2019}
+  year      = {2019},
   pages     = {3245-3261},
   doi       = {10.1002/mrm.27606},
   url       = {https://doi.org/10.1002/mrm.27606}
@@ -1106,7 +1118,7 @@
   number    = {3},
   pages     = {526--540},
   year      = {1999},
-  doi       = {10.1002/(SICI)1522-2594(199909)42:3<526::AID-MRM15>3.0.CO;2-J}
+  doi       = {10.1002/(SICI)1522-2594(199909)42:3<526::AID-MRM15>3.0.CO;2-J},
   url       = {https://doi.org/10.1002/(SICI)1522-2594(199909)42:3<526::AID-MRM15>3.0.CO;2-J}
 }
 
@@ -1289,14 +1301,14 @@
 }
 
 @article{Soderman1995,
-  author    = {Olle S\"{o}derman and Bengt J\"{o}onsson}
+  author    = {Olle S\"{o}derman and Bengt J\"{o}onsson},
   title     = {{Restricted Diffusion in Cylindrical Geometry}},
   journal   = {Journal of Magnetic Resonance, Series A},
   volume    = {117},
   number    = {1},
   pages     = {94-97},
   year      = {1995},
-  url       = {10.1006/jmra.1995.0014},
+  doi       = {10.1006/jmra.1995.0014},
   url       = {https://doi.org/10.1006/jmra.1995.0014}
 }
 
@@ -1657,7 +1669,7 @@
   year         = {2014}
 }
 
-@inproceedings{Descoteaux2008,
+@inproceedings{Descoteaux2008a,
   author    = {Maxime Descoteaux and Nicolas Wiest-Daessl\'{e} and Sylvain Prima and Christian Barillot and Rachid Deriche},
   title     = {{Impact of Rician adapted Non-Local Means filtering on HARDI}},
   booktitle = {Medical Image Computing and Computer-Assisted Intervention (MICCAI)},
@@ -1774,7 +1786,6 @@
   author    = {Agatha D. Lee and Natasha Lepore and Marina Barysheva and Yi-Yu Chou and Caroline Brun and Sarah K. Madsen and Katie L. McMahon and Greig I. {de Zubicaray} and Matthew Meredith and Margaret J. Wright and Arthur W. Toga and Paul M. Thompson},
   title     = {{Comparison of fractional and geodesic anisotropy in diffusion tensor images of 90 monozygotic and dizygotic twins}},
   booktitle = {2008 5th IEEE International Symposium on Biomedical Imaging: From Nano to Macro},
-  volume    = {},
   volume    = {},
   pages     = {943-946},
   month     = {May},
@@ -1957,7 +1968,7 @@
   url       = {}
 }
 
-@phdthesis{Descoteaux2007,
+@phdthesis{Descoteaux2008b,
   author    = {Maxime Descoteaux},
   title     = {{High Angular Resolution Diffusion MRI: from Local Estimation to Segmentation and Tractography}},
   type      = {PhD thesis},

--- a/doc/user_guide/bibliography.rst
+++ b/doc/user_guide/bibliography.rst
@@ -1,0 +1,8 @@
+.. _general_bibliography:
+
+General bibliography
+====================
+
+.. bibliography:: ./../references.bib
+   :all:
+   :list: enumerated

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -14,3 +14,4 @@ DIPY User Guide
    dependencies
    getting_started
    data
+   bibliography


### PR DESCRIPTION
> build succeeded, 1871 warnings.

A lot of those warning are due to references. This PR add `sphinxcontrib-bibtex` to manage references, avoid duplication, avoid formatting error, etc. 

This PR will take a bit of time to be finalize so I wonder if I should split it in multiple PR or not.  It should make review process easier. Looking forward for your feedback.