### PR TITLE
[RF] replace Bunch by Enum

### DIFF
--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -1,18 +1,10 @@
+from enum import Enum
+
 import numpy as np
 floating = np.float32
 
 
-class Bunch:
-    def __init__(self, **kwds):
-        r"""A 'bunch' of values (a replacement of Enum)
-
-        This is a temporary replacement of Enum, which is not available
-        on all versions of Python 2
-        """
-        self.__dict__.update(kwds)
-
-
-VerbosityLevels = Bunch(NONE=0, STATUS=1, DIAGNOSE=2, DEBUG=3)
+VerbosityLevels = Enum(NONE=0, STATUS=1, DIAGNOSE=2, DEBUG=3)
 r""" VerbosityLevels
 This enum defines the four levels of verbosity we use in the align
 module.

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1,7 +1,8 @@
 """  Classes and functions for Symmetric Diffeomorphic Registration """
 
-import logging
 import abc
+from enum import Enum
+import logging
 
 import numpy as np
 import numpy.linalg as npl
@@ -11,17 +12,16 @@ from nibabel.streamlines import ArraySequence as Streamlines
 from dipy.align import vector_fields as vfu
 from dipy.align import floating
 from dipy.align import VerbosityLevels
-from dipy.align import Bunch
 from dipy.align.scalespace import ScaleSpace
 
-RegistrationStages = Bunch(INIT_START=0,
-                           INIT_END=1,
-                           OPT_START=2,
-                           OPT_END=3,
-                           SCALE_START=4,
-                           SCALE_END=5,
-                           ITER_START=6,
-                           ITER_END=7)
+RegistrationStages = Enum(INIT_START=0,
+                          INIT_END=1,
+                          OPT_START=2,
+                          OPT_END=3,
+                          SCALE_START=4,
+                          SCALE_END=5,
+                          ITER_START=6,
+                          ITER_END=7)
 """Registration Stages
 
 This enum defines the different stages which the Volumetric Registration


### PR DESCRIPTION
This is a small PR to replace our custom class `Bunch` by the standard object `Enum`.  

`Bunch` was created because `Enum` was not available with python2. It is not anymore the case. 