### PR TITLE
NF: Updating EVAC+ model and adding util function

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -323,18 +323,18 @@ fetch_evac_weights = _make_fetcher(
     "fetch_evac_weights",
     pjoin(dipy_home, 'evac'),
     'https://ndownloader.figshare.com/files/',
-    ['40150867'],
+    ['43037191'],
     ['evac_default_weights.h5'],
-    ['998d5122e0aef1ccf7c0d58e41e978af'],
+    ['491cfa4f9a2860fad6c19f2b71b918e1'],
     doc="Download EVAC+ model weights for Park et. al 2022")
 
 fetch_evac_test = _make_fetcher(
     "fetch_evac_test",
     pjoin(dipy_home, 'evac'),
     'https://ndownloader.figshare.com/files/',
-    ['40150894'],
+    ['43040074'],
     ['evac_test_data.npz'],
-    ['a2173e8f800ab7ab3b159b86bf3a8536'],
+    ['a5ad7116c9914a53ba891f9e73f3a132'],
     doc="Download EVAC+ test data for Park et. al 2022")
 
 fetch_stanford_t1 = _make_fetcher(

--- a/dipy/nn/evac.py
+++ b/dipy/nn/evac.py
@@ -15,13 +15,13 @@ from dipy.utils.optpkg import optional_package
 from dipy.io.image import load_nifti
 from dipy.align.reslice import reslice
 from dipy.nn.utils import normalize, set_logger_level, transform_img
-from dipy.nn.utils import recover_img
+from dipy.nn.utils import recover_img, correct_minor_errors
 
 tf, have_tf, _ = optional_package('tensorflow')
 if have_tf:
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Softmax, Conv3DTranspose
-    from tensorflow.keras.layers import Conv3D, LayerNormalization, LeakyReLU
+    from tensorflow.keras.layers import Conv3D, LayerNormalization, ReLU
     from tensorflow.keras.layers import Concatenate, Layer, Dropout, Add
     if Version(tf.__version__) < Version('2.0.0'):
         raise ImportError('Please upgrade to TensorFlow 2+')
@@ -99,13 +99,13 @@ class Block(Layer):
                                           padding=padding))
             self.layer_list.append(Dropout(drop_r))
             self.layer_list.append(LayerNormalization())
-            self.layer_list.append(LeakyReLU())
+            self.layer_list.append(ReLU())
         if layer_type=='down':
             self.layer_list2.append(Conv3D(1, 2, strides=2, padding='same'))
-            self.layer_list2.append(LeakyReLU())
+            self.layer_list2.append(ReLU())
         elif layer_type=='up':
             self.layer_list2.append(Conv3DTranspose(1, 2, strides=2, padding='same'))
-            self.layer_list2.append(LeakyReLU())
+            self.layer_list2.append(ReLU())
 
         self.channel_sum = ChannelSum()
         self.add = Add()
@@ -303,7 +303,8 @@ class EVACPlus:
 
     def predict(self, T1, affine,
                 voxsize=(1, 1, 1), batch_size=None,
-                return_affine=False, return_prob=False):
+                return_affine=False, return_prob=False,
+                largest_area=True):
         r"""
         Wrapper function to facilitate prediction of larger dataset.
 
@@ -311,7 +312,7 @@ class EVACPlus:
         ----------
         T1 : np.ndarray or list of np.ndarrys
             For a single image, input should be a 3D array.
-            If multiple images, it should be a 4D array or a list.
+            If multiple images, it should be a a list or tuple.
 
         affine : np.ndarray (4, 4) or (batch, 4, 4)
             or list of np.ndarrays with len of batch
@@ -342,6 +343,11 @@ class EVACPlus:
             binary mask. Useful for testing.
             Default is False
 
+        largest_area : bool, optional
+            Whether to exclude only the largest background/foreground.
+            Useful for solving minor errors.
+            Default is True
+
         Returns
         -------
         pred_output : np.ndarray (...) or (batch, ...)
@@ -350,6 +356,7 @@ class EVACPlus:
         affine : np.ndarray (...) or (batch, ...)
             affine matrix of mask
             only if return_affine is True
+
         """
 
         voxsize = np.array(voxsize)
@@ -358,7 +365,7 @@ class EVACPlus:
         if isinstance(T1, (list, tuple)):
             dim = 4
             T1 = np.array(T1)
-        elif len(T1.shape)==3:
+        elif len(T1.shape) == 3:
             dim = 3
             if batch_size is not None:
                 logger.warning('Batch size specified, but not used',
@@ -370,24 +377,27 @@ class EVACPlus:
             affine = np.expand_dims(affine, 0)
             voxsize = np.expand_dims(voxsize, 0)
         else:
-            raise ValueError("T1 data should be a np.ndarray of dimension 3 or"
-                             "a list/tuple of it")
+            raise ValueError("T1 data should be a np.ndarray of dimension 3 "
+                             "or a list/tuple of it")
 
         input_data = np.zeros((128, 128, 128, len(T1)))
         rev_affine = np.zeros((len(T1), 4, 4))
+        ori_shapes = np.zeros((len(T1), 3)).astype(int)
 
         # Normalize the data.
         n_T1 = np.zeros(T1.shape)
         for i, T1_img in enumerate(T1):
             n_T1[i] = normalize(T1_img, new_min=0, new_max=1)
-            t_img, t_affine = transform_img(n_T1[i],
-                                            affine[i])
+            t_img, t_affine, ori_shape = transform_img(n_T1[i],
+                                                       affine[i],
+                                                       voxsize[i])
             input_data[..., i] = t_img
             rev_affine[i] = t_affine
+            ori_shapes[i] = ori_shape
 
         # Prediction stage
         prediction = np.zeros((len(T1), 128, 128, 128),
-                               dtype=np.float32)
+                              dtype=np.float32)
         for batch_idx in range(batch_size, len(T1)+1, batch_size):
             batch = input_data[..., batch_idx-batch_size:batch_idx]
             temp_input = prepare_img(batch)
@@ -403,9 +413,13 @@ class EVACPlus:
         for i, T1_img in enumerate(T1):
             output = recover_img(prediction[i],
                                  rev_affine[i],
-                                 T1_img.shape)
-            if return_prob == False:
+                                 voxsize=voxsize[i],
+                                 ori_shape=ori_shapes[i],
+                                 image_shape=T1_img.shape)
+            if not return_prob:
                 output = np.where(output >= 0.5, 1, 0)
+                if largest_area:
+                    output = correct_minor_errors(output)
             output_mask.append(output)
 
         if dim == 3:

--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -1,10 +1,11 @@
 import pytest
 from packaging.version import Version
 
+import numpy as np
+import numpy.testing as npt
+
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
-import numpy as np
-from numpy.testing import assert_almost_equal
 
 tf, have_tf, _ = optional_package('tensorflow')
 
@@ -12,6 +13,7 @@ if have_tf:
     from dipy.nn.evac import EVACPlus
     if Version(tf.__version__) < Version('2.0.0'):
         raise ImportError('Please upgrade to TensorFlow 2+')
+
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
 def test_default_weights():
@@ -21,7 +23,7 @@ def test_default_weights():
 
     evac_model = EVACPlus()
     results_arr = evac_model.predict(input_arr, np.eye(4), return_prob=True)
-    assert_almost_equal(results_arr, output_arr, decimal=4)
+    npt.assert_almost_equal(results_arr, output_arr, decimal=4)
 
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
@@ -35,4 +37,12 @@ def test_default_weights_batch():
     fake_affine = np.array([np.eye(4), np.eye(4)])
     fake_voxsize = np.ones((2, 3))
     results_arr = evac_model.predict(input_arr, fake_affine, fake_voxsize, batch_size=2, return_prob=True)
-    assert_almost_equal(results_arr, output_arr, decimal=4)
+    npt.assert_almost_equal(results_arr, output_arr, decimal=4)
+
+
+@pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
+def test_T1_error():
+    T1 = np.ones((3, 32, 32, 32))
+    evac_model = EVACPlus()
+    fake_affine = np.array([np.eye(4), np.eye(4), np.eye(4)])
+    npt.assert_raises(ValueError, evac_model.predict, T1, fake_affine)

--- a/dipy/nn/tests/test_utils.py
+++ b/dipy/nn/tests/test_utils.py
@@ -1,14 +1,22 @@
 import numpy as np
 from dipy.nn.utils import normalize, unnormalize, transform_img, recover_img
+from dipy.testing.decorators import set_random_number_generator
 
-def test_norm():
-    temp = np.random.random((8, 8, 8)) * 10
+
+@set_random_number_generator()
+def test_norm(rng=None):
+    temp = rng.random((8, 8, 8)) * 10
     temp2 = normalize(temp)
     temp2 = unnormalize(temp2, -1, 1, 0, 10)
     np.testing.assert_almost_equal(temp, temp2, 1)
 
-def test_transform():
-    temp = np.random.random((30, 31, 32))
-    temp2, new_affine = transform_img(temp, np.eye(4), (32, 32, 32))
-    temp2 = recover_img(temp2, new_affine, temp.shape)
+
+@set_random_number_generator()
+def test_transform(rng=None):
+    temp = rng.random((30, 31, 32))
+    temp2, new_affine, ori_shape = transform_img(temp, np.eye(4),
+                                                 init_shape=(32, 32, 32),
+                                                 voxsize=np.ones(3)*2)
+    temp2 = recover_img(temp2, new_affine, ori_shape, temp.shape,
+                        init_shape=(32, 32, 32), voxsize=np.ones(3)*2)
     np.testing.assert_almost_equal(np.array(temp.shape), np.array(temp2.shape))

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
-from scipy.ndimage import affine_transform
+from scipy.ndimage import affine_transform, label
 from dipy.align.reslice import reslice
+
 
 def normalize(image, min_v=None, max_v=None, new_min=-1, new_max=1):
     r"""
@@ -9,20 +10,20 @@ def normalize(image, min_v=None, max_v=None, new_min=-1, new_max=1):
     Parameters
     ----------
     image : np.ndarray
-    min_v : int or float (optional)
+    min_v : int or float, optional
         minimum value range for normalization
         intensities below min_v will be clipped
         if None it is set to min value of image
         Default : None
-    max_v : int or float (optional)
+    max_v : int or float, optional
         maximum value range for normalization
         intensities above max_v will be clipped
         if None it is set to max value of image
         Default : None
-    new_min : int or float (optional)
+    new_min : int or float, optional
         new minimum value after normalization
         Default : 0
-    new_max : int or float (optional)
+    new_max : int or float, optional
         new maximum value after normalization
         Default : 1
 
@@ -36,6 +37,7 @@ def normalize(image, min_v=None, max_v=None, new_min=-1, new_max=1):
     if max_v is None:
         max_v = np.max(image)
     return np.interp(image, (min_v, max_v), (new_min, new_max))
+
 
 def unnormalize(image, norm_min, norm_max, min_v, max_v):
     r"""
@@ -73,7 +75,9 @@ def set_logger_level(log_level, logger):
     """
     logger.setLevel(level=log_level)
 
-def transform_img(image, affine, init_shape=(256, 256, 256), scale=2):
+
+def transform_img(image, affine, voxsize=None,
+                  init_shape=(256, 256, 256), scale=2):
     r"""
     Function to reshape image as an input to the model
 
@@ -83,10 +87,12 @@ def transform_img(image, affine, init_shape=(256, 256, 256), scale=2):
         Image to transform to voxelspace
     affine : np.ndarray
         Affine matrix provided by the file
-    init_shape : tuple
+    voxsize : np.ndarray (3,), optional
+        Voxel size of the image
+    init_shape : tuple, optional
         Initial shape to transform the image to
         Default is (256, 256, 256)
-    scale : float
+    scale : float, optional
         How much we want to scale the image
         Default is 2
 
@@ -94,7 +100,11 @@ def transform_img(image, affine, init_shape=(256, 256, 256), scale=2):
     -------
     transformed_img : np.ndarray
     """
-    affine2 = affine.copy()
+    if voxsize is not None and np.any(voxsize != np.ones(3)):
+        image, affine2 = reslice(image, affine, voxsize, (1, 1, 1))
+    else:
+        affine2 = affine.copy()
+    ori_shape = np.array(image.shape)
     affine2[:3, 3] += np.array([init_shape[0]//2,
                                 init_shape[1]//2,
                                 init_shape[2]//2])
@@ -102,9 +112,11 @@ def transform_img(image, affine, init_shape=(256, 256, 256), scale=2):
     transformed_img = affine_transform(image, inv_affine, output_shape=init_shape)
     transformed_img, _ = reslice(transformed_img, np.eye(4), (1, 1, 1),
                                  (scale, scale, scale))
-    return transformed_img, affine2
+    return transformed_img, affine2, ori_shape
 
-def recover_img(image, affine, ori_shape, scale=2):
+
+def recover_img(image, affine, ori_shape, image_shape,
+                init_shape=(256, 256, 256), voxsize=None, scale=2):
     r"""
     Function to recover image back to its original shape
 
@@ -114,9 +126,16 @@ def recover_img(image, affine, ori_shape, scale=2):
         Image to recover
     affine : np.ndarray
         Affine matrix provided from transform_img
-    ori_shape : tuple
-        Original shape of image
-    scale : float
+    ori_shape : np.ndarray (3,)
+        Original shape of isotropic image
+    image_shape : tuple (3,)
+        Original shape of actual image
+    init_shape : tuple (3,), optional
+        Initial shape to transform the image to
+        Default is (256, 256, 256)
+    voxsize : np.ndarray (3,), optional
+        Voxel size of the original image
+    scale : float, optional
         Scale that was used in transform_img
         Default is 2
 
@@ -126,4 +145,57 @@ def recover_img(image, affine, ori_shape, scale=2):
     """
     new_image, _ = reslice(image, np.eye(4), (scale, scale, scale), (1, 1, 1))
     recovered_img = affine_transform(new_image, affine, output_shape=ori_shape)
+    affine[:3, 3] += np.array([init_shape[0]//2,
+                               init_shape[1]//2,
+                               init_shape[2]//2])
+    if voxsize is not None and np.any(voxsize != np.ones(3)):
+        kwargs = {'order': 1,
+                  'mode': 'constant',
+                  'matrix': voxsize,
+                  'output_shape': image_shape}
+        recovered_img = np.round(affine_transform(recovered_img, **kwargs))
     return recovered_img
+
+
+def correct_minor_errors(binary_img):
+    """
+    Remove any small mask chunks or holes
+    that could be in the segmentation output.
+
+    Parameters
+    ----------
+    binary_img : np.ndarray
+        Binary image
+
+    Returns
+    -------
+    largest_img : np.ndarray
+    """
+    largest_img = np.zeros_like(binary_img)
+    chunks, n_chunk = label(np.abs(1-binary_img))
+    u, c = np.unique(chunks[chunks != 0], return_counts=True)
+    target = u[np.argmax(c)]
+    largest_img = np.where(chunks == target, 0, 1)
+
+    chunks, n_chunk = label(largest_img)
+    u, c = np.unique(chunks[chunks != 0], return_counts=True)
+    target = u[np.argmax(c)]
+    largest_img = np.where(chunks == target, 1, 0)
+
+    for x in range(largest_img.shape[0]):
+        chunks, n_chunk = label(np.abs(1-largest_img[x]))
+        u, c = np.unique(chunks[chunks != 0], return_counts=True)
+        target = u[np.argmax(c)]
+        largest_img[x] = np.where(chunks == target, 0, 1)
+    for y in range(largest_img.shape[1]):
+        chunks, n_chunk = label(np.abs(1-largest_img[:, y]))
+        u, c = np.unique(chunks[chunks != 0], return_counts=True)
+        target = u[np.argmax(c)]
+        largest_img[:, y] = np.where(chunks == target, 0, 1)
+    for z in range(largest_img.shape[2]):
+        chunks, n_chunk = label(np.abs(1-largest_img[..., z]))
+        u, c = np.unique(chunks[chunks != 0], return_counts=True)
+        target = u[np.argmax(c)]
+        largest_img[..., z] = np.where(chunks == target, 0, 1)
+
+    return largest_img


### PR DESCRIPTION
This commit changes the EVAC+ model and its default weights for better brain extraction output. It also adds an option to only select the largest foreground and remove its holes, so that most prediction noises can be removed.