### PR TITLE
doc/tools/: fix trailing dot in version number.

### DIFF
--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     source_version = '.'.join([v.split('=')[1].strip(" '\n.")
                                for v in info_lines if re.match(
                                        '^_version_(major|minor|micro|extra)', v
-                                       )])
+                                       )]).strip('.')
     source_version = Version(source_version)
     print('***', source_version)
 

--- a/doc/tools/docgen_cmd.py
+++ b/doc/tools/docgen_cmd.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     source_version = '.'.join(
         [v.split('=')[1].strip(" '\n.")
          for v in info_lines
-         if re.match('^_version_(major|minor|micro|extra)', v)])
+         if re.match('^_version_(major|minor|micro|extra)', v)]).strip('.')
     source_version = Version(source_version)
     print('***', source_version)
 


### PR DESCRIPTION
When trying to build the documentation, there is a trailing dot appearing in the version specification, that the packaging module fails to parse:

	$ cd doc; /usr/bin/make html SPHINXOPTS="-D today=\"""\""
	make[2]: Entering directory '/<<PKGBUILDDIR>>/doc'
	tools/build_modref_templates.py dipy reference
	Traceback (most recent call last):
	  File "/<<PKGBUILDDIR>>/doc/tools/build_modref_templates.py", line 58, in <module>
	    source_version = Version(source_version)
	                     ^^^^^^^^^^^^^^^^^^^^^^^
	  File "/usr/lib/python3/dist-packages/packaging/version.py", line 198, in __init__
	    raise InvalidVersion(f"Invalid version: '{version}'")
	packaging.version.InvalidVersion: Invalid version: '1.7.0.'
	make[2]: *** [Makefile:40: api] Error 1

Trimming the leading dot fixes the problem.  Note that the issue may be specifically caused by force erasing the date of the day, to ensure 100% reproducibility of the construction of the documentation.