### PR TITLE
pyproject.toml: no cython at run time.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 ]
 dynamic = ['version']
 dependencies = [
-    "cython>=0.29.24, !=0.29.29",
     "numpy>=1.22.4",
     "scipy>=1.8",
     "nibabel>=3.0.0",


### PR DESCRIPTION
As first identified in [Debian bug #1060438], the pyproject.toml declares a run time dependency on cython for dipy, but running the program and suite after cythonizing the code does not require cython anymore.  In such configuration, the cython requirement for the build system should be sufficient.

[Debian bug #1060438]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1060438