### PR TITLE
[TEST] Manage http errors for stateful tractograms

### DIFF
--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -3,8 +3,7 @@ import os
 from os.path import join as pjoin
 from copy import deepcopy
 from tempfile import TemporaryDirectory
-from requests import HTTPError
-from urllib.error import URLError
+from urllib.error import URLError, HTTPError
 
 import numpy as np
 import numpy.testing as npt

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -3,6 +3,8 @@ import os
 from os.path import join as pjoin
 from copy import deepcopy
 from tempfile import TemporaryDirectory
+from requests import HTTPError
+from urllib.error import URLError
 
 import numpy as np
 import numpy.testing as npt
@@ -20,26 +22,44 @@ import trx.trx_file_memmap as tmm
 from dipy.utils.optpkg import optional_package
 fury, have_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
-filepath_dix = {}
-files, folder = fetch_gold_standard_io()
-for filename in files:
-    filepath_dix[filename] = os.path.join(folder, filename)
 
-with open(filepath_dix['points_data.json']) as json_file:
-    points_data = dict(json.load(json_file))
+FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
 
-with open(filepath_dix['streamlines_data.json']) as json_file:
-    streamlines_data = dict(json.load(json_file))
+
+def setup_module():
+    global FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA
+    try:
+        files, folder = fetch_gold_standard_io()
+    except (HTTPError, URLError) as e:
+        FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
+        error_msg = f'"Tests Data failed to download." Reason: {e}'
+        pytest.skip(error_msg, allow_module_level=True)
+        return
+
+    FILEPATH_DIX = {}
+    for filename in files:
+        FILEPATH_DIX[filename] = os.path.join(folder, filename)
+
+    with open(FILEPATH_DIX['points_data.json']) as json_file:
+        POINTS_DATA = dict(json.load(json_file))
+
+    with open(FILEPATH_DIX['streamlines_data.json']) as json_file:
+        STREAMLINES_DATA = dict(json.load(json_file))
+
+
+def teardown_module():
+    global FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA
+    FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
 
 
 def test_direct_trx_loading():
-    trx = tmm.load(filepath_dix['gs.trx'])
+    trx = tmm.load(FILEPATH_DIX['gs.trx'])
     tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
     assert os.path.isdir(tmp_dir)
     sft = trx.to_sft()
 
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
     trx.close()
     assert not os.path.isdir(tmp_dir)
@@ -52,25 +72,25 @@ def test_direct_trx_loading():
 
 
 def test_trk_equal_in_vox_space():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOX)
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
     assert_allclose(tmp_points_vox,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_tck_equal_in_vox_space():
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOX)
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
     assert_allclose(tmp_points_vox,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_trx_equal_in_vox_space():
-    sft = load_tractogram(filepath_dix['gs.trx'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trx'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOX)
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
     assert_allclose(tmp_points_vox,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
@@ -79,41 +99,41 @@ def test_trx_equal_in_vox_space():
 def test_fib_equal_in_vox_space():
     if not have_fury:
         return
-    sft = load_tractogram(filepath_dix['gs.fib'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.fib'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOX)
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
     assert_allclose(tmp_points_vox,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_dpy_equal_in_vox_space():
-    sft = load_tractogram(filepath_dix['gs.dpy'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.dpy'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOX)
-    tmp_points_vox = np.loadtxt(filepath_dix['gs_vox_space.txt'])
+    tmp_points_vox = np.loadtxt(FILEPATH_DIX['gs_vox_space.txt'])
     assert_allclose(tmp_points_vox,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_trk_equal_in_rasmm_space():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_tck_equal_in_rasmm_space():
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_trx_equal_in_rasmm_space():
-    sft = load_tractogram(filepath_dix['gs.trx'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trx'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
@@ -122,41 +142,41 @@ def test_trx_equal_in_rasmm_space():
 def test_fib_equal_in_rasmm_space():
     if not have_fury:
         return
-    sft = load_tractogram(filepath_dix['gs.fib'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.fib'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_dpy_equal_in_rasmm_space():
-    sft = load_tractogram(filepath_dix['gs.dpy'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.dpy'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_trk_equal_in_voxmm_space():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_tck_equal_in_voxmm_space():
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_trx_equal_in_voxmm_space():
-    sft = load_tractogram(filepath_dix['gs.trx'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trx'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
@@ -165,29 +185,29 @@ def test_trx_equal_in_voxmm_space():
 def test_fib_equal_in_voxmm_space():
     if not have_fury:
         return
-    sft = load_tractogram(filepath_dix['gs.fib'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.fib'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_dpy_equal_in_voxmm_space():
-    sft = load_tractogram(filepath_dix['gs.dpy'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.dpy'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
                     sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
 def test_switch_voxel_sizes_from_rasmm():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     sft_switch = StatefulTractogram(sft.streamlines,
-                                    filepath_dix['gs_3mm.nii'],
+                                    FILEPATH_DIX['gs_3mm.nii'],
                                     Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
@@ -199,13 +219,13 @@ def test_switch_voxel_sizes_from_rasmm():
 
 
 def test_switch_voxel_sizes_from_voxmm():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.VOXMM)
     sft_switch = StatefulTractogram(sft.streamlines,
-                                    filepath_dix['gs_3mm.nii'],
+                                    FILEPATH_DIX['gs_3mm.nii'],
                                     Space.VOXMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
-    tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
+    tmp_points_voxmm = np.loadtxt(FILEPATH_DIX['gs_voxmm_space.txt'])
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
@@ -217,9 +237,9 @@ def test_switch_voxel_sizes_from_voxmm():
 
 
 def test_to_rasmm_equivalence():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
 
     sft_1.to_rasmm()
@@ -229,9 +249,9 @@ def test_to_rasmm_equivalence():
 
 
 def test_to_voxmm_equivalence():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
 
     sft_1.to_voxmm()
@@ -241,9 +261,9 @@ def test_to_voxmm_equivalence():
 
 
 def test_to_vox_equivalence():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.RASMM)
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.RASMM)
 
     sft_1.to_vox()
@@ -253,9 +273,9 @@ def test_to_vox_equivalence():
 
 
 def test_to_corner_equivalence():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
 
     sft_1.to_corner()
@@ -265,9 +285,9 @@ def test_to_corner_equivalence():
 
 
 def test_to_center_equivalence():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
 
     sft_1.to_center()
@@ -277,7 +297,7 @@ def test_to_center_equivalence():
 
 
 def test_empty_sft_case():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX, to_origin=Origin('corner'))
     # Removing data_per_point
     sft_1 = sft_1.from_sft(sft_1.streamlines, sft_1)
@@ -295,15 +315,15 @@ def test_empty_sft_case():
 
 
 def test_trk_iterative_saving_loading():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     with TemporaryDirectory() as tmp_dir:
         save_tractogram(sft, pjoin(tmp_dir, 'gs_iter.trk'))
-        tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
         for _ in range(100):
             sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.trk'),
-                                       filepath_dix['gs.nii'],
+                                       FILEPATH_DIX['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -312,15 +332,15 @@ def test_trk_iterative_saving_loading():
 
 
 def test_tck_iterative_saving_loading():
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     with TemporaryDirectory() as tmp_dir:
         save_tractogram(sft, pjoin(tmp_dir, 'gs_iter.tck'))
-        tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
         for _ in range(100):
             sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.tck'),
-                                       filepath_dix['gs.nii'],
+                                       FILEPATH_DIX['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -329,15 +349,15 @@ def test_tck_iterative_saving_loading():
 
 
 def test_trx_iterative_saving_loading():
-    sft = load_tractogram(filepath_dix['gs.trx'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trx'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     with TemporaryDirectory() as tmp_dir:
         save_tractogram(sft, pjoin(tmp_dir, 'gs_iter.trx'))
-        tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
         for _ in range(100):
             sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.trx'),
-                                       filepath_dix['gs.nii'],
+                                       FILEPATH_DIX['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -349,14 +369,15 @@ def test_trx_iterative_saving_loading():
 def test_fib_iterative_saving_loading():
     if not have_fury:
         return
-    sft = load_tractogram(filepath_dix['gs.fib'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.fib'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     with TemporaryDirectory() as tmp_dir:
         save_tractogram(sft, pjoin(tmp_dir, 'gs_iter.fib'))
-        tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.fib'), filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.fib'),
+                                       FILEPATH_DIX['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -365,14 +386,15 @@ def test_fib_iterative_saving_loading():
 
 
 def test_dpy_iterative_saving_loading():
-    sft = load_tractogram(filepath_dix['gs.dpy'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.dpy'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     with TemporaryDirectory() as tmp_dir:
         save_tractogram(sft, pjoin(tmp_dir, 'gs_iter.dpy'))
-        tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
 
         for _ in range(100):
-            sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.dpy'), filepath_dix['gs.nii'],
+            sft_iter = load_tractogram(pjoin(tmp_dir, 'gs_iter.dpy'),
+                                       FILEPATH_DIX['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
                             sft_iter.streamlines.get_data(),
@@ -381,9 +403,9 @@ def test_dpy_iterative_saving_loading():
 
 
 def test_iterative_to_vox_transformation():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     for _ in range(1000):
         sft.to_vox()
         sft.to_rasmm()
@@ -392,9 +414,9 @@ def test_iterative_to_vox_transformation():
 
 
 def test_iterative_to_voxmm_transformation():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
-    tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX['gs_rasmm_space.txt'])
     for _ in range(1000):
         sft.to_voxmm()
         sft.to_rasmm()
@@ -403,7 +425,7 @@ def test_iterative_to_voxmm_transformation():
 
 
 def test_empty_space_change():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft = StatefulTractogram([], FILEPATH_DIX['gs.nii'], Space.VOX)
     sft.to_vox()
     sft.to_voxmm()
     sft.to_rasmm()
@@ -411,25 +433,25 @@ def test_empty_space_change():
 
 
 def test_empty_shift_change():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft = StatefulTractogram([], FILEPATH_DIX['gs.nii'], Space.VOX)
     sft.to_corner()
     sft.to_center()
     assert_array_equal([], sft.streamlines.get_data())
 
 
 def test_empty_remove_invalid():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft = StatefulTractogram([], FILEPATH_DIX['gs.nii'], Space.VOX)
     sft.remove_invalid_streamlines()
     assert_array_equal([], sft.streamlines.get_data())
 
 
 def test_shift_corner_from_rasmm():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
     sft_1.to_corner()
     bbox_1 = sft_1.compute_bounding_box()
 
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.RASMM)
     sft_2.to_corner()
     sft_2.to_vox()
@@ -439,12 +461,12 @@ def test_shift_corner_from_rasmm():
 
 
 def test_shift_corner_from_voxmm():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOX)
     sft_1.to_corner()
     bbox_1 = sft_1.compute_bounding_box()
 
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                             to_space=Space.VOXMM)
     sft_2.to_corner()
     sft_2.to_vox()
@@ -454,7 +476,7 @@ def test_shift_corner_from_voxmm():
 
 
 def test_iterative_shift_corner():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     tmp_streamlines = sft.get_streamlines_copy()
 
@@ -466,7 +488,7 @@ def test_iterative_shift_corner():
 
 
 def test_replace_streamlines():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     tmp_streamlines = sft.get_streamlines_copy()[::-1]
 
@@ -478,7 +500,7 @@ def test_replace_streamlines():
 
 
 def test_subsample_streamlines():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
     tmp_streamlines = sft.get_streamlines_copy()[0:8]
 
@@ -490,7 +512,7 @@ def test_subsample_streamlines():
 
 
 def test_reassign_both_data_sep_to_empty():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
 
     try:
@@ -504,12 +526,12 @@ def test_reassign_both_data_sep_to_empty():
 
 
 def test_reassign_both_data_sep():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_space=Space.RASMM)
 
     try:
-        sft.data_per_point = points_data
-        sft.data_per_streamline = streamlines_data
+        sft.data_per_point = POINTS_DATA
+        sft.data_per_streamline = STREAMLINES_DATA
         assert_(True)
     except (TypeError, ValueError):
         assert_(False)
@@ -517,7 +539,7 @@ def test_reassign_both_data_sep():
 
 @pytest.mark.parametrize('standard', [Origin.NIFTI, Origin.TRACKVIS])
 def test_bounding_bbox_valid(standard):
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'],
                           to_origin=standard, bbox_valid_check=False)
 
     assert_(sft.is_bbox_in_vox_valid())
@@ -525,7 +547,7 @@ def test_bounding_bbox_valid(standard):
 
 @set_random_number_generator(0)
 def test_random_point_color(rng):
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'])
 
     random_colors = rng.integers(0, 255, (13, 8, 3))
     coloring_dict = {'colors': random_colors}
@@ -541,7 +563,7 @@ def test_random_point_color(rng):
 
 @set_random_number_generator(0)
 def test_random_point_gray(rng):
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'])
 
     random_colors = rng.integers(0, 255, (13, 8, 1))
     coloring_dict = {
@@ -561,7 +583,7 @@ def test_random_point_gray(rng):
 
 @set_random_number_generator(0)
 def test_random_streamline_color(rng):
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'])
 
     uniform_colors_x = rng.integers(0, 255, (13, 1))
     uniform_colors_y = rng.integers(0, 255, (13, 1))
@@ -592,7 +614,7 @@ def test_random_streamline_color(rng):
 @pytest.mark.parametrize('value, is_out_of_grid',
                          [(100, True), (-100, True), (0, False)])
 def test_out_of_grid(value, is_out_of_grid):
-    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'])
     sft.to_vox()
     tmp_streamlines = list(sft.get_streamlines_copy())
     tmp_streamlines[0] += value
@@ -605,7 +627,7 @@ def test_out_of_grid(value, is_out_of_grid):
 
 
 def test_data_per_point_consistency_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -618,7 +640,7 @@ def test_data_per_point_consistency_addition():
 
 
 def test_data_per_streamline_consistency_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -631,7 +653,7 @@ def test_data_per_streamline_consistency_addition():
 
 
 def test_space_consistency_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -644,7 +666,7 @@ def test_space_consistency_addition():
 
 
 def test_origin_consistency_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -657,9 +679,9 @@ def test_origin_consistency_addition():
 
 
 def test_space_attributes_consistency_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_switch = StatefulTractogram(sft.streamlines,
-                                    filepath_dix['gs_3mm.nii'],
+                                    FILEPATH_DIX['gs_3mm.nii'],
                                     Space.RASMM)
 
     try:
@@ -670,15 +692,15 @@ def test_space_attributes_consistency_addition():
 
 
 def test_equality():
-    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
-    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
+    sft_2 = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
 
     assert_(sft_1 == sft_2,
             msg='Identical sft should be equal (==)')
 
 
 def test_basic_slicing():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     first_streamline_sft = sft[0]
 
     npt.assert_allclose(first_streamline_sft.streamlines[0][0],
@@ -695,7 +717,7 @@ def test_basic_slicing():
 
 
 def test_space_side_effect_slicing():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     first_streamline = deepcopy(sft.streamlines[0])
 
     first_streamline_sft = sft[0]
@@ -713,7 +735,7 @@ def test_space_side_effect_slicing():
 
 
 def test_origin_side_effect_slicing():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     first_streamline = deepcopy(sft.streamlines[0])
 
     first_streamline_sft = sft[0]
@@ -731,7 +753,7 @@ def test_origin_side_effect_slicing():
 
 
 def test_advanced_slicing():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     last_streamline_sft = sft[::-1][0]
 
     npt.assert_allclose(last_streamline_sft.streamlines[0][0],
@@ -748,7 +770,7 @@ def test_advanced_slicing():
 
 
 def test_basic_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -758,7 +780,7 @@ def test_basic_addition():
 
 
 def test_space_side_effect_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -777,7 +799,7 @@ def test_space_side_effect_addition():
 
 
 def test_origin_side_effect_addition():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     sft_first_half = sft[0:7]
     sft_last_half = sft[7:13]
 
@@ -797,7 +819,7 @@ def test_origin_side_effect_addition():
 
 def test_invalid_streamlines():
 
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     src_strml_count = len(sft)
 
     obtained_idx_to_remove, obtained_idx_to_keep = \
@@ -831,7 +853,7 @@ def test_invalid_streamlines():
 
 def test_invalid_streamlines_epsilon():
 
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     src_strml_count = len(sft)
 
     epsilon = 1e-6
@@ -868,7 +890,7 @@ def test_invalid_streamlines_epsilon():
 
 
 def test_create_from_sft():
-    sft_1 = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft_1 = load_tractogram(FILEPATH_DIX['gs.tck'], FILEPATH_DIX['gs.nii'])
     sft_2 = StatefulTractogram.from_sft(
         sft_1.streamlines, sft_1,
         data_per_point=sft_1.data_per_point,
@@ -893,7 +915,7 @@ def test_create_from_sft():
 
 
 def test_init_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'positions': np.float32,
                   'offsets': np.int_,
                   'dpp': {'color_x': np.float32,
@@ -909,7 +931,7 @@ def test_init_dtype_dict_attributes():
 
 
 def test_set_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'positions': np.float16,
                   'offsets': np.int32,
                   'dpp': {'color_x': np.uint8,
@@ -925,7 +947,7 @@ def test_set_dtype_dict_attributes():
 
 
 def test_set_partial_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'positions': np.float16,
                   'offsets': np.int32}
     dpp_dtype_dict = {'dpp': {'color_x': np.float32,
@@ -947,7 +969,7 @@ def test_set_partial_dtype_dict_attributes():
 
 
 def test_non_existing_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'dpp': {'color_a': np.uint8,   # Fake
                           'color_b': np.uint8,   # Fake
                           'color_c': np.uint8},  # Fake
@@ -963,7 +985,7 @@ def test_non_existing_dtype_dict_attributes():
 
 
 def test_from_sft_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'positions': np.float16,
                   'offsets': np.int32,
                   'dpp': {'color_x': np.uint8,
@@ -983,7 +1005,7 @@ def test_from_sft_dtype_dict_attributes():
 
 
 def test_slicing_dtype_dict_attributes():
-    sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'])
+    sft = load_tractogram(FILEPATH_DIX['gs.trk'], FILEPATH_DIX['gs.nii'])
     dtype_dict = {'positions': np.float16,
                   'offsets': np.int32,
                   'dpp': {'color_x': np.uint8,


### PR DESCRIPTION
This PR provides an alternative when there is http issue with `fetch_gold_standard_io`. 

Instead of failing, we just skip the tests and provide a reason. It also one step further concerning offline testing (see https://github.com/dipy/dipy/issues/2647)

It also cleanup some global variable.