### PR TITLE
RF: Moving to numpy.random.Generator from numpy.random

### DIFF
--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1042,8 +1042,8 @@ def slr_with_qbx(static, moving,
     progressive : boolean, optional
             (default True)
 
-    rng : RandomState
-        If None creates RandomState in function.
+    rng : np.random.Generator
+        If None creates random generator in function.
 
     num_threads : int, optional
         Number of threads to be used for OpenMP parallelization. If None
@@ -1072,7 +1072,7 @@ def slr_with_qbx(static, moving,
 
     """
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
 
     if verbose:
         logger.info('Static streamlines size {}'.format(len(static)))
@@ -1207,8 +1207,8 @@ def groupwise_slr(bundles, x0='affine', tol=0, max_iter=20, qbx_thr=[4],
     verbose : bool, optional
         If True, logs information. Default: False.
 
-    rng : RandomState
-        If None, creates RandomState in function. Default: None.
+    rng : np.random.Generator
+        If None, creates random generator in function. Default: None.
 
     References
     ----------
@@ -1233,7 +1233,7 @@ def groupwise_slr(bundles, x0='affine', tol=0, max_iter=20, qbx_thr=[4],
         return d
 
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
 
     metric = JointBundleMinDistanceMetric()
 

--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -265,7 +265,9 @@ def bundlewarp_shape_analysis(moving_aligned, deformed_bundle, no_disks=10,
     indx = assignment_map(deformed_bundle, deformed_bundle, n)
     indx = np.array(indx)
 
-    colors = np.random.rand(n, 3)
+    rng = np.random.default_rng()
+
+    colors = rng.random((n, 3))
 
     disks_color = []
     for _, ind in enumerate(indx):

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -23,6 +23,7 @@ from dipy.io.streamline import save_trk
 from dipy.io.stateful_tractogram import StatefulTractogram, Space
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+from dipy.testing.decorators import set_random_number_generator
 
 
 def setup_module():
@@ -246,11 +247,12 @@ def test_register_dwi_series_and_motion_correction():
         npt.assert_array_equal(reg_affines, reg_affines_2)
 
 
-def test_streamline_registration():
+@set_random_number_generator()
+def test_streamline_registration(rng):
     sl1 = [np.array([[0, 0, 0], [0, 0, 0.5], [0, 0, 1], [0, 0, 1.5]]),
            np.array([[0, 0, 0], [0, 0.5, 0.5], [0, 1, 1]])]
     affine_mat = np.eye(4)
-    affine_mat[:3, 3] = np.random.randn(3)
+    affine_mat[:3, 3] = rng.standard_normal(3)
     sl2 = list(transform_tracking_output(sl1, affine_mat))
     aligned, matrix = streamline_registration(sl2, sl1)
     npt.assert_almost_equal(matrix, np.linalg.inv(affine_mat))
@@ -259,7 +261,7 @@ def test_streamline_registration():
 
     # We assume the two tracks come from the same space, but it might have
     # some affine associated with it:
-    base_aff = np.eye(4) * np.random.rand()
+    base_aff = np.eye(4) * rng.random()
     base_aff[:3, 3] = np.array([1, 2, 3])
     base_aff[3, 3] = 1
 

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -309,7 +309,7 @@ def test_quantize_positive_2d(rng):
     # make sure additive noise doesn't change the quantization result
     noise_amplitude = np.min([delta / 4.0, min_positive / 4.0])
     sz = np.size(true_quantization)
-    noise = np.random.ranf(sz).reshape(img_shape) * noise_amplitude
+    noise = rng.random(sz).reshape(img_shape) * noise_amplitude
     noise = noise.astype(floating)
     input_image = np.ndarray(img_shape, dtype=floating)
     # assign intensities plus noise
@@ -372,7 +372,7 @@ def test_quantize_positive_3d(rng):
     # make sure additive noise doesn't change the quantization result
     noise_amplitude = np.min([delta / 4.0, min_positive / 4.0])
     sz = np.size(true_quantization)
-    noise = np.random.ranf(sz).reshape(img_shape) * noise_amplitude
+    noise = rng.random(sz).reshape(img_shape) * noise_amplitude
     noise = noise.astype(floating)
     input_image = np.ndarray(img_shape, dtype=floating)
     # assign intensities plus noise

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -175,7 +175,8 @@ def test_transform_origins_3d():
                     assert_array_almost_equal(actual.affine, expected)
 
 
-def test_affreg_all_transforms():
+@set_random_number_generator(202311)
+def test_affreg_all_transforms(rng):
     # Test affine registration using all transforms with typical settings
 
     # Make sure dictionary entries are processed in the same order regardless
@@ -198,7 +199,8 @@ def test_affreg_all_transforms():
                                                                       trans,
                                                                       factor,
                                                                       nslices,
-                                                                      1.0)
+                                                                      1.0,
+                                                                      rng=rng)
         # Sum of absolute differences
         start_sad = np.abs(static - moving).sum()
         metric = imaffine.MutualInformationMetric(32, sampling_pc)
@@ -243,7 +245,8 @@ def test_affreg_all_transforms():
                               np.zeros_like(smask), np.zeros_like(mmask))
 
 
-def test_affreg_defaults():
+@set_random_number_generator(202311)
+def test_affreg_defaults(rng):
     # Test all default arguments with an arbitrary transform
     # Select an arbitrary transform (all of them are already tested
     # in test_affreg_all_transforms)
@@ -260,7 +263,7 @@ def test_affreg_defaults():
         factor = factors[ttype][0]
         transform = regtransforms[ttype]
         static, moving, static_grid2world, moving_grid2world, smask, mmask, T = \
-            setup_random_transform(transform, factor, nslices, 1.0)
+            setup_random_transform(transform, factor, nslices, 1.0, rng=rng)
         # Sum of absolute differences
         start_sad = np.abs(static - moving).sum()
 
@@ -297,7 +300,7 @@ def test_affreg_defaults():
             end_sad = np.abs(moving - transformed_inv).sum()
             reduction = 1 - end_sad / start_sad
             print("%s>>%f" % (ttype, reduction))
-            assert(reduction > 0.9)
+            assert(reduction > 0.89)
 
 
 @set_random_number_generator(2022966)
@@ -326,7 +329,7 @@ def test_mi_gradient(rng):
             start.param_to_matrix(0.25 * rng.standard_normal(nrot))
         # Get data (pair of images related to each other by an known transform)
         static, moving, static_g2w, moving_g2w, smask, mmask, M = \
-            setup_random_transform(transform, factor, nslices, 2.0)
+            setup_random_transform(transform, factor, nslices, 2.0, rng=rng)
 
         # Prepare a MutualInformationMetric instance
         mi_metric = imaffine.MutualInformationMetric(32, sampling_proportion)
@@ -608,10 +611,11 @@ def test_affine_map(rng):
             assert_raises(AffineInversionError, AffineMap, mat_large_dim)
 
 
-def test_MIMetric_invalid_params():
+@set_random_number_generator()
+def test_MIMetric_invalid_params(rng):
     transform = regtransforms[('AFFINE', 3)]
-    static = np.random.rand(20, 20, 20)
-    moving = np.random.rand(20, 20, 20)
+    static = rng.random((20, 20, 20))
+    moving = rng.random((20, 20, 20))
     n = transform.get_number_of_parameters()
     sampling_proportion = 0.3
     theta_sing = np.zeros(n)

--- a/dipy/align/tests/test_parzenhist.py
+++ b/dipy/align/tests/test_parzenhist.py
@@ -31,7 +31,7 @@ factors = {('TRANSLATION', 2): 2.0,
            ('AFFINE', 3): 0.1}
 
 
-def create_random_image_pair(sh, nvals, seed):
+def create_random_image_pair(sh, nvals, rng=None):
     r""" Create a pair of images with an arbitrary, non-uniform joint PDF
 
     Parameters
@@ -42,6 +42,9 @@ def create_random_image_pair(sh, nvals, seed):
         maximum number of different values in the generated 2D images.
         The voxel intensities of the returned images will be in
         {0, 1, ..., nvals-1}
+    rng : numpy.random.generator
+        numpy's random generator. If None, it is set with a random seed.
+        Default is None
 
     Returns
     -------
@@ -50,7 +53,8 @@ def create_random_image_pair(sh, nvals, seed):
     moving : array, shape=sh
         second image in the image pair
     """
-    rng = np.random.default_rng(seed)
+    if rng is None:
+        rng = np.random.default_rng()
     sz = reduce(mul, sh, 1)
     sh = tuple(sh)
     static = rng.integers(0, nvals, sz).reshape(sh)
@@ -173,10 +177,10 @@ def test_parzen_joint_histogram():
                     assert_equal(index, P.padding + i)
 
 
-def test_parzen_densities():
+@set_random_number_generator(1246592)
+def test_parzen_densities(rng):
     # Test the computation of the joint intensity distribution
     # using a dense and a sparse set of values
-    seed = 1246592
     nbins = 32
     nr = 30
     nc = 35
@@ -186,10 +190,10 @@ def test_parzen_densities():
     for dim in [2, 3]:
         if dim == 2:
             shape = (nr, nc)
-            static, moving = create_random_image_pair(shape, nvals, seed)
+            static, moving = create_random_image_pair(shape, nvals, rng)
         else:
             shape = (ns, nr, nc)
-            static, moving = create_random_image_pair(shape, nvals, seed)
+            static, moving = create_random_image_pair(shape, nvals, rng)
 
         # Initialize
         parzen_hist = ParzenJointHistogram(nbins)
@@ -257,7 +261,6 @@ def test_parzen_densities():
                                   expected_smarginal_sparse)
 
 
-@set_random_number_generator(3147702)
 def setup_random_transform(transform, rfactor, nslices=45, sigma=1, rng=None):
     r""" Creates a pair of images related to each other by an affine transform
 
@@ -276,7 +279,14 @@ def setup_random_transform(transform, rfactor, nslices=45, sigma=1, rng=None):
         added to the identity parameters to create the random transform
     nslices: int
         number of slices to be stacked to form the volumes
+    sigma: float
+        standard deviation of the gaussian filter
+    rng: np.random.Generator
+        numpy's random generator. If None, it is set with a random seed.
+        Default is None
     """
+    if rng is None:
+        rng = np.random.default_rng()
     dim = 2 if nslices == 1 else 3
     if transform.get_dim() != dim:
         raise ValueError("Transform and requested volume have different dims.")
@@ -316,7 +326,8 @@ def setup_random_transform(transform, rfactor, nslices=45, sigma=1, rng=None):
     return static, moving, static_g2w, moving_g2w, smask, mmask, M
 
 
-def test_joint_pdf_gradients_dense():
+@set_random_number_generator(3147702)
+def test_joint_pdf_gradients_dense(rng):
     # Compare the analytical and numerical (finite differences) gradient of
     # the joint distribution (i.e. derivatives of each histogram cell) w.r.t.
     # the transform parameters. Since the histograms are discrete partitions
@@ -351,7 +362,8 @@ def test_joint_pdf_gradients_dense():
         theta = transform.get_identity_parameters()
 
         static, moving, static_g2w, moving_g2w, smask, mmask, M = \
-            setup_random_transform(transform, factor, nslices, 5.0)
+            setup_random_transform(transform, factor, nslices, 5.0,
+                                   rng=rng)
         parzen_hist = ParzenJointHistogram(32)
         parzen_hist.setup(static, moving, smask, mmask)
 
@@ -412,7 +424,8 @@ def test_joint_pdf_gradients_dense():
         assert(std_cosine < 0.25)
 
 
-def test_joint_pdf_gradients_sparse():
+@set_random_number_generator(3147702)
+def test_joint_pdf_gradients_sparse(rng):
     h = 1e-4
 
     # Make sure dictionary entries are processed in the same order regardless
@@ -435,14 +448,14 @@ def test_joint_pdf_gradients_sparse():
         theta = transform.get_identity_parameters()
 
         static, moving, static_g2w, moving_g2w, smask, mmask, M = \
-            setup_random_transform(transform, factor, nslices, 5.0)
+            setup_random_transform(transform, factor, nslices, 5.0,
+                                   rng=rng)
         parzen_hist = ParzenJointHistogram(32)
         parzen_hist.setup(static, moving, smask, mmask)
 
         # Sample the fixed-image domain
         k = 3
         sigma = 0.25
-        rng = np.random.default_rng(1234)
         shape = np.array(static.shape, dtype=np.int32)
         samples = sample_domain_regular(k, shape, static_g2w, sigma, rng)
         samples = np.array(samples)

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -27,6 +27,7 @@ from dipy.data import get_fnames, two_cingulum_bundles, read_five_af_bundles
 from dipy.align.bundlemin import (_bundle_minimum_distance_matrix,
                                   _bundle_minimum_distance,
                                   distance_matrix_mdf)
+from dipy.testing.decorators import set_random_number_generator
 
 
 def simulated_bundle(no_streamlines=10, waves=False, no_pts=12):
@@ -198,12 +199,12 @@ def test_min_vs_min_fast_precision():
     assert_equal(bmd.distance(x_test), bmdf.distance(x_test))
 
 
-def test_same_number_of_points():
-
-    A = [np.random.rand(10, 3), np.random.rand(20, 3)]
-    B = [np.random.rand(21, 3), np.random.rand(30, 3)]
-    C = [np.random.rand(10, 3), np.random.rand(10, 3)]
-    D = [np.random.rand(20, 3), np.random.rand(20, 3)]
+@set_random_number_generator()
+def test_same_number_of_points(rng):
+    A = [rng.random((10, 3)), rng.random((20, 3))]
+    B = [rng.random((21, 3)), rng.random((30, 3))]
+    C = [rng.random((10, 3)), rng.random((10, 3))]
+    D = [rng.random((20, 3)), rng.random((20, 3))]
 
     slr = StreamlineLinearRegistration()
     assert_raises(ValueError, slr.optimize, A, B)
@@ -254,14 +255,14 @@ def test_efficient_bmd():
     assert_almost_equal(dist, dist2)
 
 
-def test_openmp_locks():
-
+@set_random_number_generator()
+def test_openmp_locks(rng):
     static = []
     moving = []
     pts = 20
 
     for i in range(1000):
-        s = np.random.rand(pts, 3)
+        s = rng.random((pts, 3))
         static.append(s)
         moving.append(s + 2)
 
@@ -413,18 +414,18 @@ def test_vectorize_streamlines():
     assert_equal(np.all(cb_subj1_pts_no == 10), True)
 
 
-def test_x0_input():
-
+@set_random_number_generator()
+def test_x0_input(rng):
     for x0 in [6, 7, 12, "Rigid", 'rigid', "similarity", "Affine"]:
         StreamlineLinearRegistration(x0=x0)
 
-    for x0 in [np.random.rand(6), np.random.rand(7), np.random.rand(12)]:
+    for x0 in [rng.random(6), rng.random(7), rng.random(12)]:
         StreamlineLinearRegistration(x0=x0)
 
-    for x0 in [8, 20, "Whatever", np.random.rand(20), np.random.rand(20, 3)]:
+    for x0 in [8, 20, "Whatever", rng.random(20), rng.random((20, 3))]:
         assert_raises(ValueError, StreamlineLinearRegistration, x0=x0)
 
-    x0 = np.random.rand(4, 3)
+    x0 = rng.random((4, 3))
     assert_raises(ValueError, StreamlineLinearRegistration, x0=x0)
 
     x0_6 = np.zeros(6)
@@ -438,10 +439,10 @@ def test_x0_input():
         assert_equal(slr.x0, x0_s[i])
 
 
-def test_compose_decompose_matrix44():
-
+@set_random_number_generator()
+def test_compose_decompose_matrix44(rng):
     for i in range(20):
-        x0 = np.random.rand(12)
+        x0 = rng.random(12)
         mat = compose_matrix44(x0[:6])
         assert_array_almost_equal(x0[:6], decompose_matrix44(mat, size=6))
         mat = compose_matrix44(x0[:7])
@@ -482,9 +483,10 @@ def test_cascade_of_optimizations_and_threading():
     assert_(slm3.fopt < slm2.fopt)
 
 
-def test_wrong_num_threads():
-    A = [np.random.rand(10, 3), np.random.rand(10, 3)]
-    B = [np.random.rand(10, 3), np.random.rand(10, 3)]
+@set_random_number_generator()
+def test_wrong_num_threads(rng):
+    A = [rng.random((10, 3)), rng.random((10, 3))]
+    B = [rng.random((10, 3)), rng.random((10, 3))]
 
     slr = StreamlineLinearRegistration(num_threads=0)
     assert_raises(ValueError, slr.optimize, A, B)

--- a/dipy/align/tests/test_transforms.py
+++ b/dipy/align/tests/test_transforms.py
@@ -1,9 +1,11 @@
-from dipy.align.transforms import regtransforms, Transform
 import numpy as np
 from numpy.testing import (assert_array_equal,
                            assert_array_almost_equal,
                            assert_equal,
                            assert_raises)
+
+from dipy.align.transforms import regtransforms, Transform
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_number_of_parameters():
@@ -28,8 +30,8 @@ def test_number_of_parameters():
             expected_params[ttype])
 
 
-def test_param_to_matrix_2d():
-    rng = np.random.RandomState()
+@set_random_number_generator()
+def test_param_to_matrix_2d(rng):
     # Test translation matrix 2D
     transform = regtransforms[('TRANSLATION', 2)]
     dx, dy = rng.uniform(size=(2,))
@@ -107,8 +109,8 @@ def test_param_to_matrix_2d():
         assert_raises(ValueError, transform.param_to_matrix, theta)
 
 
-def test_param_to_matrix_3d():
-    rng = np.random.RandomState()
+@set_random_number_generator()
+def test_param_to_matrix_3d(rng):
     # Test translation matrix 3D
     transform = regtransforms[('TRANSLATION', 3)]
     dx, dy, dz = rng.uniform(size=(3,))
@@ -222,8 +224,8 @@ def test_identity_parameters():
         assert_array_almost_equal(actual, expected)
 
 
-def test_jacobian_functions():
-    rng = np.random.RandomState()
+@set_random_number_generator()
+def test_jacobian_functions(rng):
     # Compare the analytical Jacobians with their numerical approximations
     h = 1e-8
     nsamples = 50

--- a/dipy/boots/resampling.py
+++ b/dipy/boots/resampling.py
@@ -72,9 +72,11 @@ def bootstrap(x, statistic=bs_se, B=1000, alpha=0.95):
     N = len(x)
     bs_pdf = np.empty((B,))
 
+    rng = np.random.default_rng()
+
     for ii in range(0, B):
         # resample with replacement
-        rand_index = np.int16(np.round(np.random.random(N) * (N - 1)))
+        rand_index = np.int16(np.round(rng.random(N) * (N - 1)))
         bs_pdf[ii] = statistic(x[rand_index])
 
     return bs_pdf, bs_se(bs_pdf), abc(x, statistic, alpha=alpha)
@@ -272,11 +274,13 @@ def jackknife(pdf, statistic=np.std, M=None):
     M = np.minimum(M, N - 1)
     jk_pdf = np.empty((M,))
 
+    rng = np.random.default_rng()
+
     for ii in range(0, M):
-        rand_index = np.round(np.random.random() * (N - 1))
+        rand_index = np.round(rng.random() * (N - 1))
         # choose a unique random sample to remove
         while pdf_mask[rand_index] == 0:
-            rand_index = np.round(np.random.random() * (N - 1))
+            rand_index = np.round(rng.random() * (N - 1))
         # set mask to zero for chosen random index so not to choose again
         pdf_mask[rand_index] = 0
         mask_index[rand_index] = 0

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -704,7 +704,7 @@ def reorient_bvecs(gtab, affines, atol=1e-2):
                           b0_threshold=gtab.b0_threshold, atol=atol)
 
 
-def generate_bvecs(N, iters=5000):
+def generate_bvecs(N, iters=5000, rng=None):
     """Generates N bvectors.
 
     Uses dipy.core.sphere.disperse_charges to model electrostatic repulsion on
@@ -717,6 +717,9 @@ def generate_bvecs(N, iters=5000):
         of bvals used.
     iters : int
         Number of iterations to run.
+    rng : numpy.random.Generator, optional
+        Numpy's random number generator. If None, the generator is created.
+        Default is None.
 
     Returns
     -------
@@ -724,8 +727,10 @@ def generate_bvecs(N, iters=5000):
         The generated directions, represented as a unit vector, of each
         gradient.
     """
-    theta = np.pi * np.random.rand(N)
-    phi = 2 * np.pi * np.random.rand(N)
+    if rng is None:
+        rng = np.random.default_rng()
+    theta = np.pi * rng.random(N)
+    phi = 2 * np.pi * rng.random(N)
     hsph_initial = HemiSphere(theta=theta, phi=phi)
     hsph_updated, potential = disperse_charges(hsph_initial, iters)
     bvecs = hsph_updated.vertices

--- a/dipy/core/sphere_stats.py
+++ b/dipy/core/sphere_stats.py
@@ -43,9 +43,10 @@ def random_uniform_on_sphere(n=1, coords='xyz'):
     >>> X.shape == (4, 3)
     True
     """
-    z = np.random.uniform(-1, 1, n)
+    rng = np.random.default_rng()
+    z = rng.uniform(-1, 1, n)
     theta = np.arccos(z)
-    phi = np.random.uniform(0, 2*np.pi, n)
+    phi = rng.uniform(0, 2*np.pi, n)
     if coords == 'xyz':
         r = np.ones(n)
         return np.vstack(geometry.sphere2cart(r, theta, phi)).T

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -26,6 +26,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_equal, assert_raises, assert_almost_equal,)
 
 from dipy.testing.spherepoints import sphere_points
+from dipy.testing.decorators import set_random_number_generator
 from dipy.core.sphere_stats import random_uniform_on_sphere
 from itertools import permutations
 
@@ -149,7 +150,8 @@ def test_sphere_distance():
     assert_raises(ValueError, sphere_distance, [1, 0], [0, 1], 2.0)
 
 
-def test_vector_cosine():
+@set_random_number_generator()
+def test_vector_cosine(rng):
     a = [0, 1]
     b = [1, 0]
     assert_array_almost_equal(vector_cosine(a, b), 0)
@@ -164,8 +166,8 @@ def test_vector_cosine():
     assert_array_almost_equal(vector_cosine(pts1, pts2), [-1, 1])
     # test relationship with correlation
     # not the same if non-zero vector mean
-    a = np.random.uniform(size=(100,))
-    b = np.random.uniform(size=(100,))
+    a = rng.uniform(size=(100,))
+    b = rng.uniform(size=(100,))
     cc = np.corrcoef(a, b)[0, 1]
     vcos = vector_cosine(a, b)
     assert not np.allclose(cc, vcos)
@@ -267,12 +269,12 @@ def test_compose_transformations():
     assert_raises(ValueError, compose_transformations, A)
 
 
-def test_compose_decompose_matrix():
-
-    for translate in permutations(40 * np.random.rand(3), 3):
-        for angles in permutations(np.deg2rad(90 * np.random.rand(3)), 3):
-            for shears in permutations(3 * np.random.rand(3), 3):
-                for scale in permutations(3 * np.random.rand(3), 3):
+@set_random_number_generator()
+def test_compose_decompose_matrix(rng):
+    for translate in permutations(40 * rng.random(3), 3):
+        for angles in permutations(np.deg2rad(90 * rng.random(3)), 3):
+            for shears in permutations(3 * rng.random(3), 3):
+                for scale in permutations(3 * rng.random(3), 3):
 
                     mat = compose_matrix(translate=translate, angles=angles,
                                          shear=shears, scale=scale)
@@ -333,7 +335,8 @@ def _rotation_from_angles(r):
     return R
 
 
-def test_dist_to_corner():
+@set_random_number_generator()
+def test_dist_to_corner(rng):
     affine = np.eye(4)
     # Calculate the distance with the pythagorean theorem:
     pythagoras = np.sqrt(np.sum((np.diag(affine)[:-1] / 2) ** 2))
@@ -341,7 +344,7 @@ def test_dist_to_corner():
     assert_array_almost_equal(dist_to_corner(affine), pythagoras)
     # Apply a rotation to the matrix, just to demonstrate the calculation is
     # robust to that:
-    R = _rotation_from_angles(np.random.randn(3) * np.pi)
+    R = _rotation_from_angles(rng.random(3) * np.pi)
     new_aff = np.vstack([np.dot(R, affine[:3, :]), [0, 0, 0, 1]])
     assert_array_almost_equal(dist_to_corner(new_aff), pythagoras)
 

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -20,6 +20,7 @@ from dipy.core.geometry import vec2vec_rotmat, vector_norm
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.testing import clear_and_catch_warnings
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_unique_bvals_deprecated():
@@ -354,7 +355,8 @@ def test_qvalues():
     npt.assert_almost_equal(bt.qvals, qvals)
 
 
-def test_reorient_bvecs():
+@set_random_number_generator()
+def test_reorient_bvecs(rng):
     sq2 = np.sqrt(2) / 2
     bvals = np.concatenate([[0], np.ones(6) * 1000])
     bvecs = np.array([[0, 0, 0],
@@ -379,7 +381,7 @@ def test_reorient_bvecs():
     rotation_affines = []
     rotated_bvecs = bvecs[:]
     for i in np.where(~gt.b0s_mask)[0]:
-        rot_ang = np.random.rand()
+        rot_ang = rng.random()
         cos_rot = np.cos(rot_ang)
         sin_rot = np.sin(rot_ang)
         rotation_affines.append(np.array([[1, 0, 0, 0],
@@ -449,16 +451,17 @@ def test_nan_bvecs():
         npt.assert_(len(selected_w) == 0)
 
 
-def test_generate_bvecs():
+@set_random_number_generator()
+def test_generate_bvecs(rng):
     """Tests whether we have properly generated bvecs.
     """
     # Test if the generated b-vectors are unit vectors
-    bvecs = generate_bvecs(100)
+    bvecs = generate_bvecs(100, rng=rng)
     norm = [np.linalg.norm(v) for v in bvecs]
     npt.assert_almost_equal(norm, np.ones(100))
 
     # Test if two generated vectors are almost orthogonal
-    bvecs_2 = generate_bvecs(2)
+    bvecs_2 = generate_bvecs(2, rng=rng)
     cos_theta = np.dot(bvecs_2[0], bvecs_2[1])
     npt.assert_almost_equal(cos_theta, 0., decimal=6)
 
@@ -625,7 +628,8 @@ def test_check_multi_b():
     npt.assert_(check_multi_b(gtab, 2, non_zero=False))
 
 
-def test_btens_to_params():
+@set_random_number_generator()
+def test_btens_to_params(rng):
     """
     Checks if bvals, bdeltas and b_etas are as expected for 4 b-tensor shapes
     (LTE, PTE, STE, CTE) as well as scaled and rotated versions of them
@@ -687,14 +691,14 @@ def test_btens_to_params():
     # Test function after rotating+scaling baseline tensors
     # -----------------------------------------------------
 
-    scales = np.concatenate((np.array([1]), np.random.random(n_scales)))
+    scales = np.concatenate((np.array([1]), rng.random(n_scales)))
 
     for scale in scales:
 
         ebs = expected_bvals*scale
 
         # Generate `n_rotations` random 3-element vectors of norm 1
-        v = np.random.random((n_rotations, 3)) - 0.5
+        v = rng.random((n_rotations, 3)) - 0.5
         u = np.apply_along_axis(lambda w: w/np.linalg.norm(w), axis=1, arr=v)
 
         for rot_idx in range(n_rotations):

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -20,10 +20,11 @@ from dipy.align import floating
 from dipy.testing.decorators import set_random_number_generator
 
 
-def test_trilinear_interpolate():
+@set_random_number_generator()
+def test_trilinear_interpolate(rng):
     """This tests that the trilinear interpolation returns the correct values.
     """
-    a, b, c = np.random.random(3)
+    a, b, c = rng.random(3)
 
     def linear_function(x, y, z):
         return a * x + b * y + c * z

--- a/dipy/core/tests/test_optimize.py
+++ b/dipy/core/tests/test_optimize.py
@@ -4,6 +4,7 @@ import scipy.sparse as sps
 import numpy.testing as npt
 from dipy.core.optimize import Optimizer, sparse_nnls, spdot
 import dipy.core.optimize as opt
+from dipy.testing.decorators import set_random_number_generator
 
 
 def func(x):
@@ -56,7 +57,8 @@ def test_optimize_new_scipy():
     npt.assert_array_almost_equal(opt.xopt, np.array([0, 0, 0, 0.]))
 
 
-def test_sklearn_linear_solver():
+@set_random_number_generator()
+def test_sklearn_linear_solver(rng):
     class SillySolver(opt.SKLearnLinearSolver):
         def fit(self, X, y):
             self.coef_ = np.ones(X.shape[-1])
@@ -64,17 +66,18 @@ def test_sklearn_linear_solver():
     MySillySolver = SillySolver()
     n_samples = 100
     n_features = 20
-    y = np.random.rand(n_samples)
+    y = rng.random(n_samples)
     X = np.ones((n_samples, n_features))
     MySillySolver.fit(X, y)
     npt.assert_equal(MySillySolver.coef_, np.ones(n_features))
     npt.assert_equal(MySillySolver.predict(X), np.ones(n_samples) * 20)
 
 
-def test_nonnegativeleastsquares():
+@set_random_number_generator()
+def test_nonnegativeleastsquares(rng):
     n = 100
     X = np.eye(n)
-    beta = np.random.rand(n)
+    beta = rng.random(n)
     y = np.dot(X, beta)
     my_nnls = opt.NonNegativeLeastSquares()
     my_nnls.fit(X, y)
@@ -82,12 +85,13 @@ def test_nonnegativeleastsquares():
     npt.assert_equal(my_nnls.predict(X), y)
 
 
-def test_spdot():
+@set_random_number_generator()
+def test_spdot(rng):
     n = 100
     m = 20
     k = 10
-    A = np.random.randn(n, m)
-    B = np.random.randn(m, k)
+    A = rng.standard_normal((n, m))
+    B = rng.standard_normal((m, k))
     A_sparse = sps.csr_matrix(A)
     B_sparse = sps.csr_matrix(B)
     dense_dot = np.dot(A, B)
@@ -98,10 +102,11 @@ def test_spdot():
     npt.assert_array_almost_equal(dense_dot, spdot(A_sparse, B))
 
 
-def test_sparse_nnls():
+@set_random_number_generator()
+def test_sparse_nnls(rng):
     # Set up the regression:
-    beta = np.random.rand(10)
-    X = np.random.randn(1000, 10)
+    beta = rng.random(10)
+    X = rng.standard_normal((1000, 10))
     y = np.dot(X, beta)
     beta_hat = sparse_nnls(y, X)
     beta_hat_sparse = sparse_nnls(y, sps.csr_matrix(X))

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -73,6 +73,8 @@ cdef class EnhancementKernel:
         self.t = t
 
         # define a sphere
+        rng = np.random.default_rng()
+
         if isinstance(orientations, Sphere):
             # use the sphere defined by the user
             sphere = orientations
@@ -82,8 +84,8 @@ cdef class EnhancementKernel:
             if n_pts == 0:
                 sphere = None
             else:
-                theta = np.pi * np.random.rand(n_pts)
-                phi = 2 * np.pi * np.random.rand(n_pts)
+                theta = np.pi * rng.random(n_pts)
+                phi = 2 * np.pi * rng.random(n_pts)
                 hsph_initial = HemiSphere(theta=theta, phi=phi)
                 sphere, potential = disperse_charges(hsph_initial, 5000)
         else:

--- a/dipy/denoise/tests/test_ascm.py
+++ b/dipy/denoise/tests/test_ascm.py
@@ -7,6 +7,7 @@ from numpy.testing import (assert_,
 from dipy.denoise.non_local_means import non_local_means
 from dipy.denoise.noise_estimate import estimate_sigma
 from dipy.denoise.adaptive_soft_matching import adaptive_soft_matching
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_ascm_static():
@@ -19,8 +20,9 @@ def test_ascm_static():
     assert_array_almost_equal(S0, S0n)
 
 
-def test_ascm_random_noise():
-    S0 = 100 + 2 * np.random.standard_normal((22, 23, 30))
+@set_random_number_generator()
+def test_ascm_random_noise(rng):
+    S0 = 100 + 2 * rng.standard_normal((22, 23, 30))
     S0n1 = non_local_means(S0, sigma=1, rician=False,
                            patch_radius=1, block_radius=1)
     S0n2 = non_local_means(S0, sigma=1, rician=False,
@@ -35,12 +37,13 @@ def test_ascm_random_noise():
     assert_equal(np.round(S0n.mean()), 100)
 
 
-def test_ascm_rmse_with_nlmeans():
+@set_random_number_generator()
+def test_ascm_rmse_with_nlmeans(rng):
     # checks the smoothness
     S0 = np.ones((30, 30, 30)) * 100
     S0[10:20, 10:20, 10:20] = 50
     S0[20:30, 20:30, 20:30] = 0
-    S0_noise = S0 + 20 * np.random.standard_normal((30, 30, 30))
+    S0_noise = S0 + 20 * rng.standard_normal((30, 30, 30))
     print("Original RMSE", np.sum(np.abs(S0 - S0_noise)) / np.sum(S0))
 
     S0n1 = non_local_means(
@@ -67,12 +70,13 @@ def test_ascm_rmse_with_nlmeans():
     assert_(90 < np.mean(S0n) < 110)
 
 
-def test_sharpness():
+@set_random_number_generator()
+def test_sharpness(rng):
     # check the edge-preserving nature
     S0 = np.ones((30, 30, 30)) * 100
     S0[10:20, 10:20, 10:20] = 50
     S0[20:30, 20:30, 20:30] = 0
-    S0_noise = S0 + 20 * np.random.standard_normal((30, 30, 30))
+    S0_noise = S0 + 20 * rng.standard_normal((30, 30, 30))
     S0n1 = non_local_means(
         S0_noise,
         sigma=400,

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -1,17 +1,21 @@
+from time import time
+
 import numpy as np
 from numpy.testing import (assert_,
                            assert_equal,
                            assert_array_almost_equal,
                            assert_raises)
 import pytest
+
 from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.denspeed import (add_padding_reflection, remove_padding)
 from dipy.utils.omp import cpu_count, have_openmp
-from time import time
+from dipy.testing.decorators import set_random_number_generator
 
 
-def test_nlmeans_padding():
-    S0 = 100 + 2 * np.random.standard_normal((50, 50, 50))
+@set_random_number_generator()
+def test_nlmeans_padding(rng):
+    S0 = 100 + 2 * rng.standard_normal((50, 50, 50))
     S0 = S0.astype('f8')
     S0n = add_padding_reflection(S0, 5)
     S0n2 = remove_padding(S0n, 5)
@@ -34,8 +38,9 @@ def test_nlmeans_wrong():
     assert_raises(ValueError, nlmeans, data, sigma, num_threads=0)
 
 
-def test_nlmeans_random_noise():
-    S0 = 100 + 2 * np.random.standard_normal((22, 23, 30))
+@set_random_number_generator()
+def test_nlmeans_random_noise(rng):
+    S0 = 100 + 2 * rng.standard_normal((22, 23, 30))
 
     S0n = nlmeans(S0, sigma=np.ones((22, 23, 30)) * np.std(S0), rician=False)
 
@@ -47,12 +52,13 @@ def test_nlmeans_random_noise():
     assert_equal(np.round(S0n.mean()), 100)
 
 
-def test_nlmeans_boundary():
+@set_random_number_generator()
+def test_nlmeans_boundary(rng):
     # nlmeans preserves boundaries
 
     S0 = 100 + np.zeros((20, 20, 20))
 
-    noise = 2 * np.random.standard_normal((20, 20, 20))
+    noise = 2 * rng.standard_normal((20, 20, 20))
 
     S0 += noise
 

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -26,7 +26,8 @@ def test_inv_nchi():
     assert_almost_equal(lambdaPlus, 9.722849086419043)
 
 
-def test_piesno():
+@set_random_number_generator()
+def test_piesno(rng):
     # Values taken from hispeed.OptimalPIESNO with the test data
     # in the package computed in matlab
     test_piesno_data = load_nifti_data(dpd.get_fnames("test_piesno"))
@@ -34,8 +35,8 @@ def test_piesno():
                    return_mask=False)
     assert_almost_equal(sigma, 0.010749458025559)
 
-    noise1 = (np.random.randn(100, 100, 100) * 50) + 10
-    noise2 = (np.random.randn(100, 100, 100) * 50) + 10
+    noise1 = (rng.standard_normal((100, 100, 100)) * 50) + 10
+    noise2 = (rng.standard_normal((100, 100, 100)) * 50) + 10
     rician_noise = np.sqrt(noise1**2 + noise2**2)
     sigma, mask = piesno(rician_noise, N=1, alpha=0.01, l=1, eps=1e-10,
                          return_mask=True)

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -4,6 +4,7 @@ from numpy.testing import (assert_,
                            assert_array_almost_equal,
                            assert_raises)
 from dipy.denoise.non_local_means import non_local_means
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_nlmeans_static():
@@ -12,8 +13,9 @@ def test_nlmeans_static():
     assert_array_almost_equal(S0, S0nb)
 
 
-def test_nlmeans_random_noise():
-    S0 = 100 + 2 * np.random.standard_normal((22, 23, 30))
+@set_random_number_generator()
+def test_nlmeans_random_noise(rng):
+    S0 = 100 + 2 * rng.standard_normal((22, 23, 30))
 
     masker = np.zeros(S0.shape[:3]).astype(bool)
     masker[8:15, 8:15, 8:15] = 1
@@ -31,9 +33,10 @@ def test_nlmeans_random_noise():
         assert_equal(np.round(S0nb[mask].mean()), 100)
 
 
-def test_scalar_sigma():
+@set_random_number_generator()
+def test_scalar_sigma(rng):
     S0 = 100 + np.zeros((20, 20, 20))
-    noise = 2 * np.random.standard_normal((20, 20, 20))
+    noise = 2 * rng.standard_normal((20, 20, 20))
     S0 += noise
     S0[:10, :10, :10] = 300 + noise[:10, :10, :10]
 
@@ -41,10 +44,11 @@ def test_scalar_sigma():
         ValueError, non_local_means, S0, sigma=noise, rician=False)
 
 
-def test_nlmeans_boundary():
+@set_random_number_generator()
+def test_nlmeans_boundary(rng):
     # nlmeans preserves boundaries
     S0 = 100 + np.zeros((20, 20, 20))
-    noise = 2 * np.random.standard_normal((20, 20, 20))
+    noise = 2 * rng.standard_normal((20, 20, 20))
     S0 += noise
     S0[:10, :10, :10] = 300 + noise[:10, :10, :10]
     non_local_means(S0, sigma=np.std(noise), rician=False)

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -18,7 +18,7 @@ needs_sklearn = pytest.mark.skipif(
 
 @needs_sklearn
 @set_random_number_generator(1234)
-def test_patch2self_random_noise(rng=None):
+def test_patch2self_random_noise(rng):
     S0 = 30 + 2 * rng.standard_normal((20, 20, 20, 50))
 
     bvals = np.repeat(30, 50)
@@ -60,7 +60,7 @@ def test_patch2self_random_noise(rng=None):
 
 @needs_sklearn
 @set_random_number_generator(1234)
-def test_patch2self_boundary(rng=None):
+def test_patch2self_boundary(rng):
     # patch2self preserves boundaries
     S0 = 100 + np.zeros((20, 20, 20, 20))
     noise = 2 * rng.standard_normal((20, 20, 20, 20))
@@ -74,7 +74,6 @@ def test_patch2self_boundary(rng=None):
     assert_less(S0[10, 10, 10, 10], 110)
 
 
-@set_random_number_generator(4321)
 def rfiw_phantom(gtab, snr=None, rng=None):
     """rectangle fiber immersed in water"""
     # define voxel index
@@ -140,7 +139,8 @@ def rfiw_phantom(gtab, snr=None, rng=None):
 
 
 @needs_sklearn
-def test_phantom():
+@set_random_number_generator(4321)
+def test_phantom(rng):
 
     # generate a gradient table for phantom data
     directions8 = generate_bvecs(8)
@@ -157,7 +157,7 @@ def test_phantom():
                        directions8, directions30, directions60))
     gtab = gradient_table(bvals, bvecs)
 
-    dwi, sigma = rfiw_phantom(gtab, snr=10)
+    dwi, sigma = rfiw_phantom(gtab, snr=10, rng=rng)
     dwi_den1 = p2s.patch2self(dwi, model='ridge',
                               bvals=bvals, alpha=1.0)
 

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -14,6 +14,7 @@ from dipy.reconst import dti, shm
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    TensorModel)
 from dipy.sims.voxel import multi_tensor, single_tensor
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_bdg_initial_direction():
@@ -129,7 +130,8 @@ def test_bdg_get_direction():
                                         max_attempts=0))
 
 
-def test_bdg_residual():
+@set_random_number_generator()
+def test_bdg_residual(rng):
     """This tests the bootstrapping residual.
     """
 
@@ -146,7 +148,7 @@ def test_bdg_residual():
             "ignore", message=shm.descoteaux07_legacy_msg,
             category=PendingDeprecationWarning)
         B, m, n = shm.real_sh_descoteaux(6, theta, phi)
-    shm_coeff = np.random.random(B.shape[1])
+    shm_coeff = rng.random(B.shape[1])
 
     # sphere_func is sampled of the spherical function for each point of
     # the sphere

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -22,6 +22,7 @@ from dipy.core.sphere_stats import angular_similarity
 from dipy.core.sphere import HemiSphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.shm import descoteaux07_legacy_msg, tournier07_legacy_msg
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_peak_directions_nl():
@@ -403,7 +404,8 @@ def test_difference_with_minmax():
     assert_almost_equal(values_1, values_4)
 
 
-def test_degenerate_cases():
+@set_random_number_generator()
+def test_degenerate_cases(rng):
 
     sphere = default_sphere
 
@@ -440,13 +442,13 @@ def test_degenerate_cases():
     assert_equal(values[0], 0.02)
 
     odf = np.ones(sphere.vertices.shape[0])
-    odf += 0.1 * np.random.rand(odf.shape[0])
+    odf += 0.1 * rng.random(odf.shape[0])
     directions, values, indices = peak_directions(odf, sphere, .5, 25)
     assert_(all(values > values[0] * .5))
     assert_array_equal(values, odf[indices])
 
     odf = np.ones(sphere.vertices.shape[0])
-    odf[1:] = np.finfo(float).eps * np.random.rand(odf.shape[0] - 1)
+    odf[1:] = np.finfo(float).eps * rng.random(odf.shape[0] - 1)
     directions, values, indices = peak_directions(odf, sphere, .5, 25)
 
     assert_equal(values[0], 1)
@@ -670,11 +672,12 @@ def test_peaks_shm_coeff():
     assert_array_almost_equal(pam.odf, odf2)
 
 
-def test_reshape_peaks_for_visualization():
+@set_random_number_generator()
+def test_reshape_peaks_for_visualization(rng):
 
-    data1 = np.random.randn(10, 5, 3).astype('float32')
-    data2 = np.random.randn(10, 2, 5, 3).astype('float32')
-    data3 = np.random.randn(10, 2, 12, 5, 3).astype('float32')
+    data1 = rng.standard_normal((10, 5, 3)).astype('float32')
+    data2 = rng.standard_normal((10, 2, 5, 3)).astype('float32')
+    data3 = rng.standard_normal((10, 2, 12, 5, 3)).astype('float32')
 
     data1_reshape = reshape_peaks_for_visualization(data1)
     data2_reshape = reshape_peaks_for_visualization(data2)

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -9,23 +9,25 @@ from dipy.reconst import shm
 from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
+from dipy.testing.decorators import set_random_number_generator
 
 response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
 
 
-def test_pmf_val():
+@set_random_number_generator()
+def test_pmf_val(rng):
     sphere = get_sphere('symmetric724')
     with warnings.catch_warnings():
         warnings.filterwarnings(
             'ignore', message=shm.descoteaux07_legacy_msg,
             category=PendingDeprecationWarning)
-        pmfgen = SHCoeffPmfGen(np.random.random([2, 2, 2, 28]), sphere, None)
+        pmfgen = SHCoeffPmfGen(rng.random([2, 2, 2, 28]), sphere, None)
     point = np.array([1, 1, 1], dtype='float')
 
     for idx in [0, 5, 15, -1]:
         pmf = pmfgen.get_pmf(point)
         # Create a direction vector close to the vertex idx
-        xyz = sphere.vertices[idx] + np.random.random([3]) / 100
+        xyz = sphere.vertices[idx] + rng.random([3]) / 100
         pmf_idx = pmfgen.get_pmf_value(point, xyz)
         # Test that the pmf sampled for the direction xyz is correct
         npt.assert_array_almost_equal(pmf[idx], pmf_idx)

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -8,15 +8,17 @@ import numpy.testing as npt
 from dipy.direction.peaks import PeaksAndMetrics
 from dipy.data import default_sphere
 from dipy.io.peaks import load_peaks, save_peaks, peaks_to_niftis
+from dipy.testing.decorators import set_random_number_generator
 
 
-def test_io_peaks():
+@set_random_number_generator()
+def test_io_peaks(rng):
     with TemporaryDirectory() as tmpdir:
         fname = 'test.pam5'
 
         pam = PeaksAndMetrics()
         pam.affine = np.eye(4)
-        pam.peak_dirs = np.random.rand(10, 10, 10, 5, 3)
+        pam.peak_dirs = rng.random((10, 10, 10, 5, 3))
         pam.peak_values = np.zeros((10, 10, 10, 5))
         pam.peak_indices = np.zeros((10, 10, 10, 5))
         pam.shm_coeff = np.zeros((10, 10, 10, 45))
@@ -99,7 +101,8 @@ def test_io_peaks():
         os.path.isfile(fname_gfa)
 
 
-def test_io_save_peaks_error():
+@set_random_number_generator()
+def test_io_save_peaks_error(rng):
     with TemporaryDirectory() as tmpdir:
         fname = 'test.pam5'
 
@@ -110,7 +113,7 @@ def test_io_save_peaks_error():
                           pjoin(tmpdir, fname), pam)
 
         pam.affine = np.eye(4)
-        pam.peak_dirs = np.random.rand(10, 10, 10, 5, 3)
+        pam.peak_dirs = rng.random((10, 10, 10, 5, 3))
         pam.peak_values = np.zeros((10, 10, 10, 5))
         pam.peak_indices = np.zeros((10, 10, 10, 5))
         pam.shm_coeff = np.zeros((10, 10, 10, 45))

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -2,6 +2,11 @@ import os
 import tempfile
 import pytest
 
+import nibabel as nib
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal, assert_
+import trx.trx_file_memmap as tmm
+
 from dipy.data import fetch_gold_standard_io
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import (create_nifti_header,
@@ -9,11 +14,7 @@ from dipy.io.utils import (create_nifti_header,
                            get_reference_info,
                            is_reference_info_valid,
                            read_img_arr_or_path)
-
-import nibabel as nib
-import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal, assert_
-import trx.trx_file_memmap as tmm
+from dipy.testing.decorators import set_random_number_generator
 
 filepath_dix = {}
 files, folder = fetch_gold_standard_io()
@@ -200,10 +201,11 @@ def test_all_zeros_affine():
             msg='An all zeros affine should not be valid')
 
 
-def test_read_img_arr_or_path():
-    data = np.random.rand(4, 4, 4, 3)
+@set_random_number_generator()
+def test_read_img_arr_or_path(rng):
+    data = rng.random((4, 4, 4, 3))
     aff = np.eye(4)
-    aff[:3, :] = np.random.randn(3, 4)
+    aff[:3, :] = rng.standard_normal((3, 4))
     img = nib.Nifti1Image(data, aff)
     path = tempfile.NamedTemporaryFile().name + '.nii.gz'
     nib.save(img, path)

--- a/dipy/nn/tests/test_cnn_1denoiser.py
+++ b/dipy/nn/tests/test_cnn_1denoiser.py
@@ -1,18 +1,21 @@
 import pytest
-import numpy as np
 from dipy.utils.optpkg import optional_package
+from dipy.testing.decorators import set_random_number_generator
 tf, have_tf, _ = optional_package('tensorflow')
-if have_tf:
+sklearn, have_sklearn, _ = optional_package('sklearn.model_selection')
+if have_tf and have_sklearn:
     from dipy.nn.cnn_1d_denoising import Cnn1DDenoiser
 
 
-@pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
-def test_default_Cnn1DDenoiser_sequential():
+@pytest.mark.skipif(not have_tf or not have_sklearn,
+                    reason='Requires TensorFlow and scikit-learn')
+@set_random_number_generator()
+def test_default_Cnn1DDenoiser_sequential(rng=None):
     # Create dummy data
-    normal_img = np.random.rand(10, 10, 10, 30)
-    nos_img = normal_img + np.random.normal(loc=0.0, scale=0.1,
+    normal_img = rng.random((10, 10, 10, 30))
+    nos_img = normal_img + rng.normal(loc=0.0, scale=0.1,
                                             size=normal_img.shape)
-    x = np.random.rand(10, 10, 10, 30)
+    x = rng.random((10, 10, 10, 30))
     # Test 1D denoiser
     model = Cnn1DDenoiser(30)
     model.compile(optimizer='adam', loss='mean_squared_error',
@@ -25,13 +28,15 @@ def test_default_Cnn1DDenoiser_sequential():
     assert data.shape == x.shape
 
 
-@pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')
-def test_default_Cnn1DDenoiser_flow(pytestconfig):
+@pytest.mark.skipif(not have_tf or not have_sklearn,
+                    reason='Requires TensorFlow and scikit-learn')
+@set_random_number_generator()
+def test_default_Cnn1DDenoiser_flow(pytestconfig, rng):
     # Create dummy data
-    normal_img = np.random.rand(10, 10, 10, 30)
-    nos_img = normal_img + np.random.normal(loc=0.0, scale=0.1,
+    normal_img = rng.random((10, 10, 10, 30))
+    nos_img = normal_img + rng.normal(loc=0.0, scale=0.1,
                                             size=normal_img.shape)
-    x = np.random.rand(10, 10, 10, 30)
+    x = rng.random((10, 10, 10, 30))
     # Test 1D denoiser with flow API
     model = Cnn1DDenoiser(30)
     if pytestconfig.getoption('verbose') > 0:

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -20,8 +20,9 @@ from dipy.testing.decorators import set_random_number_generator
 fdata, fbval, fbvec = dpd.get_fnames('small_64D')
 
 
-def test_coeff_of_determination():
-    model = np.random.randn(10, 10, 10, 150)
+@set_random_number_generator()
+def test_coeff_of_determination(rng):
+    model = rng.standard_normal((10, 10, 10, 150))
     data = np.copy(model)
     # If the model predicts the data perfectly, the COD is all 100s:
     cod = xval.coeff_of_determination(data, model)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -36,6 +36,7 @@ from dipy.reconst.shm import (
 from dipy.reconst.shm import lazy_index
 from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.testing.decorators import set_random_number_generator
 
 
 def get_test_data():
@@ -524,7 +525,8 @@ def test_r2_term_odf_sharp():
     assert_equal(directions.shape[0], 2)
 
 
-def test_csd_predict():
+@set_random_number_generator()
+def test_csd_predict(rng):
     """
     Test prediction API
     """
@@ -572,7 +574,7 @@ def test_csd_predict():
 
     # For "well behaved" coefficients, the model should be able to find the
     # coefficients from the predicted signal.
-    coeff = np.random.random(csd_fit.shm_coeff.shape) - .5
+    coeff = rng.random(csd_fit.shm_coeff.shape) - .5
     coeff[..., 0] = 10.
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -595,7 +597,8 @@ def test_csd_predict():
     npt.assert_array_almost_equal(predict1, predict2)
 
 
-def test_csd_predict_multi():
+@set_random_number_generator()
+def test_csd_predict_multi(rng):
     """
     Check that we can predict reasonably from multi-voxel fits:
 
@@ -610,7 +613,7 @@ def test_csd_predict_multi():
             "ignore", message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning)
         csd = ConstrainedSphericalDeconvModel(gtab, response)
-    coeff = np.random.random(45) - .5
+    coeff = rng.random(45) - .5
     coeff[..., 0] = 10.
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/dipy/reconst/tests/test_cti.py
+++ b/dipy/reconst/tests/test_cti.py
@@ -69,9 +69,10 @@ def _perpendicular_directions_temp(v, num=20, half=False):
 # compared to QTE, while Kmicro would be zero.
 
 
+rng = np.random.default_rng(1234)
 n_pts = 20
-theta = np.pi * np.random.rand(n_pts)
-phi = 2 * np.pi * np.random.rand(n_pts)
+theta = np.pi * rng.random(n_pts)
+phi = 2 * np.pi * rng.random(n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 hsph_updated, potential = disperse_charges(hsph_initial, 5000)
 

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -24,6 +24,8 @@ import dipy.core.sphere as dps
 
 from dipy.sims.voxel import single_tensor
 
+from dipy.testing.decorators import set_random_number_generator
+
 
 def test_roll_evals():
     # Just making sure this never passes through
@@ -31,9 +33,10 @@ def test_roll_evals():
     npt.assert_raises(ValueError, dti._roll_evals, weird_evals)
 
 
-def test_tensor_algebra():
+@set_random_number_generator()
+def test_tensor_algebra(rng):
     # Test that the computation of tensor determinant and norm is correct
-    test_arr = np.random.rand(10, 3, 3)
+    test_arr = rng.random((10, 3, 3))
     t_det = dti.determinant(test_arr)
     t_norm = dti.norm(test_arr)
     for i, x in enumerate(test_arr):
@@ -511,7 +514,8 @@ def test_mask():
                                     dtifit.S0_hat[0, 0, 0])
 
 
-def test_nnls_jacobian_func():
+@set_random_number_generator()
+def test_nnls_jacobian_func(rng):
     b0 = 1000.
     bval, bvecs = read_bvals_bvecs(*get_fnames('55dir_grad'))
     gtab = grad.gradient_table(bval, bvecs)
@@ -526,7 +530,7 @@ def test_nnls_jacobian_func():
     # Signals
     Y = np.exp(np.dot(X, D_orig))
     scale = 10
-    error = np.random.normal(scale=scale, size=Y.shape)
+    error = rng.normal(scale=scale, size=Y.shape)
     Y = Y + error
 
     # although sigma and gmm gradients seem correct from inspection,

--- a/dipy/reconst/tests/test_eudx_dg.py
+++ b/dipy/reconst/tests/test_eudx_dg.py
@@ -5,10 +5,11 @@ import numpy.testing as npt
 
 from dipy.direction.peaks import default_sphere, peaks_from_model
 from dipy.reconst.shm import descoteaux07_legacy_msg
+from dipy.testing.decorators import set_random_number_generator
 
 
-def test_EuDXDirectionGetter():
-
+@set_random_number_generator()
+def test_EuDXDirectionGetter(rng):
     class SillyModel:
         def fit(self, data, mask=None):
             return SillyFit(self)
@@ -20,7 +21,7 @@ def test_EuDXDirectionGetter():
 
         def odf(self, sphere):
             odf = np.zeros(sphere.theta.shape)
-            r = np.random.randint(0, len(odf))
+            r = rng.integers(0, len(odf))
             odf[r] = 1
             return odf
 
@@ -29,7 +30,7 @@ def test_EuDXDirectionGetter():
         state = dg.get_direction(point, newdir)
         return state, np.array(newdir)
 
-    data = np.random.random((3, 4, 5, 2))
+    data = rng.random((3, 4, 5, 2))
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message=descoteaux07_legacy_msg,
@@ -64,7 +65,7 @@ def test_EuDXDirectionGetter():
                 npt.assert_array_almost_equal(nd, -expected_dir)
 
                 # Check that we can get directions at non-integer points
-                point += np.random.random(3)
+                point += rng.random(3)
                 state, nd = get_direction(peaks, point, up)
                 npt.assert_equal(state, 0)
 

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -32,8 +32,7 @@ gm_response = np.array([[4.0E-4, 4.0E-4, 4.0E-4, 40.],
                         [4.0E-4, 4.0E-4, 4.0E-4, 40.]])
 
 
-@set_random_number_generator(1234)
-def get_test_data(rng=None):
+def get_test_data(rng):
     gtab = get_3shell_gtab()
     evals_list = [np.array([1.7E-3, 0.4E-3, 0.4E-3]),
                   np.array([6.0E-4, 4.0E-4, 4.0E-4]),
@@ -255,8 +254,9 @@ def test_multi_shell_fiber_response():
         npt.assert_equal(response.response.shape, (3, 7))
 
 
-def test_mask_for_response_msmt():
-    gtab, data, masks_gt, _ = get_test_data()
+@set_random_number_generator()
+def test_mask_for_response_msmt(rng):
+    gtab, data, masks_gt, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:
         wm_mask, gm_mask, csf_mask = mask_for_response_msmt(gtab, data,
@@ -282,8 +282,9 @@ def test_mask_for_response_msmt():
     npt.assert_array_almost_equal(masks_gt[2], csf_mask)
 
 
-def test_mask_for_response_msmt_nvoxels():
-    gtab, data, _, _ = get_test_data()
+@set_random_number_generator()
+def test_mask_for_response_msmt_nvoxels(rng):
+    gtab, data, _, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:
         wm_mask, gm_mask, csf_mask = mask_for_response_msmt(gtab, data,
@@ -339,8 +340,9 @@ def test_mask_for_response_msmt_nvoxels():
     npt.assert_equal(csf_nvoxels, 0)
 
 
-def test_response_from_mask_msmt():
-    gtab, data, masks_gt, responses_gt = get_test_data()
+@set_random_number_generator()
+def test_response_from_mask_msmt(rng):
+    gtab, data, masks_gt, responses_gt = get_test_data(rng)
 
     response_wm, response_gm, response_csf \
         = response_from_mask_msmt(gtab, data, masks_gt[0],
@@ -364,8 +366,9 @@ def test_response_from_mask_msmt():
     npt.assert_array_almost_equal(response_csf[0], responses_gt[2], 1)
 
 
-def test_auto_response_msmt():
-    gtab, data, _, _ = get_test_data()
+@set_random_number_generator()
+def test_auto_response_msmt(rng):
+    gtab, data, _, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:
         response_auto_wm, response_auto_gm, response_auto_csf = \

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 
 from dipy.reconst.multi_voxel import _squash, multi_voxel_fit, CallableArray
 from dipy.core.sphere import unit_icosahedron
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_squash():
@@ -99,7 +100,8 @@ def test_CallableArray():
     npt.assert_array_equal(callarray(4), expected)
 
 
-def test_multi_voxel_fit():
+@set_random_number_generator()
+def test_multi_voxel_fit(rng):
 
     class SillyModel:
 
@@ -123,7 +125,7 @@ def test_multi_voxel_fit():
 
         @property
         def directions(self):
-            n = np.random.randint(0, 10)
+            n = rng.integers(0, 10)
             return np.zeros((n, 3))
 
         def predict(self, S0):

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+
 from dipy.data import default_sphere, get_isbi2013_2shell_gtab, get_3shell_gtab
 from dipy.reconst.shore import ShoreModel, shore_matrix
 from dipy.reconst.shm import sh_to_sf, descoteaux07_legacy_msg
@@ -11,6 +12,7 @@ from dipy.sims.voxel import sticks_and_ball
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_shore_odf():
@@ -78,10 +80,11 @@ def test_shore_odf():
             npt.assert_equal(gfa(odf) < 0.1, True)
 
 
-def test_multivox_shore():
+@set_random_number_generator()
+def test_multivox_shore(rng):
     gtab = get_3shell_gtab()
 
-    data = np.random.random([20, 30, 1, gtab.gradients.shape[0]])
+    data = rng.random([20, 30, 1, gtab.gradients.shape[0]])
     radial_order = 4
     zeta = 700
     asm = ShoreModel(gtab, radial_order=radial_order,

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -127,7 +127,8 @@ def cluster_bundle(bundle, clust_thr, rng, nb_pts=20, select_randomly=500000):
         White matter tract
     clust_thr : float
         clustering threshold used in quickbundlesX
-    rng : RandomState
+    rng : np.random.Generator
+        numpy's random generator for generating random values.
     nb_pts: integer (default 20)
         Discretizing streamlines to have nb_points number of points
     select_randomly: integer (default 500000)
@@ -165,7 +166,7 @@ def bundle_shape_similarity(bundle1, bundle2, rng, clust_thr=(5, 3, 1.5),
         White matter tract from one subject (eg: AF_L)
     bundle2 : Streamlines
         White matter tract from another subject (eg: AF_L)
-    rng : RandomState
+    rng : np.random.Generator
     clust_thr : array-like, optional
         list of clustering thresholds used in quickbundlesX
     threshold : float, optional
@@ -236,8 +237,8 @@ class RecoBundles:
             Default: 15.
         nb_pts : int, optional.
             Number of points per streamline (default 20)
-        rng : RandomState
-            If None define RandomState in initialization function.
+        rng : np.random.Generator
+            If None define generator in initialization function.
             Default: None
         verbose: bool, optional.
             If True, log information.
@@ -272,7 +273,7 @@ class RecoBundles:
 
         self.start_thr = [40, 25, 20]
         if rng is None:
-            self.rng = np.random.RandomState()
+            self.rng = np.random.default_rng()
         else:
             self.rng = rng
 

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -691,8 +691,8 @@ def qbx_and_merge(streamlines, thresholds,
     select_randomly : int
         Randomly select a specific number of streamlines. If None all the
         streamlines are used.
-    rng : RandomState
-        If None then RandomState is initialized internally.
+    rng : numpy.random.Generator
+        If None then generator is initialized internally.
     verbose : bool, optional.
         If True, log information. Default False.
 
@@ -719,7 +719,7 @@ def qbx_and_merge(streamlines, thresholds,
         select_randomly = len_s
 
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
     indices = rng.choice(len_s, min(select_randomly, len_s),
                          replace=False)
     sample_streamlines = set_number_of_points(streamlines, nb_pts)

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,15 +1,17 @@
 import sys
-import numpy as np
 import pytest
 import warnings
 
+import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
+
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 from dipy.segment.bundles import RecoBundles
 from dipy.tracking.distances import bundles_distances_mam
 from dipy.tracking.streamline import Streamlines
 from dipy.segment.clustering import qbx_and_merge
+from dipy.testing.decorators import set_random_number_generator
 
 is_big_endian = 'big' in sys.byteorder.lower()
 
@@ -105,11 +107,11 @@ def test_rb_disable_slr():
 
 @pytest.mark.skipif(is_big_endian,
                     reason="Little Endian architecture required")
-def test_rb_slr_threads():
+@set_random_number_generator(42)
+def test_rb_slr_threads(rng):
 
-    rng_multi = np.random.RandomState(42)
     rb_multi = RecoBundles(f, greater_than=0, clust_thr=10,
-                           rng=np.random.RandomState(42))
+                           rng=rng)
     rec_trans_multi_threads, _ = rb_multi.recognize(model_bundle=f2,
                                                     model_clust_thr=5.,
                                                     reduction_thr=10,
@@ -117,7 +119,7 @@ def test_rb_slr_threads():
                                                     num_threads=None)
 
     rb_single = RecoBundles(f, greater_than=0, clust_thr=10,
-                            rng=np.random.RandomState(42))
+                            rng=np.random.default_rng(42))
     rec_trans_single_thread, _ = rb_single.recognize(model_bundle=f2,
                                                      model_clust_thr=5.,
                                                      reduction_thr=10,

--- a/dipy/segment/tests/test_clustering.py
+++ b/dipy/segment/tests/test_clustering.py
@@ -1,13 +1,15 @@
-import numpy as np
-import itertools
 import copy
+import itertools
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_raises, assert_equal
 
 from dipy.segment.clustering import Cluster, ClusterCentroid
 from dipy.segment.clustering import ClusterMap, ClusterMapCentroid
 from dipy.segment.clustering import Clustering
 
 from dipy.testing import assert_true, assert_false, assert_arrays_equal
-from numpy.testing import assert_array_equal, assert_raises, assert_equal
+from dipy.testing.decorators import set_random_number_generator
 
 
 features_shape = (1, 10)
@@ -60,9 +62,10 @@ def test_cluster_assign():
     assert_array_equal(cluster.indices, indices)
 
 
-def test_cluster_iter():
+@set_random_number_generator()
+def test_cluster_iter(rng):
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
 
     # Test without specifying refdata
     cluster = Cluster()
@@ -75,9 +78,10 @@ def test_cluster_iter():
     assert_arrays_equal(list(cluster), [data[i] for i in indices])
 
 
-def test_cluster_getitem():
+@set_random_number_generator()
+def test_cluster_getitem(rng):
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
 
     # Test without specifying refdata in ClusterMap
@@ -132,9 +136,10 @@ def test_cluster_getitem():
     assert_raises(TypeError, cluster.__getitem__, "wrong")
 
 
-def test_cluster_str_and_repr():
+@set_random_number_generator()
+def test_cluster_str_and_repr(rng):
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
 
     # Test without specifying refdata in ClusterMap
     cluster = Cluster()
@@ -187,9 +192,10 @@ def test_cluster_centroid_assign():
         assert_array_equal(cluster.centroid, centroid)
 
 
-def test_cluster_centroid_iter():
+@set_random_number_generator()
+def test_cluster_centroid_iter(rng):
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
 
     # Test without specifying refdata in ClusterCentroid
     centroid = np.zeros(features_shape)
@@ -205,9 +211,10 @@ def test_cluster_centroid_iter():
     assert_arrays_equal(list(cluster), [data[i] for i in indices])
 
 
-def test_cluster_centroid_getitem():
+@set_random_number_generator()
+def test_cluster_centroid_getitem(rng):
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
 
     # Test without specifying refdata in ClusterCentroid
@@ -355,15 +362,15 @@ def test_cluster_map_clear():
     assert_array_equal(list(itertools.chain(*clusters)), [])
 
 
-def test_cluster_map_iter():
-    rng = np.random.RandomState(42)
+@set_random_number_generator(42)
+def test_cluster_map_iter(rng):
     nb_clusters = 11
 
     # Test without specifying refdata in ClusterMap
     cluster_map = ClusterMap()
     clusters = []
     for i in range(nb_clusters):
-        new_cluster = Cluster(indices=rng.randint(0, len(data), size=10))
+        new_cluster = Cluster(indices=rng.integers(0, len(data), size=10))
         cluster_map.add_cluster(new_cluster)
         clusters.append(new_cluster)
 
@@ -383,10 +390,11 @@ def test_cluster_map_iter():
     assert_array_equal(cluster_map, [cluster.indices for cluster in clusters])
 
 
-def test_cluster_map_getitem():
+@set_random_number_generator()
+def test_cluster_map_getitem(rng):
     nb_clusters = 11
     indices = list(range(nb_clusters))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
 
     cluster_map = ClusterMap()
@@ -441,11 +449,11 @@ def test_cluster_map_size():
     assert_equal(cluster_map.size(), nb_clusters)
 
 
-def test_cluster_map_clusters_sizes():
-    rng = np.random.RandomState(42)
+@set_random_number_generator(42)
+def test_cluster_map_clusters_sizes(rng):
     nb_clusters = 11
     # Generate random indices
-    indices = [range(rng.randint(1, 10)) for _ in range(nb_clusters)]
+    indices = [range(rng.integers(1, 10)) for _ in range(nb_clusters)]
 
     cluster_map = ClusterMap()
     clusters = [Cluster(indices=indices[i]) for i in range(nb_clusters)]
@@ -454,18 +462,18 @@ def test_cluster_map_clusters_sizes():
     assert_equal(cluster_map.clusters_sizes(), list(map(len, indices)))
 
 
-def test_cluster_map_get_small_and_large_clusters():
-    rng = np.random.RandomState(42)
+@set_random_number_generator(42)
+def test_cluster_map_get_small_and_large_clusters(rng):
     nb_clusters = 11
     cluster_map = ClusterMap()
 
     # Randomly generate small clusters
-    indices = [rng.randint(0, 10, size=i) for i in range(1, nb_clusters+1)]
+    indices = [rng.integers(0, 10, size=i) for i in range(1, nb_clusters+1)]
     small_clusters = [Cluster(indices=indices[i]) for i in range(nb_clusters)]
     cluster_map.add_cluster(*small_clusters)
 
     # Randomly generate small clusters
-    indices = [rng.randint(0, 10, size=i)
+    indices = [rng.integers(0, 10, size=i)
                for i in range(nb_clusters+1, 2*nb_clusters+1)]
     large_clusters = [Cluster(indices=indices[i]) for i in range(nb_clusters)]
     cluster_map.add_cluster(*large_clusters)
@@ -591,18 +599,19 @@ def test_cluster_map_centroid_add_cluster():
     assert_raises(ValueError, cluster.assign, 123, features_too_long)
 
 
-def test_cluster_map_centroid_remove_cluster():
+@set_random_number_generator()
+def test_cluster_map_centroid_remove_cluster(rng):
     clusters = ClusterMapCentroid()
 
-    centroid1 = np.random.rand(*features_shape).astype(dtype)
+    centroid1 = rng.random(features_shape).astype(dtype)
     cluster1 = ClusterCentroid(centroid1, indices=[1])
     clusters.add_cluster(cluster1)
 
-    centroid2 = np.random.rand(*features_shape).astype(dtype)
+    centroid2 = rng.random(features_shape).astype(dtype)
     cluster2 = ClusterCentroid(centroid2, indices=[1, 2])
     clusters.add_cluster(cluster2)
 
-    centroid3 = np.random.rand(*features_shape).astype(dtype)
+    centroid3 = rng.random(features_shape).astype(dtype)
     cluster3 = ClusterCentroid(centroid3, indices=[1, 2, 3])
     clusters.add_cluster(cluster3)
 
@@ -628,8 +637,8 @@ def test_cluster_map_centroid_remove_cluster():
     assert_array_equal(clusters.centroids, [])
 
 
-def test_cluster_map_centroid_iter():
-    rng = np.random.RandomState(42)
+@set_random_number_generator(42)
+def test_cluster_map_centroid_iter(rng):
     nb_clusters = 11
 
     cluster_map = ClusterMapCentroid()
@@ -637,8 +646,8 @@ def test_cluster_map_centroid_iter():
     for i in range(nb_clusters):
         new_centroid = np.zeros_like(features)
         new_cluster = ClusterCentroid(new_centroid,
-                                      indices=rng.randint(0, len(data),
-                                                          size=10))
+                                      indices=rng.integers(0, len(data),
+                                                           size=10))
         cluster_map.add_cluster(new_cluster)
         clusters.append(new_cluster)
 
@@ -654,10 +663,11 @@ def test_cluster_map_centroid_iter():
         assert_arrays_equal(c1, [data[i] for i in c2.indices])
 
 
-def test_cluster_map_centroid_getitem():
+@set_random_number_generator()
+def test_cluster_map_centroid_getitem(rng):
     nb_clusters = 11
     indices = list(range(len(data)))
-    np.random.shuffle(indices)  # None trivial ordering
+    rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
 
     cluster_map = ClusterMapCentroid()

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -1,20 +1,23 @@
 import sys
+
 import numpy as np
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_raises, assert_equal,)
+
 import dipy.segment.featurespeed as dipysfeature
 import dipy.segment.metric as dipymetric
 import dipy.segment.metricspeed as dipysmetric
 from dipy.segment.featurespeed import extract
-
 from dipy.testing import assert_true, assert_false
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_equal,)
+from dipy.testing.decorators import set_random_number_generator
 
 
 dtype = "float32"
+rng = np.random.default_rng()
 s1 = np.array([np.arange(10, dtype=dtype)]*3).T  # 10x3
 s2 = np.arange(3*10, dtype=dtype).reshape((-1, 3))[::-1]  # 10x3
-s3 = np.random.rand(5, 4).astype(dtype)  # 5x4
-s4 = np.random.rand(5, 3).astype(dtype)  # 5x3
+s3 = rng.random((5, 4), dtype=dtype)  # 5x4
+s4 = rng.random((5, 3), dtype=dtype)  # 5x3
 
 
 def test_identity_feature():
@@ -222,7 +225,8 @@ def test_feature_vector_of_endpoints():
             assert_array_almost_equal(features, -features_flip)
 
 
-def test_feature_extract():
+@set_random_number_generator(1234)
+def test_feature_extract(rng):
     # Test that features are automatically cast into float32 when
     # coming from Python space
     class CenterOfMass64bit(dipysfeature.Feature):
@@ -232,12 +236,11 @@ def test_feature_extract():
         def extract(self, streamline):
             return np.mean(streamline.astype(np.float64), axis=0)
 
-    rng = np.random.RandomState(1234)
     nb_streamlines = 100
     feature_shape = (1, 3)  # One N-dimensional point
     feature = CenterOfMass64bit()
 
-    nb_points = rng.randint(20, 30, size=(nb_streamlines,)) * 3
+    nb_points = rng.integers(20, 30, size=(nb_streamlines,)) * 3
     streamlines = [np.arange(nb).reshape((-1, 3)).astype(np.float32)
                    for nb in nb_points]
     features = extract(feature, streamlines)

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -1,13 +1,15 @@
+import itertools
+
 import numpy as np
+from numpy.testing import (assert_array_equal, assert_raises,
+                           assert_almost_equal, assert_equal)
+
 import dipy.segment.featurespeed as dipysfeature
 import dipy.segment.metric as dipymetric
 import dipy.segment.metricspeed as dipysmetric
-import itertools
-
 from dipy.testing import (assert_true, assert_false,
                           assert_greater_equal, assert_less_equal)
-from numpy.testing import (assert_array_equal, assert_raises,
-                           assert_almost_equal, assert_equal)
+from dipy.testing.decorators import set_random_number_generator
 
 
 def norm(x, order=None, axis=None):
@@ -22,9 +24,9 @@ dtype = "float32"
 
 # Create wiggling streamline
 nb_points = 18
-rng = np.random.RandomState(42)
+rng = np.random.default_rng(42)
 x = np.linspace(0, 10, nb_points)
-y = rng.rand(nb_points)
+y = rng.random(nb_points)
 z = np.sin(np.linspace(0, np.pi, nb_points))  # Bending
 s = np.array([x, y, z], dtype=dtype).T
 
@@ -225,13 +227,14 @@ def test_subclassing_metric():
     assert_raises(NotImplementedError, metric.dist, None, None)
 
 
-def test_distance_matrix():
+@set_random_number_generator()
+def test_distance_matrix(rng):
     metric = dipysmetric.SumPointwiseEuclideanMetric()
 
     for dtype in [np.int32, np.int64, np.float32, np.float64]:
         # Compute distances of all tuples spawn by the Cartesian product
         # of `data` with itself.
-        data = (np.random.rand(4, 10, 3)*10).astype(dtype)
+        data = (rng.random((4, 10, 3))*10).astype(dtype)
         D = dipysmetric.distance_matrix(metric, data)
         assert_equal(D.shape, (len(data), len(data)))
         assert_array_equal(np.diag(D), np.zeros(len(data)))
@@ -247,7 +250,7 @@ def test_distance_matrix():
 
         # Compute distances of all tuples spawn by the Cartesian product
         # of `data` with `data2`.
-        data2 = (np.random.rand(3, 10, 3)*10).astype(dtype)
+        data2 = (rng.random((3, 10, 3))*10).astype(dtype)
         D = dipysmetric.distance_matrix(metric, data, data2)
         assert_equal(D.shape, (len(data), len(data2)))
 
@@ -257,12 +260,13 @@ def test_distance_matrix():
                                                        data2[j]))
 
 
-def test_mean_distances():
+@set_random_number_generator()
+def test_mean_distances(rng):
     nb_slines = 10
     nb_pts = 22
     dim = 3
-    a = np.random.rand(nb_slines, nb_pts, dim)
-    b = np.random.rand(nb_slines, nb_pts, dim)
+    a = rng.random((nb_slines, nb_pts, dim))
+    b = rng.random((nb_slines, nb_pts, dim))
     diff = a - b
 
     # Test Euclidean distance (L2)

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -8,34 +8,32 @@ from dipy.segment.tissue import (TissueClassifierHMRF)
 from dipy.testing.decorators import set_random_number_generator
 
 
-# Load a coronal slice from a T1-weighted MRI
-fname = get_fnames('t1_coronal_slice')
-single_slice = np.load(fname)
+def create_image():
+    # Load a coronal slice from a T1-weighted MRI
+    fname = get_fnames('t1_coronal_slice')
+    single_slice = np.load(fname)
 
-# Stack a few copies to form a 3D volume
-nslices = 5
-image = np.zeros(shape=single_slice.shape + (nslices,))
-image[..., :nslices] = single_slice[..., None]
+    # Stack a few copies to form a 3D volume
+    nslices = 5
+    image = np.zeros(shape=single_slice.shape + (nslices,))
+    image[..., :nslices] = single_slice[..., None]
+    return image
 
-# Set up parameters
-nclasses = 4
-beta = np.float64(0.0)
-max_iter = 10
-background_noise = True
 
 # Making squares
-square = np.zeros((256, 256, 3), dtype=np.int16)
-square[42:213, 42:213, :] = 1
-square[71:185, 71:185, :] = 2
-square[99:157, 99:157, :] = 3
+def create_square():
+    square = np.zeros((256, 256, 3), dtype=np.int16)
+    square[42:213, 42:213, :] = 1
+    square[71:185, 71:185, :] = 2
+    square[99:157, 99:157, :] = 3
+
+    return square
 
 
-@set_random_number_generator(1234)
-def create_square_uniform(rng=None):
+def create_square_uniform(rng):
     square_1 = np.zeros((256, 256, 3)) + 0.001
     square_1 = add_noise(square_1, 10000, 1,
                          noise_type='gaussian', rng=rng)
-    rng = np.random.default_rng(1234)
     temp_1 = rng.integers(1, 21, size=(171, 171, 3))
     temp_1 = np.where(temp_1 < 20, 1, 3)
     square_1[42:213, 42:213, :] = temp_1
@@ -49,13 +47,11 @@ def create_square_uniform(rng=None):
     return square_1
 
 
-@set_random_number_generator(1234)
-def create_square_gauss(rng=None):
+def create_square_gauss(rng):
     square_gauss = np.zeros((256, 256, 3)) + 0.001
     square_gauss = add_noise(square_gauss, 10000, 1,
                              noise_type='gaussian', rng=rng)
     square_gauss[42:213, 42:213, :] = 1
-    rng = np.random.default_rng(1234)
     noise_1 = rng.normal(1.001, 0.0001,
                          size=square_gauss[42:213, 42:213, :].shape)
     square_gauss[42:213, 42:213, :] = square_gauss[42:213, 42:213, :] + noise_1
@@ -73,6 +69,10 @@ def create_square_gauss(rng=None):
 
 def test_grayscale_image():
 
+    nclasses = 4
+    beta = np.float64(0.0)
+
+    image = create_image()
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
@@ -139,9 +139,12 @@ def test_grayscale_image():
 
 def test_grayscale_iter():
 
-    max_iter = 15
+    nclasses = 4
     beta = np.float64(0.1)
+    max_iter = 15
+    background_noise = True
 
+    image = create_image()
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
@@ -240,13 +243,18 @@ def test_grayscale_iter():
     npt.assert_(np.abs(np.sum(difference_map)) != 0)
 
 
-def test_square_iter():
+@set_random_number_generator()
+def test_square_iter(rng):
+
+    nclasses = 4
+    beta = np.float64(0.0)
+    max_iter = 10
 
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
-    initial_segmentation = square
-    square_gauss = create_square_gauss()
+    initial_segmentation = create_square()
+    square_gauss = create_square_gauss(rng)
 
     mu, sigmasq = com.seg_stats(square_gauss, initial_segmentation,
                                 nclasses)
@@ -333,13 +341,17 @@ def test_square_iter():
     npt.assert_(np.abs(np.sum(difference_map)) == 0.0)
 
 
-def test_icm_square():
+@set_random_number_generator()
+def test_icm_square(rng):
+
+    nclasses = 4
+    max_iter = 10
 
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
 
-    initial_segmentation = square
-    square_1 = create_square_uniform()
+    initial_segmentation = create_square()
+    square_1 = create_square_uniform(rng)
 
     mu, sigma = com.seg_stats(square_1, initial_segmentation,
                               nclasses)
@@ -371,7 +383,7 @@ def test_icm_square():
         initial_segmentation = final_segmentation_1
 
     beta = 2
-    initial_segmentation = square
+    initial_segmentation = create_square()
 
     for j in range(max_iter):
 
@@ -391,9 +403,12 @@ def test_classify():
 
     imgseg = TissueClassifierHMRF()
 
+    nclasses = 4
     beta = 0.1
     tolerance = 0.0001
     max_iter = 10
+
+    image = create_image()
 
     npt.assert_(image.max() == 1.0)
     npt.assert_(image.min() == 0.0)

--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -1,4 +1,5 @@
 import itertools
+
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
@@ -9,18 +10,21 @@ from dipy.segment.metricspeed import (
 )
 from dipy.tracking.streamline import set_number_of_points
 from dipy.tracking.streamline import Streamlines
+from dipy.testing.decorators import set_random_number_generator
 
 
 def straight_bundle(nb_streamlines=1, nb_pts=30, step_size=1,
-                    radius=1, rng=np.random.RandomState(42)):
+                    radius=1, rng=None):
+    if rng is None:
+        rng = np.random.default_rng(42)
     bundle = []
 
     bundle_length = step_size * nb_pts
 
     Z = -np.linspace(0, bundle_length, nb_pts)
     for k in range(nb_streamlines):
-        theta = rng.rand() * (2*np.pi)
-        r = radius * rng.rand()
+        theta = rng.random() * (2*np.pi)
+        r = radius * rng.random()
 
         Xk = np.ones(nb_pts) * (r * np.cos(theta))
         Yk = np.ones(nb_pts) * (r * np.sin(theta))
@@ -214,18 +218,18 @@ def test_raise_mdf():
     assert_raises(ValueError, QuickBundles, thresholds[1], metric=metric)
 
 
-def test_qbx_and_merge():
+@set_random_number_generator(42)
+def test_qbx_and_merge(rng):
 
     # Generate synthetic streamlines
     bundles = bearing_bundles(4, 2)
-    bundles.append(straight_bundle(1))
+    bundles.append(straight_bundle(1, rng=rng))
 
 
     streamlines = Streamlines(list(itertools.chain(*bundles)))
 
     thresholds = [10, 2, 1]
 
-    rng = np.random.RandomState(seed=42)
     qbxm = qbx_and_merge(streamlines, thresholds, rng=rng)
 
     qbxm_centroids = qbxm.centroids

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -64,9 +64,9 @@ def test_quickbundles_shape_incompatibility():
                         list(itertools.chain(*clusters2)))
 
 
-def test_quickbundles_2D():
+@set_random_number_generator(7)
+def test_quickbundles_2D(rng):
     # Test quickbundles clustering using 2D points and the Eulidean metric.
-    rng = np.random.default_rng(7)
     data = []
     data += \
         [rng.standard_normal((1, 2)) + np.array([0, 0]) for _ in range(1)]

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -7,6 +7,7 @@ Decorators for dipy tests
 import re
 import os
 import platform
+import inspect
 import numpy as np
 
 SKIP_RE = re.compile("(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")
@@ -82,10 +83,14 @@ def set_random_number_generator(seed_v=1234):
 
     """
     def _set_random_number_generator(func):
-        def _set_random_number_generator_wrapper(*args, **kwargs):
+        def _set_random_number_generator_wrapper(pytestconfig, *args, **kwargs):
             rng = np.random.default_rng(seed_v)
             kwargs['rng'] = rng
-            output = func(*args, **kwargs)
+            signature = inspect.signature(func)
+            if pytestconfig and 'pytestconfig' in signature.parameters.keys():
+                output = func(pytestconfig, *args, **kwargs)
+            else:
+                output = func(*args, **kwargs)
             return output
         return _set_random_number_generator_wrapper
     return _set_random_number_generator

--- a/dipy/tracking/mesh.py
+++ b/dipy/tracking/mesh.py
@@ -18,7 +18,7 @@ def random_coordinates_from_surface(nb_triangles, nb_seed, triangles_mask=None,
         Specifies which triangles should be chosen (or not)
     triangles_weight : [n] numpy array
         Specifies the weight/probability of choosing each triangle
-    random_seed : int
+    rand_gen : int
         The seed for the random seed generator (numpy.random.seed).
 
     Returns
@@ -44,15 +44,15 @@ def random_coordinates_from_surface(nb_triangles, nb_seed, triangles_mask=None,
         triangles_weight /= triangles_weight.sum()
 
     # Set the random seed generator
-    np.random.seed(rand_gen)
+    rng = np.random.default_rng(rand_gen)
 
     # Choose random triangles
     triangles_idx = \
-        np.random.choice(nb_triangles, size=nb_seed, p=triangles_weight)
+        rng.choice(nb_triangles, size=nb_seed, p=triangles_weight)
 
     # Choose random trilinear coordinates
     # https://mathworld.wolfram.com/TrianglePointPicking.html
-    trilin_coord = np.random.rand(nb_seed, 3)
+    trilin_coord = rng.random((nb_seed, 3))
     is_upper = (trilin_coord[:, 1:].sum(axis=-1) > 1.0)
     trilin_coord[is_upper] = 1.0 - trilin_coord[is_upper]
     trilin_coord[:, 0] = 1.0 - (trilin_coord[:, 1] + trilin_coord[:, 2])

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -277,18 +277,19 @@ cdef class CmcStoppingCriterion(AnatomicalStoppingCriterion):
             raise RuntimeError("Unexpected interpolation error " +
                                "(exclude_map - code:%i)" % exclude_err)
 
+        rng = np.random.default_rng()
         # test if the tracking continues
         if include_result + exclude_result <= 0:
             return TRACKPOINT
         num = max(0, (1 - include_result - exclude_result))
         den = num + include_result + exclude_result
         p = (num / den) ** self.correction_factor
-        if np.random.random() < p:
+        if rng.random() < p:
             return TRACKPOINT
 
         # test if the tracking stopped in the include tissue map
         p = (include_result / (include_result + exclude_result))
-        if np.random.random() < p:
+        if rng.random() < p:
             return ENDPOINT
 
         # the tracking stopped in the exclude tissue map

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -1,16 +1,20 @@
 import warnings
+
 import numpy as np
-from dipy.testing import assert_true
 from numpy.testing import (assert_array_almost_equal,
                            assert_equal, assert_almost_equal,
                            assert_array_equal)
+
+from dipy.testing import assert_true
+from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking import distances as pf
 from dipy.tracking.streamline import set_number_of_points
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 
 
-def test_LSCv2(verbose=False):
+@set_random_number_generator()
+def test_LSCv2(verbose=False, rng=None):
     xyz1 = np.array([[1, 0, 0], [2, 0, 0], [3, 0, 0]], dtype='float32')
     xyz2 = np.array([[1, 0, 0], [1, 2, 0], [1, 3, 0]], dtype='float32')
     xyz3 = np.array([[1.1, 0, 0], [1, 2, 0], [1, 3, 0]], dtype='float32')
@@ -25,7 +29,7 @@ def test_LSCv2(verbose=False):
     pf.local_skeleton_clustering_3pts(T, 0.2)
 
     for i in range(40):
-        xyz = np.random.rand(3, 3).astype('f4')
+        xyz = rng.random((3, 3), dtype='f4')
         T.append(xyz)
 
     from time import time
@@ -48,7 +52,7 @@ def test_LSCv2(verbose=False):
 
     T2 = []
     for i in range(10**4):
-        xyz = np.random.rand(10, 3).astype('f4')
+        xyz = rng.random((10, 3), dtype='f4')
         T2.append(xyz)
     t1 = time()
     C5 = pf.local_skeleton_clustering(T2, .5)

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_equal, assert_array_almost_equal
 from dipy.tracking import metrics as tm
 from dipy.tracking import distances as pf
 from dipy.utils.deprecator import ExpiredDeprecationError
+from dipy.testing.decorators import set_random_number_generator
 
 
 def test_downsample_deprecated():
@@ -13,16 +14,17 @@ def test_downsample_deprecated():
     npt.assert_raises(ExpiredDeprecationError, tm.downsample, streamline, 12)
 
 
-def test_splines():
+@set_random_number_generator()
+def test_splines(rng):
     # create a helix
     t = np.linspace(0, 1.75*2*np.pi, 100)
     x = np.sin(t)
     y = np.cos(t)
     z = t
     # add noise
-    x += np.random.normal(scale=0.1, size=x.shape)
-    y += np.random.normal(scale=0.1, size=y.shape)
-    z += np.random.normal(scale=0.1, size=z.shape)
+    x += rng.normal(scale=0.1, size=x.shape)
+    y += rng.normal(scale=0.1, size=y.shape)
+    z += rng.normal(scale=0.1, size=z.shape)
     xyz = np.vstack((x, y, z)).T
     # get the B-splines smoothed result
     tm.spline(xyz, 3, 2, -1)

--- a/dipy/tracking/tests/test_stopping_criterion.py
+++ b/dipy/tracking/tests/test_stopping_criterion.py
@@ -8,14 +8,16 @@ from dipy.tracking.stopping_criterion import (ActStoppingCriterion,
                                               CmcStoppingCriterion,
                                               ThresholdStoppingCriterion,
                                               StreamlineStatus)
+from dipy.testing.decorators import set_random_number_generator
 
 
-def test_binary_stopping_criterion():
+@set_random_number_generator()
+def test_binary_stopping_criterion(rng):
     """This tests that the binary stopping criterion returns expected
     streamline statuses.
     """
 
-    mask = np.random.random((4, 4, 4))
+    mask = rng.random((4, 4, 4))
     mask[mask < 0.4] = 0.0
 
     btc_boolean = BinaryStoppingCriterion(mask > 0)
@@ -36,7 +38,7 @@ def test_binary_stopping_criterion():
     # Test random points in voxel
     for ind in ndindex(mask.shape):
         for _ in range(50):
-            pts = np.array(ind, dtype='float64') + np.random.random(3) - 0.5
+            pts = np.array(ind, dtype='float64') + rng.random(3) - 0.5
             state_boolean = btc_boolean.check_point(pts)
             state_float64 = btc_float64.check_point(pts)
             if mask[ind] > 0:
@@ -59,12 +61,13 @@ def test_binary_stopping_criterion():
         npt.assert_equal(state_float64, int(StreamlineStatus.OUTSIDEIMAGE))
 
 
-def test_threshold_stopping_criterion():
+@set_random_number_generator()
+def test_threshold_stopping_criterion(rng):
     """This tests that the threshold stopping criterion returns expected
     streamline statuses.
     """
 
-    tissue_map = np.random.random((4, 4, 4))
+    tissue_map = rng.random((4, 4, 4))
 
     ttc = ThresholdStoppingCriterion(tissue_map.astype('float32'), 0.5)
 
@@ -100,14 +103,15 @@ def test_threshold_stopping_criterion():
         npt.assert_equal(state, int(StreamlineStatus.OUTSIDEIMAGE))
 
 
-def test_act_stopping_criterion():
+@set_random_number_generator()
+def test_act_stopping_criterion(rng):
     """This tests that the act stopping criterion returns expected
     streamline statuses.
     """
 
-    gm = np.random.random((4, 4, 4))
-    wm = np.random.random((4, 4, 4))
-    csf = np.random.random((4, 4, 4))
+    gm = rng.random((4, 4, 4))
+    wm = rng.random((4, 4, 4))
+    csf = rng.random((4, 4, 4))
     tissue_sum = gm + wm + csf
     gm /= tissue_sum
     wm /= tissue_sum

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -959,7 +959,8 @@ def test_affine_transformations():
         npt.assert_(np.allclose(streamlines_inv[1], expected[1], atol=0.3))
 
 
-def test_random_seed_initialization():
+@set_random_number_generator()
+def test_random_seed_initialization(rng):
     """Test that the random generator can be initialized correctly with the
     tracking seeds.
     """
@@ -970,13 +971,13 @@ def test_random_seed_initialization():
     z = np.array([1., 1, 1, 51.67881720942744])
 
     seeds = np.row_stack([np.column_stack([x, y, z]),
-                          np.random.random((10, 3))])
+                          rng.random((10, 3))])
     sc = BinaryStoppingCriterion(np.ones((4, 4, 4)))
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
 
     randoms_seeds = [None, 0, 1, -1, np.iinfo(np.uint32).max + 1] \
-        + list(np.random.random(10)) \
-        + list(np.random.randint(0, np.iinfo(np.int32).max, 10))
+        + list(rng.random(10)) \
+        + list(rng.integers(0, np.iinfo(np.int32).max, 10))
 
     for rdm_seed in randoms_seeds:
         _ = Streamlines(LocalTracking(direction_getter=dg,

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -17,6 +17,7 @@ from dipy.tracking._utils import _to_voxel_coordinates
 from dipy.tracking.vox2track import streamline_mapping
 import numpy.testing as npt
 from dipy.testing import assert_true
+from dipy.testing.decorators import set_random_number_generator
 
 
 def make_streamlines(return_seeds=False):
@@ -464,7 +465,8 @@ def test_streamline_mapping():
     npt.assert_equal(mapping, expected)
 
 
-def test_length():
+@set_random_number_generator()
+def test_length(rng):
     # Generate a simulated bundle of fibers:
     n_streamlines = 50
     n_pts = 100
@@ -475,8 +477,8 @@ def test_length():
         pts = np.vstack((np.cos(2 * t / np.pi), np.zeros(t.shape) + i, t)).T
         bundle.append(pts)
 
-    start = np.random.randint(10, 30, n_streamlines)
-    end = np.random.randint(60, 100, n_streamlines)
+    start = rng.integers(10, 30, n_streamlines)
+    end = rng.integers(60, 100, n_streamlines)
 
     bundle = [10 * streamline[start[i]:end[i]] for (i, streamline) in
               enumerate(bundle)]
@@ -486,8 +488,9 @@ def test_length():
         npt.assert_equal(this_length, metrics.length(bundle[idx]))
 
 
-def test_seeds_from_mask():
-    mask = np.random.randint(0, 1, size=(10, 10, 10))
+@set_random_number_generator()
+def test_seeds_from_mask(rng):
+    mask = rng.integers(0, 1, size=(10, 10, 10))
     seeds = seeds_from_mask(mask, np.eye(4), density=1)
     npt.assert_equal(mask.sum(), len(seeds))
     npt.assert_array_equal(np.argwhere(mask), seeds)
@@ -508,8 +511,9 @@ def test_seeds_from_mask():
     npt.assert_equal(in_444.sum(), 3 * 4 * 5)
 
 
-def test_random_seeds_from_mask():
-    mask = np.random.randint(0, 1, size=(4, 6, 3))
+@set_random_number_generator()
+def test_random_seeds_from_mask(rng):
+    mask = rng.integers(0, 1, size=(4, 6, 3))
     seeds = random_seeds_from_mask(mask, np.eye(4),
                                    seeds_count=24,
                                    seed_count_per_voxel=True)
@@ -624,7 +628,8 @@ def test_reduce_rois():
     npt.assert_warns(UserWarning, reduce_rois, [roi2], [True])
 
 
-def test_path_length():
+@set_random_number_generator()
+def test_path_length(rng):
     aoi = np.zeros((20, 20, 20), dtype=bool)
     aoi[0, 0, 0] = 1
 
@@ -660,7 +665,7 @@ def test_path_length():
     aoi[0, 0, 0] = 1
     streamlines = []
     for i in range(1000):
-        rando = np.random.random(size=(100, 3)) * 19 + .5
+        rando = rng.random(size=(100, 3)) * 19 + .5
         assert (rando > .5).all()
         assert (rando < 19.5).all()
         streamlines.append(rando)

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -469,7 +469,7 @@ def random_seeds_from_mask(mask, affine, seeds_count=1,
         If True, seeds_count is per voxel, else seeds_count is the total number
         of seeds.
     random_seed : int
-        The seed for the random seed generator (numpy.random.seed).
+        The seed for the random seed generator (numpy.random.Generator).
 
     See Also
     --------
@@ -486,22 +486,22 @@ def random_seeds_from_mask(mask, affine, seeds_count=1,
     >>> mask[0,0,0] = 1
     >>> random_seeds_from_mask(mask, np.eye(4), seeds_count=1,
     ... seed_count_per_voxel=True, random_seed=1)
-    array([[-0.0640051 , -0.47407377,  0.04966248]])
+    array([[-0.23838787, -0.20150886,  0.31422574]])
     >>> random_seeds_from_mask(mask, np.eye(4), seeds_count=6,
     ... seed_count_per_voxel=True, random_seed=1)
-    array([[-0.0640051 , -0.47407377,  0.04966248],
-           [ 0.0507979 ,  0.20814782, -0.20909526],
-           [ 0.46702984,  0.04723225,  0.47268436],
-           [-0.27800683,  0.37073231, -0.29328084],
-           [ 0.39286015, -0.16802019,  0.32122912],
-           [-0.42369171,  0.27991879, -0.06159077]])
+    array([[-0.23838787, -0.20150886,  0.31422574],
+           [-0.41435083, -0.26318949,  0.30127447],
+           [ 0.44305611,  0.01132755,  0.47624371],
+           [ 0.30500292,  0.30794079,  0.01532556],
+           [ 0.03816435, -0.15672913, -0.13093276],
+           [ 0.12509547,  0.3972138 ,  0.27568569]])
     >>> mask[0,1,2] = 1
     >>> random_seeds_from_mask(mask, np.eye(4),
     ... seeds_count=2, seed_count_per_voxel=True, random_seed=1)
-    array([[-0.0640051 , -0.47407377,  0.04966248],
-           [-0.27800683,  1.37073231,  1.70671916],
-           [ 0.0507979 ,  0.20814782, -0.20909526],
-           [-0.48962585,  1.00187459,  1.99577329]])
+    array([[ 0.30500292,  1.30794079,  2.01532556],
+           [-0.23838787, -0.20150886,  0.31422574],
+           [ 0.3702492 ,  0.78681721,  2.10314815],
+           [-0.41435083, -0.26318949,  0.30127447]])
 
     """
     mask = np.array(mask, dtype=bool, copy=False, ndmin=3)
@@ -509,11 +509,11 @@ def random_seeds_from_mask(mask, affine, seeds_count=1,
         raise ValueError('mask cannot be more than 3d')
 
     # Randomize the voxels
-    np.random.seed(random_seed)
+    rng = np.random.default_rng(random_seed)
     shape = mask.shape
     mask = mask.flatten()
     indices = np.arange(len(mask))
-    np.random.shuffle(indices)
+    rng.shuffle(indices)
 
     where = [np.unravel_index(i, shape) for i in indices if mask[i] == 1]
     num_voxels = len(where)
@@ -532,9 +532,9 @@ def random_seeds_from_mask(mask, affine, seeds_count=1,
             if random_seed is not None:
                 s_random_seed = hash((np.sum(s) + 1) * i + random_seed) \
                     % (2**32 - 1)
-                np.random.seed(s_random_seed)
+                rng = np.random.default_rng(s_random_seed)
             # Generate random triplet
-            grid = np.random.random(3)
+            grid = rng.random(3)
             seed = s + grid - .5
             seeds.append(seed)
     seeds = np.asarray(seeds)

--- a/dipy/utils/tests/test_arrfuncs.py
+++ b/dipy/utils/tests/test_arrfuncs.py
@@ -9,6 +9,7 @@ from dipy.utils.arrfuncs import as_native_array, pinv
 from numpy.testing import (assert_array_almost_equal, assert_equal,
                            assert_array_equal)
 from dipy.testing import assert_true, assert_false
+from dipy.testing.decorators import set_random_number_generator
 
 NATIVE_ORDER = '<' if sys.byteorder == 'little' else '>'
 SWAPPED_ORDER = '>' if sys.byteorder == 'little' else '<'
@@ -28,8 +29,9 @@ def test_as_native():
     assert_equal(narr.dtype.byteorder, NATIVE_ORDER)
 
 
-def test_pinv():
-    arr = np.random.randn(4, 4, 4, 3, 7)
+@set_random_number_generator()
+def test_pinv(rng):
+    arr = rng.standard_normal((4, 4, 4, 3, 7))
     _pinv = pinv(arr)
     for i in range(4):
         for j in range(4):

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -23,14 +23,15 @@ skip_it = use_xvfb == 'skip'
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
-def test_horizon_events():
+@set_random_number_generator()
+def test_horizon_events(rng):
     # using here MNI template affine 2009a
     affine = np.array([[1., 0., 0., -98.],
                        [0., 1., 0., -134.],
                        [0., 0., 1., -72.],
                        [0., 0., 0., 1.]])
 
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
     vox_size = (1., 1., 1.)
 
     images = [(data, affine)]
@@ -60,8 +61,8 @@ def test_horizon_events():
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
-def test_horizon():
-
+@set_random_number_generator()
+def test_horizon(rng):
     s1 = 10 * np.array([[0, 0, 0],
                         [1, 0, 0],
                         [2, 0, 0],
@@ -90,7 +91,7 @@ def test_horizon():
                        [0., 0., 1., -72.],
                        [0., 0., 0., 1.]])
 
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
     vox_size = (1., 1., 1.)
 
     streamlines._data += np.array([-98., -134., -72.])

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -3,7 +3,7 @@ import warnings
 import pytest
 import numpy as np
 import numpy.testing as npt
-from dipy.testing.decorators import use_xvfb
+from dipy.testing.decorators import use_xvfb, set_random_number_generator
 from dipy.utils.optpkg import optional_package
 from dipy.data import get_sphere
 from dipy.align.reslice import reslice
@@ -30,9 +30,10 @@ skip_it = use_xvfb == 'skip'
 
 @pytest.mark.skipif(skip_it or not has_fury,
                     reason="Needs xvfb")
-def test_slicer():
+@set_random_number_generator()
+def test_slicer(rng):
     scene = window.Scene()
-    data = (255 * np.random.rand(50, 50, 50))
+    data = (255 * rng.random((50, 50, 50)))
     affine = np.diag([1, 3, 2, 1])
     data2, affine2 = reslice(data, affine, zooms=(1, 3, 2),
                              new_zooms=(1, 1, 1))
@@ -113,7 +114,8 @@ def test_contour_from_roi():
 
 @pytest.mark.skipif(skip_it or not has_fury,
                     reason="Needs xvfb")
-def test_bundle_maps():
+@set_random_number_generator()
+def test_bundle_maps(rng):
     scene = window.Scene()
     bundle = fornix_streamlines()
     bundle, _ = center_streamlines(bundle)
@@ -149,7 +151,7 @@ def test_bundle_maps():
     scene.clear()
 
     nb_points = np.sum([len(b) for b in bundle])
-    values = 100 * np.random.rand(nb_points)
+    values = 100 * rng.random((nb_points))
     # values[:nb_points/2] = 0
 
     line = actor.streamtube(bundle, values, linewidth=0.1, lookup_colormap=lut)
@@ -161,7 +163,7 @@ def test_bundle_maps():
 
     scene.clear()
 
-    colors = np.random.rand(nb_points, 3)
+    colors = rng.random((nb_points, 3))
     # values[:nb_points/2] = 0
 
     line = actor.line(bundle, colors, linewidth=2)
@@ -181,7 +183,7 @@ def test_bundle_maps():
     actor.line(bundle, (1., 0.5, 0))
     actor.line(bundle, np.arange(len(bundle)))
     actor.line(bundle)
-    colors = [np.random.rand(*b.shape) for b in bundle]
+    colors = [rng.random(b.shape) for b in bundle]
     actor.line(bundle, colors=colors)
 
 

--- a/dipy/viz/tests/test_regtools.py
+++ b/dipy/viz/tests/test_regtools.py
@@ -4,6 +4,7 @@ import numpy.testing as npt
 import pytest
 from dipy.align.metrics import SSDMetric
 from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
+from dipy.testing.decorators import set_random_number_generator
 
 # Conditional import machinery for matplotlib
 from dipy.utils.optpkg import optional_package
@@ -12,12 +13,13 @@ _, have_matplotlib, _ = optional_package('matplotlib')
 
 
 @pytest.mark.skipif(not have_matplotlib, reason='Requires Matplotlib')
-def test_plot_2d_diffeomorphic_map():
+@set_random_number_generator()
+def test_plot_2d_diffeomorphic_map(rng):
     # Test the regtools plotting interface (lightly).
     mv_shape = (11, 12)
-    moving = np.random.rand(*mv_shape)
+    moving = rng.random(mv_shape)
     st_shape = (13, 14)
-    static = np.random.rand(*st_shape)
+    static = rng.random(st_shape)
     dim = static.ndim
     metric = SSDMetric(dim)
     level_iters = [200, 100, 50, 25]

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -553,7 +553,7 @@ class BundleShapeAnalysis(Workflow):
         populations. Sci Rep 10, 17149 (2020)
 
         """
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
         all_subjects = []
         if os.path.isdir(subject_folder):
             groups = os.listdir(subject_folder)

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -19,6 +19,7 @@ from dipy.workflows.align import (ImageRegistrationFlow, SynRegistrationFlow,
                                   ApplyTransformFlow, ResliceFlow,
                                   SlrWithQbxFlow, MotionCorrectionFlow,
                                   BundleWarpFlow)
+from dipy.testing.decorators import set_random_number_generator
 
 _, have_pd, _ = optional_package("pandas")
 
@@ -70,12 +71,13 @@ def test_slr_flow():
         npt.assert_equal(os.path.isfile(out_path), True)
 
 
-def test_image_registration():
+@set_random_number_generator(1234)
+def test_image_registration(rng):
     with TemporaryDirectory() as temp_out_dir:
 
         static, moving, static_g2w, moving_g2w, smask, mmask, M\
             = setup_random_transform(transform=regtransforms[('AFFINE', 3)],
-                                     rfactor=0.1)
+                                     rfactor=0.1, rng=rng)
 
         save_nifti(pjoin(temp_out_dir, 'b0.nii.gz'), data=static,
                    affine=static_g2w)
@@ -122,7 +124,7 @@ def test_image_registration():
                                         out_quality='trans_q.txt')
 
             dist = read_distance('trans_q.txt')
-            npt.assert_almost_equal(float(dist), -0.3953547764454917, 1)
+            npt.assert_almost_equal(float(dist), -0.42097809101318934, 1)
             check_existence(out_moved, out_affine)
 
         def test_rigid():

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -11,6 +11,7 @@ from dipy.io.image import save_nifti, load_nifti, load_nifti_data
 
 from dipy.testing import (assert_true, assert_false, assert_greater,
                           assert_less)
+from dipy.testing.decorators import set_random_number_generator
 from dipy.workflows.denoise import (NLMeansFlow, LPCAFlow, MPPCAFlow,
                                     GibbsRingingFlow, Patch2SelfFlow)
 
@@ -60,9 +61,10 @@ def test_lpca_flow():
             lpca_flow.last_generated_outputs['out_denoised']))
 
 
-def test_mppca_flow():
+@set_random_number_generator()
+def test_mppca_flow(rng):
     with TemporaryDirectory() as out_dir:
-        S0 = 100 + 2 * np.random.standard_normal((22, 23, 30, 20))
+        S0 = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
         data_path = os.path.join(out_dir, "random_noise.nii.gz")
         save_nifti(data_path, S0, np.eye(4))
 

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -4,15 +4,16 @@ import os
 from os.path import join
 from tempfile import TemporaryDirectory
 
+import numpy as np
 import numpy.testing as npt
 import pytest
-import numpy as np
 
 from dipy.data import get_fnames
 from dipy.io.image import save_nifti, load_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.testing import assert_true
+from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
 from dipy.workflows.stats import SNRinCCFlow
@@ -76,7 +77,8 @@ def test_stats():
 @pytest.mark.skipif(not have_pandas or not have_statsmodels or not have_tables
                     or not have_matplotlib,
                     reason='Requires Pandas, StatsModels and PyTables')
-def test_buan_bundle_profiles():
+@set_random_number_generator()
+def test_buan_bundle_profiles(rng):
 
     with TemporaryDirectory() as dirpath:
         data_path = get_fnames('fornix')
@@ -110,7 +112,7 @@ def test_buan_bundle_profiles():
         dt = os.path.join(dirpath, "anatomical_measures")
         os.mkdir(dt)
 
-        fa = np.random.rand(255, 255, 255)
+        fa = rng.random((255, 255, 255))
 
         save_nifti(os.path.join(dt, "fa.nii.gz"),
                    fa, affine=np.eye(4))
@@ -128,7 +130,8 @@ def test_buan_bundle_profiles():
                     or not have_matplotlib,
                     reason='Requires Pandas, StatsModels, PyTables, and '
                            'matplotlib')
-def test_bundle_analysis_tractometry_flow():
+@set_random_number_generator()
+def test_bundle_analysis_tractometry_flow(rng):
 
     with TemporaryDirectory() as dirpath:
         data_path = get_fnames('fornix')
@@ -171,7 +174,7 @@ def test_bundle_analysis_tractometry_flow():
                             bbox_valid_check=False)
             os.mkdir(os.path.join(pre, "anatomical_measures"))
 
-            fa = np.random.rand(255, 255, 255)
+            fa = rng.random((255, 255, 255))
 
             save_nifti(os.path.join(pre, "anatomical_measures", "fa.nii.gz"),
                        fa, affine=np.eye(4))
@@ -264,7 +267,8 @@ def test_linear_mixed_models_flow():
                     or not have_matplotlib,
                     reason='Requires Pandas, StatsModels, PyTables, and '
                            'matplotlib')
-def test_bundle_shape_analysis_flow():
+@set_random_number_generator()
+def test_bundle_shape_analysis_flow(rng):
 
     with TemporaryDirectory() as dirpath:
         data_path = get_fnames('fornix')
@@ -307,7 +311,7 @@ def test_bundle_shape_analysis_flow():
                             bbox_valid_check=False)
             os.mkdir(os.path.join(pre, "anatomical_measures"))
 
-            fa = np.random.rand(255, 255, 255)
+            fa = rng.random((255, 255, 255))
 
             save_nifti(os.path.join(pre, "anatomical_measures", "fa.nii.gz"),
                        fa, affine=np.eye(4))

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -12,6 +12,7 @@ from dipy.io.utils import create_nifti_header
 from dipy.tracking.streamline import Streamlines
 from dipy.testing.decorators import use_xvfb
 from dipy.utils.optpkg import optional_package
+from dipy.testing.decorators import set_random_number_generator
 
 fury, has_fury, setup_module = optional_package('fury')
 
@@ -25,7 +26,8 @@ skip_it = use_xvfb == 'skip'
 
 @pytest.mark.skipif(skip_it or not has_fury,
                     reason='Requires FURY')
-def test_horizon_flow():
+@set_random_number_generator()
+def test_horizon_flow(rng):
 
     s1 = 10 * np.array([[0, 0, 0],
                         [1, 0, 0],
@@ -50,7 +52,7 @@ def test_horizon_flow():
                        [0., 0., 1., -72.],
                        [0., 0., 0., 1.]])
 
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
     vox_size = (1., 1., 1.)
 
     streamlines = Streamlines()
@@ -75,7 +77,7 @@ def test_horizon_flow():
             world_coords=True, interactive=False)
 
 
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
 
     images = [(data, affine)]
 
@@ -96,7 +98,7 @@ def test_horizon_flow():
         sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
         save_tractogram(sft, ftrk, bbox_valid_check=False)
 
-        pvalues = np.random.uniform(low=0, high=1, size=(10,))
+        pvalues = rng.uniform(low=0, high=1, size=(10,))
         np.save(fnpy, pvalues)
 
         input_files = [ftrk, fimg]

--- a/doc/examples/bundle_assignment_maps.py
+++ b/doc/examples/bundle_assignment_maps.py
@@ -57,11 +57,13 @@ if interactive:
 #
 # Creating 100 bundle assignment maps on AF_L using BUAN [Chandio2020]_
 
+rng = np.random.default_rng()
+
 n = 100
 indx = assignment_map(model_af_l, model_af_l, n)
 indx = np.array(indx)
 
-colors = [np.random.rand(3) for si in range(n)]
+colors = [rng.random(3) for si in range(n)]
 
 disks_color = []
 for i in range(len(indx)):

--- a/doc/examples/bundle_shape_similarity.py
+++ b/doc/examples/bundle_shape_similarity.py
@@ -33,7 +33,7 @@ cb_subj1, _ = two_cingulum_bundles()
 # Let's create two streamline sets (bundles) from same bundle cb_subj1 by
 # randomly selecting 60 streamlines two times.
 
-rng = np.random.RandomState()
+rng = np.random.default_rng()
 bundle1 = select_random_set_of_streamlines(cb_subj1, 60, rng=None)
 bundle2 = select_random_set_of_streamlines(cb_subj1, 60, rng=None)
 

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -108,8 +108,9 @@ gtab = gradient_table(bvals, bvecs)
 # Add Rician noise
 b0_slice = data[:, :, :, 1]
 b0_mask, mask = median_otsu(b0_slice)
-np.random.seed(1)
-data_noisy = add_noise(data, 10.0, np.mean(b0_slice[mask]), noise_type='rician')
+rng = np.random.default_rng(1)
+data_noisy = add_noise(data, 10.0, np.mean(b0_slice[mask]),
+                       noise_type='rician', rng=rng)
 
 # Select a small part of it.
 padding = 3  # Include a larger region to avoid boundary effects

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -60,7 +60,7 @@ from dipy.viz import window, actor
 # Enables/disables interactive visualization
 interactive = False
 # Fix seed
-np.random.seed(1)
+rng = np.random.default_rng(1)
 
 # Read data
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -33,9 +33,10 @@ from dipy.viz import window, actor
 # We can first create some random points on a ``HemiSphere`` using spherical
 # polar coordinates.
 
+rng = np.random.default_rng()
 n_pts = 64
-theta = np.pi * np.random.rand(n_pts)
-phi = 2 * np.pi * np.random.rand(n_pts)
+theta = np.pi * rng.random(n_pts)
+phi = 2 * np.pi * rng.random(n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 
 ###############################################################################

--- a/doc/examples/kfold_xval.py
+++ b/doc/examples/kfold_xval.py
@@ -80,10 +80,12 @@ csd_model = csd.ConstrainedSphericalDeconvModel(gtab, response)
 # the model will be fit to half of the data, and used to predict the other
 # half.
 
-dti_cc = xval.kfold_xval(dti_model, cc_vox, 2)
-csd_cc = xval.kfold_xval(csd_model, cc_vox, 2, response)
-dti_cso = xval.kfold_xval(dti_model, cso_vox, 2)
-csd_cso = xval.kfold_xval(csd_model, cso_vox, 2, response)
+rng = np.random.default_rng(2014)
+
+dti_cc = xval.kfold_xval(dti_model, cc_vox, 2, rng=rng)
+csd_cc = xval.kfold_xval(csd_model, cc_vox, 2, response, rng=rng)
+dti_cso = xval.kfold_xval(dti_model, cso_vox, 2, rng=rng)
+csd_cso = xval.kfold_xval(csd_model, cso_vox, 2, response, rng=rng)
 
 ###############################################################################
 # We plot a scatter plot of the data with the model predictions in each of

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -78,9 +78,11 @@ mevals = np.array([[0.00099, 0, 0],
 # three different b-values).
 
 # Sample the spherical coordinates of 60 random diffusion-weighted directions.
+rng = np.random.default_rng()
+
 n_pts = 60
-theta = np.pi * np.random.rand(n_pts)
-phi = 2 * np.pi * np.random.rand(n_pts)
+theta = np.pi * rng.random(n_pts)
+phi = 2 * np.pi * rng.random(n_pts)
 
 # Convert direction to cartesian coordinates.
 hsph_initial = HemiSphere(theta=theta, phi=phi)

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -21,9 +21,10 @@ from dipy.viz import window, actor
 # We can first create some random points on a ``HemiSphere`` using spherical
 # polar coordinates.
 
+rng = np.random.default_rng()
 n_pts = 64
-theta = np.pi * np.random.rand(n_pts)
-phi = 2 * np.pi * np.random.rand(n_pts)
+theta = np.pi * rng.random(n_pts)
+phi = 2 * np.pi * rng.random(n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 
 ###############################################################################

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -21,9 +21,11 @@ from dipy.viz import window, actor
 # b-vectors. To create one, we can first create some random points on a
 # ``HemiSphere`` using spherical polar coordinates.
 
+rng = np.random.default_rng()
+
 n_pts = 64
-theta = np.pi * np.random.rand(n_pts)
-phi = 2 * np.pi * np.random.rand(n_pts)
+theta = np.pi * rng.random(size=n_pts)
+phi = 2 * np.pi * rng.random(size=n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 
 ###############################################################################

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -27,21 +27,23 @@ from dipy.viz import window, actor
 
 
 def simulated_bundles(no_streamlines=50, n_pts=100):
-    t = np.linspace(-10, 10, n_pts)
+   rng = np.random.default_rng()
 
-    bundle = []
-    for i in np.linspace(3, 5, no_streamlines):
-        pts = np.vstack((np.cos(2 * t/np.pi), np.zeros(t.shape) + i, t)).T
-        bundle.append(pts)
+   t = np.linspace(-10, 10, n_pts)
 
-    start = np.random.randint(10, 30, no_streamlines)
-    end = np.random.randint(60, 100, no_streamlines)
+   bundle = []
+   for i in np.linspace(3, 5, no_streamlines):
+      pts = np.vstack((np.cos(2 * t/np.pi), np.zeros(t.shape) + i, t )).T
+      bundle.append(pts)
 
-    bundle = [10 * streamline[start[i]:end[i]]
-              for (i, streamline) in enumerate(bundle)]
-    bundle = [np.ascontiguousarray(streamline) for streamline in bundle]
+   start = rng.integers(10, 30, no_streamlines)
+   end = rng.integers(60, 100, no_streamlines)
 
-    return bundle
+   bundle = [10 * streamline[start[i]:end[i]]
+             for (i, streamline) in enumerate(bundle)]
+   bundle = [np.ascontiguousarray(streamline) for streamline in bundle]
+
+   return bundle
 
 
 bundle = simulated_bundles()
@@ -128,7 +130,7 @@ scene.add(bundle_actor3)
 scene.set_camera(position=(0, 0, 0), focal_point=(30, 0, 0))
 window.record(scene, out_path='simulated_cosine_bundle.png', size=(900, 900))
 if interactive:
-    window.show(scene)
+   window.show(scene)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/viz_bundles.py
+++ b/doc/examples/viz_bundles.py
@@ -190,9 +190,11 @@ window.record(scene, out_path='bundle5.png', size=(600, 600))
 
 scene.clear()
 
-colors = [np.random.rand(*streamline.shape) for streamline in bundle_native]
-stream_actor6 = actor.line(bundle_native, np.array(colors, dtype=object),
-                           linewidth=0.2)
+rng = np.random.default_rng()
+
+colors = [rng.random(streamline.shape) for streamline in bundle_native]
+
+stream_actor6 = actor.line(bundle_native, colors, linewidth=0.2)
 
 scene.add(stream_actor6)
 


### PR DESCRIPTION
This commit is to move from numpy.random to numpy.random.Generator as numpy suggests. All tests that require random numbers are now using set_random_number_generator decorator from dipy.testing. Some functions were changed to accept rng (or replaced seed with rng) as an argument so that this complies with the changes made to the test. Randomstates were changed to Generators as well.