### PR TITLE
bugfix for --force issue

### DIFF
--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -106,6 +106,7 @@ class HorizonFlow(Workflow):
             adaptive visualization, Proceedings of: International Society of
             Magnetic Resonance in Medicine (ISMRM), Montreal, Canada, 2019.
         """
+        super(HorizonFlow, self).__init__(force=True)
         verbose = True
         tractograms = []
         images = []


### PR DESCRIPTION
### Current behavior

As a horizon user, if you use once the stealth mode of horizon it generates an output file. Once the output file is generated it mandates the user to use --force in every new run otherwise the viewer shows empty screen.

### PR behavior

- Every run will by default overwrite the file if any output is generated. Thus, the user does not need to append --force option on every single run.

### Approach

- The `Workflow` class provides a flag named force, which by default is set to `False`. While creating the HorizonWorkflow, we can enable the flag by calling `__init__` function of the Workflow class.

### Steps to check

1. Run any visualization in stealth mode. For that use command `dipy_horizon <file> --stealth`.
2. Make sure you have a tmp.png file created in your folder structure.
3. Run the same visualization in normal flow without --force flag. To do that use command `dipy_horizon <file>`.
4. Check if the visualization is available
