### PR TITLE
[RF] Fix cython 3 warnings

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -20,7 +20,7 @@ cdef cnp.dtype f64_dt = np.dtype(np.float64)
 
 
 cdef double min_direct_flip_dist(double *a,double *b,
-                                 cnp.npy_intp rows) nogil:
+                                 cnp.npy_intp rows) noexcept nogil:
     r""" Minimum of direct and flip average (MDF) distance [Garyfallidis12]
     between two streamlines.
 

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -6,14 +6,14 @@ cimport cython
 cimport numpy as cnp
 
 
-cdef inline int _int_max(int a, int b) nogil:
+cdef inline int _int_max(int a, int b) noexcept nogil:
     r"""
     Returns the maximum of a and b
     """
     return a if a >= b else b
 
 
-cdef inline int _int_min(int a, int b) nogil:
+cdef inline int _int_min(int a, int b) noexcept nogil:
     r"""
     Returns the minimum of a and b
     """
@@ -32,7 +32,7 @@ cdef enum:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef inline int _wrap(int x, int m)nogil:
+cdef inline int _wrap(int x, int m) noexcept nogil:
     r""" Auxiliary function to `wrap` an array around its low-end side.
     Negative indices are mapped to last coordinates so that no extra memory
     is required to account for local rectangular windows that exceed the
@@ -57,7 +57,7 @@ cdef inline void _update_factors(double[:, :, :, :] factors,
                                  floating[:, :, :] moving,
                                  floating[:, :, :] static,
                                  cnp.npy_intp ss, cnp.npy_intp rr, cnp.npy_intp cc,
-                                 cnp.npy_intp s, cnp.npy_intp r, cnp.npy_intp c, int operation)nogil:
+                                 cnp.npy_intp s, cnp.npy_intp r, cnp.npy_intp c, int operation)noexcept nogil:
     r"""Updates the precomputed CC factors of a rectangular window
 
     Updates the precomputed CC factors of the rectangular window centered

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -14,7 +14,7 @@ cdef extern from "dpy_math.h" nogil:
 @cython.cdivision(True)
 cdef void _solve_2d_symmetric_positive_definite(double* A, double* y,
                                                 double det,
-                                                double* out) nogil:
+                                                double* out) noexcept nogil:
     r"""Solves a 2-variable symmetric positive-definite linear system
 
     The C implementation of the public-facing Python function

--- a/dipy/align/transforms.pxd
+++ b/dipy/align/transforms.pxd
@@ -2,6 +2,6 @@ cdef class Transform:
     cdef:
         int number_of_parameters
         int dim
-    cdef int _jacobian(self, double[:] theta, double[:] x, double[:, :] J)nogil
-    cdef void _get_identity_parameters(self, double[:] theta) nogil
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] T)nogil
+    cdef int _jacobian(self, double[:] theta, double[:] x, double[:, :] J) noexcept nogil
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] T) noexcept nogil

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -39,13 +39,13 @@ cdef class Transform:
         self.number_of_parameters = -1
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         return -1
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         return
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] T)nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] T) noexcept nogil:
         return
 
     def jacobian(self, double[:] theta, double[:] x):
@@ -122,7 +122,7 @@ cdef class TranslationTransform2D(Transform):
         self.number_of_parameters = 2
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the 2D translation transform
         The transformation is given by:
 
@@ -157,7 +157,7 @@ cdef class TranslationTransform2D(Transform):
         # This Jacobian does not depend on x (it's constant): return 1
         return 1
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -169,7 +169,7 @@ cdef class TranslationTransform2D(Transform):
         """
         theta[:2] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D translation transform
 
         Parameters
@@ -192,7 +192,7 @@ cdef class TranslationTransform3D(Transform):
         self.number_of_parameters = 3
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the 3D translation transform
         The transformation is given by:
 
@@ -228,7 +228,7 @@ cdef class TranslationTransform3D(Transform):
         # This Jacobian does not depend on x (it's constant): return 1
         return 1
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -240,7 +240,7 @@ cdef class TranslationTransform3D(Transform):
         """
         theta[:3] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 3D translation transform
 
         Parameters
@@ -264,7 +264,7 @@ cdef class RotationTransform2D(Transform):
         self.number_of_parameters = 1
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 2D rotation with parameter theta, at x
 
         The transformation is given by:
@@ -301,7 +301,7 @@ cdef class RotationTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -313,7 +313,7 @@ cdef class RotationTransform2D(Transform):
         """
         theta[0] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D rotation transform
 
         Parameters
@@ -339,7 +339,7 @@ cdef class RotationTransform3D(Transform):
         self.number_of_parameters = 3
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 3D rotation with parameters theta, at x
 
         Parameters
@@ -382,7 +382,7 @@ cdef class RotationTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -394,7 +394,7 @@ cdef class RotationTransform3D(Transform):
         """
         theta[:3] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 3D rotation transform
 
         The matrix is the product of rotation matrices of angles theta[0],
@@ -441,7 +441,7 @@ cdef class RigidTransform2D(Transform):
         self.number_of_parameters = 3
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 2D rigid transform (rotation + translation)
 
         The transformation is given by:
@@ -482,7 +482,7 @@ cdef class RigidTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -497,7 +497,7 @@ cdef class RigidTransform2D(Transform):
         """
         theta[:3] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D rigid transform
 
         Parameters
@@ -533,7 +533,7 @@ cdef class RigidTransform3D(Transform):
         self.number_of_parameters = 6
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 3D rigid transform (rotation + translation)
 
         Parameters
@@ -587,7 +587,7 @@ cdef class RigidTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -605,7 +605,7 @@ cdef class RigidTransform3D(Transform):
         """
         theta[:6] = 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 3D rigid transform
 
         Parameters
@@ -658,7 +658,7 @@ cdef class RigidIsoScalingTransform2D(Transform):
         self.number_of_parameters = 4
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 2D rigid isoscaling transform.
 
         The transformation (rotation + translation + isoscaling) is given by:
@@ -699,7 +699,7 @@ cdef class RigidIsoScalingTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         """ Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -716,7 +716,7 @@ cdef class RigidIsoScalingTransform2D(Transform):
         theta[:3] = 0
         theta[3] = 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D rigid isoscaling transform
 
         Parameters
@@ -757,7 +757,7 @@ cdef class RigidIsoScalingTransform3D(Transform):
         self.number_of_parameters = 7
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 3D isoscaling rigid transform.
 
         (rotation + translation + scaling)
@@ -825,7 +825,7 @@ cdef class RigidIsoScalingTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         """ Parameter values corresponding to the identity
 
         Sets in theta the parameter values corresponding to the identity
@@ -847,7 +847,7 @@ cdef class RigidIsoScalingTransform3D(Transform):
         theta[:6] = 0
         theta[6] = 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         """ Matrix associated with the 3D rigid isoscaling transform
 
         Parameters
@@ -903,7 +903,7 @@ cdef class RigidScalingTransform2D(Transform):
         self.number_of_parameters = 5
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of a 2D rigid scaling transform.
 
         The transformation (rotation + translation + scaling) is given by:
@@ -946,7 +946,7 @@ cdef class RigidScalingTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         """ Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -964,7 +964,7 @@ cdef class RigidScalingTransform2D(Transform):
         theta[:3] = 0
         theta[3], theta[4] = 1, 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D rigid scaling transform
 
         Parameters
@@ -1007,7 +1007,7 @@ cdef class RigidScalingTransform3D(Transform):
         self.number_of_parameters = 9
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         """Jacobian matrix of a 3D rigid scaling transform.
 
         (rotation + translation + scaling)
@@ -1079,7 +1079,7 @@ cdef class RigidScalingTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -1101,7 +1101,7 @@ cdef class RigidScalingTransform3D(Transform):
         theta[:6] = 0
         theta[6:9] = 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 3D rigid scaling transform
 
         Parameters
@@ -1152,7 +1152,7 @@ cdef class ScalingTransform2D(Transform):
         self.number_of_parameters = 1
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the isotropic 2D scale transform
         The transformation is given by:
 
@@ -1181,7 +1181,7 @@ cdef class ScalingTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -1193,7 +1193,7 @@ cdef class ScalingTransform2D(Transform):
         """
         theta[0] = 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 2D (isotropic) scaling transform
 
         Parameters
@@ -1216,7 +1216,7 @@ cdef class ScalingTransform3D(Transform):
         self.number_of_parameters = 1
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the isotropic 3D scale transform
         The transformation is given by:
 
@@ -1245,7 +1245,7 @@ cdef class ScalingTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -1257,7 +1257,7 @@ cdef class ScalingTransform3D(Transform):
         """
         theta[0] = 1
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with the 3D (isotropic) scaling transform
 
         Parameters
@@ -1281,7 +1281,7 @@ cdef class AffineTransform2D(Transform):
         self.number_of_parameters = 6
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the 2D affine transform
         The transformation is given by:
 
@@ -1325,7 +1325,7 @@ cdef class AffineTransform2D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -1338,7 +1338,7 @@ cdef class AffineTransform2D(Transform):
         theta[0], theta[1], theta[2] = 1, 0, 0
         theta[3], theta[4], theta[5] = 0, 1, 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with a general 2D affine transform
 
         The transformation is given by the matrix:
@@ -1367,7 +1367,7 @@ cdef class AffineTransform3D(Transform):
         self.number_of_parameters = 12
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
-                       double[:, :] J)nogil:
+                       double[:, :] J) noexcept nogil:
         r""" Jacobian matrix of the 3D affine transform
         The transformation is given by:
 
@@ -1422,7 +1422,7 @@ cdef class AffineTransform3D(Transform):
         # This Jacobian depends on x (it's not constant): return 0
         return 0
 
-    cdef void _get_identity_parameters(self, double[:] theta) nogil:
+    cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil:
         r""" Parameter values corresponding to the identity
         Sets in theta the parameter values corresponding to the identity
         transform
@@ -1436,7 +1436,7 @@ cdef class AffineTransform3D(Transform):
         theta[4], theta[5], theta[6], theta[7] = 0, 1, 0, 0
         theta[8], theta[9], theta[10], theta[11] = 0, 0, 1, 0
 
-    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) nogil:
+    cdef void _param_to_matrix(self, double[:] theta, double[:, :] R) noexcept nogil:
         r""" Matrix associated with a general 3D affine transform
 
         The transformation is given by the matrix:

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -37,7 +37,7 @@ cdef void _compose_vector_fields_2d(floating[:, :, :] d1, floating[:, :, :] d2,
                                     double[:, :] premult_disp,
                                     double time_scaling,
                                     floating[:, :, :] comp,
-                                    double[:] stats) nogil:
+                                    double[:] stats) noexcept nogil:
     r"""Computes the composition of two 2D displacement fields
 
     Computes the composition of the two 2-D displacements d1 and d2. The
@@ -237,7 +237,7 @@ cdef void _compose_vector_fields_3d(floating[:, :, :, :] d1,
                                     double[:, :] premult_disp,
                                     double t,
                                     floating[:, :, :, :] comp,
-                                    double[:] stats) nogil:
+                                    double[:] stats) noexcept nogil:
     r"""Computes the composition of two 3D displacement fields
 
     Computes the composition of the two 3-D displacements d1 and d2. The

--- a/dipy/core/interpolation.pxd
+++ b/dipy/core/interpolation.pxd
@@ -10,27 +10,27 @@ cpdef trilinear_interpolate4d(
 cdef int trilinear_interpolate4d_c(
     double[:, :, :, :] data,
     double* point,
-    double[:] result) nogil
+    double[:] result) noexcept nogil
 
 cdef int _interpolate_vector_2d(floating[:, :, :] field, double dii,
-                                double djj, floating *out) nogil
+                                double djj, floating *out) noexcept nogil
 cdef int _interpolate_scalar_2d(floating[:, :] image, double dii,
-                                double djj, floating *out) nogil
+                                double djj, floating *out) noexcept nogil
 cdef int _interpolate_scalar_nn_2d(number[:, :] image, double dii,
-                                   double djj, number *out) nogil
+                                   double djj, number *out) noexcept nogil
 cdef int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
                                    double dii, double djj,
-                                   number *out) nogil
+                                   number *out) noexcept nogil
 cdef int _interpolate_scalar_3d(floating[:, :, :] volume,
                                 double dkk, double dii, double djj,
-                                floating *out) nogil
+                                floating *out) noexcept nogil
 cdef int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
                                 double dii, double djj,
-                                floating* out) nogil
+                                floating* out) noexcept nogil
 cdef void _trilinear_interpolation_iso(double *X,
                                        double *W,
-                                       cnp.npy_intp *IN) nogil
+                                       cnp.npy_intp *IN) noexcept nogil
 cdef cnp.npy_intp offset(cnp.npy_intp *indices,
                          cnp.npy_intp *strides,
                          int lenind,
-                         int typesize) nogil
+                         int typesize) noexcept nogil

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -89,7 +89,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
 cdef cnp.npy_intp offset(cnp.npy_intp *indices,
                          cnp.npy_intp *strides,
                          int lenind,
-                         int typesize) nogil:
+                         int typesize) noexcept nogil:
     """ Access any element of any ndimensional numpy array using cython.
 
     Parameters
@@ -114,7 +114,7 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
     return summ
 
 
-cdef void splitoffset(float *offset, cnp.npy_intp *index, cnp.npy_intp shape) nogil:
+cdef void splitoffset(float *offset, cnp.npy_intp *index, cnp.npy_intp shape) noexcept nogil:
     """Splits a global offset into an integer index and a relative offset"""
     offset[0] -= .5
     if offset[0] <= 0:
@@ -129,7 +129,7 @@ cdef void splitoffset(float *offset, cnp.npy_intp *index, cnp.npy_intp shape) no
 
 
 @cython.profile(False)
-cdef inline float wght(int i, float r) nogil:
+cdef inline float wght(int i, float r) noexcept nogil:
     if i:
         return r
     else:
@@ -244,7 +244,7 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
 
 cdef void _trilinear_interpolation_iso(double *X,
                                        double *W,
-                                       cnp.npy_intp *IN) nogil:
+                                       cnp.npy_intp *IN) noexcept nogil:
     """ Interpolate in 3d volumes given point X
 
     Returns
@@ -295,7 +295,7 @@ cdef void _trilinear_interpolation_iso(double *X,
 cdef int trilinear_interpolate4d_c(
         double[:, :, :, :] data,
         double* point,
-        double[:] result) nogil:
+        double[:] result) noexcept nogil:
     """Tri-linear interpolation along the last dimension of a 4d array
 
     Parameters
@@ -438,7 +438,7 @@ def interpolate_vector_2d(floating[:, :, :] field, double[:, :] locations):
 
 
 cdef inline int _interpolate_vector_2d(floating[:, :, :] field, double dii,
-                                       double djj, floating *out) nogil:
+                                       double djj, floating *out) noexcept nogil:
     r"""Bilinear interpolation of a 2D vector field
 
     Interpolates the 2D displacement field at (dii, djj) and stores the
@@ -548,7 +548,7 @@ def interpolate_scalar_2d(floating[:, :] image, double[:, :] locations):
 
 
 cdef inline int _interpolate_scalar_2d(floating[:, :] image, double dii,
-                                       double djj, floating *out) nogil:
+                                       double djj, floating *out) noexcept nogil:
     r"""Bilinear interpolation of a 2D scalar image
 
     Interpolates the 2D image at (dii, djj) and stores the
@@ -652,7 +652,7 @@ def interpolate_scalar_nn_2d(number[:, :] image, double[:, :] locations):
 
 
 cdef inline int _interpolate_scalar_nn_2d(number[:, :] image, double dii,
-                                          double djj, number *out) nogil:
+                                          double djj, number *out) noexcept nogil:
     r"""Nearest-neighbor interpolation of a 2D scalar image
 
     Interpolates the 2D image at (dii, djj) using nearest neighbor
@@ -746,7 +746,7 @@ def interpolate_scalar_nn_3d(number[:, :, :] image, double[:, :] locations):
 
 cdef inline int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
                                          double dii, double djj,
-                                         number *out) nogil:
+                                         number *out) noexcept nogil:
     r"""Nearest-neighbor interpolation of a 3D scalar image
 
     Interpolates the 3D image at (dkk, dii, djj) using nearest neighbor
@@ -849,7 +849,7 @@ def interpolate_scalar_3d(floating[:, :, :] image, locations):
 
 cdef inline int _interpolate_scalar_3d(floating[:, :, :] volume,
                                        double dkk, double dii, double djj,
-                                       floating *out) nogil:
+                                       floating *out) noexcept nogil:
     r"""Trilinear interpolation of a 3D scalar image
 
     Interpolates the 3D image at (dkk, dii, djj) and stores the
@@ -982,7 +982,7 @@ def interpolate_vector_3d(floating[:, :, :, :] field, double[:, :] locations):
 
 cdef inline int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
                                        double dii, double djj,
-                                       floating* out) nogil:
+                                       floating* out) noexcept nogil:
     r"""Trilinear interpolation of a 3D vector field
 
     Interpolates the 3D displacement field at (dkk, dii, djj) and stores the

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -261,7 +261,7 @@ cdef class EnhancementKernel:
     @cython.boundscheck(False)
     @cython.nonecheck(False)
     cdef double k2(self, double [:] x, double [:] y,
-                   double [:] r, double [:] v) nogil:
+                   double [:] r, double [:] v) noexcept nogil:
         """ Evaluate the kernel at position x relative to
         position y, with orientation r relative to orientation v.
 
@@ -308,7 +308,7 @@ cdef class EnhancementKernel:
     @cython.cdivision(True)
     cdef double [:] coordinate_map(self, double x, double y,
                                    double z, double beta,
-                                   double gamma) nogil:
+                                   double gamma) noexcept nogil:
         """ Compute a coordinate map for the kernel
 
         Parameters
@@ -371,7 +371,7 @@ cdef class EnhancementKernel:
     @cython.boundscheck(False)
     @cython.nonecheck(False)
     @cython.cdivision(True)
-    cdef double kernel(self, double [:] c) nogil:
+    cdef double kernel(self, double [:] c) noexcept nogil:
         """ Internal function, evaluates the kernel based on the coordinate map.
 
         Parameters
@@ -396,7 +396,7 @@ cdef double PI = 3.1415926535897932
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef double [:] euler_angles(double [:] inp) nogil:
+cdef double [:] euler_angles(double [:] inp) noexcept nogil:
     """ Compute the Euler angles for a given input vector
 
     Parameters
@@ -441,7 +441,7 @@ cdef double [:] euler_angles(double [:] inp) nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef double [:,:] R(double [:] inp) nogil:
+cdef double [:,:] R(double [:] inp) noexcept nogil:
     """ Compute the Rotation matrix for a given input vector
 
     Parameters

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -72,7 +72,7 @@ def _upfir_matrix(double[:, :] F, double[:] h, double[:, :] out):
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void _average_block(double[:, :, :] ima, int x, int y, int z,
-                         double[:, :, :] average, double weight) nogil:
+                         double[:, :, :] average, double weight) noexcept nogil:
     """
     Computes the weighted average of the patches in a blockwise manner
 
@@ -118,7 +118,7 @@ cdef void _average_block(double[:, :, :] ima, int x, int y, int z,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void _value_block(double[:, :, :] estimate, double[:, :, :] Label, int x, int y,
-                       int z, double[:, :, :] average, double global_sum, double hh, int rician_int) nogil:
+                       int z, double[:, :, :] average, double global_sum, double hh, int rician_int) noexcept nogil:
 
     """
     Computes the final estimate of the denoised image

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -92,7 +92,8 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
 
     data0 = data0.astype(np.float64)
     cdef:
-        cnp.npy_intp dsm = np.min(data0.shape[0:-1])
+        # We need to be explicit because of boundscheck = False
+        cnp.npy_intp dsm = np.min(data0.shape[0:3])
         cnp.npy_intp n0 = data0.shape[0]
         cnp.npy_intp n1 = data0.shape[1]
         cnp.npy_intp n2 = data0.shape[2]

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -1,3 +1,5 @@
+# cython: wraparound=False, cdivision=True, boundscheck=False
+
 cimport numpy as cnp
 import numpy as np
 
@@ -142,7 +144,6 @@ cdef class BootDirectionGetter(DirectionGetter):
         else:
             self.pmf = self.model.fit(self.vox_data).odf(self.sphere)
         return self.pmf
-
 
     cdef void __clear_pmf(self) nogil:
         cdef:

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -8,11 +8,11 @@ cdef class PmfGen:
         object sphere
 
     cpdef double[:] get_pmf(self, double[::1] point)
-    cdef double* get_pmf_c(self, double* point) nogil
-    cdef int find_closest(self, double* xyz) nogil
+    cdef double* get_pmf_c(self, double* point) noexcept nogil
+    cdef int find_closest(self, double* xyz) noexcept nogil
     cpdef double get_pmf_value(self, double[::1] point, double[::1] xyz)
-    cdef double get_pmf_value_c(self, double* point, double* xyz) nogil
-    cdef void __clear_pmf(self) nogil
+    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil
+    cdef void __clear_pmf(self) noexcept nogil
     pass
 
 

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -24,10 +24,10 @@ cdef class PmfGen:
             cnp.npy_intp len_pmf = self.pmf.shape[0]
         return <double[:len_pmf]>self.get_pmf_c(&point[0])
 
-    cdef double* get_pmf_c(self, double* point) nogil:
+    cdef double* get_pmf_c(self, double* point) noexcept nogil:
         pass
 
-    cdef int find_closest(self, double* xyz) nogil:
+    cdef int find_closest(self, double* xyz) noexcept nogil:
         cdef:
             cnp.npy_intp idx = 0
             cnp.npy_intp i
@@ -49,7 +49,7 @@ cdef class PmfGen:
     cpdef double get_pmf_value(self, double[::1] point, double[::1] xyz):
         return self.get_pmf_value_c(&point[0], &xyz[0])
 
-    cdef double get_pmf_value_c(self, double* point, double* xyz) nogil:
+    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil:
         """
         Return the pmf value corresponding to the closest vertex to the
         direction xyz.
@@ -57,7 +57,7 @@ cdef class PmfGen:
         cdef int idx = self.find_closest(xyz)
         return self.get_pmf_c(point)[idx]
 
-    cdef void __clear_pmf(self) nogil:
+    cdef void __clear_pmf(self) noexcept nogil:
         cdef:
             cnp.npy_intp len_pmf = self.pmf.shape[0]
             cnp.npy_intp i
@@ -79,12 +79,12 @@ cdef class SimplePmfGen(PmfGen):
             raise ValueError("pmf should have the same number of values as the"
                              + " number of vertices of sphere.")
 
-    cdef double* get_pmf_c(self, double* point) nogil:
+    cdef double* get_pmf_c(self, double* point) noexcept nogil:
         if trilinear_interpolate4d_c(self.data, point, self.pmf) != 0:
             PmfGen.__clear_pmf(self)
         return &self.pmf[0]
 
-    cdef double get_pmf_value_c(self, double* point, double* xyz) nogil:
+    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil:
         """
         Return the pmf value corresponding to the closest vertex to the
         direction xyz.
@@ -122,7 +122,7 @@ cdef class SHCoeffPmfGen(PmfGen):
         self.coeff = np.empty(shcoeff_array.shape[3])
         self.pmf = np.empty(self.B.shape[0])
 
-    cdef double* get_pmf_c(self, double* point) nogil:
+    cdef double* get_pmf_c(self, double* point) noexcept nogil:
         cdef:
             cnp.npy_intp i, j
             cnp.npy_intp len_pmf = self.pmf.shape[0]

--- a/dipy/meson.build
+++ b/dipy/meson.build
@@ -324,8 +324,8 @@ install_subdir('../doc/examples',
 # Custom Meson Command line tools
 # ------------------------------------------------------------------------
 
-cython_args = ['-3', '--fast-fail', '@EXTRA_ARGS@', '--output-file', '@OUTPUT@',
-               '--include-dir', incdir_local,
+cython_args = ['-3', '--fast-fail', '--warning-errors', '@EXTRA_ARGS@',
+               '--output-file', '@OUTPUT@', '--include-dir', incdir_local,
                '@INPUT@']
 cython_cplus_args = ['--cplus'] + cython_args
 

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -257,7 +257,7 @@ def local_maxima(double[:] odf, cnp.uint16_t[:, :] edges):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef void _cosort(double[::1] A, cnp.npy_intp[::1] B) nogil:
+cdef void _cosort(double[::1] A, cnp.npy_intp[::1] B) noexcept nogil:
     """Sorts `A` in-place and applies the same reordering to `B`"""
     cdef:
         cnp.npy_intp n = A.shape[0]
@@ -280,7 +280,7 @@ cdef void _cosort(double[::1] A, cnp.npy_intp[::1] B) nogil:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef long _compare_neighbors(double[:] odf, cnp.uint16_t[:, :] edges,
-                             cnp.npy_intp *wpeak_ptr) nogil:
+                             cnp.npy_intp *wpeak_ptr) noexcept nogil:
     """Compares every pair of points in edges
 
     Parameters

--- a/dipy/segment/clusteringspeed.pxd
+++ b/dipy/segment/clusteringspeed.pxd
@@ -59,9 +59,9 @@ cdef class Clusters:
     cdef int** clusters_indices
     cdef int* clusters_size
 
-    cdef void c_assign(Clusters self, int id_cluster, int id_element, Data2D element) nogil except *
-    cdef int c_create_cluster(Clusters self) nogil except -1
-    cdef int c_size(Clusters self) nogil
+    cdef void c_assign(Clusters self, int id_cluster, int id_element, Data2D element) noexcept nogil
+    cdef int c_create_cluster(Clusters self) except -1 nogil
+    cdef int c_size(Clusters self) noexcept nogil
 
 
 cdef class ClustersCentroid(Clusters):
@@ -69,9 +69,9 @@ cdef class ClustersCentroid(Clusters):
     cdef Centroid* _updated_centroids
     cdef Shape _centroid_shape
     cdef float eps
-    cdef void c_assign(ClustersCentroid self, int id_cluster, int id_element, Data2D element) nogil except *
-    cdef int c_create_cluster(ClustersCentroid self) nogil except -1
-    cdef int c_update(ClustersCentroid self, cnp.npy_intp id_cluster) nogil except -1
+    cdef void c_assign(ClustersCentroid self, int id_cluster, int id_element, Data2D element) noexcept nogil
+    cdef int c_create_cluster(ClustersCentroid self) except -1 nogil
+    cdef int c_update(ClustersCentroid self, cnp.npy_intp id_cluster) except -1 nogil
 
 
 cdef class QuickBundles:
@@ -86,9 +86,9 @@ cdef class QuickBundles:
     cdef int bvh
     cdef QuickBundlesStats stats
 
-    cdef NearestCluster find_nearest_cluster(QuickBundles self, Data2D features) nogil except *
-    cdef int assignment_step(QuickBundles self, Data2D datum, int datum_id) nogil except -1
-    cdef void update_step(QuickBundles self, int cluster_id) nogil except *
+    cdef NearestCluster find_nearest_cluster(QuickBundles self, Data2D features) noexcept nogil
+    cdef int assignment_step(QuickBundles self, Data2D datum, int datum_id) except -1 nogil
+    cdef void update_step(QuickBundles self, int cluster_id) noexcept nogil
     cdef object _build_clustermap(self)
 
 
@@ -105,9 +105,9 @@ cdef class QuickBundlesX:
     cdef QuickBundlesXStats stats
     cdef StreamlineInfos* current_streamline
 
-    cdef int _add_child(self, CentroidNode* node) nogil
-    cdef void _update_node(self, CentroidNode* node, StreamlineInfos* streamline_infos) nogil
-    cdef void _insert_in(self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path) nogil
+    cdef int _add_child(self, CentroidNode* node) noexcept nogil
+    cdef void _update_node(self, CentroidNode* node, StreamlineInfos* streamline_infos) noexcept nogil
+    cdef void _insert_in(self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path) noexcept nogil
     cpdef object insert(self, Data2D datum, int datum_idx)
     cdef void traverse_postorder(self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*))
     cdef void _dealloc_node(self, CentroidNode* node)

--- a/dipy/segment/cythonutils.pxd
+++ b/dipy/segment/cythonutils.pxd
@@ -26,7 +26,7 @@ cdef struct Shape:
    Py_ssize_t size
 
 
-cdef Shape shape_from_memview(Data data) nogil
+cdef Shape shape_from_memview(Data data) noexcept nogil
 
 
 cdef Shape tuple2shape(dims) except *
@@ -35,8 +35,8 @@ cdef Shape tuple2shape(dims) except *
 cdef shape2tuple(Shape shape)
 
 
-cdef int same_shape(Shape shape1, Shape shape2) nogil
+cdef int same_shape(Shape shape1, Shape shape2) noexcept nogil
 
-cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) nogil
+cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) noexcept nogil
 
-cdef void free_memview_2d(Data2D* memview) nogil
+cdef void free_memview_2d(Data2D* memview) noexcept nogil

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -11,7 +11,7 @@ cdef extern from "stdlib.h" nogil:
 
 cdef Py_ssize_t sizeof_memviewslice = 2 * sizeof(cnp.npy_intp) + 3 * sizeof(cnp.npy_intp) * 8
 
-cdef Shape shape_from_memview(Data data) nogil:
+cdef Shape shape_from_memview(Data data) noexcept nogil:
     """ Retrieves shape from a memoryview object.
 
     Parameters
@@ -82,7 +82,7 @@ cdef shape2tuple(Shape shape):
     return tuple(dims)
 
 
-cdef int same_shape(Shape shape1, Shape shape2) nogil:
+cdef int same_shape(Shape shape1, Shape shape2) noexcept nogil:
     """ Checks if two shapes are the same.
 
     Two shapes are equals if they have the same number of dimensions
@@ -112,7 +112,7 @@ cdef int same_shape(Shape shape1, Shape shape2) nogil:
     return same_shape
 
 
-cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) nogil:
+cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) noexcept nogil:
     """ Create a light version of cython memory view.
 
     Parameters
@@ -140,7 +140,7 @@ cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]
 
     return memview
 
-cdef void free_memview_2d(Data2D* memview) nogil:
+cdef void free_memview_2d(Data2D* memview) noexcept nogil:
     """ free a light version of cython memory view
 
     Parameters

--- a/dipy/segment/featurespeed.pxd
+++ b/dipy/segment/featurespeed.pxd
@@ -4,8 +4,8 @@ cimport numpy as cnp
 cdef class Feature:
     cdef int is_order_invariant
 
-    cdef Shape c_infer_shape(Feature self, Data2D datum) nogil except *
-    cdef void c_extract(Feature self, Data2D datum, Data2D out) nogil except *
+    cdef Shape c_infer_shape(Feature self, Data2D datum) noexcept nogil
+    cdef void c_extract(Feature self, Data2D datum, Data2D out) noexcept nogil
 
     cpdef infer_shape(Feature self, datum)
     cpdef extract(Feature self, datum)

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -36,7 +36,7 @@ cdef class Feature:
         def __set__(self, int value):
             self.is_order_invariant = bool(value)
 
-    cdef Shape c_infer_shape(Feature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(Feature self, Data2D datum) noexcept nogil:
         """ Cython version of `Feature.infer_shape`. """
         with gil:
             shape = self.infer_shape(np.asarray(datum))
@@ -49,7 +49,7 @@ cdef class Feature:
             else:
                 raise TypeError("Only scalar, 1D or 2D array features are supported!")
 
-    cdef void c_extract(Feature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(Feature self, Data2D datum, Data2D out) noexcept nogil:
         """ Cython version of `Feature.extract`. """
         cdef Data2D c_features
         with gil:
@@ -174,10 +174,10 @@ cdef class IdentityFeature(CythonFeature):
     def __init__(IdentityFeature self):
         super(IdentityFeature, self).__init__(is_order_invariant=False)
 
-    cdef Shape c_infer_shape(IdentityFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(IdentityFeature self, Data2D datum) noexcept nogil:
         return shape_from_memview(datum)
 
-    cdef void c_extract(IdentityFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(IdentityFeature self, Data2D datum, Data2D out) noexcept nogil:
         cdef:
             int N = datum.shape[0], D = datum.shape[1]
             int n, d
@@ -204,12 +204,12 @@ cdef class ResampleFeature(CythonFeature):
         if nb_points <= 0:
             raise ValueError("ResampleFeature: `nb_points` must be strictly positive: {0}".format(nb_points))
 
-    cdef Shape c_infer_shape(ResampleFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(ResampleFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.dims[0] = self.nb_points
         return shape
 
-    cdef void c_extract(ResampleFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(ResampleFeature self, Data2D datum, Data2D out) noexcept nogil:
         c_set_number_of_points(datum, out)
 
 
@@ -225,7 +225,7 @@ cdef class CenterOfMassFeature(CythonFeature):
     def __init__(CenterOfMassFeature self):
         super(CenterOfMassFeature, self).__init__(is_order_invariant=True)
 
-    cdef Shape c_infer_shape(CenterOfMassFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(CenterOfMassFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
@@ -233,7 +233,7 @@ cdef class CenterOfMassFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) noexcept nogil:
         cdef int N = datum.shape[0], D = datum.shape[1]
         cdef int i, d
 
@@ -260,7 +260,7 @@ cdef class MidpointFeature(CythonFeature):
     def __init__(MidpointFeature self):
         super(MidpointFeature, self).__init__(is_order_invariant=False)
 
-    cdef Shape c_infer_shape(MidpointFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(MidpointFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
@@ -268,7 +268,7 @@ cdef class MidpointFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(MidpointFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(MidpointFeature self, Data2D datum, Data2D out) noexcept nogil:
         cdef:
             int N = datum.shape[0], D = datum.shape[1]
             int mid = N/2
@@ -290,7 +290,7 @@ cdef class ArcLengthFeature(CythonFeature):
     def __init__(ArcLengthFeature self):
         super(ArcLengthFeature, self).__init__(is_order_invariant=True)
 
-    cdef Shape c_infer_shape(ArcLengthFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(ArcLengthFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
@@ -298,7 +298,7 @@ cdef class ArcLengthFeature(CythonFeature):
         shape.size = 1
         return shape
 
-    cdef void c_extract(ArcLengthFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(ArcLengthFeature self, Data2D datum, Data2D out) noexcept nogil:
         out[0, 0] = c_length(datum)
 
 
@@ -315,7 +315,7 @@ cdef class VectorOfEndpointsFeature(CythonFeature):
     def __init__(VectorOfEndpointsFeature self):
         super(VectorOfEndpointsFeature, self).__init__(is_order_invariant=False)
 
-    cdef Shape c_infer_shape(VectorOfEndpointsFeature self, Data2D datum) nogil except *:
+    cdef Shape c_infer_shape(VectorOfEndpointsFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
@@ -323,7 +323,7 @@ cdef class VectorOfEndpointsFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(VectorOfEndpointsFeature self, Data2D datum, Data2D out) nogil except *:
+    cdef void c_extract(VectorOfEndpointsFeature self, Data2D datum, Data2D out) noexcept nogil:
         cdef:
             int N = datum.shape[0], D = datum.shape[1]
             int d

--- a/dipy/segment/metricspeed.pxd
+++ b/dipy/segment/metricspeed.pxd
@@ -6,8 +6,8 @@ cdef class Metric:
     cdef Feature feature
     cdef int is_order_invariant
 
-    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1
-    cdef int c_are_compatible(Metric self, Shape shape1, Shape shape2) nogil except -1
+    cdef double c_dist(Metric self, Data2D features1, Data2D features2) except -1 nogil
+    cdef int c_are_compatible(Metric self, Shape shape1, Shape shape2) except -1 nogil
 
     cpdef double dist(Metric self, features1, features2) except -1
     cpdef are_compatible(Metric self, shape1, shape2)

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -45,12 +45,12 @@ cdef class Metric:
         def __get__(Metric self):
             return bool(self.is_order_invariant)
 
-    cdef int c_are_compatible(Metric self, Shape shape1, Shape shape2) nogil except -1:
+    cdef int c_are_compatible(Metric self, Shape shape1, Shape shape2) except -1 nogil:
         """ Cython version of `Metric.are_compatible`. """
         with gil:
             return self.are_compatible(shape2tuple(shape1), shape2tuple(shape2))
 
-    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1:
+    cdef double c_dist(Metric self, Data2D features1, Data2D features2) except -1 nogil:
         """ Cython version of `Metric.dist`. """
         with gil:
             _features1 = np.asarray(<float[:features1.shape[0], :features1.shape[1]]> <float*> features1._data)
@@ -227,7 +227,7 @@ cdef class SumPointwiseEuclideanMetric(CythonMetric):
     is equal to $a+b+c$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1:
+    cdef double c_dist(SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2) except -1 nogil:
         cdef :
             int N = features1.shape[0], D = features1.shape[1]
             int n, d
@@ -243,7 +243,7 @@ cdef class SumPointwiseEuclideanMetric(CythonMetric):
 
         return dist
 
-    cdef int c_are_compatible(SumPointwiseEuclideanMetric self, Shape shape1, Shape shape2) nogil except -1:
+    cdef int c_are_compatible(SumPointwiseEuclideanMetric self, Shape shape1, Shape shape2) except -1 nogil:
         return same_shape(shape1, shape2)
 
 
@@ -279,7 +279,7 @@ cdef class AveragePointwiseEuclideanMetric(SumPointwiseEuclideanMetric):
     is equal to $(a+b+c)/3$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1:
+    cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) except -1 nogil:
         cdef int N = features1.shape[0]
         cdef double dist = SumPointwiseEuclideanMetric.c_dist(self, features1, features2)
         return dist / N
@@ -317,7 +317,7 @@ cdef class MinimumAverageDirectFlipMetric(AveragePointwiseEuclideanMetric):
         def __get__(MinimumAverageDirectFlipMetric self):
             return True  # Ordering is handled in the distance computation
 
-    cdef double c_dist(MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2) nogil except -1:
+    cdef double c_dist(MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2) except -1 nogil:
         cdef double dist_direct = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2)
         cdef double dist_flipped = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2[::-1])
         return min(dist_direct, dist_flipped)
@@ -338,10 +338,10 @@ cdef class CosineMetric(CythonMetric):
     def __init__(CosineMetric self, Feature feature):
         super(CosineMetric, self).__init__(feature=feature)
 
-    cdef int c_are_compatible(CosineMetric self, Shape shape1, Shape shape2) nogil except -1:
+    cdef int c_are_compatible(CosineMetric self, Shape shape1, Shape shape2) except -1 nogil:
         return same_shape(shape1, shape2) != 0 and shape1.dims[0] == 1
 
-    cdef double c_dist(CosineMetric self, Data2D features1, Data2D features2) nogil except -1:
+    cdef double c_dist(CosineMetric self, Data2D features1, Data2D features2) except -1 nogil:
         cdef :
             int d, D = features1.shape[1]
             double sqr_norm_features1 = 0.0, sqr_norm_features2 = 0.0

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -237,7 +237,7 @@ class ConstantObservationModel:
 
 
 cdef void _initialize_param_uniform(double[:, :, :] image, double[:] mu,
-                                    double[:] var) nogil:
+                                    double[:] var) noexcept nogil:
     r""" Initializes the means and standard deviations uniformly
 
     The means are initialized uniformly along the dynamic range of `image`.
@@ -283,7 +283,7 @@ cdef void _initialize_param_uniform(double[:, :, :] image, double[:] mu,
 
 cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
                             double[:] sigmasq, int classid,
-                            double[:, :, :, :] neglogl) nogil:
+                            double[:, :, :, :] neglogl) noexcept nogil:
     r""" Computes the gaussian negative log-likelihood of each class at
     each voxel of `image` assuming a gaussian distribution with means and
     variances given by `mu` and `sigmasq`, respectively (constant models
@@ -338,7 +338,7 @@ cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
 cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
                       double[:] mu, double[:] sigmasq, int classid,
                       double[:, :, :, :] P_L_N,
-                      double[:, :, :, :] P_L_Y) nogil:
+                      double[:, :, :, :] P_L_Y) noexcept nogil:
     r""" Conditional probability of the label given the image
 
     Parameters
@@ -505,7 +505,7 @@ class IteratedConditionalModes:
 
 
 cdef void _initialize_maximum_likelihood(double[:,:,:,:] nloglike,
-                                         cnp.npy_short[:,:,:] seg) nogil:
+                                         cnp.npy_short[:,:,:] seg) noexcept nogil:
     r""" Initializes the segmentation of an image with given
     neg-log-likelihood.
 
@@ -550,7 +550,7 @@ cdef void _initialize_maximum_likelihood(double[:,:,:,:] nloglike,
 
 cdef void _icm_ising(double[:,:,:,:] nloglike, double beta,
                      cnp.npy_short[:,:,:] seg, double[:,:,:] energy,
-                     cnp.npy_short[:,:,:] new_seg) nogil:
+                     cnp.npy_short[:,:,:] new_seg) noexcept nogil:
     r""" Executes one iteration of the ICM algorithm for MRF MAP estimation
     The prior distribution of the MRF is a Gibbs distribution with the
     Potts/Ising model with parameter `beta`:
@@ -631,7 +631,7 @@ cdef void _icm_ising(double[:,:,:,:] nloglike, double beta,
 
 
 cdef void _prob_class_given_neighb(cnp.npy_short[:, :, :] seg, double beta,
-                                   int classid, double[:, :, :] P_L_N) nogil:
+                                   int classid, double[:, :, :] P_L_N) noexcept nogil:
     r""" Conditional probability of the label given the neighborhood
     Equation 2.18 of the Stan Z. Li book.
 

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -17,7 +17,7 @@ cdef extern from "dpy_math.h" nogil:
     double fabs(double)
 
 @cython.cdivision(True)
-cdef inline double _stepsize(double point, double increment) nogil:
+cdef inline double _stepsize(double point, double increment) noexcept nogil:
     """Compute the step size to the closest boundary in units of increment."""
     cdef:
         double dist
@@ -30,7 +30,7 @@ cdef inline double _stepsize(double point, double increment) nogil:
         return dist / increment
 
 cdef void _step_to_boundary(double * point, double * direction,
-                           double overstep) nogil:
+                           double overstep) noexcept nogil:
     """Takes a step from point in along direction just past a voxel boundary.
 
     Parameters
@@ -62,7 +62,7 @@ cdef void _step_to_boundary(double * point, double * direction,
     for i in range(3):
         point[i] += smallest_step * direction[i]
 
-cdef void _fixed_step(double * point, double * direction, double step_size) nogil:
+cdef void _fixed_step(double * point, double * direction, double step_size) noexcept nogil:
     """Updates point by stepping in direction.
 
     Parameters
@@ -105,7 +105,7 @@ cdef class DirectionGetter:
            cnp.npy_intp len_streamlines = streamline.shape[0]
            double point[3]
            double voxdir[3]
-           void (*step)(double*, double*, double) nogil
+           void (*step)(double*, double*, double) noexcept nogil
 
        if fixedstep > 0:
            step = _fixed_step

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -116,7 +116,7 @@ def inner_3vecs(vec1, vec2):
     return cinner_3vecs(<float *> cnp.PyArray_DATA(fvec1), <float*> cnp.PyArray_DATA(fvec2))
 
 
-cdef inline float cinner_3vecs(float *vec1, float *vec2) nogil:
+cdef inline float cinner_3vecs(float *vec1, float *vec2) noexcept nogil:
     cdef int i
     cdef float ip = 0
     for i from 0<=i<3:
@@ -134,7 +134,7 @@ def sub_3vecs(vec1, vec2):
     return vec_out
 
 
-cdef inline void csub_3vecs(float *vec1, float *vec2, float *vec_out) nogil:
+cdef inline void csub_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
     cdef int i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]-vec2[i]
@@ -150,7 +150,7 @@ def add_3vecs(vec1, vec2):
     return vec_out
 
 
-cdef inline void cadd_3vecs(float *vec1, float *vec2, float *vec_out) nogil:
+cdef inline void cadd_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
     cdef int i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]+vec2[i]
@@ -164,7 +164,7 @@ def mul_3vecs(vec1, vec2):
                <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
-cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) nogil:
+cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
     cdef int i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]*vec2[i]
@@ -176,7 +176,7 @@ def mul_3vec(a, vec):
               <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
-cdef inline void cmul_3vec(float a, float *vec, float *vec_out) nogil:
+cdef inline void cmul_3vec(float a, float *vec, float *vec_out) noexcept nogil:
     cdef int i
     for i from 0<=i<3:
         vec_out[i] = a*vec[i]
@@ -651,7 +651,7 @@ cdef inline cnp.float32_t czhang(cnp.npy_intp t1_len,
                                  cnp.npy_intp t2_len,
                                  cnp.float32_t *track2_ptr,
                                  cnp.float32_t *min_buffer,
-                                 int metric_type) nogil:
+                                 int metric_type) noexcept nogil:
     """ Note ``nogil`` - no python calls allowed in this function """
     cdef:
         cnp.float32_t *min_t2t1
@@ -691,7 +691,7 @@ cdef inline void min_distances(cnp.npy_intp t1_len,
                                cnp.npy_intp t2_len,
                                cnp.float32_t *track2_ptr,
                                cnp.float32_t *min_t2t1,
-                               cnp.float32_t *min_t1t2) nogil:
+                               cnp.float32_t *min_t1t2) noexcept nogil:
     cdef:
         cnp.float32_t *t1_pt
         cnp.float32_t *t2_pt
@@ -1374,7 +1374,7 @@ def point_segment_sq_distance(a, b, c):
 
 
 @cython.cdivision(True)
-cdef inline float cpoint_segment_sq_dist(float * a, float * b, float * c) nogil:
+cdef inline float cpoint_segment_sq_dist(float * a, float * b, float * c) noexcept nogil:
     """ Calculate the squared distance from a point c to a line segment ab.
 
     """
@@ -1442,7 +1442,7 @@ def track_dist_3pts(tracka,trackb):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
+cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) noexcept nogil:
     r""" Direct and flip average distance between two tracks
 
     Parameters
@@ -1501,7 +1501,7 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
 
 
 @cython.cdivision(True)
-cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out) nogil:
+cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out) noexcept nogil:
     """ Calculate the euclidean distance between two 3pt tracks
     both direct and flip are given as output
 

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -206,7 +206,7 @@ cdef _pft_tracker(DirectionGetter dg,
         int strl_array_len
         double max_wm_pve, current_wm_pve
         double point[3]
-        void (*step)(double* , double*, double) nogil
+        void (*step)(double* , double*, double) noexcept nogil
 
     copy_point(seed, point)
     copy_point(seed, &streamline[0,0])

--- a/dipy/tracking/propspeed.pxd
+++ b/dipy/tracking/propspeed.pxd
@@ -4,4 +4,4 @@ cdef cnp.npy_intp _propagation_direction(double *point, double* prev, double* qa
                                 double *ind, double *odf_vertices,
                                 double qa_thr, double ang_thr,
                                 cnp.npy_intp *qa_shape,cnp.npy_intp* strides,
-                                double *direction,double total_weight) nogil
+                                double *direction,double total_weight) noexcept nogil

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -78,7 +78,7 @@ cdef cnp.npy_intp _nearest_direction(double* dx,
                                      cnp.npy_intp peaks,
                                      double *odf_vertices,
                                      double qa_thr, double ang_thr,
-                                     double *direction) nogil:
+                                     double *direction) noexcept nogil:
     """ Give the nearest direction to a point, checking threshold and angle
 
     Parameters
@@ -165,7 +165,7 @@ cdef cnp.npy_intp _propagation_direction(double *point,
                                          cnp.npy_intp *qa_shape,
                                          cnp.npy_intp* strides,
                                          double *direction,
-                                         double total_weight) nogil:
+                                         double total_weight) noexcept nogil:
     cdef:
         double total_w = 0 # total weighting useful for interpolation
         double delta = 0 # store delta function (stopping function) result
@@ -233,7 +233,7 @@ cdef cnp.npy_intp _initial_direction(double* seed,double *qa,
                                      double qa_thr,
                                      cnp.npy_intp* strides,
                                      cnp.npy_intp ref,
-                                     double* direction) nogil:
+                                     double* direction) noexcept nogil:
     """ First direction that we get from a seeding point
     """
     cdef:

--- a/dipy/tracking/streamlinespeed.pxd
+++ b/dipy/tracking/streamlinespeed.pxd
@@ -8,8 +8,8 @@ ctypedef fused Streamline:
     double2d
 
 
-cdef double c_length(Streamline streamline) nogil
+cdef double c_length(Streamline streamline) noexcept nogil
 
-cdef void c_arclengths(Streamline streamline, double * out) nogil
+cdef void c_arclengths(Streamline streamline, double * out) noexcept nogil
 
-cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil
+cdef void c_set_number_of_points(Streamline streamline, Streamline out) noexcept nogil

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -13,7 +13,7 @@ cdef extern from "dpy_math.h" nogil:
     bint dpy_isnan(double x)
 
 
-cdef double c_length(Streamline streamline) nogil:
+cdef double c_length(Streamline streamline) noexcept nogil:
     cdef:
         cnp.npy_intp i
         double out = 0.0
@@ -33,7 +33,7 @@ cdef double c_length(Streamline streamline) nogil:
 cdef void c_arclengths_from_arraysequence(Streamline points,
                                           cnp.npy_intp[:] offsets,
                                           cnp.npy_intp[:] lengths,
-                                          double[:] arclengths) nogil:
+                                          double[:] arclengths) noexcept nogil:
     cdef:
         cnp.npy_intp i, j, k
         cnp.npy_intp offset
@@ -179,7 +179,7 @@ def length(streamlines):
         return streamlines_length
 
 
-cdef void c_arclengths(Streamline streamline, double* out) nogil:
+cdef void c_arclengths(Streamline streamline, double* out) noexcept nogil:
     cdef cnp.npy_intp i = 0
     cdef double dn
 
@@ -193,7 +193,7 @@ cdef void c_arclengths(Streamline streamline, double* out) nogil:
         out[i] = out[i-1] + sqrt(out[i])
 
 
-cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
+cdef void c_set_number_of_points(Streamline streamline, Streamline out) noexcept nogil:
     cdef:
         cnp.npy_intp N = streamline.shape[0]
         cnp.npy_intp D = streamline.shape[1]
@@ -246,7 +246,7 @@ cdef void c_set_number_of_points_from_arraysequence(Streamline points,
                                                     cnp.npy_intp[:] offsets,
                                                     cnp.npy_intp[:] lengths,
                                                     long nb_points,
-                                                    Streamline out) nogil:
+                                                    Streamline out) noexcept nogil:
     cdef:
         cnp.npy_intp i, j, k
         cnp.npy_intp offset, length
@@ -433,7 +433,7 @@ def set_number_of_points(streamlines, nb_points=3):
 
 
 cdef double c_norm_of_cross_product(double bx, double by, double bz,
-                                    double cx, double cy, double cz) nogil:
+                                    double cx, double cy, double cz) noexcept nogil:
     """ Computes the norm of the cross-product in 3D. """
     cdef double ax, ay, az
     ax = by*cz - bz*cy
@@ -443,7 +443,7 @@ cdef double c_norm_of_cross_product(double bx, double by, double bz,
 
 
 cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp p1,
-                           cnp.npy_intp p2, cnp.npy_intp p0) nogil:
+                           cnp.npy_intp p2, cnp.npy_intp p0) noexcept nogil:
     """ Computes the shortest Euclidean distance between a point `curr` and
         the line passing through `prev` and `next`. """
 
@@ -470,7 +470,7 @@ cdef double c_dist_to_line(Streamline streamline, cnp.npy_intp p1,
 
 
 cdef double c_segment_length(Streamline streamline,
-                             cnp.npy_intp start, cnp.npy_intp end) nogil:
+                             cnp.npy_intp start, cnp.npy_intp end) noexcept nogil:
     """ Computes the length of the segment going from `start` to `end`. """
     cdef:
         cnp.npy_intp D = streamline.shape[1]
@@ -486,7 +486,7 @@ cdef double c_segment_length(Streamline streamline,
 
 
 cdef cnp.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
-                                       double tol_error, double max_segment_length) nogil:
+                                       double tol_error, double max_segment_length) noexcept nogil:
     """ Compresses a streamline (see function `compress_streamlines`)."""
     cdef:
         cnp.npy_intp N = streamline.shape[0]

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -160,7 +160,7 @@ def streamline_mapping(streamlines, affine=None,
 @cython.wraparound(False)
 cdef inline cnp.double_t norm(cnp.double_t x,
                               cnp.double_t y,
-                              cnp.double_t z) nogil:
+                              cnp.double_t z) noexcept nogil:
     cdef cnp.double_t val = sqrt(x*x + y*y + z*z)
     return val
 
@@ -171,7 +171,7 @@ cdef inline cnp.double_t norm(cnp.double_t x,
 cdef inline void c_get_closest_edge(cnp.double_t* p,
                                     cnp.double_t* direction,
                                     cnp.double_t* edge,
-                                    double eps=1.) nogil:
+                                    double eps=1.) noexcept nogil:
      edge[0] = floor(p[0] + eps) if direction[0] >= 0.0 else ceil(p[0] - eps)
      edge[1] = floor(p[1] + eps) if direction[1] >= 0.0 else ceil(p[1] - eps)
      edge[2] = floor(p[2] + eps) if direction[2] >= 0.0 else ceil(p[2] - eps)
@@ -228,7 +228,7 @@ def _streamlines_in_mask(list streamlines,
 @cython.cdivision(True)
 cdef cnp.npy_intp _streamline_in_mask(
         cnp.double_t[:,:] streamline,
-        cnp.uint8_t[:,:,:] mask) nogil:
+        cnp.uint8_t[:,:,:] mask) noexcept nogil:
     """
     Check if a single streamline is passing through a mask. This is an utility
     function to make streamlines_in_mask() more readable.

--- a/dipy/utils/fast_numpy.pxd
+++ b/dipy/utils/fast_numpy.pxd
@@ -12,45 +12,45 @@ from libc.math cimport sqrt
 cdef int where_to_insert(
         cnp.float_t* arr,
         cnp.float_t number,
-        int size) nogil
+        int size) noexcept nogil
 
 cdef void cumsum(
         cnp.float_t* arr_in,
         cnp.float_t* arr_out,
-        int N) nogil
+        int N) noexcept nogil
 
 cdef void copy_point(
         double * a,
-        double * b) nogil
+        double * b) noexcept nogil
 
 cdef void scalar_muliplication_point(
         double * a,
-        double scalar) nogil
+        double scalar) noexcept nogil
 
 cdef double norm(
-        double * v) nogil
+        double * v) noexcept nogil
 
 cdef double dot(
         double * v1,
-        double * v2) nogil
+        double * v2) noexcept nogil
 
 cdef void normalize(
-        double * v) nogil
+        double * v) noexcept nogil
 
 cdef void cross(
         double * out,
         double * v1,
-        double * v2) nogil
+        double * v2) noexcept nogil
 
 cdef void random_vector(
-        double * out) nogil
+        double * out) noexcept nogil
 
 cdef void random_perpendicular_vector(
         double * out,
-        double * v) nogil
+        double * v) noexcept nogil
 
 cpdef (double, double) random_point_within_circle(
-        double r) nogil
+        double r) noexcept nogil
 
 cpdef double random() nogil
 

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -2,7 +2,7 @@
 # cython: initializedcheck=False
 # cython: wraparound=False
 
-cdef int where_to_insert(cnp.float_t* arr, cnp.float_t number, int size) nogil:
+cdef int where_to_insert(cnp.float_t* arr, cnp.float_t number, int size) noexcept nogil:
     cdef:
         int idx
         cnp.float_t current
@@ -14,7 +14,7 @@ cdef int where_to_insert(cnp.float_t* arr, cnp.float_t number, int size) nogil:
     return 0
 
 
-cdef void cumsum(cnp.float_t* arr_in, cnp.float_t* arr_out, int N) nogil:
+cdef void cumsum(cnp.float_t* arr_in, cnp.float_t* arr_out, int N) noexcept nogil:
     cdef:
         int i = 0
         cnp.float_t csum = 0
@@ -23,21 +23,21 @@ cdef void cumsum(cnp.float_t* arr_in, cnp.float_t* arr_out, int N) nogil:
         arr_out[i] = csum
 
 
-cdef void copy_point(double * a, double * b) nogil:
+cdef void copy_point(double * a, double * b) noexcept nogil:
     cdef:
         int i = 0
     for i in range(3):
         b[i] = a[i]
 
 
-cdef void scalar_muliplication_point(double * a, double scalar) nogil:
+cdef void scalar_muliplication_point(double * a, double scalar) noexcept nogil:
     cdef:
         int i = 0
     for i in range(3):
         a[i] *= scalar
 
 
-cdef double norm(double * v) nogil:
+cdef double norm(double * v) noexcept nogil:
     """Compute the vector norm.
 
     Parameters
@@ -49,7 +49,7 @@ cdef double norm(double * v) nogil:
     return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
 
 
-cdef double dot(double * v1, double * v2) nogil:
+cdef double dot(double * v1, double * v2) noexcept nogil:
     """Compute vectors dot product.
 
     Parameters
@@ -67,7 +67,7 @@ cdef double dot(double * v1, double * v2) nogil:
     return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]
 
 
-cdef void normalize(double * v) nogil:
+cdef void normalize(double * v) noexcept nogil:
     """Normalize the vector.
 
     Parameters
@@ -86,7 +86,7 @@ cdef void normalize(double * v) nogil:
     v[2] = v[2] * scale
 
 
-cdef void cross(double * out, double * v1, double * v2) nogil:
+cdef void cross(double * out, double * v1, double * v2) noexcept nogil:
     """Compute vectors cross product.
 
     Parameters
@@ -108,7 +108,7 @@ cdef void cross(double * out, double * v1, double * v2) nogil:
     out[2] = v1[0] * v2[1] - v1[1] * v2[0]
 
 
-cdef void random_vector(double * out) nogil:
+cdef void random_vector(double * out) noexcept nogil:
     """Generate a unit random vector
 
     Parameters
@@ -126,7 +126,7 @@ cdef void random_vector(double * out) nogil:
     normalize(out)
 
 
-cdef void random_perpendicular_vector(double * out, double * v) nogil:
+cdef void random_perpendicular_vector(double * out, double * v) noexcept nogil:
     """Generate a random perpendicular vector
 
     Parameters
@@ -148,7 +148,7 @@ cdef void random_perpendicular_vector(double * out, double * v) nogil:
     normalize(out)
 
 
-cpdef (double, double) random_point_within_circle(double r) nogil:
+cpdef (double, double) random_point_within_circle(double r) noexcept nogil:
     """Generate a random point within a circle
 
     Parameters
@@ -174,7 +174,7 @@ cpdef (double, double) random_point_within_circle(double r) nogil:
     return (r * x, r * y)
 
 
-cpdef double random() nogil:
+cpdef double random() noexcept nogil:
     """Sample a random number between 0 and 1.
 
     Returns
@@ -185,7 +185,7 @@ cpdef double random() nogil:
     return rand() / float(RAND_MAX)
 
 
-cpdef void seed(cnp.npy_uint32 s) nogil:
+cpdef void seed(cnp.npy_uint32 s) noexcept nogil:
     """Set the random seed of stdlib.
 
     Parameters

--- a/doc/devel/coding_style_guideline.rst
+++ b/doc/devel/coding_style_guideline.rst
@@ -137,7 +137,7 @@ unless it is needed for functions returning ``void``::
 
   # Good
   cdef void bar() except *
-  cdef void c_extract(Feature self, Data2D datum, Data2D out) nogil except *:
+  cdef void c_extract(Feature self, Data2D datum, Data2D out) noexcept nogil:
   cdef int front(x) except +:
       ...
 

--- a/src/safe_openmp.pxd
+++ b/src/safe_openmp.pxd
@@ -1,14 +1,14 @@
 cdef extern from "conditional_omp.h":
     ctypedef struct omp_lock_t:
         pass
-    extern void omp_init_lock(omp_lock_t *) nogil
-    extern void omp_destroy_lock(omp_lock_t *) nogil
-    extern void omp_set_lock(omp_lock_t *) nogil
-    extern void omp_unset_lock(omp_lock_t *) nogil
-    extern int omp_test_lock(omp_lock_t *) nogil
-    extern void omp_set_dynamic(int dynamic_threads) nogil
-    extern void omp_set_num_threads(int num_threads) nogil
-    extern int omp_get_num_procs() nogil
-    extern int omp_get_max_threads() nogil
+    extern void omp_init_lock(omp_lock_t *) noexcept nogil
+    extern void omp_destroy_lock(omp_lock_t *) noexcept nogil
+    extern void omp_set_lock(omp_lock_t *) noexcept nogil
+    extern void omp_unset_lock(omp_lock_t *) noexcept nogil
+    extern int omp_test_lock(omp_lock_t *) noexcept nogil
+    extern void omp_set_dynamic(int dynamic_threads) noexcept nogil
+    extern void omp_set_num_threads(int num_threads) noexcept nogil
+    extern int omp_get_num_procs() noexcept nogil
+    extern int omp_get_max_threads() noexcept nogil
     cdef int have_openmp
 


### PR DESCRIPTION
The PR fixes #3003. 

It addresses all Cython 3.x warnings on DIPY codebases. it replaces:

- `nogil` with `noexcept nogil`
- `nogil except -1` with `except -1 nogil`
- `nogil except *` with `noexcept nogil`

These changes are backward compatible with Cython 0.29.33 but we aim to use only Cython 3.x soon 