### PR TITLE
NF -  add initial directions to local tracking

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -59,11 +59,11 @@ class LocalTracking:
             The maximum number of direction to track from each seed in crossing
             voxels. By default all initial directions are tracked.
         maxlen : int, optional
-            Maximum number of steps to track from seed. Used to prevent
-            infinite loops.
+            Maximum length of generated streamlines. Longer streamlines will be
+            discarted if `return_all=False`.
         minlen : int, optional
-            Minimum number of steps to track from seed. Can be useful
-            for filtering out useless streamlines.
+            Minimum length of generated streamlines. Shorter streamlines will
+            be discarted if `return_all=False`.
         fixedstep : bool, optional
             If true, a fixed stepsize is used, otherwise a variable step size
             is used.
@@ -263,6 +263,7 @@ class ParticleFilteringTracking(LocalTracking):
         max_cross : int or None, optional
             The maximum number of direction to track from each seed in crossing
             voxels. By default all initial directions are tracked.
+<<<<<<< HEAD
         maxlen : int, optional
             Maximum number of steps to track from seed. Used to prevent
             infinite loops.
@@ -270,6 +271,16 @@ class ParticleFilteringTracking(LocalTracking):
             Minimum number of steps to track from seed. Can be useful
             for filtering out useless streamlines.
         pft_back_tracking_dist : float, optional
+=======
+        maxlen : int
+            Maximum number of steps to track from the seed position in both the
+            foward and the backward initial direction. The maximum length of
+            the generated streamlines can be 2 times maxlen when tracking in
+            both forward and backward directions (e.g. when
+            `unidirectional=False`). Used to prevent infinite loops.
+            By default `maxlen=500`.
+        pft_back_tracking_dist : float
+>>>>>>> DOC - improve maxlen parameter doc
             Distance in mm to back track before starting the particle filtering
             tractography. The total particle filtering tractography distance is
             equal to back_tracking_dist + front_tracking_dist.

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -198,25 +198,28 @@ class LocalTracking:
                     yield [s]
 
             for first_step in directions:
+                stepsF = stepsB = 1
                 stepsF, stream_status = self._tracker(s, first_step, F)
                 if not (self.return_all
                         or stream_status in (StreamlineStatus.ENDPOINT,
                                              StreamlineStatus.OUTSIDEIMAGE)):
                     continue
-                if stepsF > 1:
-                    # Use the opposite of the first selected orientation for
-                    # the backward tracking segment
-                    opposite_step = F[0] - F[1]
-                    opposite_step_norm = np.linalg.norm(opposite_step)
-                    if opposite_step_norm > 0:
-                        first_step = opposite_step / opposite_step_norm
+                if not self.unidirectional:
+                    if stepsF > 1:
+                        # Use the opposite of the first selected orientation for
+                        # the backward tracking segment
+                        opposite_step = F[0] - F[1]
+                        opposite_step_norm = np.linalg.norm(opposite_step)
+                        if opposite_step_norm > 0:
+                            first_step = opposite_step / opposite_step_norm
+                        else:
+                            first_step = -first_step
                     else:
                         first_step = -first_step
-                else:
-                    first_step = -first_step
-                stepsB, stream_status = self._tracker(s, first_step, B)
-                if not (self.return_all
-                        or stream_status in (StreamlineStatus.ENDPOINT,
+                    stepsB, stream_status = self._tracker(s, first_step, B)
+
+                if not (self.return_all or
+                        stream_status == in (StreamlineStatus.ENDPOINT,
                                              StreamlineStatus.OUTSIDEIMAGE)):
                     continue
                 if stepsB == 1:

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -75,13 +75,13 @@ class LocalTracking:
             random.seed).
         save_seeds : bool, optional
             If True, return seeds alongside streamlines
-        unidirectional : bool
+        unidirectional : bool, optional
             If true, the tracking is performed only in the forward direction.
             The seed position will be the first point of all streamlines.
-        randomize_forward_direction : bool
+        randomize_forward_direction : bool, optional
             If true, the forward direction is randomized (multiplied by 1
             or -1). Otherwise, the provided forward direction is used.
-        initial_directions: array (N, npeaks, 3)
+        initial_directions: array (N, npeaks, 3), optional
             Initial direction to follow from the ``seed`` position. If
             ``max_cross`` is None, one streamline will be generated per peak
             per voxel. If None, `direction_getter.initial_direction` is used.
@@ -263,24 +263,13 @@ class ParticleFilteringTracking(LocalTracking):
         max_cross : int or None, optional
             The maximum number of direction to track from each seed in crossing
             voxels. By default all initial directions are tracked.
-<<<<<<< HEAD
         maxlen : int, optional
-            Maximum number of steps to track from seed. Used to prevent
-            infinite loops.
+            Maximum length of generated streamlines. Longer streamlines will be
+            discarted if `return_all=False`.
         minlen : int, optional
-            Minimum number of steps to track from seed. Can be useful
-            for filtering out useless streamlines.
-        pft_back_tracking_dist : float, optional
-=======
-        maxlen : int
-            Maximum number of steps to track from the seed position in both the
-            foward and the backward initial direction. The maximum length of
-            the generated streamlines can be 2 times maxlen when tracking in
-            both forward and backward directions (e.g. when
-            `unidirectional=False`). Used to prevent infinite loops.
-            By default `maxlen=500`.
+            Minimum length of generated streamlines. Shorter streamlines will
+            be discarted if `return_all=False`.
         pft_back_tracking_dist : float
->>>>>>> DOC - improve maxlen parameter doc
             Distance in mm to back track before starting the particle filtering
             tractography. The total particle filtering tractography distance is
             equal to back_tracking_dist + front_tracking_dist.
@@ -307,13 +296,13 @@ class ParticleFilteringTracking(LocalTracking):
             Minimum white matter pve (1 - stopping_criterion.include_map -
             stopping_criterion.exclude_map) to reach before allowing the
             tractography to stop.
-        unidirectional : bool
+        unidirectional : bool, optional
             If true, the tracking is performed only in the forward direction.
             The seed position will be the first point of all streamlines.
-        randomize_forward_direction : bool
+        randomize_forward_direction : bool, optional
             If true, the forward direction is randomized (multiplied by 1
             or -1). Otherwise, the provided forward direction is used.
-        initial_directions: array (N, npeaks, 3)
+        initial_directions: array (N, npeaks, 3), optional
             Initial direction to follow from the ``seed`` position. If
             ``max_cross`` is None, one streamline will be generated per peak
             per voxel. If None, `direction_getter.initial_direction` is used.

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -176,8 +176,13 @@ class LocalTracking:
             if self.initial_directions is None:
                 directions = self.direction_getter.initial_direction(s)
             else:
-                directions = self.initial_directions[i, :, :]
-
+                directions = []
+                for d in self.initial_directions[i, :, :]:
+                    d_norm = np.linalg.norm(d)
+                    if d_norm > 0:
+                        new_d = d / d_norm
+                        directions.append(new_d)
+                directions = np.array(directions)
             if self.randomize_forward_direction:
                 directions = [d * random.choice([1, -1]) for d in directions]
             directions = directions[:self.max_cross]

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -177,8 +177,17 @@ class LocalTracking:
                         new_d = d / d_norm
                         directions.append(new_d)
                 directions = np.array(directions)
+
+            if directions.size == 0 and self.return_all:
+                # only the seed position
+                if self.save_seeds:
+                    yield [s], s
+                else:
+                    yield [s]
+
             if self.randomize_forward_direction:
                 directions = [d * random.choice([1, -1]) for d in directions]
+
             directions = directions[:self.max_cross]
 
             if len(directions) == 0 and self.return_all:

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -170,13 +170,9 @@ class LocalTracking:
             if self.initial_directions is None:
                 directions = self.direction_getter.initial_direction(s)
             else:
-                directions = []
-                for d in self.initial_directions[i, :, :]:
-                    d_norm = np.linalg.norm(d)
-                    if d_norm > 0:
-                        new_d = d / d_norm
-                        directions.append(new_d)
-                directions = np.array(directions)
+                d_ns = np.linalg.norm(self.initial_directions[i, :, :], axis=1)
+                directions = self.initial_directions[i, d_ns > 0, :] \
+                    / d_ns[d_ns > 0, np.newaxis]
 
             if len(directions) == 0 and self.return_all:
                 # only the seed position
@@ -350,7 +346,7 @@ class ParticleFilteringTracking(LocalTracking):
         self.particle_steps = np.empty((2, self.particle_count), dtype=int)
         self.particle_stream_statuses = np.empty((2, self.particle_count),
                                                  dtype=int)
-         super(ParticleFilteringTracking, self).__init__(
+        super(ParticleFilteringTracking, self).__init__(
             direction_getter=direction_getter,
             stopping_criterion=stopping_criterion,
             seeds=seeds,
@@ -358,7 +354,7 @@ class ParticleFilteringTracking(LocalTracking):
             step_size=step_size,
             max_cross=max_cross,
             maxlen=maxlen,
-            minLen=minlen,
+            minlen=minlen,
             fixedstep=True,
             return_all=return_all,
             random_seed=random_seed,

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -159,7 +159,7 @@ class LocalTracking:
         B = F.copy()
         for i, s in enumerate(self.seeds):
             s = np.dot(lin, s) + offset
-            # Set the random seed in numpy and random
+            # Set the random seed in numpy, random and fast_numpy (lic.stdlib)
             if self.random_seed is not None:
                 s_random_seed = hash(np.abs((np.sum(s)) + self.random_seed)) \
                     % (np.iinfo(np.uint32).max - 1)

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -109,7 +109,7 @@ class LocalTracking:
             raise ValueError("initial_directions and seeds must have the "
                              + "same shape[0].")
         if (initial_directions is None and unidirectional and
-                self.randomize_forward_direction is False):
+                not self.randomize_forward_direction):
             warn("Unidirectional tractography will be performed "
                  + "without providing initial directions nor "
                  + "randomizing extracted initial forward "
@@ -170,6 +170,8 @@ class LocalTracking:
             if self.initial_directions is None:
                 directions = self.direction_getter.initial_direction(s)
             else:
+                # normalize the initial directions.
+                # initial directions with norm 0 are removed.
                 d_ns = np.linalg.norm(self.initial_directions[i, :, :], axis=1)
                 directions = self.initial_directions[i, d_ns > 0, :] \
                     / d_ns[d_ns > 0, np.newaxis]

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -984,3 +984,154 @@ def test_random_seed_initialization():
                                       affine=np.eye(4),
                                       step_size=1.,
                                       random_seed=rdm_seed))
+
+
+def test_tracking_with_initial_directions():
+    """This tests that tractography play well with using seeding directions."""
+
+    def allclose(x, y):
+        return x.shape == y.shape and np.allclose(x, y)
+
+    sphere = HemiSphere.from_sphere(unit_octahedron)
+    # A simple image with three possible configurations, a vertical tract,
+    # a horizontal tract and a crossing
+    pmf_lookup = np.array([[0., 0., 1.],
+                           [1., 0., 0.],
+                           [0., 1., 0.],
+                           [.6, .4, 0.]])
+    simple_image = np.array([[0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 0, 0, 0],
+                             [2, 3, 2, 2, 2, 2],
+                             [0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 0, 0, 0]])
+    simple_image = simple_image[..., None]
+    simple_wm = np.array([[0, 1, 0, 0, 0, 0],
+                          [0, 1, 0, 0, 0, 0],
+                          [1, 1, 1, 1, 1, 1],
+                          [0, 1, 0, 0, 0, 0],
+                          [0, 1, 0, 0, 0, 0]])
+    simple_wm = simple_wm[..., None]
+    simple_csf = np.ones(simple_wm.shape) - simple_wm
+    simple_gm = np.zeros(simple_wm.shape)
+    pmf = pmf_lookup[simple_image]
+    mask = (simple_image > 0).astype(float)
+    expected = [np.array([[0., 1., 0.],
+                          [1., 1., 0.],
+                          [2., 1., 0.],
+                          [2., 2., 0.],
+                          [2., 3., 0.],
+                          [2., 4., 0.],
+                          [2., 5., 0.]]),
+                np.array([[0., 1., 0.],
+                          [1., 1., 0.],
+                          [2., 1., 0.],
+                          [3., 1., 0.],
+                          [4., 1., 0.]]),
+                np.array([[2., 0., 0.],
+                          [2., 1., 0.],
+                          [2., 2., 0.],
+                          [2., 3., 0.],
+                          [2., 4., 0.],
+                          [2., 5., 0.]])]
+
+    # Test LocalTracking with inital directions
+    sc = ThresholdStoppingCriterion(mask, .5)
+    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 45, sphere,
+                                               pmf_threshold=0.1)
+    crossing_pos = np.array([2, 1, 0])
+    seeds = np.array([crossing_pos, crossing_pos, crossing_pos])
+    initial_directions = np.array([[sphere.vertices[0], [0, 0, 0]],
+                                   [sphere.vertices[1], sphere.vertices[0]],
+                                   [[0, 0, 0], [0, 0, 0]]])
+    # with max_cross=1
+    streamline_generator = LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                         max_cross=1, return_all=True,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1]))
+    npt.assert_(allclose(streamlines[1], expected[2]))
+    npt.assert_(allclose(streamlines[2], np.array([crossing_pos])))
+    # with max_cross=2
+    streamline_generator = LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                         max_cross=2, return_all=True,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1]))
+    npt.assert_(allclose(streamlines[1], expected[2]))
+    npt.assert_(allclose(streamlines[2], expected[1]))
+    npt.assert_(allclose(streamlines[3], np.array([crossing_pos])))
+
+    # Test inital_directions with norm != 1 and not sphere vertices
+    initial_directions = np.array([[[0, 0, 0], [2, 0, 0]],
+                                   [[0.1, 0.8, 0], [-0.4, 0, 0]],
+                                   [[0, 0, 0], [0.7, 0.6, -0.1]]])
+    streamline_generator = LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                         max_cross=2, return_all=False,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1]))
+    npt.assert_(allclose(streamlines[1], expected[2]))
+    npt.assert_(allclose(streamlines[2], expected[1][::-1]))
+    npt.assert_(allclose(streamlines[3], expected[1]))
+
+    # Test dimension mismatch between seeds and initial_directions
+    npt.assert_raises(
+        ValueError,
+        lambda: LocalTracking(dg, sc, seeds, np.eye(4), 0.2, max_cross=1,
+                              return_all=True,
+                              initial_directions=initial_directions[:1, :, :]))
+
+    # Test ParticleFilteringTracking with inital directions
+    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 45, sphere,
+                                               pmf_threshold=0.1)
+    sc = ActStoppingCriterion.from_pve(simple_wm, simple_gm, simple_csf)
+    crossing_pos = np.array([2, 1, 0])
+    seeds = np.array([crossing_pos, crossing_pos, crossing_pos])
+    initial_directions = np.array([[sphere.vertices[0], [0, 0, 0]],
+                                   [sphere.vertices[1], sphere.vertices[0]],
+                                   [[0, 0, 0], [0, 0, 0]]])
+
+    streamline_generator = ParticleFilteringTracking(
+        dg, sc, seeds, np.eye(4), 1, return_all=True,
+        initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1]))
+    npt.assert_(allclose(streamlines[1], expected[2]))
+    npt.assert_(allclose(streamlines[2], expected[1]))
+    npt.assert_(allclose(streamlines[3], np.array([crossing_pos])))
+
+    # Test unidirectional tracking with initial directions
+    initial_directions = np.array([[[1, 0, 0], [0, 0, 0]],
+                                   [[-1, 0, 0], [0, 0, 0]],
+                                   [[0, -1, 0], [0, 1, 0]]])
+    streamline_generator = LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                         max_cross=2, return_all=False,
+                                         unidirectional=True,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1][2:]))
+    npt.assert_(allclose(streamlines[1], expected[1][:3][::-1]))
+    npt.assert_(allclose(streamlines[2], expected[2][:2][::-1]))
+    npt.assert_(allclose(streamlines[3], expected[2][1:]))
+
+    streamline_generator = ParticleFilteringTracking(
+        dg, sc, seeds, np.eye(4), 1, return_all=True, unidirectional=True,
+        initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    npt.assert_(allclose(streamlines[0], expected[1][2:]))
+    npt.assert_(allclose(streamlines[1], expected[1][:3][::-1]))
+    npt.assert_(allclose(streamlines[2], expected[2][:2][::-1]))
+    npt.assert_(allclose(streamlines[3], expected[2][1:]))
+
+    # Test randomized initial forward direction
+    seeds = np.array([crossing_pos] * 30)
+    initial_directions = np.array([np.array([1, 0, 0])] * 30)[:, np.newaxis, :]
+    streamline_generator = LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                         max_cross=2, return_all=False,
+                                         unidirectional=True,
+                                         randomize_forward_direction=True,
+                                         initial_directions=initial_directions)
+    streamlines = Streamlines(streamline_generator)
+    for sl in streamlines:
+        npt.assert_(np.allclose(sl, expected[1][2:])
+                    or np.allclose(sl, expected[1][:3][::-1]))

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -567,7 +567,6 @@ def test_particle_filtering_tractography():
     pmf = np.zeros(list(simple_gm.shape) + [3])
     pmf[:, :, :, 1] = 1  # horizontal bundle
 
-    #inital_directions = np.array([[0, 1, 0]]).reshape([1, 1, 3])
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 30, sphere)
 
     pft_streamlines_generator = ParticleFilteringTracking(
@@ -1034,7 +1033,7 @@ def test_tracking_with_initial_directions():
                           [2., 4., 0.],
                           [2., 5., 0.]])]
 
-    # Test LocalTracking with inital directions
+    # Test LocalTracking with initial directions
     sc = ThresholdStoppingCriterion(mask, .5)
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 45, sphere,
                                                pmf_threshold=0.1)
@@ -1061,7 +1060,7 @@ def test_tracking_with_initial_directions():
     npt.assert_(allclose(streamlines[2], expected[1]))
     npt.assert_(allclose(streamlines[3], np.array([crossing_pos])))
 
-    # Test inital_directions with norm != 1 and not sphere vertices
+    # Test initial_directions with norm != 1 and not sphere vertices
     initial_directions = np.array([[[0, 0, 0], [2, 0, 0]],
                                    [[0.1, 0.8, 0], [-0.4, 0, 0]],
                                    [[0, 0, 0], [0.7, 0.6, -0.1]]])
@@ -1081,7 +1080,7 @@ def test_tracking_with_initial_directions():
                               return_all=True,
                               initial_directions=initial_directions[:1, :, :]))
 
-    # Test ParticleFilteringTracking with inital directions
+    # Test ParticleFilteringTracking with initial directions
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 45, sphere,
                                                pmf_threshold=0.1)
     sc = ActStoppingCriterion.from_pve(simple_wm, simple_gm, simple_csf)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -1,3 +1,4 @@
+from logging import warn
 import warnings
 
 import nibabel as nib
@@ -1079,6 +1080,14 @@ def test_tracking_with_initial_directions():
         lambda: LocalTracking(dg, sc, seeds, np.eye(4), 0.2, max_cross=1,
                               return_all=True,
                               initial_directions=initial_directions[:1, :, :]))
+
+    # Test warning is raised for possible directional biases
+    npt.assert_warns(Warning,
+                     lambda: LocalTracking(dg, sc, seeds, np.eye(4), 1,
+                                           max_cross=2, return_all=False,
+                                           unidirectional=True,
+                                           randomize_forward_direction=False,
+                                           initial_directions=None))
 
     # Test ParticleFilteringTracking with initial directions
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 45, sphere,


### PR DESCRIPTION
This is the part 2 of 2 of refactoring PR https://github.com/dipy/dipy/pull/1627, adding initial tracking direction to local tracking.

PR #2806 need merging before this one.

- Add option to input a list of tracking orientation alongside each input seed.
- Add option to tracking only in the forward orientation.
- Add option to randomize the sign of the initial tracking orientation ( 1, -1).