### PR TITLE
Adding support for btens to multi_shell_fiber_response function

### DIFF
--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -222,6 +222,19 @@ def test_multi_shell_fiber_response():
 
     npt.assert_equal(response.response.shape, (4, 7))
 
+    btens = ["LTE", "PTE", "STE", "CTE"]
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        response = multi_shell_fiber_response(sh_order, [0, 1000, 2000, 3500],
+                                              wm_response,
+                                              gm_response,
+                                              csf_response,
+                                              btens=btens)
+
+    npt.assert_equal(response.response.shape, (4, 7))
+
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=PendingDeprecationWarning)
         response = multi_shell_fiber_response(sh_order, [1000, 2000, 3500],


### PR DESCRIPTION
Hi!

This is a really small modification of `reconst.mcsd.multi_shell_fiber_response` , adding support for the b-tensor (btens) option. I used the new implementation of btens in `gradient_table` and `single_tensor`, so that the `reconst.mcsd.multi_shell_fiber_response` function now returns the response function according to the b-tensor shape of each inputed b-value. For example, I use this for multi-encoding msmt-CSD (see my paper for more details https://doi.org/10.1016/j.media.2022.102476) on Scilpy (I am a PhD student supervised by Maxime Descoteaux), and I had this version of the function in my code. It runs as usual when no btens is given, by setting every b-value as LTE (linear tensor encoding).

It would be very appreciated if this could go in the next release. @gabknight 