### PR TITLE
NF -  added pft min wm parameter

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -234,7 +234,7 @@ class ParticleFilteringTracking(LocalTracking):
             random.seed).
         save_seeds : bool
             If True, return seeds alongside streamlines
-        min_wm_pve_before_stopping : int
+        min_wm_pve_before_stopping : int, optional
             Minimum white matter pve (1 - stopping_criterion.include_map -
             stopping_criterion.exclude_map) to reach before allowing the
             tractography to stop.
@@ -265,7 +265,7 @@ class ParticleFilteringTracking(LocalTracking):
         if particle_count <= 0:
             raise ValueError("The particle count must be greater than 0.")
 
-        if min_wm_pve_before_stopping < 0 or min_wm_pve_before_stopping > 1:
+        if 0 < min_wm_pve_before_stopping < 1:
             raise ValueError("The min_wm_pve_before_stopping value must be "
                              "between 0 and 1.")
 

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -265,7 +265,7 @@ class ParticleFilteringTracking(LocalTracking):
         if particle_count <= 0:
             raise ValueError("The particle count must be greater than 0.")
 
-        if not 0 < min_wm_pve_before_stopping < 1:
+        if not 0 <= min_wm_pve_before_stopping <= 1:
             raise ValueError("The min_wm_pve_before_stopping value must be "
                              "between 0 and 1.")
 

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -182,7 +182,8 @@ class ParticleFilteringTracking(LocalTracking):
                  step_size, max_cross=None, maxlen=500,
                  pft_back_tracking_dist=2, pft_front_tracking_dist=1,
                  pft_max_trial=20, particle_count=15, return_all=True,
-                 random_seed=None, save_seeds=False):
+                 random_seed=None, save_seeds=False,
+                 min_wm_pve_before_stopping=0):
         r"""A streamline generator using the particle filtering tractography
         method [1]_.
 
@@ -233,6 +234,10 @@ class ParticleFilteringTracking(LocalTracking):
             random.seed).
         save_seeds : bool
             If True, return seeds alongside streamlines
+        min_wm_pve_before_stopping : int
+            Minimum white matter pve (1 - stopping_criterion.include_map -
+            stopping_criterion.exclude_map) to reach before allowing the
+            tractography to stop.
 
 
         References
@@ -260,8 +265,12 @@ class ParticleFilteringTracking(LocalTracking):
         if particle_count <= 0:
             raise ValueError("The particle count must be greater than 0.")
 
-        self.directions = np.empty((maxlen + 1, 3), dtype=float)
+        if min_wm_pve_before_stopping < 0 or min_wm_pve_before_stopping > 1:
+            raise ValueError("The min_wm_pve_before_stopping value must be "
+                             "between 0 and 1.")
 
+        self.min_wm_pve_before_stopping = min_wm_pve_before_stopping
+        self.directions = np.empty((maxlen + 1, 3), dtype=float)
         self.pft_max_trial = pft_max_trial
         self.particle_count = particle_count
         self.particle_paths = np.empty((2, self.particle_count,
@@ -302,4 +311,5 @@ class ParticleFilteringTracking(LocalTracking):
                            self.particle_dirs,
                            self.particle_weights,
                            self.particle_steps,
-                           self.particle_stream_statuses)
+                           self.particle_stream_statuses,
+                           self.min_wm_pve_before_stopping)

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -265,7 +265,7 @@ class ParticleFilteringTracking(LocalTracking):
         if particle_count <= 0:
             raise ValueError("The particle count must be greater than 0.")
 
-        if 0 < min_wm_pve_before_stopping < 1:
+        if not 0 < min_wm_pve_before_stopping < 1:
             raise ValueError("The min_wm_pve_before_stopping value must be "
                              "between 0 and 1.")
 

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -142,7 +142,7 @@ def pft_tracker(
         Temporary array for the number of steps of particles.
     particle_stream_statuses : array, float, (2, particle_count)
         Temporary array for the stream status of particles.
-    min_wm_pve_before_stopping : int
+    min_wm_pve_before_stopping : int, optional
         Minimum white matter pve (1 - sc.include_map - sc.exclude_map) to
         reach before allowing the tractography to stop.
 

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -54,7 +54,7 @@ def local_tracker(
         Ending state of the streamlines as determined by the StoppingCriterion.
     """
     cdef:
-        int i
+        cnp.npy_intp i
         StreamlineStatus stream_status
         double input_direction[3]
         double input_voxel_size[3]
@@ -155,7 +155,7 @@ def pft_tracker(
 
     """
     cdef:
-        int i
+        cnp.npy_intp i
         StreamlineStatus stream_status
         double input_direction[3]
         double input_voxel_size[3]
@@ -201,7 +201,8 @@ cdef _pft_tracker(DirectionGetter dg,
                   cnp.int_t[:, :] particle_stream_statuses,
                   double min_wm_pve_before_stopping):
     cdef:
-        int i, j, pft_trial, back_steps, front_steps
+        cnp.npy_intp i, j
+        int pft_trial, back_steps, front_steps
         int strl_array_len
         double max_wm_pve, current_wm_pve
         double point[3]
@@ -308,7 +309,7 @@ cdef _pft(cnp.float_t[:, :] streamline,
         double point[3]
         double dir[3]
         double eps = 1e-16
-        int s, p, j
+        cnp.npy_intp s, p, j
 
     if pft_nbr_steps <= 0:
         return streamline_i

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -156,9 +156,9 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
         return self.get_include_c(&point[0])
 
     cdef get_include_c(self, double* point):
-        exclude_err = trilinear_interpolate4d_c(self.include_map[..., None],
+        include_err = trilinear_interpolate4d_c(self.include_map[..., None],
                                                 point, self.interp_out_view)
-        if exclude_err != 0:
+        if include_err != 0:
             return 0
         return self.interp_out_view[0]
 

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -213,7 +213,8 @@ class PFTrackingPAMFlow(Workflow):
             pft_count=15,
             out_dir='',
             out_tractogram='tractogram.trk',
-            save_seeds=False):
+            save_seeds=False,
+            min_wm_pve_before_stopping=0):
         """Workflow for Particle Filtering Tracking.
 
         This workflow use a saved peaks and metrics (PAM) file as input.
@@ -263,6 +264,10 @@ class PFTrackingPAMFlow(Workflow):
             If true, save the seeds associated to their streamline
             in the 'data_per_streamline' Tractogram dictionary using
             'seeds' as the key.
+        min_wm_pve_before_stopping : int, optional
+            Minimum white matter pve (1 - stopping_criterion.include_map -
+            stopping_criterion.exclude_map) to reach before allowing the
+            tractography to stop.
 
         References
         ----------
@@ -309,7 +314,8 @@ class PFTrackingPAMFlow(Workflow):
                 pft_front_tracking_dist=pft_front,
                 pft_max_trial=20,
                 particle_count=pft_count,
-                save_seeds=save_seeds)
+                save_seeds=save_seeds,
+                min_wm_pve_before_stopping=min_wm_pve_before_stopping)
 
             logging.info('ParticleFilteringTracking initiated')
 

--- a/doc/examples/tracking_pft.py
+++ b/doc/examples/tracking_pft.py
@@ -101,7 +101,7 @@ Particle Filtering Tractography
 tractography incorrectly stops in the WM or CSF. `pft_front_tracking_dist` is
 the distance in mm to track after the stopping event using PFT.
 
-The `particle_count` parameter is the number of sample in the particle
+The `particle_count` parameter is the number of samples used in the particle
 filtering algorithm.
 
 `min_wm_pve_before_stopping` controls when the tracking can stop in the GM.


### PR DESCRIPTION
This is the part 1 of 2 of refactoring PR #1627, adding a new parameter to PFT.

The new optional parameter (default value is 0), `min_wm_pve_before_stopping`, improves PFT starting in voxel with non-zero GM partial volume estimate (PVE). The 'ENDPOINT' streamline status is ignored until the tracking reaches a position with `WM PVE > min_wm_pve_before_stopping`. This is useful when seeding from the GM-WM interface or in subcortical GM, where tractography may stop prematurely in the GM. This parameter forces the tracking to reach the deep WM before stopping, or to reach voxels with WM PVE of 0.

