### PR TITLE
make order_from_ncoef return an int

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -645,7 +645,7 @@ def order_from_ncoef(ncoef, full_basis=False):
 
     # Solve the quadratic equation derived from :
     # ncoef = (sh_order + 2) * (sh_order + 1) / 2
-    return int(-3 + np.sqrt(9 - 4 * (2-2*ncoef)))/2
+    return -1 + int(np.sqrt(9 - 4 * (2-2*ncoef))//2)
 
 
 def smooth_pinv(B, L):


### PR DESCRIPTION
Seems like a parenthesis was misplaced as it returns a float currently. From the test:

~~~python
In [7]:     for sh_order in [2, 4, 6, 8, 12, 24]:
   ...:         m, n = sph_harm_ind_list(sh_order)
   ...:         n_coef = m.shape[0]
   ...:         assert_equal(order_from_ncoef(n_coef), sh_order)
   ...:         print(order_from_ncoef(n_coef))
   ...:         # Try out full basis
   ...:         m_full, n_full = sph_harm_ind_list(sh_order, True)
   ...:         n_coef_full = m_full.shape[0]
   ...:         assert_equal(order_from_ncoef(n_coef_full, True), sh_order)
   ...:         print(order_from_ncoef(n_coef_full, True))
   ...: 
2.0
2
4.0
4
6.0
6
8.0
8
12.0
12
24.0
24
~~~

So the full order returns an int, but the old real only part returns a float, which means the output of the function can not be used as is in a range(norder) since this does not work on floats. 
This change makes it consistent by returning an int in both cases as seems to be originally intended, I suspect an old python 2 leftover from when the division was still in C style.