### PR TITLE
d/d/t/test_data.py: endian independent dtype.

### DIFF
--- a/dipy/data/tests/test_data.py
+++ b/dipy/data/tests/test_data.py
@@ -5,4 +5,4 @@ import numpy as np
 def test_sphere_dtypes():
     for sphere_name, sphere_path in SPHERE_FILES.items():
         sphere_data = np.load(sphere_path)
-        npt.assert_equal(sphere_data['vertices'].dtype, np.float64)
+        npt.assert_equal(sphere_data['vertices'].dtype, np.dtype('<f8'))


### PR DESCRIPTION
test_sphere_dtypes produces consistently little endian float64 numpy objects.  This is usually not an issue, but big endian systems, the little endian value is compared against a big endian float64, causing the test to fail.  This fixes/worksaround the test failure on big endian CPUs.