### PR TITLE
[FIX] int_t to npy_intp

### DIFF
--- a/dipy/tracking/_utils.py
+++ b/dipy/tracking/_utils.py
@@ -49,4 +49,4 @@ def _to_voxel_coordinates(streamline, lin_T, offset):
     if inds.min().round(decimals=6) < 0:
         raise IndexError('streamline has points that map to negative voxel'
                          ' indices')
-    return inds.astype(int)
+    return inds.astype(np.intp)

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -345,9 +345,9 @@ class ParticleFilteringTracking(LocalTracking):
         self.particle_weights = np.empty(self.particle_count, dtype=float)
         self.particle_dirs = np.empty((2, self.particle_count,
                                        pft_max_steps + 1, 3), dtype=float)
-        self.particle_steps = np.empty((2, self.particle_count), dtype=int)
+        self.particle_steps = np.empty((2, self.particle_count), dtype=np.intp)
         self.particle_stream_statuses = np.empty((2, self.particle_count),
-                                                 dtype=int)
+                                                 dtype=np.intp)
         super(ParticleFilteringTracking, self).__init__(
             direction_getter=direction_getter,
             stopping_criterion=stopping_criterion,

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -92,8 +92,8 @@ def pft_tracker(
         cnp.float_t[:, :, :, :] particle_paths,
         cnp.float_t[:, :, :, :] particle_dirs,
         cnp.float_t[:] particle_weights,
-        cnp.int_t[:, :]  particle_steps,
-        cnp.int_t[:, :]  particle_stream_statuses,
+        cnp.npy_intp[:, :]  particle_steps,
+        cnp.npy_intp[:, :]  particle_stream_statuses,
         int min_wm_pve_before_stopping):
     """Tracks one direction from a seed using the particle filtering algorithm.
 
@@ -197,8 +197,8 @@ cdef _pft_tracker(DirectionGetter dg,
                   cnp.float_t[:, :, :, :] particle_paths,
                   cnp.float_t[:, :, :, :] particle_dirs,
                   cnp.float_t[:] particle_weights,
-                  cnp.int_t[:, :] particle_steps,
-                  cnp.int_t[:, :] particle_stream_statuses,
+                  cnp.npy_intp[:, :] particle_steps,
+                  cnp.npy_intp[:, :] particle_stream_statuses,
                   double min_wm_pve_before_stopping):
     cdef:
         cnp.npy_intp i, j
@@ -302,8 +302,8 @@ cdef _pft(cnp.float_t[:, :] streamline,
           cnp.float_t[:, :, :, :] particle_paths,
           cnp.float_t[:, :, :, :] particle_dirs,
           cnp.float_t[:] particle_weights,
-          cnp.int_t[:, :] particle_steps,
-          cnp.int_t[:, :] particle_stream_statuses):
+          cnp.npy_intp[:, :] particle_steps,
+          cnp.npy_intp[:, :] particle_stream_statuses):
     cdef:
         double sum_weights, sum_squared, N_effective, rdm_sample
         double point[3]

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -399,7 +399,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
     n_voxels = np.prod(vol_dims)
     # output track counts array, flattened
     cdef cnp.ndarray[cnp.npy_intp, ndim=1] tcs = \
-        np.zeros((n_voxels,), dtype=int)
+        np.zeros((n_voxels,), dtype=np.intp)
     # pointer to output track indices
     cdef cnp.npy_intp i
     if return_elements:

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -123,7 +123,7 @@ def streamline_mapping(streamlines, affine=None,
 
     """
     cdef:
-        cnp.int_t[:, :] voxel_indices
+        cnp.npy_intp[:, :] voxel_indices
 
     lin, offset = _mapping_to_voxel(affine)
     if mapping_as_streamlines:
@@ -398,7 +398,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
     vox_sizes = np.asarray(vox_sizes).astype(np.double)
     n_voxels = np.prod(vol_dims)
     # output track counts array, flattened
-    cdef cnp.ndarray[cnp.int_t, ndim=1] tcs = \
+    cdef cnp.ndarray[cnp.npy_intp, ndim=1] tcs = \
         np.zeros((n_voxels,), dtype=int)
     # pointer to output track indices
     cdef cnp.npy_intp i


### PR DESCRIPTION
In Numpy 2.0, `int_t` type is not available anymore and it is not recommended to use it. 

In our case, it can be safely replaced by `npy_intp`.

This fix DIPY compilation with Numpy 2.0. 

 A follow up PR should come today for the tests

PS: #2979 