### PR TITLE
[RF] Define minimum version for some optional packages

### DIFF
--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -6,10 +6,9 @@ import numpy as np
 import scipy.sparse as sps
 import scipy.optimize as opt
 from scipy.optimize import minimize
-from packaging.version import Version
 from dipy.utils.optpkg import optional_package
 
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 
 class Optimizer:
@@ -393,10 +392,6 @@ class PositiveDefiniteLeastSquares:
                for common diffusion MRI models using sum of squares
                programming". NeuroImage 209, 2020, 116405.
         """
-        # Check for cvxpy solver
-        if not have_cvxpy:
-            raise ValueError('CVXPY package needed to enforce constraints.')
-
         # Input
         self.A = A
         self.L = L
@@ -417,14 +412,9 @@ class PositiveDefiniteLeastSquares:
         self._zeros = np.zeros(m)
 
         # Objective
-        if Version(cvxpy.__version__) < Version('1.1'):
-            c = self._X*self._h - self._y
-            if L is not None:
-                c += L*self._h
-        else:
-            c = self._X@self._h - self._y
-            if L is not None:
-                c += L@self._h
+        c = self._X@self._h - self._y
+        if L is not None:
+            c += L@self._h
 
         f_objective = cvxpy.Minimize(0)
         p_objective = cvxpy.Minimize(cvxpy.norm(c))

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -2,19 +2,13 @@ from functools import partial
 from multiprocessing import Pool
 
 import numpy as np
-from numpy.lib import NumpyVersion as Version
 import scipy
 
 from dipy.utils.multiproc import determine_num_processes
 from dipy.utils.deprecator import deprecated_params
 
-if Version(scipy.__version__) >= Version('1.4.0'):
-    import scipy.fft
-    _fft = scipy.fft
-else:
-    import scipy.fftpack
-    _fft = scipy.fftpack
-
+import scipy.fft
+_fft = scipy.fft
 
 def _image_tv(x, axis=0, n_points=3):
     """ Computes total variation (TV) of matrix x across a given axis and

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -18,7 +18,7 @@ from dipy.testing.decorators import set_random_number_generator
 import trx.trx_file_memmap as tmm
 
 from dipy.utils.optpkg import optional_package
-fury, have_fury, setup_module = optional_package('fury')
+fury, have_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 filepath_dix = {}
 files, folder = fetch_gold_standard_io()

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -14,7 +14,7 @@ import numpy.testing as npt
 import pytest
 
 from dipy.utils.optpkg import optional_package
-fury, have_fury, setup_module = optional_package('fury')
+fury, have_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 filepath_dix = {}
 files, folder = fetch_gold_standard_io()

--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -1,7 +1,7 @@
 import numpy as np
 from dipy.tracking.streamline import transform_streamlines
 from dipy.utils.optpkg import optional_package
-fury, have_fury, setup_module = optional_package('fury')
+fury, have_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if have_fury:
     import fury.utils

--- a/dipy/nn/cnn_1d_denoising.py
+++ b/dipy/nn/cnn_1d_denoising.py
@@ -27,15 +27,13 @@ PLoS ONE 17(9): e0274396. https://doi.org/10.1371/journal.pone.0274396
 
 """
 
-from packaging.version import Version
 from dipy.utils.optpkg import optional_package
 import numpy as np
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Input, Conv1D, Activation
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
+
 sklearn, have_sklearn, _ = optional_package('sklearn.model_selection')
 
 

--- a/dipy/nn/evac.py
+++ b/dipy/nn/evac.py
@@ -2,29 +2,22 @@
 """
 Class and helper functions for fitting the EVAC+ model.
 """
-
-
-from packaging.version import Version
 import logging
 import numpy as np
-from scipy.ndimage import affine_transform
 
 from dipy.data import get_fnames
 from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
-from dipy.io.image import load_nifti
 from dipy.align.reslice import reslice
 from dipy.nn.utils import normalize, set_logger_level, transform_img
 from dipy.nn.utils import recover_img, correct_minor_errors
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Softmax, Conv3DTranspose
     from tensorflow.keras.layers import Conv3D, LayerNormalization, ReLU
     from tensorflow.keras.layers import Concatenate, Layer, Dropout, Add
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 else:
     class Model:
         pass

--- a/dipy/nn/histo_resdnn.py
+++ b/dipy/nn/histo_resdnn.py
@@ -2,9 +2,6 @@
 """
 Class and helper functions for fitting the Histological ResDNN model.
 """
-
-
-from packaging.version import Version
 import logging
 import numpy as np
 
@@ -16,12 +13,10 @@ from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
 from dipy.nn.utils import set_logger_level
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Input, Dense, Add
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 else:
     logging.warning('This model requires Tensorflow.\
                     Please install these packages using \

--- a/dipy/nn/model.py
+++ b/dipy/nn/model.py
@@ -1,12 +1,6 @@
-from packaging.version import Version
-
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package('tensorflow')
-
-if have_tf:
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 
 class SingleLayerPerceptron:

--- a/dipy/nn/synb0.py
+++ b/dipy/nn/synb0.py
@@ -2,9 +2,6 @@
 """
 Class and helper functions for fitting the Synb0 model.
 """
-
-
-from packaging.version import Version
 import logging
 import numpy as np
 
@@ -13,7 +10,7 @@ from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
 from dipy.nn.utils import normalize, unnormalize, set_logger_level
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 tfa, have_tfa, _ = optional_package('tensorflow_addons')
 if have_tf and have_tfa:
     from tensorflow.keras.models import Model
@@ -21,8 +18,6 @@ if have_tf and have_tfa:
     from tensorflow.keras.layers import Conv3D, LeakyReLU
     from tensorflow.keras.layers import Concatenate, Layer
     from tensorflow_addons.layers import InstanceNormalization
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 else:
     class Model:
         pass

--- a/dipy/nn/tests/test_cnn_1denoiser.py
+++ b/dipy/nn/tests/test_cnn_1denoiser.py
@@ -1,7 +1,7 @@
 import pytest
 from dipy.utils.optpkg import optional_package
 from dipy.testing.decorators import set_random_number_generator
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 sklearn, have_sklearn, _ = optional_package('sklearn.model_selection')
 if have_tf and have_sklearn:
     from dipy.nn.cnn_1d_denoising import Cnn1DDenoiser

--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -1,5 +1,4 @@
 import pytest
-from packaging.version import Version
 
 import numpy as np
 import numpy.testing as npt
@@ -7,12 +6,10 @@ import numpy.testing as npt
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 if have_tf:
     from dipy.nn.evac import EVACPlus
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')

--- a/dipy/nn/tests/test_histo_resdnn.py
+++ b/dipy/nn/tests/test_histo_resdnn.py
@@ -1,5 +1,4 @@
 import pytest
-from packaging.version import Version
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
@@ -10,11 +9,7 @@ from dipy.utils.optpkg import optional_package
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_raises, assert_equal
 
-tf, have_tf, _ = optional_package('tensorflow')
-
-if have_tf:
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')

--- a/dipy/nn/tests/test_synb0.py
+++ b/dipy/nn/tests/test_synb0.py
@@ -1,18 +1,15 @@
 import pytest
-from packaging.version import Version
 
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 tfa, have_tfa, _ = optional_package('tensorflow_addons')
 
 if have_tf and have_tfa:
     from dipy.nn.synb0 import Synb0
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
 
 
 @pytest.mark.skipif(not all([have_tf, have_tfa]), reason='Requires TensorFlow \

--- a/dipy/nn/tests/test_tf.py
+++ b/dipy/nn/tests/test_tf.py
@@ -1,15 +1,11 @@
 import pytest
-from packaging.version import Version
 from numpy.testing import assert_equal, assert_
 
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package('tensorflow')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 if have_tf:
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
-
     from dipy.nn.model import SingleLayerPerceptron, MultipleLayerPercepton
 
 

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -1,6 +1,4 @@
 """ Classes and functions for fitting ivim model """
-
-from packaging.version import Version
 import warnings
 
 import numpy as np
@@ -9,8 +7,8 @@ from scipy.optimize import least_squares, differential_evolution
 from dipy.reconst.base import ReconstModel
 from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.utils.optpkg import optional_package
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
 
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 # global variable for bounding least_squares in both models
 BOUNDS = ([0., 0., 0., 0.], [np.inf, .2, 1., 1.])
@@ -738,10 +736,7 @@ class IvimModelVP(ReconstModel):
                        f[1] <= 0.89]
 
         # Form objective.
-        if Version(cvxpy.__version__) < Version('1.1'):
-            obj = cvxpy.Minimize(cvxpy.sum(cvxpy.square(phi * f - signal)))
-        else:
-            obj = cvxpy.Minimize(cvxpy.sum(cvxpy.square(phi @ f - signal)))
+        obj = cvxpy.Minimize(cvxpy.sum(cvxpy.square(phi @ f - signal)))
 
         # Form and solve problem.
         prob = cvxpy.Problem(obj, constraints)

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -17,7 +17,7 @@ from dipy.reconst.utils import _roi_in_volume, _mask_from_roi
 from dipy.sims.voxel import single_tensor
 
 from dipy.utils.optpkg import optional_package
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 SH_CONST = .5 / np.sqrt(np.pi)
 
@@ -382,16 +382,8 @@ def solve_qp(P, Q, G, H):
     """
     x = cvxpy.Variable(Q.shape[0])
     P = cvxpy.Constant(P)
-    if Version(cvxpy.__version__) >= Version('1.3'):
-        objective = cvxpy.Minimize(0.5 * cvxpy.quad_form(x, P, True) + Q @ x)
-        constraints = [G @ x <= H]
-    elif Version(cvxpy.__version__) >= Version('1.2'):
-        P_psd = cvxpy.atoms.affine.wraps.psd_wrap(P)
-        objective = cvxpy.Minimize(0.5 * cvxpy.quad_form(x, P_psd) + Q @ x)
-        constraints = [G @ x <= H]
-    elif Version(cvxpy.__version__) < Version('1.2'):
-        msg = """Dipy does not support versions of cvxpy below 1.2."""
-        raise ValueError(msg)
+    objective = cvxpy.Minimize(0.5 * cvxpy.quad_form(x, P, True) + Q @ x)
+    constraints = [G @ x <= H]
 
     # setting up the problem
     prob = cvxpy.Problem(objective, constraints)

--- a/dipy/reconst/qti.py
+++ b/dipy/reconst/qti.py
@@ -7,14 +7,11 @@ from warnings import warn
 
 import numpy as np
 
-from packaging.version import Version
-
 from dipy.reconst.base import ReconstModel
-from dipy.core.ndindex import ndindex
 from dipy.reconst.dti import auto_attr
 from dipy.utils.optpkg import optional_package
 
-cp, have_cvxpy, _ = optional_package("cvxpy")
+cp, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 
 # XXX Eventually to be replaced with `reconst.dti.lower_triangular`
@@ -546,7 +543,7 @@ def _sdpdc_fit(data, mask, X, cvxpy_solver):
     """
 
     if not have_cvxpy:
-        raise ValueError(
+        raise ImportError(
                     'CVXPY package needed to enforce constraints')
 
     if cvxpy_solver not in cp.installed_solvers():
@@ -568,10 +565,7 @@ def _sdpdc_fit(data, mask, X, cvxpy_solver):
     dc = cvxpy_1x6_to_3x3(x[1:7])
     cc = cvxpy_1x21_to_6x6(x[7:])
     constraints = [dc >> 0, cc >> 0]
-    if Version(cp.__version__) < Version('1.1'):
-        objective = cp.Minimize(cp.norm(A * x - y))
-    else:
-        objective = cp.Minimize(cp.norm(A @ x - y))
+    objective = cp.Minimize(cp.norm(A @ x - y))
     prob = cp.Problem(objective, constraints)
     unconstrained = cp.Problem(objective)
 

--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -21,8 +21,9 @@ from dipy.core.sphere import Sphere
 from dipy.data import default_sphere
 from dipy.core.geometry import sphere2cart
 from dipy.utils.optpkg import optional_package
+from dipy.utils.tripwire import TripWireError
 
-_, have_cvxpy, _ = optional_package("cvxpy")
+_, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 fimg, fbvals, fbvecs = get_fnames('small_64D')
 bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
@@ -133,9 +134,9 @@ def test_dki_fits():
 
         assert_array_almost_equal(dki_cwlsF.model_params, crossing_ref)
     else:
-        assert_raises(ValueError, dki.DiffusionKurtosisModel,
+        assert_raises(TripWireError, dki.DiffusionKurtosisModel,
                       gtab_2s, fit_method="CLS")
-        assert_raises(ValueError, dki.DiffusionKurtosisModel,
+        assert_raises(TripWireError, dki.DiffusionKurtosisModel,
                       gtab_2s, fit_method="CWLS")
 
     # NLS fitting

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -14,8 +14,8 @@ import pytest
 from dipy.direction.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
 from dipy.utils.optpkg import optional_package
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
 
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 needs_cvxpy = pytest.mark.skipif(not have_cvxpy, reason="Requires CVXPY")
 
 

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -25,7 +25,7 @@ from dipy.sims.voxel import multi_tensor
 
 from dipy.utils.optpkg import optional_package
 
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 needs_cvxpy = pytest.mark.skipif(not have_cvxpy, reason="REQUIRES CVXPY")
 
 

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -138,10 +138,11 @@ def test_mapmri_initialize_pos_radius():
     """
     gtab = get_gtab_taiwan_dsi()
     # When string is provided it has to be "adaptive"
-    assert_raises(ValueError, MapmriModel, gtab, positivity_constraint=True,
+    ErrorType = ImportError if not mapmri.have_cvxpy else ValueError
+    assert_raises(ErrorType, MapmriModel, gtab, positivity_constraint=True,
                   pos_radius="notadaptive")
     # When a number is provided it has to be positive
-    assert_raises(ValueError, MapmriModel, gtab, positivity_constraint=True,
+    assert_raises(ErrorType, MapmriModel, gtab, positivity_constraint=True,
                   pos_radius=-1)
 
 

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -15,8 +15,8 @@ from dipy.core.gradients import GradientTable
 from dipy.testing.decorators import set_random_number_generator
 
 from dipy.utils.optpkg import optional_package
-cvx, have_cvxpy, _ = optional_package("cvxpy")
 
+cvx, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 needs_cvxpy = pytest.mark.skipif(not have_cvxpy, reason="Requires CVXPY")
 
 

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -104,15 +104,17 @@ def test_input_parameters():
     assert_raises(ValueError, qtdmri.QtdmriModel,
                   gtab_4d, eigenvalue_threshold=-1)
 
+    error = ValueError if qtdmri.have_cvxpy else ImportError
+
     # unavailable cvxpy solver is caught
-    assert_raises(ValueError, qtdmri.QtdmriModel, gtab_4d,
-                  laplacian_regularization=True,
-                  cvxpy_solver='test')
+    assert_raises(error, qtdmri.QtdmriModel, gtab_4d,
+                laplacian_regularization=True,
+                cvxpy_solver='test')
 
     # non-normalized non-cartesian l1-regularization is caught
-    assert_raises(ValueError, qtdmri.QtdmriModel, gtab_4d,
-                  l1_regularization=True, cartesian=False,
-                  normalization=False)
+    assert_raises(error, qtdmri.QtdmriModel, gtab_4d,
+                l1_regularization=True, cartesian=False,
+                normalization=False)
 
 
 def test_orthogonality_temporal_basis_functions():

--- a/dipy/reconst/tests/test_qti.py
+++ b/dipy/reconst/tests/test_qti.py
@@ -9,9 +9,9 @@ from dipy.sims.voxel import vec2vec_rotmat
 from dipy.core.sphere import disperse_charges, HemiSphere
 from dipy.reconst.dti import fractional_anisotropy
 from dipy.testing.decorators import set_random_number_generator
-
 from dipy.utils.optpkg import optional_package
-cp, have_cvxpy, _ = optional_package("cvxpy")
+
+cp, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 
 def test_from_3x3_to_6x1():

--- a/dipy/reconst/tests/test_shore.py
+++ b/dipy/reconst/tests/test_shore.py
@@ -6,16 +6,15 @@ import numpy as np
 import numpy.testing as npt
 
 from scipy.special import genlaguerre, gamma
+import pytest
 
 from dipy.data import get_gtab_taiwan_dsi
 from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.reconst.shore import ShoreModel
 from dipy.sims.voxel import multi_tensor
-
-import pytest
 from dipy.utils.optpkg import optional_package
-cvxpy, have_cvxpy, _ = optional_package("cvxpy")
 
+cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 needs_cvxpy = pytest.mark.skipif(not have_cvxpy, reason="Requires CVXPY")
 
 

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -4,7 +4,6 @@ from scipy.spatial import cKDTree
 from scipy.ndimage import map_coordinates
 from scipy.spatial.distance import mahalanobis
 
-from dipy.utils.optpkg import optional_package
 from dipy.io.utils import save_buan_profiles_hdf5
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric

--- a/dipy/viz/__init__.py
+++ b/dipy/viz/__init__.py
@@ -9,7 +9,7 @@ fury, has_fury, _ = optional_package(
     'fury',
     trip_msg="You do not have FURY installed. Some visualization functions"
     "might not work for you. For installation instructions, please visit: "
-    "https://fury.gl/")
+    "https://fury.gl/", min_version="0.9.0")
 
 
 if has_fury:

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -14,7 +14,7 @@ from dipy.viz.horizon.tab import (ClustersTab, PeaksTab, ROIsTab, SlicesTab,
 from dipy.viz.horizon.visualizer import ClustersVisualizer, SlicesVisualizer
 from dipy.viz.horizon.util import check_img_shapes
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import __version__ as fury_version

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from dipy.utils.optpkg import optional_package
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import ui

--- a/dipy/viz/horizon/tab/cluster.py
+++ b/dipy/viz/horizon/tab/cluster.py
@@ -3,7 +3,7 @@ import numpy as np
 from dipy.utils.optpkg import optional_package
 from dipy.viz.horizon.tab import (HorizonTab, build_label, color_single_slider)
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import ui

--- a/dipy/viz/horizon/tab/peak.py
+++ b/dipy/viz/horizon/tab/peak.py
@@ -4,7 +4,7 @@ from dipy.utils.optpkg import optional_package
 from dipy.viz.horizon.tab import (HorizonTab, build_label, color_double_slider,
                                   color_single_slider)
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import ui

--- a/dipy/viz/horizon/tab/roi.py
+++ b/dipy/viz/horizon/tab/roi.py
@@ -1,7 +1,7 @@
 from dipy.utils.optpkg import optional_package
 from dipy.viz.horizon.tab import (HorizonTab, build_label, color_single_slider)
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import ui

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -7,7 +7,7 @@ from dipy.utils.optpkg import optional_package
 from dipy.viz.horizon.tab import (HorizonTab, build_label, build_slider,
                                   build_switcher, build_checkbox)
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import colormap

--- a/dipy/viz/horizon/tab/tests/test_base.py
+++ b/dipy/viz/horizon/tab/tests/test_base.py
@@ -7,7 +7,7 @@ from dipy.testing.decorators import use_xvfb
 from dipy.viz.horizon.tab.base import (build_checkbox, build_label,
                                        build_slider, build_switcher)
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 skip_it = use_xvfb == 'skip'
 

--- a/dipy/viz/horizon/visualizer/cluster.py
+++ b/dipy/viz/horizon/visualizer/cluster.py
@@ -1,12 +1,10 @@
-import warnings
-
 import numpy as np
 
 from dipy.segment.clustering import qbx_and_merge
-from dipy.tracking.streamline import Streamlines, length
+from dipy.tracking.streamline import length
 from dipy.utils.optpkg import optional_package
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import actor

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -5,7 +5,7 @@ from scipy import stats
 
 from dipy.utils.optpkg import optional_package
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import actor

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -4,7 +4,7 @@ from dipy.utils.optpkg import optional_package
 import itertools
 from dipy.viz.gmem import GlobalHorizon
 
-fury, have_fury, setup_module = optional_package('fury')
+fury, have_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if have_fury:
     from dipy.viz import actor, ui, colormap

--- a/dipy/viz/streamline.py
+++ b/dipy/viz/streamline.py
@@ -1,6 +1,6 @@
 from dipy.utils.optpkg import optional_package
 plt, have_plt, _ = optional_package("matplotlib.pyplot")
-fury, has_fury, _ = optional_package('fury')
+fury, has_fury, _ = optional_package('fury', min_version="0.9.0")
 if has_fury:
     from dipy.viz import window, actor
 

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -12,7 +12,7 @@ from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
 from dipy.testing.decorators import set_random_number_generator
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from fury import window

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -20,7 +20,8 @@ from dipy.align.tests.test_streamlinear import fornix_streamlines
 from dipy.tracking.streamline import (center_streamlines,
                                       transform_streamlines)
 from dipy.reconst.dti import color_fa, fractional_anisotropy
-fury, has_fury, setup_module = optional_package('fury')
+
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from dipy.viz import actor, window, colormap

--- a/dipy/viz/tests/test_streamline.py
+++ b/dipy/viz/tests/test_streamline.py
@@ -3,16 +3,15 @@ import os
 from numpy.testing import assert_raises, assert_equal
 import pytest
 
-from dipy.utils.optpkg import optional_package
+from dipy.align.streamwarp import bundlewarp, bundlewarp_vector_filed
 from dipy.data import read_five_af_bundles, two_cingulum_bundles
 from dipy.tracking.streamline import (set_number_of_points, unlist_streamlines,
                                       Streamlines)
+from dipy.utils.optpkg import optional_package
 
-from dipy.align.streamwarp import bundlewarp, bundlewarp_vector_filed
 
 _, have_matplotlib, _ = optional_package("matplotlib")
-
-fury, have_fury, _ = optional_package('fury')
+fury, have_fury, _ = optional_package('fury', min_version="0.9.0")
 if have_fury:
     from dipy.viz.streamline import (show_bundles, viz_two_bundles,
                                      viz_displacement_mag, viz_vector_field)

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -1,5 +1,4 @@
 from os.path import join as pjoin
-from packaging.version import Version
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -13,12 +12,7 @@ from dipy.utils.optpkg import optional_package
 from dipy.workflows.nn import EVACPlusFlow
 
 
-tf, have_tf, _ = optional_package('tensorflow')
-
-if have_tf:
-    from dipy.nn.evac import EVACPlus
-    if Version(tf.__version__) < Version('2.0.0'):
-        raise ImportError('Please upgrade to TensorFlow 2+')
+tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -23,7 +23,7 @@ from dipy.workflows.stats import BundleShapeAnalysis
 from dipy.workflows.stats import buan_bundle_profiles
 
 pd, have_pandas, _ = optional_package("pandas")
-_, have_statsmodels, _ = optional_package("statsmodels")
+_, have_statsmodels, _ = optional_package("statsmodels", min_version="0.14.0")
 _, have_tables, _ = optional_package("tables")
 _, have_matplotlib, _ = optional_package("matplotlib")
 

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -10,11 +10,10 @@ from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
 from dipy.io.utils import create_nifti_header
 from dipy.tracking.streamline import Streamlines
-from dipy.testing.decorators import use_xvfb
+from dipy.testing.decorators import use_xvfb, set_random_number_generator
 from dipy.utils.optpkg import optional_package
-from dipy.testing.decorators import set_random_number_generator
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 if has_fury:
     from dipy.workflows.viz import HorizonFlow

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -10,7 +10,7 @@ from dipy.stats.analysis import assignment_map
 from dipy.utils.optpkg import optional_package
 
 
-fury, has_fury, setup_module = optional_package('fury')
+fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
 
 if has_fury:


### PR DESCRIPTION
This PR:

- Adds minimum version for cvxpy = 1.4.1
- Adds minimum version for fury = 0.9.0
- Adds minimum version for statsmodels = 0.14.0
- Clean some import 

it should helps #2999 and, in general, improve optional dependencies management.