### PR TITLE
[NF] Introduce minimum version in `optional_package`

### DIFF
--- a/dipy/core/profile.py
+++ b/dipy/core/profile.py
@@ -8,8 +8,9 @@ from dipy.utils.optpkg import optional_package
 
 cProfile, _, _ = optional_package('cProfile')
 pstats, _, _ = optional_package('pstats',
-                                'pstats is not installed.  It is part of the'
-                                'python-profiler package in Debian/Ubuntu')
+                                trip_msg='pstats is not installed.  It is '
+                                'part of the python-profiler package in '
+                                'Debian/Ubuntu')
 
 
 class Profiler:

--- a/dipy/utils/optpkg.py
+++ b/dipy/utils/optpkg.py
@@ -1,6 +1,7 @@
 """ Routines to support optional packages """
 
 import importlib
+from packaging.version import Version
 
 try:
     import pytest
@@ -12,7 +13,7 @@ else:
 from dipy.utils.tripwire import TripWire
 
 
-def optional_package(name, trip_msg=None):
+def optional_package(name, *, trip_msg=None, min_version=None):
     """ Return package-like thing and module setup for package `name`
 
     Parameters
@@ -23,6 +24,10 @@ def optional_package(name, trip_msg=None):
         message to give when someone tries to use the return package, but we
         could not import it, and have returned a TripWire object instead.
         Default message if None.
+    min_version : None or str
+        If not None, require that the imported package be at least this
+        version.  If the package has no ``__version__`` attribute, or if the
+        version is not parseable, raise an error.
 
     Returns
     -------
@@ -74,7 +79,18 @@ def optional_package(name, trip_msg=None):
         pass
     else:  # import worked
         # top level module
-        return pkg, True, lambda: None
+        if not min_version:
+            return pkg, True, lambda: None
+
+        current_version = getattr(pkg, '__version__', '0.0.0')
+        if Version(current_version) >= Version(min_version):
+            return pkg, True, lambda: None
+
+        if trip_msg is None:
+            trip_msg = (f'We need at least version {min_version} of '
+                        f'package {name}, but ``import {name}`` '
+                        f'found version {pkg.__version__}')
+
     if trip_msg is None:
         trip_msg = ('We need package %s for these functions, but '
                     '``import %s`` raised an ImportError'

--- a/dipy/utils/tests/meson.build
+++ b/dipy/utils/tests/meson.build
@@ -5,6 +5,7 @@ python_sources = [
   'test_fast_numpy.py',
   'test_multiproc.py',
   'test_omp.py',
+  'test_optpkg.py',
   'test_parallel.py',
   'test_tripwire.py',
   'test_volume.py',

--- a/dipy/utils/tests/test_optpkg.py
+++ b/dipy/utils/tests/test_optpkg.py
@@ -1,0 +1,24 @@
+import pytest
+
+from dipy.utils.optpkg import optional_package
+from dipy.utils.tripwire import TripWireError
+from dipy.testing import assert_true, assert_false
+
+
+def test_optional_package():
+    pkg, have_pkg, setup_module = optional_package('os')
+    assert_true(have_pkg)
+    assert_true(hasattr(pkg, 'path'))
+
+    pkg, have_pkg, setup_module = optional_package('not_a_package')
+    assert_false(have_pkg)
+    with pytest.raises(TripWireError):
+        pkg.some_function()
+
+    pkg, have_pkg, setup_module = optional_package('dipy', min_version='10.0.0')
+    assert_false(have_pkg)
+    with pytest.raises(TripWireError):
+        pkg.some_function()
+
+    pkg, have_pkg, setup_module = optional_package('dipy', min_version='1.0.0')
+    assert_true(have_pkg)

--- a/dipy/viz/__init__.py
+++ b/dipy/viz/__init__.py
@@ -7,7 +7,7 @@ from dipy.utils.optpkg import optional_package
 # Allow import, but disable doctests if we don't have fury
 fury, has_fury, _ = optional_package(
     'fury',
-    "You do not have FURY installed. Some visualization functions"
+    trip_msg="You do not have FURY installed. Some visualization functions"
     "might not work for you. For installation instructions, please visit: "
     "https://fury.gl/")
 
@@ -28,9 +28,9 @@ else:
 # We make the visualization requirements optional imports:
 _, has_mpl, _ = optional_package(
     'matplotlib',
-    "You do not have Matplotlib installed. Some visualization functions"
-    "might not work for you. For installation instructions, please visit: "
-    "https://matplotlib.org/")
+    trip_msg="You do not have Matplotlib installed. Some visualization "
+    "functions might not work for you. For installation instructions, "
+    "please visit: https://matplotlib.org/")
 
 if has_mpl:
     from . import projections


### PR DESCRIPTION
This PR helps to handle minimum version for optional package. 

Currently, this is hard to handle, not standardize and can bring difficulties for the maintenance. 

I also added some test for `optional_package` function which was not tested