### PR TITLE
BundleWarp: added tutorial and fixed a small bug

### DIFF
--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -185,6 +185,7 @@ def bundlewarp(static, moving, dist=None, alpha=0.3, beta=20, max_iter=15,
         reg = DeformableRegistration(X=static_s, Y=moving_s, alpha=alpha,
                                      beta=beta, max_iterations=max_iter)
         ty, pr = reg.register()
+        ty = ty.astype(float)
         deformed_bundle.append(ty)
         warp.append(pr)
 

--- a/doc/interfaces/index.rst
+++ b/doc/interfaces/index.rst
@@ -16,3 +16,4 @@ DIPY Workflows Interfaces
     tracking_flow.rst
     buan_flow.rst
     bundle_segmentation_flow.rst
+    bundlewarp_registration_flow.rst


### PR DESCRIPTION
1. Added BundleWarp CLI tutorial to [interfaces/index.rst](https://github.com/dipy/dipy/blob/master/doc/interfaces/index.rst).

3. If streamlines are not set as float type, FURY won't visualize them, so updated that in the BundleWarp code.

This PR addresses issue #2827