### PR TITLE
Add fetcher for a sample CTI dataset

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -586,7 +586,7 @@ fetch_qte_lte_pte = _make_fetcher(
 
 fetch_cti_rat_data = _make_fetcher(
     'fetch_cti_rat_data',
-    pjoin(dipy_home, 'cti_data'),
+    pjoin(dipy_home, 'cti_rat1'),
     'https://zenodo.org/record/8276773/files/',
     ['Rat1_invivo_cti_data.nii', 'bvals1.bval', 'bvec1.bvec',
      'bvals2.bval', 'bvec2.bvec', 'Rat1_mask.nii'],

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -584,6 +584,24 @@ fetch_qte_lte_pte = _make_fetcher(
     data_size='41.5 MB')
 
 
+fetch_cti_rat_data = _make_fetcher(
+    'fetch_cti_rat_data',
+    pjoin(dipy_home, 'cti_data'),
+    'https://zenodo.org/record/8276773/files/',
+    ['Rat1_invivo_cti_data.nii', 'bvals1.bval', 'bvec1.bvec',
+     'bvals2.bval', 'bvec2.bvec', 'Rat1_mask.nii'],
+    ['Rat1_invivo_cti_data.nii', 'bvals1.bval', 'bvec1.bvec',
+     'bvals2.bval', 'bvec2.bvec', 'Rat1_mask.nii'],
+    ['2f855e7826f359d80cfd6f094d3a7008', '1deed2a91e20104ca42d7482cc096a9a',
+     '40a4f5131b8a64608d16b0c6c5ad0837', '1979c7dc074e00f01103cbdf83ed78db',
+     '653d9344060803d5576f43c65ce45ccb', '34bc3d5acea9442d05ef185717780440'],
+    doc='Download Rat Brain DDE data for CTI reconstruction'
+    + ' (Rat #1 data from Henriques et al. MRM 2021).',
+    data_size='152.92 MB',
+    msg=("More details about the data are available in the paper: " +
+         "https://onlinelibrary.wiley.com/doi/full/10.1002/mrm.28938"))
+
+
 fetch_fury_surface = _make_fetcher(
     "fetch_fury_surface",
     pjoin(dipy_home, 'fury_surface'),
@@ -855,6 +873,15 @@ def get_fnames(name='small_64D'):
         fbvec = pjoin(folder, 'lte-pte.bvec')
         fmask = pjoin(folder, 'mask.nii.gz')
         return fdata, fbval, fbvec, fmask
+    if name == 'cti_rat1':
+        _, folder = fetch_cti_rat_data()
+        fdata = pjoin(folder, 'Rat1_invivo_cti_data.nii')
+        fbval1 = pjoin(folder, 'bvals1.bval')
+        fbvec1 = pjoin(folder, 'bvec1.bvec')
+        fbval2 = pjoin(folder, 'bvals2.bval')
+        fbvec2 = pjoin(folder, 'bvec2.bvec')
+        fmask = pjoin(folder, 'Rat1_mask.nii')
+        return fdata, fbval1, fbvec1, fbval2, fbvec2, fmask
     if name == 'fury_surface':
         files, folder = fetch_fury_surface()
         surface_name = pjoin(folder, '100307_white_lh.vtk')

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -584,8 +584,8 @@ fetch_qte_lte_pte = _make_fetcher(
     data_size='41.5 MB')
 
 
-fetch_cti_rat_data = _make_fetcher(
-    'fetch_cti_rat_data',
+fetch_cti_rat1 = _make_fetcher(
+    'fetch_cti_rat1',
     pjoin(dipy_home, 'cti_rat1'),
     'https://zenodo.org/record/8276773/files/',
     ['Rat1_invivo_cti_data.nii', 'bvals1.bval', 'bvec1.bvec',
@@ -874,7 +874,7 @@ def get_fnames(name='small_64D'):
         fmask = pjoin(folder, 'mask.nii.gz')
         return fdata, fbval, fbvec, fmask
     if name == 'cti_rat1':
-        _, folder = fetch_cti_rat_data()
+        _, folder = fetch_cti_rat1()
         fdata = pjoin(folder, 'Rat1_invivo_cti_data.nii')
         fbval1 = pjoin(folder, 'bvals1.bval')
         fbvec1 = pjoin(folder, 'bvec1.bvec')

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -68,7 +68,7 @@ def test_io_fetch_fetcher_datanames():
                      'DiB_217_lte_pte_ste', 'DiB_70_lte_pte_ste',
                      'synb0_weights', 'synb0_test', 'bundle_warp_dataset',
                      'evac_weights', 'evac_test', 'ptt_minimal_dataset',
-                     'stanford_tracks']
+                     'stanford_tracks', 'cti_rat1']
 
     num_expected_fetch_methods = len(dataset_names)
     npt.assert_equal(len(available_data), num_expected_fetch_methods)


### PR DESCRIPTION
Hi all! I've added a fetcher for a sample CTI dataset that can be used for the implementation in PR #2816.

To fetch and load the data, you can use the following lines of code:
```
from dipy.data import get_fnames
from dipy.io import read_bvals_bvecs
from dipy.io.image import load_nifti

fdata, fbvals1, fbvecs1, fbvals2, fbvecs2, fmask = get_fnames('cti_rat1')

data, affine = load_nifti(fdata)
bvals1, bvecs1 = read_bvals_bvecs(fbvals1, fbvecs1)
bvals2, bvecs2 = read_bvals_bvecs(fbvals2, fbvecs2)
mask, affine = load_nifti(fmask)
```

Full details of the dataset can be found in the manuscript: Henriques et al., (2021). Evidence for microscopic kurtosis in neural tissue revealed by correlation tensor MRI. Magn Reson Med 86 (6): 3111-3130.

Fetched dataset correspond to the data for Rat 1 of that manuscript.

Please check if the fetcher is working for you and let me know if you have any comments.