### PR TITLE
BF: Mask `1` values in leveraged, residual matrix computation

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1018,7 +1018,7 @@ def lcr_matrix(H):
     if H.ndim != 2 or H.shape[0] != H.shape[1]:
         raise ValueError('H should be a square matrix')
 
-    leverages = np.sqrt(1 - H.diagonal(), where=H.diagonal() <= 1)
+    leverages = np.sqrt(1 - H.diagonal(), where=H.diagonal() < 1)
     leverages = leverages[:, None]
     R = (np.eye(len(H)) - H) / leverages
     return R - R.mean(0)


### PR DESCRIPTION
Mask strict `1` values in leveraged, residual matrix computation: when the diagonal of `H` turns out to have `1`s, `1 - H.diagonal()` gives `0`s, and then a divide by 0 operation is encountered and makes NumPy raise a warning.

Fixes:
```
direction/tests/test_bootstrap_direction_getter.py::test_boot_pmf
  python3.10/site-packages/dipy/reconst/shm.py:1023: RuntimeWarning:
   divide by zero encountered in divide
    R = (np.eye(len(H)) - H) / leverages
```

and
```
direction/tests/test_bootstrap_direction_getter.py::test_boot_pmf
  python3.10/site-packages/dipy/reconst/shm.py:1024: RuntimeWarning:
   invalid value encountered in subtract
    return R - R.mean(0)
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/7073407086/job/19253289839#step:9:4400

Masking `<=1` diagonal values was introduced in commit 6a01bf6.