### PR TITLE
RF: Prefer raising `sklearn` package warnings when required

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -7,9 +7,6 @@ import dipy.core.optimize as opt
 sklearn, has_sklearn, _ = optional_package('sklearn')
 linear_model, _, _ = optional_package('sklearn.linear_model')
 
-if not has_sklearn:
-    warn(sklearn._msg)
-
 
 def _vol_split(train, vol_idx):
     """ Split the 3D volumes into the train and test set.

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -10,10 +10,10 @@ import pytest
 from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import gradient_table, generate_bvecs
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.optpkg import optional_package
 
-needs_sklearn = pytest.mark.skipif(
-    not p2s.has_sklearn,
-    reason=p2s.sklearn._msg if not p2s.has_sklearn else "")
+sklearn, has_sklearn, _ = optional_package('sklearn')
+needs_sklearn = pytest.mark.skipif(not has_sklearn, reason="Requires sklearn")
 
 
 @needs_sklearn

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -40,12 +40,6 @@ joblib, has_joblib, _ = optional_package('joblib')
 sklearn, has_sklearn, _ = optional_package('sklearn')
 lm, _, _ = optional_package('sklearn.linear_model')
 
-# If sklearn is unavailable, we can fall back on nnls (but we also warn the
-# user that we are about to do that):
-if not has_sklearn:
-    w = sklearn._msg + "\nAlternatively, you can use 'nnls' method to fit"
-    w += " the SparseFascicleModel"
-    warnings.warn(w)
 
 # Isotropic signal models: these are models of the part of the signal that
 # changes with b-value, but does not change with direction. This collection is
@@ -418,6 +412,12 @@ class SparseFascicleModel(ReconstModel, Cache):
             self.solver = solver
 
         else:
+            # If sklearn is unavailable, we can fall back on nnls (but we also
+            # warn the user that we are about to do that):
+            if not has_sklearn:
+                w = sklearn._msg + "\nAlternatively, you can use 'nnls' method "
+                w += "to fit the SparseFascicleModel"
+                warnings.warn(w)
             e_s = "The `solver` key-word argument needs to be: "
             e_s += "'ElasticNet', 'NNLS', or a "
             e_s += "`dipy.optimize.SKLearnLinearSolver` object"

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -10,12 +10,12 @@ import dipy.core.optimize as opt
 import dipy.reconst.cross_validation as xval
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
+from dipy.utils.optpkg import optional_package
 
 warnings.filterwarnings('ignore')
 
-needs_sklearn = pytest.mark.skipif(
-    not sfm.has_sklearn,
-    reason=sfm.sklearn._msg if not sfm.has_sklearn else "")
+sklearn, has_sklearn, _ = optional_package('sklearn')
+needs_sklearn = pytest.mark.skipif(not has_sklearn, reason="Requires sklearn")
 
 
 def test_design_matrix():
@@ -166,6 +166,7 @@ def test_sfm_stick():
     npt.assert_(xval.coeff_of_determination(pred, S) > 96)
 
 
+@needs_sklearn
 def test_sfm_sklearnlinearsolver():
     class SillySolver(opt.SKLearnLinearSolver):
         def fit(self, X, y):


### PR DESCRIPTION
Prefer raising `sklearn` package warnings when required: do not raise the warnings at the module level since they cannot be effectively checked and filtered otherwise in tests.

Fixes:
```
../venv/lib/python3.10/site-packages/dipy/denoise/patch2self.py:11
  dipy/denoise/patch2self.py:11: UserWarning:
   We need package sklearn for these functions, but ``import sklearn`` raised an ImportError
    warn(sklearn._msg)
```

and
```
../venv/lib/python3.10/site-packages/dipy/reconst/sfm.py:48
  dipy/reconst/sfm.py:48: UserWarning:
   We need package sklearn for these functions, but ``import sklearn`` raised an ImportError
  Alternatively, you can use 'nnls' method to fit the SparseFascicleModel
    warnings.warn(w)
```

raised, for example, at:
https://github.com/dipy/dipy/actions/runs/7146907000/job/19465502675#step:9:4368 and
https://github.com/dipy/dipy/actions/runs/7146907000/job/19465502675#step:9:4373