### PR TITLE
Feature/opacity checkbox

### DIFF
--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -122,11 +122,16 @@ class TabManager:
                 self._tab_ui.add_element(tab_id, element.obj, element.position)
 
     def _tab_selected(self, tab_ui):
+        if self._active_tab_id == tab_ui.active_tab_idx:
+            self._active_tab_id = -1
+            return
+
         self._active_tab_id = tab_ui.active_tab_idx
 
         current_tab = self._tabs[self._active_tab_id]
         if current_tab.__class__.__name__ == 'SlicesTab':
             self.tab_changed(current_tab.actors)
+            current_tab.on_tab_selected()
 
     def reposition(self, win_size):
         """

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -36,6 +36,11 @@ class SlicesTab(HorizonTab):
 
         self.on_slice_change = lambda _tab_id, _x, _y, _z: None
 
+        self._opacity_toggle = build_checkbox(
+            labels=[''],
+            checked_labels=[''],
+            on_change=self._toggle_opacity)
+
         self._slice_opacity_label, self._slice_opacity = build_slider(
             initial_value=1.,
             max_value=1.,
@@ -167,6 +172,7 @@ class SlicesTab(HorizonTab):
         self._visualizer.register_picker_callback(self._change_picked_voxel)
 
         self.register_elements(
+            self._opacity_toggle,
             self._slice_opacity_label,
             self._slice_opacity,
             self._slice_x_toggle,
@@ -207,6 +213,15 @@ class SlicesTab(HorizonTab):
 
     def _change_opacity(self, slider):
         self._slice_opacity.selected_value = slider.value
+        self._update_opacities()
+
+    def _toggle_opacity(self, checkbox):
+        if '' in checkbox.checked_labels:
+            self._slice_opacity.selected_value = 1
+            self._slice_opacity.obj.value = 1
+        else:
+            self._slice_opacity.selected_value = 0
+            self._slice_opacity.obj.value = 0
         self._update_opacities()
 
     def _change_picked_voxel(self, message):
@@ -321,6 +336,11 @@ class SlicesTab(HorizonTab):
             slice_actor.GetProperty().SetOpacity(
                 self._slice_opacity.selected_value)
 
+    def on_tab_selected(self):
+        self._slice_x.obj.set_visibility(self._slice_x.visibility)
+        self._slice_y.obj.set_visibility(self._slice_y.visibility)
+        self._slice_z.obj.set_visibility(self._slice_z.visibility)
+
     def update_slices(self, x_slice, y_slice, z_slice):
         """Updates slicer positions.
 
@@ -359,6 +379,7 @@ class SlicesTab(HorizonTab):
         self._tab_id = tab_id
 
         x_pos = .02
+        self._opacity_toggle.position = (x_pos, .85)
         self._slice_x_toggle.position = (x_pos, .62)
         self._slice_y_toggle.position = (x_pos, .38)
         self._slice_z_toggle.position = (x_pos, .15)


### PR DESCRIPTION

- This PR introduces a new checkbox next to opacity slider in Slice Tab, which will make opacity zero if you unchecked and  will become 1 if you mark it checked.

![Screenshot from 2023-11-08 14-07-56](https://github.com/dipy/dipy/assets/39947025/4742d495-d767-4f7c-ab63-a5db57135f1d)
![Screenshot from 2023-11-08 14-08-10](https://github.com/dipy/dipy/assets/39947025/2a6ecdda-957c-4f96-92a1-06e1612fb267)

- This PR also solves issues with slider re-appearing when the slice is hidden on changing tab. with this PR if a slice in removed from the view by marking the checkbox next to it unchecked will stay hidden till the checkbox is marked again.

- To check the following changes run
`dipy_horizon <nii-1> <nii-2>`