### PR TITLE
[RF] remove cpdef in PmfGen

### DIFF
--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -154,7 +154,7 @@ cdef class BootDirectionGetter(DirectionGetter):
             self.pmf[i] = 0.0
 
 
-    cdef int get_direction_c(self, double* point, double* direction):
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         """Attempt direction getting on a few bootstrap samples.
 
         Returns
@@ -168,7 +168,7 @@ cdef class BootDirectionGetter(DirectionGetter):
             cnp.ndarray[cnp.float_t, ndim=2] peaks
 
         for _ in range(self.max_attempts):
-            pmf = self.get_pmf(<double[:3]> point)
+            pmf = self.get_pmf(point)
             peaks = peak_directions(pmf, self.sphere, **self._pf_kwargs)[0]
             if len(peaks) > 0:
                 return closest_peak(peaks, direction, self.cos_similarity)

--- a/dipy/direction/closest_peak_direction_getter.pxd
+++ b/dipy/direction/closest_peak_direction_getter.pxd
@@ -5,7 +5,7 @@ from dipy.tracking.direction_getter cimport DirectionGetter
 
 
 cdef int closest_peak(cnp.ndarray[cnp.float_t, ndim=2] peak_dirs,
-                      double* direction, double cos_similarity)
+                      double[::1] direction, double cos_similarity)
 
 
 cdef class BasePmfDirectionGetter(DirectionGetter):
@@ -22,19 +22,14 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
         self,
         double[::1] point)
 
-    cdef double* _get_pmf(
+    cdef double[:] _get_pmf(
         self,
-        double* point) nogil
-
-    cpdef int get_direction(
-        self,
-        double[::1] point,
-        double[::1] direction) except -1
+        double[::1] point) nogil
 
     cdef int get_direction_c(
         self,
-        double* point,
-        double* direction)
+        double[::1] point,
+        double[::1] direction)
 
 
 cdef class BaseDirectionGetter(BasePmfDirectionGetter):

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -1,3 +1,8 @@
+# cython: boundscheck=False
+# cython: initializedcheck=False
+# cython: wraparound=False
+# cython: nonecheck=False
+
 import numpy as np
 cimport numpy as cnp
 
@@ -9,7 +14,7 @@ from dipy.utils.fast_numpy cimport copy_point, scalar_muliplication_point
 
 
 cdef int closest_peak(cnp.ndarray[cnp.float_t, ndim=2] peak_dirs,
-                      double* direction, double cos_similarity):
+                      double[::1] direction, double cos_similarity):
     """Update direction with the closest direction from peak_dirs.
 
     All directions should be unit vectors. Antipodal symmetry is assumed, ie
@@ -48,11 +53,11 @@ cdef int closest_peak(cnp.ndarray[cnp.float_t, ndim=2] peak_dirs,
 
     if closest_peak_i >= 0:
         if closest_peak_dot >= cos_similarity:
-            copy_point(&peak_dirs[closest_peak_i, 0], direction)
+            copy_point(&peak_dirs[closest_peak_i, 0], &direction[0])
             return 0
         if closest_peak_dot <= -cos_similarity:
-            copy_point(&peak_dirs[closest_peak_i, 0], direction)
-            scalar_muliplication_point(direction, -1)
+            copy_point(&peak_dirs[closest_peak_i, 0], &direction[0])
+            scalar_muliplication_point(&direction[0], -1)
             return 0
     return 1
 
@@ -93,14 +98,14 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
             directions should be unique.
 
         """
-        cdef double* pmf = self._get_pmf(&point[0])
-        return self._get_peak_directions(<double[:self.len_pmf]> pmf)
+        cdef double[:] pmf = self._get_pmf(point)
+        return self._get_peak_directions(pmf)
 
-    cdef double* _get_pmf(self, double* point) nogil:
+    cdef double[:] _get_pmf(self, double[::1] point) nogil:
         cdef:
             cnp.npy_intp i
             cnp.npy_intp _len = self.len_pmf
-            double* pmf
+            double[:] pmf
             double pmf_threshold=self.pmf_threshold
             double absolute_pmf_threshold
             double max_pmf=0
@@ -222,7 +227,7 @@ cdef class ClosestPeakDirectionGetter(PmfGenDirectionGetter):
     direction.
     """
 
-    cdef int get_direction_c(self, double* point, double* direction):
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         """
         Returns
         -------
@@ -231,12 +236,12 @@ cdef class ClosestPeakDirectionGetter(PmfGenDirectionGetter):
         """
         cdef:
             cnp.npy_intp _len = self.len_pmf
-            double* pmf
+            double[:] pmf
             cnp.ndarray[cnp.float_t, ndim=2] peaks
 
         pmf = self._get_pmf(point)
 
-        peaks = self._get_peak_directions(<double[:_len]> pmf)
+        peaks = self._get_peak_directions(pmf)
         if len(peaks) == 0:
             return 1
         return closest_peak(peaks, direction, self.cos_similarity)

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -7,11 +7,9 @@ cdef class PmfGen:
         double[:, :] vertices
         object sphere
 
-    cpdef double[:] get_pmf(self, double[::1] point)
-    cdef double* get_pmf_c(self, double* point) noexcept nogil
+    cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil
     cdef int find_closest(self, double* xyz) noexcept nogil
-    cpdef double get_pmf_value(self, double[::1] point, double[::1] xyz)
-    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil
+    cdef double get_pmf_value_c(self, double[::1] point, double[::1] xyz) noexcept nogil
     cdef void __clear_pmf(self) noexcept nogil
     pass
 

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -19,12 +19,10 @@ cdef class PmfGen:
         self.sphere = sphere
         self.vertices = np.asarray(sphere.vertices, dtype=float)
 
-    cpdef double[:] get_pmf(self, double[::1] point):
-        cdef:
-            cnp.npy_intp len_pmf = self.pmf.shape[0]
-        return <double[:len_pmf]>self.get_pmf_c(&point[0])
+    def get_pmf(self, double[::1] point):
+        return self.get_pmf_c(point)
 
-    cdef double* get_pmf_c(self, double* point) noexcept nogil:
+    cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil:
         pass
 
     cdef int find_closest(self, double* xyz) noexcept nogil:
@@ -46,15 +44,15 @@ cdef class PmfGen:
                 idx = i
         return idx
 
-    cpdef double get_pmf_value(self, double[::1] point, double[::1] xyz):
-        return self.get_pmf_value_c(&point[0], &xyz[0])
+    def get_pmf_value(self, double[::1] point, double[::1] xyz):
+        return self.get_pmf_value_c(point, xyz)
 
-    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil:
+    cdef double get_pmf_value_c(self, double[::1] point, double[::1] xyz) noexcept nogil:
         """
         Return the pmf value corresponding to the closest vertex to the
         direction xyz.
         """
-        cdef int idx = self.find_closest(xyz)
+        cdef int idx = self.find_closest(&xyz[0])
         return self.get_pmf_c(point)[idx]
 
     cdef void __clear_pmf(self) noexcept nogil:
@@ -79,12 +77,12 @@ cdef class SimplePmfGen(PmfGen):
             raise ValueError("pmf should have the same number of values as the"
                              + " number of vertices of sphere.")
 
-    cdef double* get_pmf_c(self, double* point) noexcept nogil:
-        if trilinear_interpolate4d_c(self.data, point, self.pmf) != 0:
+    cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil:
+        if trilinear_interpolate4d_c(self.data, &point[0], self.pmf) != 0:
             PmfGen.__clear_pmf(self)
-        return &self.pmf[0]
+        return self.pmf
 
-    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil:
+    cdef double get_pmf_value_c(self, double[::1] point, double[::1] xyz) noexcept nogil:
         """
         Return the pmf value corresponding to the closest vertex to the
         direction xyz.
@@ -92,10 +90,10 @@ cdef class SimplePmfGen(PmfGen):
         cdef:
             int idx
 
-        idx = self.find_closest(xyz)
+        idx = self.find_closest(&xyz[0])
 
         if trilinear_interpolate4d_c(self.data[:,:,:,idx:idx+1],
-                                     point,
+                                     &point[0],
                                      self.pmf[0:1]) != 0:
             PmfGen.__clear_pmf(self)
         return self.pmf[0]
@@ -122,14 +120,14 @@ cdef class SHCoeffPmfGen(PmfGen):
         self.coeff = np.empty(shcoeff_array.shape[3])
         self.pmf = np.empty(self.B.shape[0])
 
-    cdef double* get_pmf_c(self, double* point) noexcept nogil:
+    cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil:
         cdef:
             cnp.npy_intp i, j
             cnp.npy_intp len_pmf = self.pmf.shape[0]
             cnp.npy_intp len_B = self.B.shape[1]
             double _sum
 
-        if trilinear_interpolate4d_c(self.data, point, self.coeff) != 0:
+        if trilinear_interpolate4d_c(self.data, &point[0], self.coeff) != 0:
             PmfGen.__clear_pmf(self)
         else:
             for i in range(len_pmf):
@@ -137,4 +135,4 @@ cdef class SHCoeffPmfGen(PmfGen):
                 for j in range(len_B):
                     _sum = _sum + (self.B[i, j] * self.coeff[j])
                 self.pmf[i] = _sum
-        return &self.pmf[0]
+        return self.pmf

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -1,3 +1,8 @@
+# cython: boundscheck=False
+# cython: initializedcheck=False
+# cython: wraparound=False
+# cython: nonecheck=False
+
 cimport cython
 cimport numpy as cnp
 import numpy as np
@@ -83,7 +88,7 @@ cdef class EuDXDirectionGetter(DirectionGetter):
     @cython.initializedcheck(False)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int get_direction_c(self, double* point, double* direction):
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         """Interpolate closest peaks to direction from voxels neighboring point
 
         Update direction and return 0 if successful. If no tracking direction

--- a/dipy/tracking/direction_getter.pxd
+++ b/dipy/tracking/direction_getter.pxd
@@ -19,9 +19,4 @@ cdef class DirectionGetter:
                                     StreamlineStatus stream_status,
                                     int fixedstep)
 
-    cpdef int get_direction(
-        self,
-        double[::1] point,
-        double[::1] direction) except -1
-
-    cdef int get_direction_c(self, double* point, double* direction)
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction)

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -117,7 +117,7 @@ cdef class DirectionGetter:
 
        stream_status = TRACKPOINT
        for i in range(1, len_streamlines):
-           if self.get_direction_c(point, &direction[0]):
+           if self.get_direction_c(point, direction):
                break
            for j in range(3):
                voxdir[j] = direction[j] / voxel_size[j]
@@ -135,10 +135,8 @@ cdef class DirectionGetter:
            i = streamline.shape[0]
        return i, stream_status
 
-    cpdef int get_direction(self,
-                            double[::1] point,
-                            double[::1] direction) except -1:
-        return self.get_direction_c(&point[0], &direction[0])
+    def get_direction(self, double[::1] point, double[::1] direction):
+        return self.get_direction_c(point, direction)
 
-    cdef int get_direction_c(self, double* point, double* direction):
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         pass

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -184,7 +184,7 @@ def pft_tracker(
 cdef _pft_tracker(DirectionGetter dg,
                   AnatomicalStoppingCriterion sc,
                   double* seed,
-                  double* direction,
+                  double[::1] direction,
                   double* voxel_size,
                   cnp.float_t[:, :] streamline,
                   cnp.float_t[:, :] directions,
@@ -210,7 +210,7 @@ cdef _pft_tracker(DirectionGetter dg,
 
     copy_point(seed, point)
     copy_point(seed, &streamline[0,0])
-    copy_point(direction, &directions[0, 0])
+    copy_point(&direction[0], &directions[0, 0])
 
     stream_status[0] = TRACKPOINT
     pft_trial = 0
@@ -227,7 +227,7 @@ cdef _pft_tracker(DirectionGetter dg,
                 point[j] += direction[j] / voxel_size[j] * step_size
 
             copy_point(point, &streamline[i, 0])
-            copy_point(direction, &directions[i, 0])
+            copy_point(&direction[0], &directions[i, 0])
             stream_status[0] = sc.check_point_c(point)
             i += 1
 
@@ -257,7 +257,7 @@ cdef _pft_tracker(DirectionGetter dg,
                 pft_trial += 1
                 # update the current point with the PFT results
                 copy_point(&streamline[i-1, 0], point)
-                copy_point(&directions[i-1, 0], direction)
+                copy_point(&directions[i-1, 0], &direction[0])
 
                 # update max_wm_pve following pft
                 for j in range(i):


### PR DESCRIPTION
This PR is a small refactoring to remove the `cpdef` in  pmf.pyx.   

`cpdef = def + cdef` , so it does not make sense to have cpdef + cdef.     it is either `def +cdef ` or `cpdef`

I also use the opportunity to replace some pointer by memoryview. When using memoryview, we should make sure to use aligned memory by using [::1] for speed reason.

@gabknight, can you have a look and try? 