### PR TITLE
[FIX] Pin scipy for the conda failing CI's

### DIFF
--- a/.github/workflows/test_optional.yml
+++ b/.github/workflows/test_optional.yml
@@ -21,4 +21,5 @@ jobs:
     with:
       runs-on: '["macos-latest", "windows-latest"]'
       install-type: '["conda"]'
-      extra-depends: scikit-learn pandas statsmodels pytables scipy
+      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py nibabel cvxpy tqdm
+      extra-depends: scikit-learn pandas statsmodels pytables scipy==1.10.1

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1962,17 +1962,17 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
                 rdx = 1
                 while rdx <= 10:  # NOTE: capped at 10 iterations
                     C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
-                    gmm = C**2 / (C**2 + residuals**2)**2
+                    denominator = (C**2 + residuals**2)**2
+                    gmm = np.divide(C**2, denominator,
+                                    out=np.zeros_like(denominator),
+                                    where=denominator != 0)
 
                     # Do nlls with GMM-weighting:
                     if jac:
-                        this_param, status = opt.leastsq(nlls.err_func,
-                                                         start_params,
-                                                         args=(design_matrix,
-                                                               flat_data[vox],
-                                                               'gmm',
-                                                               gmm),
-                                                         Dfun=nlls.jacobian_func)
+                        this_param, status = opt.leastsq(
+                            nlls.err_func, start_params,
+                            args=(design_matrix, flat_data[vox], 'gmm', gmm),
+                            Dfun=nlls.jacobian_func)
                     else:
                         this_param, status = opt.leastsq(nlls.err_func,
                                                          start_params,


### PR DESCRIPTION
All in the Title. 

Our Conda CI's are failing due to `cvxpy` version  we have to pin scipy. 

Supersed #2890