### PR TITLE
RF: Refactor duplicate code in `qtdmri` to `mapmri` coeff computation

### DIFF
--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1070,52 +1070,8 @@ class QtdmriFit:
         return eap
 
 
-def qtdmri_to_mapmri_matrix(radial_order, time_order, ut, tau):
-    """Generates the matrix that maps the qtdmri coefficients to MAP-MRI
-    coefficients. The conversion is done by only evaluating the time basis for
-    a diffusion time tau and summing up coefficients with the same spatial
-    basis orders [1].
-
-    Parameters
-    ----------
-    radial_order : unsigned int,
-        an even integer representing the spatial/radial order of the basis.
-    time_order : unsigned int,
-        an integer larger or equal than zero representing the time order
-        of the basis.
-    ut : float
-        temporal scaling factor
-    tau : float
-        diffusion time (big_delta - small_delta / 3.) in seconds
-
-    References
-    ----------
-    .. [1] Fick, Rutger HJ, et al. "Non-Parametric GraphNet-Regularized
-        Representation of dMRI in Space and Time", Medical Image Analysis,
-        2017.
-    """
-    mapmri_ind_mat = mapmri.mapmri_index_matrix(radial_order)
-    n_elem_mapmri = int(mapmri_ind_mat.shape[0])
-    qtdmri_ind_mat = qtdmri_index_matrix(radial_order, time_order)
-    n_elem_qtdmri = int(qtdmri_ind_mat.shape[0])
-
-    temporal_storage = np.zeros(time_order + 1)
-    for o in range(time_order + 1):
-        temporal_storage[o] = temporal_basis(o, ut, tau)
-
-    counter = 0
-    mapmri_mat = np.zeros((n_elem_mapmri, n_elem_qtdmri))
-    for nxt, nyt, nzt, o in qtdmri_ind_mat:
-        index_overlap = np.all([nxt == mapmri_ind_mat[:, 0],
-                                nyt == mapmri_ind_mat[:, 1],
-                                nzt == mapmri_ind_mat[:, 2]], 0)
-        mapmri_mat[:, counter] = temporal_storage[o] * index_overlap
-        counter += 1
-    return mapmri_mat
-
-
-def qtdmri_isotropic_to_mapmri_matrix(radial_order, time_order, ut, tau):
-    """Generates the matrix that maps the spherical qtdmri coefficients to
+def _qtdmri_to_mapmri_matrix(radial_order, time_order, ut, tau, isotropic):
+    """Generate the matrix that maps the spherical qtdmri coefficients to
     MAP-MRI coefficients. The conversion is done by only evaluating the time
     basis for a diffusion time tau and summing up coefficients with the same
     spatial basis orders [1].
@@ -1131,6 +1087,9 @@ def qtdmri_isotropic_to_mapmri_matrix(radial_order, time_order, ut, tau):
         temporal scaling factor
     tau : float
         diffusion time (big_delta - small_delta / 3.) in seconds
+    isotropic : bool
+        `True` if the case is isotropic.
+
 
     References
     ----------
@@ -1138,9 +1097,14 @@ def qtdmri_isotropic_to_mapmri_matrix(radial_order, time_order, ut, tau):
         Representation of dMRI in Space and Time", Medical Image Analysis,
         2017.
     """
-    mapmri_ind_mat = mapmri.mapmri_isotropic_index_matrix(radial_order)
+    if isotropic:
+        mapmri_ind_mat = mapmri.mapmri_isotropic_index_matrix(radial_order)
+        qtdmri_ind_mat = qtdmri_isotropic_index_matrix(radial_order, time_order)
+    else:
+        mapmri_ind_mat = mapmri.mapmri_index_matrix(radial_order)
+        qtdmri_ind_mat = qtdmri_index_matrix(radial_order, time_order)
+
     n_elem_mapmri = int(mapmri_ind_mat.shape[0])
-    qtdmri_ind_mat = qtdmri_isotropic_index_matrix(radial_order, time_order)
     n_elem_qtdmri = int(qtdmri_ind_mat.shape[0])
 
     temporal_storage = np.zeros(time_order + 1)
@@ -1148,14 +1112,70 @@ def qtdmri_isotropic_to_mapmri_matrix(radial_order, time_order, ut, tau):
         temporal_storage[o] = temporal_basis(o, ut, tau)
 
     counter = 0
-    mapmri_isotropic_mat = np.zeros((n_elem_mapmri, n_elem_qtdmri))
+    mapmri_mat = np.zeros((n_elem_mapmri, n_elem_qtdmri))
     for j, ll, m, o in qtdmri_ind_mat:
         index_overlap = np.all([j == mapmri_ind_mat[:, 0],
                                 ll == mapmri_ind_mat[:, 1],
                                 m == mapmri_ind_mat[:, 2]], 0)
-        mapmri_isotropic_mat[:, counter] = temporal_storage[o] * index_overlap
+        mapmri_mat[:, counter] = temporal_storage[o] * index_overlap
         counter += 1
-    return mapmri_isotropic_mat
+    return mapmri_mat
+
+
+def qtdmri_to_mapmri_matrix(radial_order, time_order, ut, tau):
+    """Generate the matrix that maps the qtdmri coefficients to MAP-MRI
+    coefficients for the anisotropic case. The conversion is done by only
+    evaluating the time basis for a diffusion time tau and summing up
+    coefficients with the same spatial basis orders [1].
+
+    Parameters
+    ----------
+    radial_order : unsigned int,
+        an even integer representing the spatial/radial order of the basis.
+    time_order : unsigned int,
+        an integer larger or equal than zero representing the time order
+        of the basis.
+    ut : float
+        temporal scaling factor
+    tau : float
+        diffusion time (big_delta - small_delta / 3.) in seconds
+
+    References
+    ----------
+    .. [1] Fick, Rutger HJ, et al. "Non-Parametric GraphNet-Regularized
+        Representation of dMRI in Space and Time", Medical Image Analysis,
+        2017.
+    """
+
+    return _qtdmri_to_mapmri_matrix(radial_order, time_order, ut, tau, False)
+
+
+def qtdmri_isotropic_to_mapmri_matrix(radial_order, time_order, ut, tau):
+    """Generate the matrix that maps the spherical qtdmri coefficients to
+    MAP-MRI coefficients for the isotropic case. The conversion is done by only
+    evaluating the time basis for a diffusion time tau and summing up
+    coefficients with the same spatial basis orders [1].
+
+    Parameters
+    ----------
+    radial_order : unsigned int,
+        an even integer representing the spatial/radial order of the basis.
+    time_order : unsigned int,
+        an integer larger or equal than zero representing the time order
+        of the basis.
+    ut : float
+        temporal scaling factor
+    tau : float
+        diffusion time (big_delta - small_delta / 3.) in seconds
+
+    References
+    ----------
+    .. [1] Fick, Rutger HJ, et al. "Non-Parametric GraphNet-Regularized
+        Representation of dMRI in Space and Time", Medical Image Analysis,
+        2017.
+    """
+
+    return _qtdmri_to_mapmri_matrix(radial_order, time_order, ut, tau, True)
 
 
 def qtdmri_temporal_normalization(ut):


### PR DESCRIPTION
Refactor duplicate code in `qtdmri` to `mapmri` coefficient mapping matrix computiation: create a new private function that holds the logic for both the isotropic and anisotropic cases that is called from the separate isotropic/anisotropic, and using a flag to characterize the different behavior.