### PR TITLE
DOC: Miscellaneous documentation improvements

### DIFF
--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -236,23 +236,22 @@ def bundlewarp_shape_analysis(moving_aligned, deformed_bundle, no_disks=10,
     """Calculate bundle shape difference profile.
 
     Bundle shape difference analysis using magnitude from BundleWarp
-    displacements and BUAN
+    displacements and BUAN.
 
     Parameters
     ----------
     moving_aligned : Streamlines
         Linearly (affinely) moved bundle
     deformed_bundle : Streamlines
-        Nonlinearly (warped) bundle
-    no_disks : int
+        Nonlinearly (warped) moved bundle
+    no_disks : int, optional
         Number of segments to be created along the length of the bundle
-        (Default 10)
     plotting : Boolean, optional
-        Plot bundle shape profile (default False)
+        Plot bundle shape profile
 
     Returns
     -------
-    shape_profilen : np.ndarray
+    shape_profile : np.ndarray
         Float array containing bundlewarp displacement magnitudes along the
         length of the bundle
     stdv : np.ndarray

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -119,7 +119,13 @@ def assignment_map(target_bundle, model_bundle, no_disks):
     model_bundle : streamlines
         atlas bundle used as reference
     no_disks : integer, optional
-        Number of disks used for dividing bundle into disks. (Default 100)
+        Number of disks used for dividing bundle into disks.
+
+    Returns
+    -------
+    indx : ndarray
+        Assignment map of the target bundle streamline point indices to the
+        model bundle centroid points.
 
     References
     ----------


### PR DESCRIPTION
Miscellaneous documentation improvements:
- Document the return value in `assignment_map`.
- Remove documenting default values to avoid any risk of the values not being sync'ed with the actual values in the method signature.
- Add the `optional` label to optional parameter.
- Improve syntax and fix inaccurate docstring variable names.