### PR TITLE
OPT: Delegate to NumPy creating a random matrix

### DIFF
--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -265,7 +265,7 @@ def bundlewarp_shape_analysis(moving_aligned, deformed_bundle, no_disks=10,
     indx = assignment_map(deformed_bundle, deformed_bundle, n)
     indx = np.array(indx)
 
-    colors = [np.random.rand(3) for si in range(n)]
+    colors = np.random.rand(n, 3)
 
     disks_color = []
     for _, ind in enumerate(indx):


### PR DESCRIPTION
Delegate to NumPy creating a random matrix, instead of creating each row independently using a list comprehension.

Additionally, fixes:
```
Local variable 'si' value is not used
```