### PR TITLE
TEST: Filter legacy SH bases warnings in PTT direction getter test

### DIFF
--- a/dipy/direction/tests/test_ptt_direction_getter.py
+++ b/dipy/direction/tests/test_ptt_direction_getter.py
@@ -1,11 +1,19 @@
 """Test file for Parallel Transport Tracking Algorithm."""
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 from dipy.core.sphere import unit_octahedron
 from dipy.data import get_fnames, default_sphere
 from dipy.direction import PTTDirectionGetter
 from dipy.io.image import load_nifti
-from dipy.reconst.shm import SphHarmFit, SphHarmModel, sh_to_sf
+from dipy.reconst.shm import (
+    SphHarmFit,
+    SphHarmModel,
+    sh_to_sf,
+    descoteaux07_legacy_msg,
+    tournier07_legacy_msg,
+)
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
@@ -99,8 +107,12 @@ def test_PTTDirectionGetter():
     dir = unit_octahedron.vertices[0].copy()
 
     # Make ptt_dg from shm_coeffs
-    dg = PTTDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
-                                         unit_octahedron)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        dg = PTTDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
+                                             unit_octahedron)
     npt.assert_equal(dg.get_direction(point, dir), 1)
 
     # Make ptt_dg from pmf
@@ -108,30 +120,35 @@ def test_PTTDirectionGetter():
     dg = PTTDirectionGetter.from_pmf(pmf, 90, unit_octahedron)
     npt.assert_equal(dg.get_direction(point, dir), 1)
 
-    # Check probe_length ValueError
-    npt.assert_raises(ValueError,
-                      PTTDirectionGetter.from_shcoeff,
-                      fit.shm_coeff, 90, unit_octahedron,
-                      basis_type="tournier07",
-                      probe_length=0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=tournier07_legacy_msg,
+            category=PendingDeprecationWarning)
 
-    # Check probe_radius ValueError
-    npt.assert_raises(ValueError,
-                      PTTDirectionGetter.from_shcoeff,
-                      fit.shm_coeff, 90, unit_octahedron,
-                      basis_type="tournier07",
-                      probe_radius=-1)
+        # Check probe_length ValueError
+        npt.assert_raises(ValueError,
+                          PTTDirectionGetter.from_shcoeff,
+                          fit.shm_coeff, 90, unit_octahedron,
+                          basis_type="tournier07",
+                          probe_length=0)
 
-    # Check probe_quality ValueError
-    npt.assert_raises(ValueError,
-                      PTTDirectionGetter.from_shcoeff,
-                      fit.shm_coeff, 90, unit_octahedron,
-                      basis_type="tournier07",
-                      probe_quality=1)
+        # Check probe_radius ValueError
+        npt.assert_raises(ValueError,
+                          PTTDirectionGetter.from_shcoeff,
+                          fit.shm_coeff, 90, unit_octahedron,
+                          basis_type="tournier07",
+                          probe_radius=-1)
 
-    # Check probe_length ValueError
-    npt.assert_raises(ValueError,
-                      PTTDirectionGetter.from_shcoeff,
-                      fit.shm_coeff, 90, unit_octahedron,
-                      basis_type="tournier07",
-                      probe_count=0)
+        # Check probe_quality ValueError
+        npt.assert_raises(ValueError,
+                          PTTDirectionGetter.from_shcoeff,
+                          fit.shm_coeff, 90, unit_octahedron,
+                          basis_type="tournier07",
+                          probe_quality=1)
+
+        # Check probe_length ValueError
+        npt.assert_raises(ValueError,
+                          PTTDirectionGetter.from_shcoeff,
+                          fit.shm_coeff, 90, unit_octahedron,
+                          basis_type="tournier07",
+                          probe_count=0)


### PR DESCRIPTION
Filter legacy SH bases warnings in PTT direction getter test. Warnings are already being tested, and there is no further need to ensure that these warnings are raised.

Filtering them avoids having them printed in the standard output, and thus, unnecessary clutter.

Fixes:
```
direction/tests/test_ptt_direction_getter.py::test_PTTDirectionGetter
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/dipy/reconst/shm.py:351:
PendingDeprecationWarning:
The legacy descoteaux07 SH basis uses absolute values for negative harmonic degrees.
It is outdated and will be deprecated in a future DIPY release.
Consider using the new descoteaux07 basis by setting the `legacy` parameter to `False`.
    warn(descoteaux07_legacy_msg, category=PendingDeprecationWarning)
```

and
```
direction/tests/test_ptt_direction_getter.py::test_PTTDirectionGetter
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/dipy/reconst/shm.py:307:
PendingDeprecationWarning: The legacy tournier07 basis is not normalized.
It is outdated and will be deprecated in a future release of DIPY.
Consider using the new tournier07 basis by setting the `legacy` parameter to `False`.
    warn(tournier07_legacy_msg, category=PendingDeprecationWarning)
```

and similar warnings across modules.

Visible, for example, at:
https://github.com/dipy/dipy/actions/runs/6565543562/job/17834291163?pr=2938#step:9:4687 and
https://github.com/dipy/dipy/actions/runs/6565543562/job/17834291163?pr=2938#step:9:4694

Related to commit 62d4a19c238aacf3d2e7362eb625c52aba7f2c84.