### PR TITLE
[FIX] Force the use of pre-wheels

### DIFF
--- a/.github/workflows/test_pre.yml
+++ b/.github/workflows/test_pre.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  PRE-py311:
+  PRE-py312:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", ]'

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -8,7 +8,9 @@ set -ex
 PIPI="pip install --timeout=60 -Csetup-args=--vsenv -Ccompile-args=-v"
 
 if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" == true ]; then
-    PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
+    # --index-url takes priority over --extra-index-url, so that packages, and
+    # their dependencies, with versions available in the nightly channel will be installed before falling back to the Python Package Index.
+    PIPI="$PIPI --upgrade --pre --index-url $PRE_WHEELS --extra-index-url https://pypi.org/simple";
 fi
 
 #---------- DIPY Installation -----------------

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -10,7 +10,7 @@ PIPI="pip install --timeout=60 -Csetup-args=--vsenv -Ccompile-args=-v"
 if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" == true ]; then
     # --index-url takes priority over --extra-index-url, so that packages, and
     # their dependencies, with versions available in the nightly channel will be installed before falling back to the Python Package Index.
-    PIPI="$PIPI --upgrade --pre --index-url $PRE_WHEELS --extra-index-url https://pypi.org/simple";
+    PIPI="$PIPI --pre --index-url $PRE_WHEELS --extra-index-url https://pypi.org/simple";
 fi
 
 #---------- DIPY Installation -----------------

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -17,7 +17,9 @@ else
     PIPI="pip install --timeout=60 "
 
     if [ "$USE_PRE" == "1" ] || [ "$USE_PRE" == true ]; then
-        PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
+        # --index-url takes priority over --extra-index-url, so that packages, and
+        # their dependencies, with versions available in the nightly channel will be installed before falling back to the Python Package Index.
+        PIPI="$PIPI --pre --index-url $PRE_WHEELS --extra-index-url https://pypi.org/simple";
     fi
 
     $PIPI pytest==8.0.0


### PR DESCRIPTION
Currently, our `PRE_WHEELS` are not using Numpy 2.0 because a dependency uninstall it. 

So, this update should force the use of `PRE_WHEELS`.

ref: #2979 