### PR TITLE
[CI] Update scientific-python/upload-nightly-action to 0.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,7 +158,7 @@ jobs:
           path: ./dist
           merge-multiple: true
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@66bc1b6beedff9619cdff8f3361a06802c8f5874   # scientific-python/upload-nightly-action@main
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_NIGHTLY_TOKEN}}


### PR DESCRIPTION
* Update the scientific-python/upload-nightly-action to v0.5.0 for dependency stability and to take advantage of Anaconda Cloud upload bug fixes.
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.5.0

* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review GH212: Require GHA update grouping
     https://learn.scientific-python.org/development/guides/gha-basic/#GH212