### PR TITLE
TEST: Bring back Python 3.8 testing to GHA workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      python-version: '["3.9", "3.10", 3.11]'
+      python-version: '["3.8", "3.9", "3.10", 3.11]'

--- a/.github/workflows/test_compat.yml
+++ b/.github/workflows/test_compat.yml
@@ -11,6 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  minimal-py38:
+    uses: ./.github/workflows/test_template.yml
+    with:
+      runs-on: '["ubuntu-latest", ]'
+      python-version: '["3.8", ]'
+      depends: cython==0.29.24 numpy==1.23.0 scipy==1.8 nibabel==4.0.0 h5py==3.0.0 tqdm
   minimal-py39:
     uses: ./.github/workflows/test_template.yml
     with:


### PR DESCRIPTION
Bring back Python 3.8 testing to GHA workflows.

Removed in commit cf4338d.

Raise the minimum required NumPy version for the Python 3.8
compatibility test to 1.23.0 from the previously required 1.22.0 version
in commit https://github.com/dipy/dipy/commit/318bfc68635fdd9410d7372e47ce734cea4ed64b so that tests can pass. Fixes:
```
ImportError: numpy.core.multiarray failed to import
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/6620737573/job/17983666930#step:9:12437