### PR TITLE
RF - changed memory view to double* trilinear_interpolation_4d

### DIFF
--- a/dipy/core/interpolation.pxd
+++ b/dipy/core/interpolation.pxd
@@ -2,9 +2,6 @@
 cimport numpy as cnp
 from dipy.align.fused_types cimport floating, number
 
-cpdef trilinear_interpolate4d(double[:, :, :, :] data,
-                              double[:] point,
-                              double[:] out=*)
 
 cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
                                    double* point,

--- a/dipy/core/interpolation.pxd
+++ b/dipy/core/interpolation.pxd
@@ -2,35 +2,33 @@
 cimport numpy as cnp
 from dipy.align.fused_types cimport floating, number
 
-cpdef trilinear_interpolate4d(
-    double[:, :, :, :] data,
-    double[:] point,
-    cnp.ndarray out=*)
+cpdef trilinear_interpolate4d(double[:, :, :, :] data,
+                              double[:] point,
+                              double[:] out=*)
 
-cdef int trilinear_interpolate4d_c(
-    double[:, :, :, :] data,
-    double* point,
-    double[:] result) noexcept nogil
+cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
+                                   double* point,
+                                   double* result) noexcept nogil
 
 cdef int _interpolate_vector_2d(floating[:, :, :] field, double dii,
-                                double djj, floating *out) noexcept nogil
+                                double djj, floating* out) noexcept nogil
 cdef int _interpolate_scalar_2d(floating[:, :] image, double dii,
-                                double djj, floating *out) noexcept nogil
+                                double djj, floating* out) noexcept nogil
 cdef int _interpolate_scalar_nn_2d(number[:, :] image, double dii,
                                    double djj, number *out) noexcept nogil
 cdef int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
                                    double dii, double djj,
-                                   number *out) noexcept nogil
+                                   number* out) noexcept nogil
 cdef int _interpolate_scalar_3d(floating[:, :, :] volume,
                                 double dkk, double dii, double djj,
-                                floating *out) noexcept nogil
+                                floating* out) noexcept nogil
 cdef int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
                                 double dii, double djj,
                                 floating* out) noexcept nogil
-cdef void _trilinear_interpolation_iso(double *X,
-                                       double *W,
-                                       cnp.npy_intp *IN) noexcept nogil
-cdef cnp.npy_intp offset(cnp.npy_intp *indices,
-                         cnp.npy_intp *strides,
+cdef void _trilinear_interpolation_iso(double* X,
+                                       double* W,
+                                       cnp.npy_intp* IN) noexcept nogil
+cdef cnp.npy_intp offset(cnp.npy_intp* indices,
+                         cnp.npy_intp* strides,
                          int lenind,
                          int typesize) noexcept nogil

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -349,9 +349,9 @@ cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
     return 0
 
 
-cpdef trilinear_interpolate4d(double[:, :, :, :] data,
-                              double[:] point,
-                              double[:] out=None):
+def trilinear_interpolate4d(double[:, :, :, :] data,
+                            double[:] point,
+                            double[:] out=None):
     """Tri-linear interpolation along the last dimension of a 4d array
 
     Parameters
@@ -370,8 +370,6 @@ cpdef trilinear_interpolate4d(double[:, :, :, :] data,
         The result of interpolation.
 
     """
-    cdef:
-        int err
 
     if out is None:
         out = np.empty(data.shape[3])

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -78,7 +78,7 @@ cdef class SimplePmfGen(PmfGen):
                              + " number of vertices of sphere.")
 
     cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil:
-        if trilinear_interpolate4d_c(self.data, &point[0], self.pmf) != 0:
+        if trilinear_interpolate4d_c(self.data, &point[0], &self.pmf[0]) != 0:
             PmfGen.__clear_pmf(self)
         return self.pmf
 
@@ -94,7 +94,7 @@ cdef class SimplePmfGen(PmfGen):
 
         if trilinear_interpolate4d_c(self.data[:,:,:,idx:idx+1],
                                      &point[0],
-                                     self.pmf[0:1]) != 0:
+                                     &self.pmf[0]) != 0:
             PmfGen.__clear_pmf(self)
         return self.pmf[0]
 
@@ -127,7 +127,9 @@ cdef class SHCoeffPmfGen(PmfGen):
             cnp.npy_intp len_B = self.B.shape[1]
             double _sum
 
-        if trilinear_interpolate4d_c(self.data, &point[0], self.coeff) != 0:
+        if trilinear_interpolate4d_c(self.data,
+                                     &point[0],
+                                     &self.coeff[0]) != 0:
             PmfGen.__clear_pmf(self)
         else:
             for i in range(len_pmf):

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -73,10 +73,9 @@ cdef class ThresholdStoppingCriterion(StoppingCriterion):
             double result
             int err
 
-        err = trilinear_interpolate4d_c(
-            self.metric_map[..., None],
-            point,
-            self.interp_out_view)
+        err = trilinear_interpolate4d_c(self.metric_map[..., None],
+                                        point,
+                                        &self.interp_out_view[0])
         if err == -1:
             return OUTSIDEIMAGE
         elif err != 0:
@@ -144,7 +143,8 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
 
     cdef get_exclude_c(self, double* point):
         exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
-                                                point, self.interp_out_view)
+                                                point,
+                                                &self.interp_out_view[0])
         if exclude_err != 0:
             return 0
         return self.interp_out_view[0]
@@ -157,7 +157,8 @@ cdef class AnatomicalStoppingCriterion(StoppingCriterion):
 
     cdef get_include_c(self, double* point):
         include_err = trilinear_interpolate4d_c(self.include_map[..., None],
-                                                point, self.interp_out_view)
+                                                point,
+                                                &self.interp_out_view[0])
         if include_err != 0:
             return 0
         return self.interp_out_view[0]
@@ -194,16 +195,14 @@ cdef class ActStoppingCriterion(AnatomicalStoppingCriterion):
             double include_result, exclude_result
             int include_err, exclude_err
 
-        include_err = trilinear_interpolate4d_c(
-            self.include_map[..., None],
-            point,
-            self.interp_out_view)
+        include_err = trilinear_interpolate4d_c(self.include_map[..., None],
+                                                point,
+                                                &self.interp_out_view[0])
         include_result = self.interp_out_view[0]
 
-        exclude_err = trilinear_interpolate4d_c(
-            self.exclude_map[..., None],
-            point,
-            self.interp_out_view)
+        exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
+                                                point,
+                                                &self.interp_out_view[0])
         exclude_result = self.interp_out_view[0]
 
         if include_err == -1 or exclude_err == -1:
@@ -257,11 +256,13 @@ cdef class CmcStoppingCriterion(AnatomicalStoppingCriterion):
             int include_err, exclude_err
 
         include_err = trilinear_interpolate4d_c(self.include_map[..., None],
-                                                point, self.interp_out_view)
+                                                point,
+                                                &self.interp_out_view[0])
         include_result = self.interp_out_view[0]
 
         exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
-                                                point, self.interp_out_view)
+                                                point,
+                                                &self.interp_out_view[0])
         exclude_result = self.interp_out_view[0]
 
         if include_err == -1 or exclude_err == -1:


### PR DESCRIPTION
- Changed the `out` type from `memoryview` to `double*` in `dipy.core.interpolation.trilinear_interpolation_4d_c`. This allows for the use of trilinear_interpolation4d_c in pure cython. In particular when the `out` needs to be instanciated in cython.  This is relevant for PR #3089
- Replaced `dipy.core.interpolation.trilinear_interpolation_4d` declaration to `def` from `cpdef`