### PR TITLE
BF - fixed random generator seed `value too large to convert to int` error

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -134,7 +134,7 @@ class LocalTracking(object):
             # Set the random seed in numpy, random and fast_numpy (libc.stdlib)
             if self.random_seed is not None:
                 s_random_seed = hash(np.abs((np.sum(s)) + self.random_seed)) \
-                    % (2**32 - 1)
+                    % (np.iinfo(np.uint32).max - 1)
                 random.seed(s_random_seed)
                 np.random.seed(s_random_seed)
                 fast_numpy.seed(s_random_seed)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -973,7 +973,8 @@ def test_random_seed_initialization():
     sc = BinaryStoppingCriterion(np.ones((4, 4, 4)))
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
 
-    randoms_seeds = [None, 0, 1, -1] + list(np.random.random(10)) \
+    randoms_seeds = [None, 0, 1, -1, np.iinfo(np.uint32).max + 1] \
+        + list(np.random.random(10)) \
         + list(np.random.randint(0, np.iinfo(np.int32).max, 10))
 
     for rdm_seed in randoms_seeds:

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -962,22 +962,24 @@ def test_random_seed_initialization():
     """Test that the random generator can be initialized correctly with the
     tracking seeds.
     """
-
     sphere = HemiSphere.from_sphere(unit_octahedron)
-    pmf = np.zeros((4,4,4,3))
+    pmf = np.zeros((4, 4, 4, 3))
     x = np.array([0., 0, 0, 57.421434502602544])
     y = np.array([0., 1, 2, 21.566539227085478])
     z = np.array([1., 1, 1, 51.67881720942744])
 
-    seeds = np.column_stack([x, y, z])
-    sc = BinaryStoppingCriterion(np.ones((4,4,4)))
+    seeds = np.row_stack([np.column_stack([x, y, z]),
+                          np.random.random((10, 3))])
+    sc = BinaryStoppingCriterion(np.ones((4, 4, 4)))
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
 
-    for rdm_seed in [None, 0, 1, 1234, 1010101010, -2]:
-        _ = iter(LocalTracking(direction_getter=dg,
-                               stopping_criterion=sc,
-                               seeds=seeds,
-                               affine=np.eye(4),
-                               step_size=1.,
-                               return_all=False,
-                               random_seed=rdm_seed))
+    randoms_seeds = [None, 0, 1, -1] + list(np.random.random(10)) \
+        + list(np.random.randint(0, np.iinfo(np.int32).max, 10))
+
+    for rdm_seed in randoms_seeds:
+        _ = Streamlines(LocalTracking(direction_getter=dg,
+                                      stopping_criterion=sc,
+                                      seeds=seeds,
+                                      affine=np.eye(4),
+                                      step_size=1.,
+                                      random_seed=rdm_seed))

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -965,24 +965,19 @@ def test_random_seed_initialization():
 
     sphere = HemiSphere.from_sphere(unit_octahedron)
     pmf = np.zeros((4,4,4,3))
+    x = np.array([0., 0, 0, 57.421434502602544])
+    y = np.array([0., 1, 2, 21.566539227085478])
+    z = np.array([1., 1, 1, 51.67881720942744])
 
-    # Create a seeds along
-    x = np.array([0., 0, 0, 0, 0, 0, 0, 0])
-    y = np.array([0., 1, 2, 3, 4, 5, 6, 7])
-    z = np.array([1., 1, 1, 0, 1, 1, 1, 1])
     seeds = np.column_stack([x, y, z])
-
-    # Set up tracking
     sc = BinaryStoppingCriterion(np.ones((4,4,4)))
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
 
-    # valid streamlines only
     for rdm_seed in [None, 0, 1, 1234, 1010101010, -2]:
-        streamlines_generator = LocalTracking(direction_getter=dg,
-                                            stopping_criterion=sc,
-                                            seeds=seeds,
-                                            affine=np.eye(4),
-                                            step_size=1.,
-                                            return_all=False,
-                                            random_seed=rdm_seed)
-        streamlines = iter(streamlines_generator)
+        _ = iter(LocalTracking(direction_getter=dg,
+                               stopping_criterion=sc,
+                               seeds=seeds,
+                               affine=np.eye(4),
+                               step_size=1.,
+                               return_all=False,
+                               random_seed=rdm_seed))

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -956,3 +956,33 @@ def test_affine_transformations():
         npt.assert_(np.allclose(streamlines_inv[0], expected[0], atol=0.3))
         npt.assert_equal(len(streamlines_inv[1]), len(expected[1]))
         npt.assert_(np.allclose(streamlines_inv[1], expected[1], atol=0.3))
+
+
+def test_random_seed_initialization():
+    """Test that the random generator can be initialized correctly with the
+    tracking seeds.
+    """
+
+    sphere = HemiSphere.from_sphere(unit_octahedron)
+    pmf = np.zeros((4,4,4,3))
+
+    # Create a seeds along
+    x = np.array([0., 0, 0, 0, 0, 0, 0, 0])
+    y = np.array([0., 1, 2, 3, 4, 5, 6, 7])
+    z = np.array([1., 1, 1, 0, 1, 1, 1, 1])
+    seeds = np.column_stack([x, y, z])
+
+    # Set up tracking
+    sc = BinaryStoppingCriterion(np.ones((4,4,4)))
+    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
+
+    # valid streamlines only
+    for rdm_seed in [None, 0, 1, 1234, 1010101010, -2]:
+        streamlines_generator = LocalTracking(direction_getter=dg,
+                                            stopping_criterion=sc,
+                                            seeds=seeds,
+                                            affine=np.eye(4),
+                                            step_size=1.,
+                                            return_all=False,
+                                            random_seed=rdm_seed)
+        streamlines = iter(streamlines_generator)

--- a/dipy/utils/fast_numpy.pxd
+++ b/dipy/utils/fast_numpy.pxd
@@ -54,5 +54,5 @@ cpdef (double, double) random_point_within_circle(
 
 cpdef double random() nogil
 
-cpdef void seed(int s) nogil
+cpdef void seed(cnp.npy_uint32 s) nogil
 

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -185,7 +185,7 @@ cpdef double random() nogil:
     return rand() / float(RAND_MAX)
 
 
-cpdef void seed(int s) nogil:
+cpdef void seed(cnp.npy_uint32 s) nogil:
     """Set the random seed of stdlib.
 
     Parameters

--- a/dipy/utils/tests/test_fast_numpy.py
+++ b/dipy/utils/tests/test_fast_numpy.py
@@ -1,6 +1,6 @@
 import numpy as np
-from numpy.testing import assert_, assert_almost_equal
-from dipy.utils.fast_numpy import random, random_point_within_circle
+from numpy.testing import assert_, assert_almost_equal, assert_raises
+from dipy.utils.fast_numpy import random, seed, random_point_within_circle
 
 """
 # commented when changing cpdef to cdef in fast_numpy
@@ -99,6 +99,12 @@ def test_random():
     for _ in range(10000):
         random_number_list.append(random())
     assert_almost_equal(np.mean(random_number_list), 0.5, decimal=1)
+
+    # Test the random generator seed input
+    for s in [0, 1, np.iinfo(np.uint32).max]:
+        seed(s)
+    for s in [np.iinfo(np.uint32).max + 1, -1]:
+        assert_raises(OverflowError, seed, s)
 
 
 def test_random_point_within_circle():


### PR DESCRIPTION
`fast_numpy.seed(int s)` could raise an error if the input value was too high for an `int`. I changed the input to `fast_numpy.seed(cnp.npy_uint32 s)` as it should have been and added a new test.

Thanks @EmmaRenauld for reporting this.