### PR TITLE
STYLE: Fix boolean variable negation warnings

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -765,7 +765,7 @@ def odf_deconv(odf_sh, R, B_reg, lambda_=1., tau=0.1, r2_term=False):
     # if sharpening a q-ball odf (it is NOT properly normalized), we need to
     # force normalization otherwise, for DSI, CSA, SHORE, Tensor odfs, they are
     # normalized by construction
-    if ~r2_term:
+    if not r2_term:
         Z = np.linalg.norm(fodf)
         fodf_sh /= Z
 

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -324,7 +324,7 @@ def select_by_rois(streamlines, affine, rois, include, mode=None,
                                          mode=mode)
         exclude = ut.streamline_near_roi(sl, x_exclude_roi_coords, tol=tol,
                                          mode=mode)
-        if include & ~exclude:
+        if include and not exclude:
             yield sl
 
 


### PR DESCRIPTION
Fix boolean variable negation warnings: use the `not` operator instead of the `~` opertor.

Fixes:
```
reconst/tests/test_csdeconv.py::test_odfdeconv
reconst/tests/test_csdeconv.py::test_odf_sh_to_sharp
reconst/tests/test_csdeconv.py::test_r2_term_odf_sharp
  dipy/venv/lib/python3.12/site-packages/dipy/reconst/csdeconv.py:768:
 DeprecationWarning: Bitwise inversion '~' on bool is deprecated.
 This returns the bitwise inversion of the underlying int object and is
 usually not what you expect from negating a bool. Use the 'not'
 operator for boolean negation or ~int(x) if you really want the bitwise
 inversion of the underlying int.
    if ~r2_term:
```

and
```
tracking/streamline.py: 9 warnings
tracking/tests/test_streamline.py: 18 warnings
  dipy/venv/lib/python3.12/site-packages/dipy/tracking/streamline.py:327:
 DeprecationWarning: Bitwise inversion '~' on bool is deprecated.
 This returns the bitwise inversion of the underlying int object and is
 usually not what you expect from negating a bool. Use the 'not'
 operator for boolean negation or ~int(x) if you really want the bitwise
 inversion of the underlying int.
    if include & ~exclude:
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/7024094921/job/19112083400?pr=2981#step:9:4599 https://github.com/dipy/dipy/actions/runs/7024094921/job/19112083400?pr=2981#step:9:4621