### PR TITLE
TEST: Set explicitly `CLARABEL` as the CVXPY solver

### DIFF
--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import random
+
 import dipy.reconst.dki as dki
 import dipy.reconst.dti as dti
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -23,7 +24,7 @@ from dipy.core.geometry import sphere2cart
 from dipy.utils.optpkg import optional_package
 from dipy.utils.tripwire import TripWireError
 
-_, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 fimg, fbvals, fbvecs = get_fnames('small_64D')
 bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
@@ -123,13 +124,15 @@ def test_dki_fits():
 
     if have_cvxpy:
         # CLS fitting
-        dki_clsM = dki.DiffusionKurtosisModel(gtab_2s, fit_method="CLS")
+        dki_clsM = dki.DiffusionKurtosisModel(
+            gtab_2s, fit_method="CLS", cvxpy_solver=cvxpy.CLARABEL)
         dki_clsF = dki_clsM.fit(signal_cross)
 
         assert_array_almost_equal(dki_clsF.model_params, crossing_ref)
 
         # CWLS fitting
-        dki_cwlsM = dki.DiffusionKurtosisModel(gtab_2s, fit_method="CWLS")
+        dki_cwlsM = dki.DiffusionKurtosisModel(
+            gtab_2s, fit_method="CWLS", cvxpy_solver=cvxpy.CLARABEL)
         dki_cwlsF = dki_cwlsM.fit(signal_cross)
 
         assert_array_almost_equal(dki_cwlsF.model_params, crossing_ref)


### PR DESCRIPTION
Set explicitly `CLARABEL` as the CVXPY solver instead of relying on CVXPY choosing the solver: CVXPY resorts to `ECOS` by default, which will be deprecated starting CVXPY 1.5.0.

Fixes:
```
reconst/tests/test_dki.py::test_dki_fits
  python3.10/site-packages/cvxpy/reductions/solvers/solving_chain.py:336: FutureWarning:
      Your problem is being solved with the ECOS solver by default. Starting in
      CVXPY 1.5.0, Clarabel will be used as the default solver instead. To continue
      using ECOS, specify the ECOS solver explicitly using the ``solver=cp.ECOS``
      argument to the ``problem.solve`` method.

    warnings.warn(ECOS_DEPRECATION_MSG, FutureWarning)
```

raised, for example, at:
https://github.com/dipy/dipy/actions/runs/7146907000/job/19465502675#step:9:4433