### PR TITLE
Add Fedora installation instructions [ci skip] 

### DIFF
--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -33,6 +33,7 @@
 .. _pip: https://www.pip-installer.org/en/latest/
 .. _easy_install: https://pypi.python.org/pypi/setuptools
 .. _homebrew: https://brew.sh/
+.. _neurofedora: https://neuro.fedoraproject.org/
 
 .. Documentation tools
 .. _graphviz: https://www.graphviz.org/

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -117,6 +117,11 @@ For Debian, Ubuntu and Mint set up the NeuroDebian_ repositories - see
 
     sudo apt-get install python-dipy
 
+In Fedora DIPY can be installed from the main repositories courtesy of
+NeuroFedora_::
+
+    sudo dnf install python3-dipy
+
 We hope to get packages for the other Linux distributions, but for now, please
 try :ref:`install-pip` instead.
 


### PR DESCRIPTION
DIPY has been available in Fedora for some time. The NeuroFedora SIG
(special interest group) has packaged it along with a multitude of other
neuroscience software.
