### PR TITLE
[DOC] Fix installation link in README  [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ or using `conda`::
     conda install -c conda-forge dipy
 
 For detailed installation instructions, including instructions for installing
-from source, please read our `installation documentation <https://dipy.org/documentation/latest/installation/>`_.
+from source, please read our `installation documentation <https://docs.dipy.org/stable/user_guide/installation.html>`_.
 
 Python versions and dependencies
 --------------------------------


### PR DESCRIPTION
This PR is to simply change the broken installation link in the README file.