### PR TITLE
TEST: Filter warning about resorting to `OLS` fitting method

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -21,6 +21,8 @@ from dipy.utils.volume import adjacency_calc
 
 MIN_POSITIVE_SIGNAL = 0.0001
 
+ols_resort_msg = "Resorted to OLS solution in some voxels"
+
 
 def _roll_evals(evals, axis=-1):
     """Check evals shape.
@@ -1833,7 +1835,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
             params[vox, 12:] = this_param[6:-1] / md2
 
     if resort_to_OLS:
-        warnings.warn("Resorted to OLS solution in some voxels", UserWarning)
+        warnings.warn(ols_resort_msg, UserWarning)
 
     params.shape = data.shape[:-1] + (npa,)
     if return_S0_hat:
@@ -2052,7 +2054,7 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
             params[vox, 12:] = this_param[6:-1] / md2
 
     if resort_to_OLS:
-        warnings.warn("Resorted to OLS solution in some voxels", UserWarning)
+        warnings.warn(ols_resort_msg, UserWarning)
 
     params.shape = data.shape[:-1] + (npa,)
     extra = {"robust": robust}

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -1,5 +1,7 @@
 """Testing DTI."""
 
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 
@@ -7,7 +9,7 @@ import scipy.optimize as opt
 
 import dipy.reconst.dti as dti
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.reconst.dti import (axial_diffusivity, color_fa,
+from dipy.reconst.dti import (ols_resort_msg, axial_diffusivity, color_fa,
                               fractional_anisotropy, from_lower_triangular,
                               geodesic_anisotropy, lower_triangular,
                               mean_diffusivity, radial_diffusivity,
@@ -650,7 +652,11 @@ def test_nlls_fit_tensor():
     sigma = np.ones(Y_less.shape[-1])
     tensor_model = dti.TensorModel(gtab_less, fit_method='NLLS',
                                    weighting='sigma', sigma=sigma)
-    tmf = tensor_model.fit(Y_less)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=ols_resort_msg,
+            category=UserWarning)
+        tmf = tensor_model.fit(Y_less)
 
     # Test sigma with an array of wrong size
     sigma = np.ones(Y_less.shape[-1] + 10)


### PR DESCRIPTION
Filter warning about resorting to `OLS` fitting method.

Fixes:
```
reconst/tests/test_dti.py::test_nlls_fit_tensor
  dipy/reconst/dti.py:1836: UserWarning:
   Resorted to OLS solution in some voxels
    warnings.warn("Resorted to OLS solution in some voxels", UserWarning)
```

raised, for example, at:
https://github.com/dipy/dipy/actions/runs/7146907000/job/19465502675#step:9:4439