### PR TITLE
Change license_file to license_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [tool:pytest]
 addopts = --ignore=dipy/testing/decorators.py


### PR DESCRIPTION
When building using setuptools 68.0.0, I see the following warning:

```
/nix/store/nsf971b656j9w4gp2zg9wh7895z5glrk-python3.10-setuptools-68.0.0/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
  parsed = self.parsers.get(option_name, lambda x: x)(value)
```

This looks simple to fix.