### PR TITLE
[WIP][RF] Use lazy loading

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -66,6 +66,7 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python-version }}
       VENV_ARGS: "--python=python"
       USE_PRE: ${{ inputs.use-pre }}
+      EAGER_IMPORT: true
       COVERAGE: ${{ inputs.coverage }}
       CODECOV_TOKEN: ${{ secrets.codecov-token }}
       TEST_WITH_XVFB: ${{ inputs.enable-viz-tests }}

--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -9,7 +9,6 @@ Subpackages
 ::
 
  align         -- Registration, streamline alignment, volume resampling
- boots         -- Bootstrapping algorithms
  core          -- Spheres, gradient tables
  core.geometry -- Spherical geometry, coordinate and vector manipulation
  core.meshes   -- Point distributions on the sphere
@@ -35,40 +34,8 @@ Utilities
  __version__   -- Dipy version
 
 """
-import sys
 
-from dipy.version import version as __version__
+from dipy.version import version as __version__  # noqa
+import lazy_loader as lazy
 
-# Plumb in version etc info stuff
-from .pkg_info import get_pkg_info as _get_pkg_info
-
-
-def get_info():
-    from os.path import dirname
-    return _get_pkg_info(dirname(__file__))
-
-
-del sys
-
-submodules = [
-    'align',
-    'boots',
-    'core',
-    'data',
-    'denoise',
-    'direction',
-    'io',
-    'nn',
-    'reconst',
-    'segment',
-    'sims',
-    'stats',
-    'tracking',
-    'utils',
-    'viz',
-    'workflows',
-    'tests',
-    'testing'
-]
-
-__all__ = submodules + ['__version__', 'setup_test', 'get_info']
+__getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)

--- a/dipy/__init__.pyi
+++ b/dipy/__init__.pyi
@@ -1,0 +1,10 @@
+from . import (align, core, data, denoise, direction, io, nn, reconst,
+               segment, sims, stats, tracking, utils, viz, workflows,
+               tests, testing)
+
+from .pkg_info import get_info
+
+__all__ = ['__version__', 'get_info', 'align', 'boots', 'core', 'data',  # noqa: F822, E501
+           'denoise', 'direction', 'io', 'nn', 'reconst', 'segment',
+           'sims', 'stats', 'tracking', 'utils', 'viz', 'workflows',
+           'tests', 'testing']

--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -1,5 +1,9 @@
+import lazy_loader as lazy
+
 import numpy as np
 floating = np.float32
+
+__getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)
 
 
 class Bunch:
@@ -22,19 +26,3 @@ DIAGNOSE : print high level information of the components involved in the
 registration that can be used to detect a failing component.
 DEBUG : print as much information as possible to isolate the cause of a bug.
 """
-
-from dipy.align._public import (syn_registration, register_dwi_to_template, # noqa
-                                write_mapping, read_mapping, resample,
-                                center_of_mass, translation,
-                                rigid_isoscaling, rigid_scaling,
-                                rigid, affine, motion_correction,
-                                affine_registration, register_series,
-                                register_dwi_series, streamline_registration)
-
-__all__ = ["syn_registration", "register_dwi_to_template",
-           "write_mapping", "read_mapping", "resample",
-           "center_of_mass", "translation",
-           "rigid_isoscaling", "rigid_scaling",
-           "rigid", "affine", "motion_correction",
-           "affine_registration", "register_series",
-           "register_dwi_series", "streamline_registration"]

--- a/dipy/align/__init__.pyi
+++ b/dipy/align/__init__.pyi
@@ -1,0 +1,23 @@
+
+from ._public import (syn_registration, register_dwi_to_template, # noqa
+                      write_mapping, read_mapping, resample,
+                      center_of_mass, translation,
+                      rigid_isoscaling, rigid_scaling,
+                      rigid, affine, motion_correction,
+                      affine_registration, register_series,
+                      register_dwi_series, streamline_registration)
+
+from . import (bundlemin, cpd, crosscorr, expectmax, imaffine, imwarp, # noqa
+               metrics, parzenhist, reslice, scalespace, streamlinear,
+               streamwarp, sumsqdiff, transforms, vector_fields)
+
+__all__ = ["syn_registration", "register_dwi_to_template",
+           "write_mapping", "read_mapping", "resample",
+           "center_of_mass", "translation",
+           "rigid_isoscaling", "rigid_scaling",
+           "rigid", "affine", "motion_correction",
+           "affine_registration", "register_series",
+           "register_dwi_series", "streamline_registration",
+           "bundlemin", "cpd", "crosscorr", "expectmax", "imaffine", "imwarp",
+           "metrics", "parzenhist", "reslice", "scalespace", "streamlinear",
+           "streamwarp", "sumsqdiff", "transforms", "vector_fields"]

--- a/dipy/align/meson.build
+++ b/dipy/align/meson.build
@@ -31,7 +31,9 @@ foreach ext: cython_sources
 endforeach
 
 
-python_sources = ['__init__.py',
+python_sources = [
+  '__init__.py',
+  '__init__.pyi',
   '_public.py',
   'cpd.py',
   'imaffine.py',

--- a/dipy/core/__init__.py
+++ b/dipy/core/__init__.py
@@ -1,2 +1,6 @@
 # Init for core dipy objects
 """ Core objects """
+
+import lazy_loader as lazy
+
+__getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)

--- a/dipy/core/__init__.pyi
+++ b/dipy/core/__init__.pyi
@@ -1,0 +1,8 @@
+from . import (geometry, gradients, graph, histeq, interpolation, ndindex,
+               onetime, optimize, profile, rng, sphere, sphere_stats,
+               subdivide_octahedron, wavelet)
+
+
+__all__ = ['geometry', 'gradients', 'graph', 'histeq', 'interpolation',
+           'ndindex', 'onetime', 'optimize', 'profile', 'rng', 'sphere',
+           'sphere_stats', 'subdivide_octahedron', 'wavelet']

--- a/dipy/core/meson.build
+++ b/dipy/core/meson.build
@@ -17,7 +17,9 @@ foreach ext: cython_sources
 endforeach
 
 
-python_sources = ['__init__.py',
+python_sources = [
+  '__init__.py',
+  '__init__.pyi',
   'geometry.py',
   'gradients.py',
   'graph.py',

--- a/dipy/denoise/__init__.py
+++ b/dipy/denoise/__init__.py
@@ -1,1 +1,5 @@
-#init for denoise aka the denoising module
+# init for denoise aka the denoising module
+
+import lazy_loader as lazy
+
+__getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)

--- a/dipy/denoise/__init__.pyi
+++ b/dipy/denoise/__init__.pyi
@@ -1,0 +1,17 @@
+__all__ = ['nlmeans', 'gibbs_removal', 'localpca', 'mppca', 'p2s',
+           'adaptive_soft_matching', 'shift_twist_convolution', 'denspeed',
+           'pca_noise_estimate', 'piesno', 'estimate_sigma',
+           'enhancement_kernel', 'non_local_means', 'nlmeans_block',
+           'noise_estimate', 'patch2self']
+
+from .nlmeans import nlmeans
+from .non_local_means import non_local_means
+from .gibbs import gibbs_removal
+from .localpca import localpca, mppca
+from .patch2self import p2s
+from .adaptive_soft_matching import adaptive_soft_matching
+from .noise_estimate import piesno, estimate_sigma
+
+from . import (shift_twist_convolution, pca_noise_estimate, denspeed,
+               enhancement_kernel, nlmeans_block, noise_estimate,
+               patch2self)

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -10,6 +10,7 @@ from dipy.utils.deprecator import deprecated_params
 import scipy.fft
 _fft = scipy.fft
 
+
 def _image_tv(x, axis=0, n_points=3):
     """ Computes total variation (TV) of matrix x across a given axis and
     along two directions.

--- a/dipy/denoise/meson.build
+++ b/dipy/denoise/meson.build
@@ -18,7 +18,9 @@ foreach ext: cython_sources
 endforeach
 
 
-python_sources = ['__init__.py',
+python_sources = [
+  '__init__.py',
+  '__init__.pyi',
   'adaptive_soft_matching.py',
   'gibbs.py',
   'localpca.py',

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -342,3 +342,6 @@ def patch2self(data, bvals, patch_radius=(0, 0, 0), model='ols',
         denoised_arr.clip(min=0, out=denoised_arr)
 
     return np.array(denoised_arr, dtype=out_dtype)
+
+
+p2s = patch2self

--- a/dipy/meson.build
+++ b/dipy/meson.build
@@ -299,8 +299,10 @@ generate_version = custom_target(
 # ------------------------------------------------------------------------
 python_sources = [
   '__init__.py',
+  '__init__.pyi',
   'conftest.py',
-  'pkg_info.py'
+  'pkg_info.py',
+  'py.typed'
 ]
 
 py3.install_sources(

--- a/dipy/pkg_info.py
+++ b/dipy/pkg_info.py
@@ -86,3 +86,8 @@ def get_pkg_info(pkg_path):
         sys_platform=sys.platform,
         np_version=numpy.__version__,
         dipy_version=dipy.__version__)
+
+
+def get_info():
+    """ Return dict describing the context of DIPY package"""
+    return get_pkg_info(os.path.dirname(__file__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "packaging>=21",
     "tqdm>=4.30.0",
     "trx-python>=0.2.9",
+    "lazy_loader>=0.3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Proof of concept for adopting [Scientific Python SPEC 1](https://discuss.scientific-python.org/t/spec-1-lazy-loading-for-submodules/25).

> This has several advantages:
>   - It exposes a nested namespace that behaves as a flat namespace. This avoids carefully having to import exactly the right combination of submodules, and allows interactive exploration of the namespace in an interactive terminal.
>   - It avoids having to optimize for import cost. Currently, developers often move imports inside of functions to avoid slowing down importing their module. Lazy importing, when implemented through out a library, makes all imports cheap.
>   - It provides direct access to submodules, avoiding local namespace conflicts. Instead of doing `import dipy.reconst as reconst` to avoid clobbering a local `reconst`, one can now import each library and access its members directly: `import dipy; dipy.reconst.`

# Todo

- [x] Add CI run that uses `EAGER_IMPORT=true` env var to smoke out circular import issues
- [ ] Convert all `__init__.py`

Feedbacks are welcomed

When this PR will be done, a follow-up PR will be created to simplify all tutorials import