### PR TITLE
Bugfix: Horizon image's dtype validation

### DIFF
--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -4,6 +4,7 @@ from functools import partial
 from os.path import dirname, abspath, join as pjoin
 from numpy.testing import assert_array_equal
 import numpy as np
+import numpy.testing as npt
 import scipy
 from packaging.version import Version
 import warnings
@@ -135,3 +136,11 @@ def setup_test():
         warnings.simplefilter(action="default", category=FutureWarning)
 
     warnings.simplefilter("always", category=UserWarning)
+
+
+def check_for_warnings(warn_printed, w_msg):
+    selected_w = [w for w in warn_printed if issubclass(w.category,
+                                                        UserWarning)]
+    assert len(selected_w) >= 1
+    msg = [str(m.message) for m in selected_w]
+    npt.assert_equal(w_msg in msg, True)

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -12,7 +12,7 @@ from dipy.viz.gmem import GlobalHorizon
 from dipy.viz.horizon.tab import (ClustersTab, PeaksTab, ROIsTab, SlicesTab,
                                   TabManager, build_label)
 from dipy.viz.horizon.visualizer import ClustersVisualizer, SlicesVisualizer
-from dipy.viz.horizon.util import check_img_shapes
+from dipy.viz.horizon.util import check_img_dtype, check_img_shapes
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
@@ -442,6 +442,7 @@ class Horizon:
                     self.__clusters_visualizer, self.cluster_thr))
 
         synchronize_slices = False
+        self.images = check_img_dtype(self.images)
         if len(self.images) > 0:
             if self.__roi_images:
                 roi_color = self.__roi_colors

--- a/dipy/viz/horizon/tab/tests/test_base.py
+++ b/dipy/viz/horizon/tab/tests/test_base.py
@@ -2,6 +2,7 @@ import pytest
 import warnings
 
 import numpy.testing as npt
+from dipy.testing import check_for_warnings
 
 from dipy.utils.optpkg import optional_package
 from dipy.testing.decorators import use_xvfb
@@ -85,14 +86,6 @@ def test_build_slider():
     npt.assert_equal(double_slider.obj.text[0].font_size, 16)
     npt.assert_equal(double_slider.obj.text[1].font_size, 16)
     npt.assert_equal(double_slider.selected_value, (4, 5))
-
-
-def check_for_warnings(warn_printed, w_msg):
-    selected_w = [w for w in warn_printed if issubclass(w.category,
-                                                        UserWarning)]
-    assert len(selected_w) >= 1
-    msg = [str(m.message) for m in selected_w]
-    npt.assert_equal(w_msg in msg, True)
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -1,9 +1,20 @@
+import warnings
+import numpy as np
+
+
 def check_img_shapes(images):
-    """
-    Checks if the images have same shapes
+    """Check if the images have same shapes.
+
+    Parameters
+    ----------
+    images : list
+
+    Returns
+    -------
+    boolean
+        True, if shapes are equal.
     """
 
-    # No need to check if there is less than 2 images
     if len(images) < 2:
         return True
     base_shape = images[0][0].shape[:3]
@@ -12,3 +23,42 @@ def check_img_shapes(images):
         if base_shape != data.shape[:3]:
             return False
     return True
+
+
+def check_img_dtype(images):
+    """Check for supported dtype. If not supported numerical type, fallback to
+    supported numerical types (either int32 or float 32). If non-numerical
+    type, skip the data.
+
+    Parameters
+    ----------
+    images : list
+        Each image is tuple of (data, affine).
+
+    Returns
+    -------
+    list
+        Valid images from the provided images.
+    """
+
+    valid_images = []
+
+    for idx, img in enumerate(images):
+        data, affine = img
+        if np.issubdtype(data.dtype, np.integer):
+            if data.dtype != np.int32:
+                msg = '{} is not supported, falling back to int32'
+                warnings.warn(msg.format(data.dtype))
+                img = (data.astype(np.int32), affine)
+            valid_images.append(img)
+        elif np.issubdtype(data.dtype, np.floating):
+            if data.dtype != np.float64 and data.dtype != np.float32:
+                msg = '{} is not supported, falling back to float32'
+                warnings.warn(msg.format(data.dtype))
+                img = (data.astype(np.float32), affine)
+            valid_images.append(img)
+        else:
+            msg = 'skipping image {}, passed image is not in numerical format'
+            warnings.warn(msg.format(idx + 1))
+
+    return valid_images

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -26,9 +26,10 @@ def check_img_shapes(images):
 
 
 def check_img_dtype(images):
-    """Check for supported dtype. If not supported numerical type, fallback to
-    supported numerical types (either int32 or float 32). If non-numerical
-    type, skip the data.
+    """Check supplied image dtype.
+
+    If not supported numerical type, fallback to supported numerical types
+    (either int32 or float 32). If non-numerical type, skip the data.
 
     Parameters
     ----------

--- a/dipy/viz/tests/meson.build
+++ b/dipy/viz/tests/meson.build
@@ -4,6 +4,7 @@ python_sources = [
   'test_fury.py',
   'test_regtools.py',
   'test_streamline.py',
+  'test_util.py',
   ]
 
 

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -131,6 +132,28 @@ def test_horizon(rng):
             random_colors=False, length_lt=np.inf, length_gt=0,
             clusters_lt=np.inf, clusters_gt=0,
             world_coords=True, interactive=False)
+
+
+def check_for_warnings(warn_printed, w_msg):
+    selected_w = [w for w in warn_printed if issubclass(w.category,
+                                                        UserWarning)]
+    assert len(selected_w) >= 1
+    msg = [str(m.message) for m in selected_w]
+    npt.assert_equal(w_msg in msg, True)
+
+
+def test_horizon_wrong_dtype_images():
+    affine = np.array([[1., 0., 0., -98.],
+                       [0., 1., 0., -134.],
+                       [0., 0., 1., -72.],
+                       [0., 0., 0., 1.]])
+
+    data = np.random.rand(197, 233, 189).astype(np.bool_)
+    images = [(data, affine)]
+    with warnings.catch_warnings(record=True) as l_warns:
+        horizon(images=images, interactive=False)
+        check_for_warnings(l_warns, 'skipping image 1, passed image is not in '
+                           + 'numerical format')
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -142,6 +142,7 @@ def check_for_warnings(warn_printed, w_msg):
     npt.assert_equal(w_msg in msg, True)
 
 
+@pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 def test_horizon_wrong_dtype_images():
     affine = np.array([[1., 0., 0., -98.],
                        [0., 1., 0., -134.],

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -8,6 +8,7 @@ import pytest
 from dipy.data import DATA_DIR
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.utils import create_nifti_header
+from dipy.testing import check_for_warnings
 from dipy.testing.decorators import use_xvfb
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
@@ -132,14 +133,6 @@ def test_horizon(rng):
             random_colors=False, length_lt=np.inf, length_gt=0,
             clusters_lt=np.inf, clusters_gt=0,
             world_coords=True, interactive=False)
-
-
-def check_for_warnings(warn_printed, w_msg):
-    selected_w = [w for w in warn_printed if issubclass(w.category,
-                                                        UserWarning)]
-    assert len(selected_w) >= 1
-    msg = [str(m.message) for m in selected_w]
-    npt.assert_equal(w_msg in msg, True)
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -1,0 +1,78 @@
+import warnings
+import numpy as np
+import numpy.testing as npt
+from dipy.viz.horizon.util import check_img_dtype, check_img_shapes
+
+
+def test_check_img_shapes():
+    affine = np.array([[1., 0., 0., -98.],
+                       [0., 1., 0., -134.],
+                       [0., 0., 1., -72.],
+                       [0., 0., 0., 1.]])
+
+    data = 255 * np.random.rand(197, 233, 189)
+    data1 = 255 * np.random.rand(197, 233, 189)
+    images = [
+        (data, affine),
+        (data1, affine)
+    ]
+    npt.assert_equal(check_img_shapes(images), True)
+
+    data1 = 255 * np.random.rand(200, 233, 189)
+    images = [
+        (data, affine),
+        (data1, affine)
+    ]
+    npt.assert_equal(check_img_shapes(images), False)
+
+
+def check_for_warnings(warn_printed, w_msg):
+    selected_w = [w for w in warn_printed if issubclass(w.category,
+                                                        UserWarning)]
+    assert len(selected_w) >= 1
+    msg = [str(m.message) for m in selected_w]
+    npt.assert_equal(w_msg in msg, True)
+
+
+def test_check_img_dtype():
+    affine = np.array([[1., 0., 0., -98.],
+                       [0., 1., 0., -134.],
+                       [0., 0., 1., -72.],
+                       [0., 0., 0., 1.]])
+
+    data = 255 * np.random.rand(197, 233, 189)
+    images = [
+        (data, affine),
+    ]
+
+    npt.assert_equal(check_img_dtype(images)[0], images[0])
+
+    data = np.random.rand(5, 5, 5).astype(np.int64)
+    images = [
+        (data, affine),
+    ]
+
+    with warnings.catch_warnings(record=True) as l_warns:
+        npt.assert_equal(check_img_dtype(images)[0][0].dtype, np.int32)
+        check_for_warnings(l_warns, 'int64 is not supported, falling back to'
+                           + ' int32')
+
+    data = np.random.rand(5, 5, 5).astype(np.float16)
+    images = [
+        (data, affine),
+    ]
+
+    with warnings.catch_warnings(record=True) as l_warns:
+        npt.assert_equal(check_img_dtype(images)[0][0].dtype, np.float32)
+        check_for_warnings(l_warns, 'float16 is not supported, falling back to'
+                           + ' float32')
+
+    data = np.random.rand(5, 5, 5).astype(np.bool_)
+    images = [
+        (data, affine),
+    ]
+
+    with warnings.catch_warnings(record=True) as l_warns:
+        check_img_dtype(images)
+        check_for_warnings(l_warns, 'skipping image 1, passed image is not in '
+                           + 'numerical format')

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 import numpy.testing as npt
+from dipy.testing import check_for_warnings
 from dipy.viz.horizon.util import check_img_dtype, check_img_shapes
 
 
@@ -24,14 +25,6 @@ def test_check_img_shapes():
         (data1, affine)
     ]
     npt.assert_equal(check_img_shapes(images), False)
-
-
-def check_for_warnings(warn_printed, w_msg):
-    selected_w = [w for w in warn_printed if issubclass(w.category,
-                                                        UserWarning)]
-    assert len(selected_w) >= 1
-    msg = [str(m.message) for m in selected_w]
-    npt.assert_equal(w_msg in msg, True)
 
 
 def test_check_img_dtype():


### PR DESCRIPTION
This PR resolves the issue https://github.com/dipy/dipy/issues/2789 about checking dtype of the passed image arrays.

#### Current behavior
- When horizon is invoked from either we do not check the type of the data passed in the images. It is implicitly assumed to be an appropriate numerical type supported by horizon.
- This causes issues when users are using the horizon from the python code as the type is not verified.

#### Proposed behavior
All the images will be checked for dtype and the following cases can be the result.
1. Data is of type int32 or float32 or float64, data will be added to the valid images.
2. Data is of a different integer subtype than int32, data will be cast to int32 and then will be added to the valid images. There will be a warning provided.
3. Data is of a different floating subtype than float32 or float64, data will be cast to float64 and hen will be added to the valid images. There will be a warning provided.
4. Data is of non-numeric type, a warning will be provided and data will not be added to the valid images.