### PR TITLE
TEST: Check and filter PCA dimensionality problem warning

### DIFF
--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -329,8 +329,20 @@ def test_mppca_in_phantom(rng):
 
     # patch radius (2: #samples > #features, 1: #samples < #features)
     for PR in [2, 1]:
-
-        DWIden = mppca(DWInoise, patch_radius=PR)
+        if PR == 1:
+            patch_radius_arr = create_patch_radius_arr(DWInoise, PR)
+            patch_size = compute_patch_size(patch_radius_arr)
+            num_samples = compute_num_samples(patch_size)
+            spr = compute_suggested_patch_radius(DWInoise, patch_size)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=dimensionality_problem_message(
+                        DWInoise, num_samples, spr),
+                    category=UserWarning)
+                DWIden = mppca(DWInoise, patch_radius=PR)
+        else:
+            DWIden = mppca(DWInoise, patch_radius=PR)
 
         # Test if denoised data is closer to ground truth than noisy data
         rmse_den = np.sum(np.abs(DWIgt - DWIden)) / np.sum(np.abs(DWIgt))


### PR DESCRIPTION
Check and filter PCA dimensionality problem warning in MPPCA test.

Fixes:
```
denoise/tests/test_lpca.py::test_mppca_in_phantom
 denoise/localpca.py:295: UserWarning:
 Number of samples 27 - 1 < Dimensionality 104.
 This might have a performance impact.
 Increase patch_radius to 2 to avoid this.
    warn(dimensionality_problem_message(arr, num_samples, spr), UserWarning)
```

raised, for example, at:
https://github.com/dipy/dipy/actions/runs/7159954273/job/19493785864#step:9:3932

Left behind in commit fe33ea9.