### PR TITLE
Np.unique check removed.

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -11,7 +11,8 @@ from dipy.viz.gmem import GlobalHorizon
 from dipy.viz.horizon.tab import (ClustersTab, PeaksTab, ROIsTab, SlicesTab,
                                   TabManager, build_label)
 from dipy.viz.horizon.visualizer import ClustersVisualizer, SlicesVisualizer
-from dipy.viz.horizon.util import check_img_dtype, check_img_shapes, is_binary_image
+from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
+                                   is_binary_image)
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -11,7 +11,7 @@ from dipy.viz.gmem import GlobalHorizon
 from dipy.viz.horizon.tab import (ClustersTab, PeaksTab, ROIsTab, SlicesTab,
                                   TabManager, build_label)
 from dipy.viz.horizon.visualizer import ClustersVisualizer, SlicesVisualizer
-from dipy.viz.horizon.util import check_img_dtype, check_img_shapes
+from dipy.viz.horizon.util import check_img_dtype, check_img_shapes, is_binary_image
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.9.0")
 
@@ -451,8 +451,7 @@ class Horizon:
             for img in self.images:
                 data, affine = img
                 self.vox2ras = affine
-                img_val_range = np.unique(data).shape[0]
-                if img_val_range == 2:
+                if is_binary_image(data):
                     if self.__roi_images:
                         if 'rois' in self.random_colors:
                             roi_color = next(self.color_gen)

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -81,14 +81,9 @@ def is_binary_image(data, unique_points=100):
     """
     indices = []
 
-    for dim in data.shape:
-        indices.append(
-            np.random.choice(
-                np.arange(0, dim - 1),
-                replace=dim <= unique_points,
-                size=(unique_points)
-                )
-            )
+    rng = np.random.default_rng()
 
-    indices = np.asarray(indices)
+    for dim in data.shape:
+        indices.append(rng.integers(0, dim - 1, size=unique_points))
+
     return np.unique(data[*indices]).shape[0] <= 2

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -63,3 +63,32 @@ def check_img_dtype(images):
             warnings.warn(msg.format(idx + 1))
 
     return valid_images
+
+
+def is_binary_image(data, unique_points=100):
+    """Check if an image is binary image.
+
+    Parameters
+    ----------
+    data : ndarray
+    unique_points : int, optional
+        number of points to sample the check, by default 100
+
+    Returns
+    -------
+    boolean
+        Whether the image is binary or not
+    """
+    indices = []
+
+    for dim in data.shape:
+        indices.append(
+            np.random.choice(
+                np.arange(0, dim - 1),
+                replace=dim <= unique_points,
+                size=(unique_points)
+                )
+            )
+
+    indices = np.asarray(indices)
+    return np.unique(data[*indices]).shape[0] <= 2

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -2,7 +2,7 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 from dipy.testing import check_for_warnings
-from dipy.viz.horizon.util import check_img_dtype, check_img_shapes
+from dipy.viz.horizon.util import check_img_dtype, check_img_shapes, is_binary_image
 
 
 def test_check_img_shapes():
@@ -69,3 +69,16 @@ def test_check_img_dtype():
         check_img_dtype(images)
         check_for_warnings(l_warns, 'skipping image 1, passed image is not in '
                            + 'numerical format')
+
+
+def test_is_binary_image():
+    data = 255 * np.random.rand(197, 233, 189)
+    npt.assert_equal(False, is_binary_image(data))
+
+    data = np.random.choice(
+                np.arange(0, 1),
+                replace=True,
+                size=(10, 20, 100, 200)
+            )
+
+    npt.assert_equal(True, is_binary_image(data))

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -2,7 +2,8 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 from dipy.testing import check_for_warnings
-from dipy.viz.horizon.util import check_img_dtype, check_img_shapes, is_binary_image
+from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
+                                   is_binary_image)
 
 
 def test_check_img_shapes():

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -75,7 +75,7 @@ def test_check_img_dtype():
 
 @set_random_number_generator()
 def test_is_binary_image(rng):
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random(197, 233, 189)
     npt.assert_equal(False, is_binary_image(data))
 
     data = rng.integers(0, 1, size=(10, 20, 100, 200))

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -2,6 +2,7 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 from dipy.testing import check_for_warnings
+from dipy.testing.decorators import set_random_number_generator
 from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
                                    is_binary_image)
 
@@ -72,14 +73,11 @@ def test_check_img_dtype():
                            + 'numerical format')
 
 
-def test_is_binary_image():
+@set_random_number_generator()
+def test_is_binary_image(rng):
     data = 255 * np.random.rand(197, 233, 189)
     npt.assert_equal(False, is_binary_image(data))
 
-    data = np.random.choice(
-                np.arange(0, 1),
-                replace=True,
-                size=(10, 20, 100, 200)
-            )
+    data = rng.integers(0, 1, size=(10, 20, 100, 200))
 
     npt.assert_equal(True, is_binary_image(data))

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -7,21 +7,22 @@ from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
                                    is_binary_image)
 
 
-def test_check_img_shapes():
+@set_random_number_generator()
+def test_check_img_shapes(rng):
     affine = np.array([[1., 0., 0., -98.],
                        [0., 1., 0., -134.],
                        [0., 0., 1., -72.],
                        [0., 0., 0., 1.]])
 
-    data = 255 * np.random.rand(197, 233, 189)
-    data1 = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
+    data1 = 255 * rng.random((197, 233, 189))
     images = [
         (data, affine),
         (data1, affine)
     ]
     npt.assert_equal(check_img_shapes(images), True)
 
-    data1 = 255 * np.random.rand(200, 233, 189)
+    data1 = 255 * rng.random((200, 233, 189))
     images = [
         (data, affine),
         (data1, affine)
@@ -29,20 +30,21 @@ def test_check_img_shapes():
     npt.assert_equal(check_img_shapes(images), False)
 
 
-def test_check_img_dtype():
+@set_random_number_generator()
+def test_check_img_dtype(rng):
     affine = np.array([[1., 0., 0., -98.],
                        [0., 1., 0., -134.],
                        [0., 0., 1., -72.],
                        [0., 0., 0., 1.]])
 
-    data = 255 * np.random.rand(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
     images = [
         (data, affine),
     ]
 
     npt.assert_equal(check_img_dtype(images)[0], images[0])
 
-    data = np.random.rand(5, 5, 5).astype(np.int64)
+    data = rng.random((5, 5, 5)).astype(np.int64)
     images = [
         (data, affine),
     ]
@@ -52,7 +54,7 @@ def test_check_img_dtype():
         check_for_warnings(l_warns, 'int64 is not supported, falling back to'
                            + ' int32')
 
-    data = np.random.rand(5, 5, 5).astype(np.float16)
+    data = rng.random((5, 5, 5)).astype(np.float16)
     images = [
         (data, affine),
     ]
@@ -62,7 +64,7 @@ def test_check_img_dtype():
         check_for_warnings(l_warns, 'float16 is not supported, falling back to'
                            + ' float32')
 
-    data = np.random.rand(5, 5, 5).astype(np.bool_)
+    data = rng.random((5, 5, 5)).astype(np.bool_)
     images = [
         (data, affine),
     ]
@@ -75,7 +77,7 @@ def test_check_img_dtype():
 
 @set_random_number_generator()
 def test_is_binary_image(rng):
-    data = 255 * rng.random(197, 233, 189)
+    data = 255 * rng.random((197, 233, 189))
     npt.assert_equal(False, is_binary_image(data))
 
     data = rng.integers(0, 1, size=(10, 20, 100, 200))


### PR DESCRIPTION
This PR introduces the change to the `np.unique` check whether an image is binary or not.

#### Issue
- This creates a lot of overhead on the system as the images can be in the size of gigabytes.

#### Solution
- A function is introduced to check an image is binary or not.
- This function samples 100 points (default, can be changed via parameter) and verifies if the image provided is a binary image.