### PR TITLE
[BF] convert_tractogram fix

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -485,7 +485,7 @@ class ConvertTractogramFlow(Workflow):
             Data type of the tractogram offsets, used for vtk files.
         out_dir : string, optional
             Output directory. (default current directory)
-        out_tractogram : variable string, optional
+        out_tractogram : string, optional
             Name of the resulting tractogram
 
         """


### PR DESCRIPTION
This PR update the output type of `convert_tractogram`  (from `variable string` to `string`) to avoid a crash during the use of this command line