### PR TITLE
TEST: Fix NumPy array to scalar value conversion warning

### DIFF
--- a/dipy/denoise/tests/test_ascm.py
+++ b/dipy/denoise/tests/test_ascm.py
@@ -105,7 +105,7 @@ def test_ascm_accuracy():
 
     # the test data was constructed in this manner
     mask = test_data > 50
-    sigma = estimate_sigma(test_data, N=4)
+    sigma = estimate_sigma(test_data, N=4).item()
 
     den_small = non_local_means(
         test_data,
@@ -124,6 +124,6 @@ def test_ascm_accuracy():
         rician=True)
 
     S0n = np.array(adaptive_soft_matching(test_data,
-                                          den_small, den_large, sigma[0]))
+                                          den_small, den_large, sigma))
 
-    assert_array_almost_equal(S0n, test_ascm_data_ref)
+    assert_array_almost_equal(S0n, test_ascm_data_ref, decimal=4)

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1271,7 +1271,7 @@ def _voxel_kurtosis_maximum(dt, md, kt, sphere, gtol=1e-2):
                 max_value = k_val
                 max_direction = k_dir
 
-    return max_value, max_direction
+    return max_value.item(), max_direction
 
 
 def kurtosis_maximum(dki_params, sphere='repulsion100', gtol=1e-2,

--- a/dipy/reconst/msdki.py
+++ b/dipy/reconst/msdki.py
@@ -212,8 +212,13 @@ def awf_from_msk(msk, mask=None):
             else:
                 mski = msk[v]
                 fini = mski / 2.4  # Initial guess based on linear assumption
-                awf[v] = opt.fsolve(_msk_from_awf_error, fini, args=(mski,),
-                                    fprime=_diff_msk_from_awf, col_deriv=True)
+                awf[v] = opt.fsolve(
+                    _msk_from_awf_error,
+                    fini,
+                    args=(mski,),
+                    fprime=_diff_msk_from_awf,
+                    col_deriv=True
+                ).item()
 
     return awf
 

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1853,8 +1853,8 @@ def qtdmri_isotropic_scaling(data, q, tau):
     B_tau = np.array([tau])
     inv_B_tau = np.linalg.pinv(B_tau)
 
-    us = np.sqrt(np.dot(logE_q, inv_B_q))
-    ut = np.dot(logE_tau, inv_B_tau)
+    us = np.sqrt(np.dot(logE_q, inv_B_q)).item()
+    ut = np.dot(logE_tau, inv_B_tau).item()
     return us, ut
 
 
@@ -1877,7 +1877,7 @@ def qtdmri_anisotropic_scaling(data, q, bvecs, tau):
     B_tau = np.array([tau])
     inv_B_tau = np.linalg.pinv(B_tau)
 
-    ut = np.dot(logE_tau, inv_B_tau)
+    ut = np.dot(logE_tau, inv_B_tau).item()
 
     return us, ut, R
 

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -394,7 +394,7 @@ def test_q0_constraint_and_unity_of_ODFs(radial_order=6, time_order=2):
     # only first tau_point is normalized with least squares.
     E_q0_first_tau = fitted_signal[
         np.all([tau == tau.min(), gtab_4d.b0s_mask], axis=0)
-    ]
+    ].item()
     assert_almost_equal(float(E_q0_first_tau), 1.)
 
     # now with cvxpy regularization cartesian
@@ -406,12 +406,12 @@ def test_q0_constraint_and_unity_of_ODFs(radial_order=6, time_order=2):
     fitted_signal = qtdmri_fit_lap.fitted_signal()
     E_q0_first_tau = fitted_signal[
         np.all([tau == tau.min(), gtab_4d.b0s_mask], axis=0)
-    ]
+    ].item()
     E_q0_last_tau = fitted_signal[
         np.all([tau == tau.max(), gtab_4d.b0s_mask], axis=0)
-    ]
-    assert_almost_equal(E_q0_first_tau[0], 1.)
-    assert_almost_equal(E_q0_last_tau[0], 1.)
+    ].item()
+    assert_almost_equal(E_q0_first_tau, 1.)
+    assert_almost_equal(E_q0_last_tau, 1.)
 
     # check if odf in spherical harmonics for cartesian raises an error
     try:
@@ -434,10 +434,10 @@ def test_q0_constraint_and_unity_of_ODFs(radial_order=6, time_order=2):
         fitted_signal = qtdmri_fit_lap.fitted_signal()
     E_q0_first_tau = fitted_signal[
         np.all([tau == tau.min(), gtab_4d.b0s_mask], axis=0)
-    ]
+    ].item()
     E_q0_last_tau = fitted_signal[
         np.all([tau == tau.max(), gtab_4d.b0s_mask], axis=0)
-    ]
+    ].item()
     assert_almost_equal(float(E_q0_first_tau), 1.)
     assert_almost_equal(float(E_q0_last_tau), 1.)
 

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -153,7 +153,7 @@ def test_metric_cosine():
 
             v1_normed = v1.astype(np.float64) / norm(v1.astype(np.float64))
             v2_normed = v2.astype(np.float64) / norm(v2.astype(np.float64))
-            cos_theta = np.dot(v1_normed, v2_normed.T)
+            cos_theta = np.dot(v1_normed, v2_normed.T).item()
             # Make sure it's in [-1, 1], i.e. within domain of arccosine
             cos_theta = np.minimum(cos_theta, 1.)
             cos_theta = np.maximum(cos_theta, -1.)


### PR DESCRIPTION
- STYLE: Conform to the expected return value in reconst dki method
- TEST: Fix NumPy array to scalar value conversion warning