### PR TITLE
[MTN] replace the deprecated sctypes

### DIFF
--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -37,9 +37,13 @@ def test_squash():
     # Check dtypes for arrays and scalars
     arr_arr = np.zeros((2,), dtype=object)
     scalar_arr = np.zeros((2,), dtype=object)
-    numeric_types = sum(
-        [np.sctypes[t] for t in ('int', 'uint', 'float', 'complex')],
-        [bool])
+    numeric_types = [getattr(np, dtype) for dtype in (
+        'int8', 'byte', 'int16', 'short', 'int32', 'intc', 'int_', 'int64',
+        'longlong', 'uint8', 'ubyte', 'uint16', 'ushort', 'uint32', 'uintc',
+        'uint', 'uint64', 'ulonglong', 'float16', 'half', 'float32', 'single',
+        'float64', 'double', 'float96', 'float128', 'longdouble', 'complex64',
+        'csingle', 'complex128', 'cdouble', 'complex192', 'complex256',
+        'clongdouble') if hasattr(np, dtype)] + [bool]
     for dt0 in numeric_types:
         arr_arr[0] = np.zeros((3,), dtype=dt0)
         scalar_arr[0] = dt0(0)


### PR DESCRIPTION
`np.sctypes` is removed from Numpy 2.0 (https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace)

This is something that we used only one time. So this PR provide an alternative to fix the future issue. 

follow up of https://github.com/dipy/dipy/issues/2979