### PR TITLE
BF: Fix bundlewarp shape analysis profile values for all `False` mask

### DIFF
--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -238,6 +238,15 @@ def bundlewarp_shape_analysis(moving_aligned, deformed_bundle, no_disks=10,
     Bundle shape difference analysis using magnitude from BundleWarp
     displacements and BUAN.
 
+    Depending on the number of points of a streamline, and the number of
+    segments requested, multiple points may be considered for the computation
+    of a given segment; a segment may contain information from a single point;
+    or some segments may not contain information from any points. In the latter
+    case, the segment will contain an ``np.nan`` value. The point-to-segment
+    mapping is defined by the :func:`assignment_map`: for each segment index,
+    the point information of the matching index positions, as returned by
+    :func:`assignment_map`, are considered for the computation.
+
     Parameters
     ----------
     moving_aligned : Streamlines
@@ -279,8 +288,13 @@ def bundlewarp_shape_analysis(moving_aligned, deformed_bundle, no_disks=10,
 
     for i in range(n):
 
-        shape_profile[i] = np.mean(offsets[indx == i])
-        stdv[i] = np.std(offsets[indx == i])
+        mask = indx == i
+        if sum(mask):
+            shape_profile[i] = np.mean(offsets[mask])
+            stdv[i] = np.std(offsets[mask])
+        else:
+            shape_profile[i] = np.nan
+            stdv[i] = np.nan
 
     if plotting:
         bundle_shape_profile(x, shape_profile, stdv)


### PR DESCRIPTION
Fix bundlewarp shape analysis profile values for the case where all mask values are `False`: set the value to `np.nan` instead of relying on NumPy to compute the mean and the std values on an empty array.

Fixes:
```
align/tests/test_streamwarp.py::test_bundle_shape_profile
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3504:
RuntimeWarning: Mean of empty slice.
    return _methods._mean(a, axis=axis, dtype=dtype,

align/tests/test_streamwarp.py::test_bundle_shape_profile
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/numpy/core/_methods.py:129:
RuntimeWarning: invalid value encountered in scalar divide
    ret = ret.dtype.type(ret / rcount)

align/tests/test_streamwarp.py::test_bundle_shape_profile
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/numpy/core/_methods.py:206:
RuntimeWarning: Degrees of freedom <= 0 for slice
    ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,

align/tests/test_streamwarp.py::test_bundle_shape_profile
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/numpy/core/_methods.py:163:
RuntimeWarning: invalid value encountered in divide
    arrmean = um.true_divide(arrmean, div, out=arrmean,

align/tests/test_streamwarp.py::test_bundle_shape_profile
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/numpy/core/_methods.py:198:
RuntimeWarning: invalid value encountered in scalar divide
    ret = ret.dtype.type(ret / rcount)
```

Raised for example at:
https://github.com/dipy/dipy/actions/runs/6565543562/job/17834291163?pr=2938#step:9:4645