### PR TITLE
TEST: Filter SciPy 0.18.0 1-D affine transform array warning in test

### DIFF
--- a/dipy/nn/tests/test_utils.py
+++ b/dipy/nn/tests/test_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from dipy.nn.utils import normalize, unnormalize, transform_img, recover_img
 from dipy.testing.decorators import set_random_number_generator
@@ -17,6 +19,15 @@ def test_transform(rng=None):
     temp2, new_affine, ori_shape = transform_img(temp, np.eye(4),
                                                  init_shape=(32, 32, 32),
                                                  voxsize=np.ones(3)*2)
-    temp2 = recover_img(temp2, new_affine, ori_shape, temp.shape,
-                        init_shape=(32, 32, 32), voxsize=np.ones(3)*2)
+    with warnings.catch_warnings():
+        scipy_affine_txfm_msg = (
+            "The behavior of affine_transform with a 1-D "
+            "array supplied for the matrix parameter has changed in "
+            "SciPy 0.18.0."
+        )
+        warnings.filterwarnings(
+            "ignore", message=scipy_affine_txfm_msg,
+            category=UserWarning)
+        temp2 = recover_img(temp2, new_affine, ori_shape, temp.shape,
+                            init_shape=(32, 32, 32), voxsize=np.ones(3)*2)
     np.testing.assert_almost_equal(np.array(temp.shape), np.array(temp2.shape))


### PR DESCRIPTION
Filter SciPy 0.18.0 1-D affine transform array warning in test.

Fixes:
```
nn/tests/test_utils.py::test_transform
  scipy/ndimage/_interpolation.py:606: UserWarning:
   The behavior of affine_transform with a 1-D array supplied for the matrix parameter has changed in SciPy 0.18.0.
    warnings.warn(
```

raised, for example, at:
https://github.com/dipy/dipy/actions/runs/7146907000/job/19465502675#step:9:4426