### PR TITLE
STYLE: Use `.astype()` on uninitialized array casting

### DIFF
--- a/dipy/align/tests/test_parzenhist.py
+++ b/dipy/align/tests/test_parzenhist.py
@@ -594,7 +594,7 @@ def test_exceptions():
         valid_grad = np.empty(shape + (dim,), dtype=np.float64)
 
         invalid_img = np.empty((2, 2, 2, 2), dtype=np.float64)
-        invalid_grad_type = valid_grad.astype(np.int32)
+        invalid_grad_type = np.empty_like(valid_grad, dtype=np.int32)
         invalid_grad_dim = np.empty(shape + (dim + 1,), dtype=np.float64)
 
         for s, m, g in [(valid_img, valid_img, invalid_grad_type),


### PR DESCRIPTION
Use `.empty_like()` over `.astype()` on uninitialized array casting: use `np.empty_like()` with data type specification to avoid casting warnings.

Fixes:
```
align/tests/test_parzenhist.py::test_exceptions
  python3.10/site-packages/dipy/align/tests/test_parzenhist.py:597:
   RuntimeWarning: invalid value encountered in cast
    invalid_grad_type = valid_grad.astype(np.int32)
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/7073407086/job/19253289839#step:9:4359