### PR TITLE
[MTN] code cleaning: remove some dependencies version checking

### DIFF
--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -38,7 +38,6 @@ Utilities
 import sys
 
 from dipy.version import version as __version__
-from .testing import setup_test
 
 # Plumb in version etc info stuff
 from .pkg_info import get_pkg_info as _get_pkg_info

--- a/dipy/conftest.py
+++ b/dipy/conftest.py
@@ -1,6 +1,5 @@
 """pytest initialization."""
 import numpy as np
-from packaging.version import Version
 import warnings
 
 """ Set numpy print options to "legacy" for new versions of numpy
@@ -12,8 +11,7 @@ https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718
 https://github.com/numpy/numpy/commit/734b907fc2f7af6e40ec989ca49ee6d87e21c495
 https://github.com/nipy/nibabel/pull/556
 """
-if Version(np.__version__) >= Version('1.14'):
-    np.set_printoptions(legacy='1.13')
+np.set_printoptions(legacy='1.13')
 
 warnings.simplefilter(action="default", category=FutureWarning)
 warnings.simplefilter("always", category=UserWarning)

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python
 """ Classes and functions for fitting tensors """
-from packaging.version import Version
 import warnings
-
 import functools
 
 import numpy as np
-
 import scipy.optimize as opt
 
-from dipy.utils.arrfuncs import pinv
 from dipy.data import get_sphere
 from dipy.core.gradients import gradient_table
 from dipy.core.geometry import vector_norm
@@ -1445,22 +1441,17 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     w = np.exp(fit_result @ design_matrix.T)
 
     # the weighted problem design_matrix * w is much larger (differs per voxel)
-    if Version(np.__version__) < Version('1.14'):
-        fit_result = np.einsum('...ij,...j',
-                               pinv(design_matrix * w[..., None]),
-                               w * log_s)
-    else:
-        fit_result = np.einsum('...ij,...j',
-                               np.linalg.pinv(design_matrix * w[..., None]),
-                               w * log_s)
+    fit_result = np.einsum('...ij,...j',
+                           np.linalg.pinv(design_matrix * w[..., None]),
+                           w * log_s)
 
     if return_S0_hat:
         return (eig_from_lo_tri(fit_result,
                                 min_diffusivity=tol / -design_matrix.min()),
                 np.exp(-fit_result[:, -1])), None
     else:
-        return eig_from_lo_tri(fit_result,
-                               min_diffusivity=tol / -design_matrix.min()), None
+        return eig_from_lo_tri(
+            fit_result, min_diffusivity=tol / -design_matrix.min()), None
 
 
 @iter_fit_tensor()

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -1,4 +1,3 @@
-from packaging.version import Version
 import numbers
 import warnings
 
@@ -466,10 +465,8 @@ def multi_shell_fiber_response(sh_order, bvals, wm_rf, gm_rf, csf_rf,
     -------
     MultiShellResponse
         MultiShellResponse object.
-    """
-    NUMPY_1_14_PLUS = Version(np.__version__) >= Version('1.14.0')
-    rcond_value = None if NUMPY_1_14_PLUS else -1
 
+    """
     bvals = np.array(bvals, copy=True)
     if btens is None:
         btens = np.repeat(["LTE"], len(bvals))
@@ -499,7 +496,7 @@ def multi_shell_fiber_response(sh_order, bvals, wm_rf, gm_rf, csf_rf,
         gtab = GradientTable(big_sphere.vertices * 0, btens=btens[0])
         wm_response = single_tensor(gtab, wm_rf[0, 3], wm_rf[0, :3], evecs,
                                     snr=None)
-        response[0, 2:] = np.linalg.lstsq(B, wm_response, rcond=rcond_value)[0]
+        response[0, 2:] = np.linalg.lstsq(B, wm_response, rcond=None)[0]
 
         response[0, 1] = gm_rf[0, 3] / A
         response[0, 0] = csf_rf[0, 3] / A
@@ -510,7 +507,7 @@ def multi_shell_fiber_response(sh_order, bvals, wm_rf, gm_rf, csf_rf,
             wm_response = single_tensor(gtab, wm_rf[i, 3], wm_rf[i, :3], evecs,
                                         snr=None)
             response[i+1, 2:] = np.linalg.lstsq(B, wm_response,
-                                                rcond=rcond_value)[0]
+                                                rcond=None)[0]
 
             response[i+1, 1] = gm_rf[i, 3] * np.exp(-bvalue * gm_rf[i, 0]) / A
             response[i+1, 0] = csf_rf[i, 3] * np.exp(-bvalue * csf_rf[i, 0]) / A
@@ -525,7 +522,7 @@ def multi_shell_fiber_response(sh_order, bvals, wm_rf, gm_rf, csf_rf,
             wm_response = single_tensor(gtab, wm_rf[i, 3], wm_rf[i, :3], evecs,
                                         snr=None)
             response[i, 2:] = np.linalg.lstsq(B, wm_response,
-                                              rcond=rcond_value)[0]
+                                              rcond=None)[0]
 
             response[i, 1] = gm_rf[i, 3] * np.exp(-bvalue * gm_rf[i, 0]) / A
             response[i, 0] = csf_rf[i, 3] * np.exp(-bvalue * csf_rf[i, 0]) / A

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -1,13 +1,12 @@
 """Utilities for testing."""
-import operator
 from functools import partial
+import operator
 from os.path import dirname, abspath, join as pjoin
-from numpy.testing import assert_array_equal
-import numpy as np
-import numpy.testing as npt
-import scipy
-from packaging.version import Version
 import warnings
+
+from numpy.testing import assert_array_equal
+import numpy.testing as npt
+
 
 # set path to example data
 IO_DATA_PATH = abspath(pjoin(dirname(__file__),
@@ -76,6 +75,7 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     Examples
     --------
     >>> import warnings
+    >>> import numpy as np
     >>> with clear_and_catch_warnings(modules=[np.core.fromnumeric]):
     ...     warnings.simplefilter('always')
     ...     # do something that raises a warning in np.core.fromnumeric
@@ -110,32 +110,6 @@ class clear_and_catch_warnings(warnings.catch_warnings):
                 mod.__warningregistry__.clear()
             if mod in self._warnreg_copies:
                 mod.__warningregistry__.update(self._warnreg_copies[mod])
-
-
-def setup_test():
-    """Set numpy print options to "legacy" for new versions of numpy.
-
-    If imported into a file, pytest will run this before any doctests.
-
-    References
-    ----------
-    https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718
-    https://github.com/numpy/numpy/commit/734b907fc2f7af6e40ec989ca49ee6d87e21c495
-    https://github.com/nipy/nibabel/pull/556
-
-    """
-    if Version(np.__version__) >= Version('1.14'):
-        np.set_printoptions(legacy='1.13')
-
-    # Temporary fix until scipy release in October 2018
-    # must be removed after that
-    # print the first occurrence of matching warnings for each location
-    # (module + line number) where the warning is issued
-    if Version(np.__version__) >= Version('1.15') and \
-            Version(scipy.version.short_version) <= '1.1.0':
-        warnings.simplefilter(action="default", category=FutureWarning)
-
-    warnings.simplefilter("always", category=UserWarning)
 
 
 def check_for_warnings(warn_printed, w_msg):

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -1,5 +1,4 @@
 from packaging.version import Version
-import warnings
 
 import numpy as np
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,11 +20,6 @@ try:
 except ImportError:
     raise RuntimeError('Cannot import dipy, please investigate')
 
-from packaging.version import Version
-import sphinx
-if Version(sphinx.__version__) < Version('2'):
-    raise RuntimeError('Need sphinx >= 2 for numpydoc to work correctly')
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
This Pr removes `from packaging.version import Version` in many modules due to the incoherence with DIPY minimal dependencies versions. 