### PR TITLE
Short import for horizon

### DIFF
--- a/dipy/viz/__init__.py
+++ b/dipy/viz/__init__.py
@@ -1,6 +1,8 @@
 # Init file for visualization package
 import warnings
 
+from dipy.viz.horizon.app import horizon
+
 from dipy.utils.optpkg import optional_package
 # Allow import, but disable doctests if we don't have fury
 fury, has_fury, _ = optional_package(

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -149,3 +149,9 @@ def test_roi_images():
     show_m = horizon(images=images, roi_images=True, return_showm=True)
     analysis = window.analyze_scene(show_m.scene)
     npt.assert_equal(analysis.actors, 2)
+
+def test_small_horizon_import():
+    
+    from dipy.viz import horizon as Horizon
+
+    assert Horizon == horizon

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -151,6 +151,7 @@ def test_roi_images():
     npt.assert_equal(analysis.actors, 2)
 
 
+@pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 def test_small_horizon_import():
     from dipy.viz import horizon as Horizon
     assert Horizon == horizon

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -150,8 +150,7 @@ def test_roi_images():
     analysis = window.analyze_scene(show_m.scene)
     npt.assert_equal(analysis.actors, 2)
 
-def test_small_horizon_import():
-    
-    from dipy.viz import horizon as Horizon
 
+def test_small_horizon_import():
+    from dipy.viz import horizon as Horizon
     assert Horizon == horizon

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -2,7 +2,7 @@ import numpy as np
 from os.path import join as pjoin
 from dipy.workflows.workflow import Workflow
 from dipy.io.image import load_nifti
-from dipy.viz.horizon.app import horizon
+from dipy.viz import horizon
 from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import create_nifti_header


### PR DESCRIPTION
- This PR introduces the smaller import for horizon.

- Old import: `from dipy.viz.horizon.app import horizon`
- New import: `from dipy.viz import horizon`.

##### Note: The old import is still working. It should not break any existing imports.

A test is also included to test that both the import have same signature.