### PR TITLE
Stabilizing some test functions with set random seeds

### DIFF
--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -5,6 +5,7 @@ from dipy.sims.voxel import add_noise
 from dipy.segment.mrf import (ConstantObservationModel,
                               IteratedConditionalModes)
 from dipy.segment.tissue import (TissueClassifierHMRF)
+from dipy.testing.decorators import set_random_seed
 
 
 # Load a coronal slice from a T1-weighted MRI
@@ -28,32 +29,42 @@ square[42:213, 42:213, :] = 1
 square[71:185, 71:185, :] = 2
 square[99:157, 99:157, :] = 3
 
-square_gauss = np.zeros((256, 256, 3)) + 0.001
-square_gauss = add_noise(square_gauss, 10000, 1, noise_type='gaussian')
-square_gauss[42:213, 42:213, :] = 1
-noise_1 = np.random.normal(1.001, 0.0001,
-                           size=square_gauss[42:213, 42:213, :].shape)
-square_gauss[42:213, 42:213, :] = square_gauss[42:213, 42:213, :] + noise_1
-square_gauss[71:185, 71:185, :] = 2
-noise_2 = np.random.normal(2.001, 0.0001,
-                           size=square_gauss[71:185, 71:185, :].shape)
-square_gauss[71:185, 71:185, :] = square_gauss[71:185, 71:185, :] + noise_2
-square_gauss[99:157, 99:157, :] = 3
-noise_3 = np.random.normal(3.001, 0.0001,
-                           size=square_gauss[99:157, 99:157, :].shape)
-square_gauss[99:157, 99:157, :] = square_gauss[99:157, 99:157, :] + noise_3
 
-square_1 = np.zeros((256, 256, 3)) + 0.001
-square_1 = add_noise(square_1, 10000, 1, noise_type='gaussian')
-temp_1 = np.random.randint(1, 21, size=(171, 171, 3))
-temp_1 = np.where(temp_1 < 20, 1, 3)
-square_1[42:213, 42:213, :] = temp_1
-temp_2 = np.random.randint(1, 21, size=(114, 114, 3))
-temp_2 = np.where(temp_2 < 19, 2, 1)
-square_1[71:185, 71:185, :] = temp_2
-temp_3 = np.random.randint(1, 21, size=(58, 58, 3))
-temp_3 = np.where(temp_3 < 20, 3, 1)
-square_1[99:157, 99:157, :] = temp_3
+@set_random_seed
+def create_square_uniform():
+    square_1 = np.zeros((256, 256, 3)) + 0.001
+    square_1 = add_noise(square_1, 10000, 1, noise_type='gaussian')
+    temp_1 = np.random.randint(1, 21, size=(171, 171, 3))
+    temp_1 = np.where(temp_1 < 20, 1, 3)
+    square_1[42:213, 42:213, :] = temp_1
+    temp_2 = np.random.randint(1, 21, size=(114, 114, 3))
+    temp_2 = np.where(temp_2 < 19, 2, 1)
+    square_1[71:185, 71:185, :] = temp_2
+    temp_3 = np.random.randint(1, 21, size=(58, 58, 3))
+    temp_3 = np.where(temp_3 < 20, 3, 1)
+    square_1[99:157, 99:157, :] = temp_3
+
+    return square_1
+
+
+@set_random_seed
+def create_square_gauss():
+    square_gauss = np.zeros((256, 256, 3)) + 0.001
+    square_gauss = add_noise(square_gauss, 10000, 1, noise_type='gaussian')
+    square_gauss[42:213, 42:213, :] = 1
+    noise_1 = np.random.normal(1.001, 0.0001,
+                            size=square_gauss[42:213, 42:213, :].shape)
+    square_gauss[42:213, 42:213, :] = square_gauss[42:213, 42:213, :] + noise_1
+    square_gauss[71:185, 71:185, :] = 2
+    noise_2 = np.random.normal(2.001, 0.0001,
+                            size=square_gauss[71:185, 71:185, :].shape)
+    square_gauss[71:185, 71:185, :] = square_gauss[71:185, 71:185, :] + noise_2
+    square_gauss[99:157, 99:157, :] = 3
+    noise_3 = np.random.normal(3.001, 0.0001,
+                            size=square_gauss[99:157, 99:157, :].shape)
+    square_gauss[99:157, 99:157, :] = square_gauss[99:157, 99:157, :] + noise_3
+
+    return square_gauss
 
 
 def test_grayscale_image():
@@ -231,6 +242,7 @@ def test_square_iter():
     icm = IteratedConditionalModes()
 
     initial_segmentation = square
+    square_gauss = create_square_gauss()
 
     mu, sigmasq = com.seg_stats(square_gauss, initial_segmentation,
                                 nclasses)
@@ -323,6 +335,7 @@ def test_icm_square():
     icm = IteratedConditionalModes()
 
     initial_segmentation = square
+    square_1 = create_square_uniform()
 
     mu, sigma = com.seg_stats(square_1, initial_segmentation,
                               nclasses)

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -7,7 +7,7 @@ Decorators for dipy tests
 import re
 import os
 import platform
-
+import numpy as np
 
 SKIP_RE = re.compile("(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")
 
@@ -73,3 +73,18 @@ def xvfb_it(my_test):
     # Plant it back in and return the new function:
     test_with_xvfb.__name__ = fname
     return test_with_xvfb if not is_windows else my_test
+
+
+def set_random_seed(func):
+    """Decorator to set equal seeds.
+
+    This will help us avoid random errors
+    that occur with low probabilitiy during testing.
+
+    """
+    def test_with_seed(*args, **kwargs):
+        np.random.seed(0)
+        output = func(*args, **kwargs)
+        return output
+    
+    return test_with_seed


### PR DESCRIPTION
This pull request was created according to #2928 
I have added a decorator to fix numpy's random seed.
To use the decorator, I have moved the global variable in `dipy/segment/tests/test_mrf.py` to a function that creates it.

Are there any more changes I should make/revert? Also, do we want to add this decorator to every test function that has a numpy random function?

Thanks!