### PR TITLE
TEST: Filter legacy SH bases warnings in bootstrap direction getter test

### DIFF
--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -82,30 +82,51 @@ def test_bdg_get_direction():
     sphere = get_sphere('symmetric362')
     response = (np.array([0.0015, 0.0003, 0.0003]), 1)
 
-    csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
+
     point = np.array([0., 0., 0.])
     prev_direction = sphere.vertices[5]
 
     # test case in which no valid direction is found with default max attempts
-    boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=10.,
-                                  sphere=sphere)
-    npt.assert_equal(boot_dg.get_direction(point, prev_direction), 1)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=10.,
+                                      sphere=sphere)
+        npt.assert_equal(boot_dg.get_direction(point, prev_direction), 1)
 
     # test case in which no valid direction is found with new max attempts
-    boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=10,
-                                  sphere=sphere, max_attempts=3)
-    npt.assert_equal(boot_dg.get_direction(point, prev_direction), 1)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=10,
+                                      sphere=sphere, max_attempts=3)
+        npt.assert_equal(boot_dg.get_direction(point, prev_direction), 1)
 
     # test case in which a valid direction is found
-    boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=60.,
-                                  sphere=sphere, max_attempts=5)
-    npt.assert_equal(boot_dg.get_direction(point, prev_direction), 0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        boot_dg = BootDirectionGetter(data, model=csd_model, max_angle=60.,
+                                      sphere=sphere, max_attempts=5)
+        npt.assert_equal(boot_dg.get_direction(point, prev_direction), 0)
 
     # test invalid max_attempts parameters
-    npt.assert_raises(
-        ValueError,
-        lambda: BootDirectionGetter(data, csd_model, 60, sphere=sphere,
-                                    max_attempts=0))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=shm.descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        npt.assert_raises(
+            ValueError,
+            lambda: BootDirectionGetter(data, csd_model, 60, sphere=sphere,
+                                        max_attempts=0))
 
 
 def test_bdg_residual():


### PR DESCRIPTION
Filter legacy SH bases warnings in bootstrap direction getter test. Warnings are already being tested, and there is no further need to ensure that these warnings are raised.

Filtering them avoids having them printed in the standard output, and thus, unnecessary clutter.

Fixes:
```
direction/tests/test_bootstrap_direction_getter.py::test_bdg_get_direction
  /home/runner/work/dipy/dipy/venv/lib/python3.11/site-packages/dipy/reconst/shm.py:351:
PendingDeprecationWarning:
The legacy descoteaux07 SH basis uses absolute values for negative harmonic degrees.
It is outdated and will be deprecated in a future DIPY release.
Consider using the new descoteaux07 basis by setting the `legacy` parameter to `False`.
    warn(descoteaux07_legacy_msg, category=PendingDeprecationWarning)
```

Raised for example at:
https://github.com/dipy/dipy/actions/runs/6657261609/job/18091595226?pr=2941#step:9:4028