### PR TITLE
[TEST] Pin pytest 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CIBW_BUILD_VERBOSITY: 2
-  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest"
+  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest==8.0.0"
   CIBW_TEST_COMMAND: pytest --pyargs dipy
   CIBW_CONFIG_SETTINGS: "compile-args=-v"
 

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -12,7 +12,7 @@ python -m pip install -U pip setuptools>=30.3.0 wheel
 
 echo "Install Dependencies"
 if [ "$INSTALL_TYPE" == "conda" ]; then
-    conda install -yq --name venv $DEPENDS $EXTRA_DEPENDS pytest
+    conda install -yq --name venv $DEPENDS $EXTRA_DEPENDS pytest==8.0.0
 else
     PIPI="pip install --timeout=60 "
 
@@ -20,7 +20,7 @@ else
         PIPI="$PIPI --extra-index-url=$PRE_WHEELS --pre";
     fi
 
-    $PIPI pytest
+    $PIPI pytest==8.0.0
     $PIPI numpy
     if [ -n "$DEPENDS" ]; then $PIPI $DEPENDS $EXTRA_DEPENDS; fi
     if [ "$COVERAGE" == "1" ] || [ "$COVERAGE" = true ]; then pip install coverage coveralls; fi


### PR DESCRIPTION
Due to issue with --doctest-module flags, it seems that `setup_module` is not recognized with pytest 8.0.1 or 8.0.2.

For now, we pin pytest to 8.0.0 until a fix appears.