### PR TITLE
Bugfix for ROI images updates

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -463,30 +463,23 @@ class Horizon:
                 title = 'Image {}'.format(img_count+1)
                 data, affine, fname = unpack_image(img)
                 self.vox2ras = affine
-                print(is_binary_image(data))
-                if is_binary_image(data):
-                    if self.__roi_images:
-                        if 'rois' in self.random_colors:
-                            roi_color = next(self.color_gen)
-                        roi_actor = actor.contour_from_roi(
-                            data, affine=affine, color=roi_color)
-                        scene.add(roi_actor)
-                        roi_actors.append(roi_actor)
-                    else:
-                        slices_viz = SlicesVisualizer(
-                            self.show_m.iren, scene, data, affine=affine,
-                            world_coords=self.world_coords,
-                            percentiles=[0, 100], rgb=self.rgb)
-                        self.__tabs.append(SlicesTab(
-                            slices_viz, title, fname, self._show_force_render))
-                        img_count += 1
+                binary_image = is_binary_image(data)
+                if binary_image and self.__roi_images:
+                    if 'rois' in self.random_colors:
+                        roi_color = next(self.color_gen)
+                    roi_actor = actor.contour_from_roi(
+                        data, affine=affine, color=roi_color)
+                    scene.add(roi_actor)
+                    roi_actors.append(roi_actor)
                 else:
                     slices_viz = SlicesVisualizer(
                         self.show_m.iren, scene, data, affine=affine,
-                        world_coords=self.world_coords, rgb=self.rgb)
+                        world_coords=self.world_coords, rgb=self.rgb,
+                        is_binary=binary_image)
                     self.__tabs.append(SlicesTab(
                         slices_viz, title, fname, self._show_force_render))
                     img_count += 1
+
             if len(roi_actors) > 0:
                 self.__tabs.append(ROIsTab(roi_actors))
 

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -463,6 +463,7 @@ class Horizon:
                 title = 'Image {}'.format(img_count+1)
                 data, affine, fname = unpack_image(img)
                 self.vox2ras = affine
+                print(is_binary_image(data))
                 if is_binary_image(data):
                     if self.__roi_images:
                         if 'rois' in self.random_colors:

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -151,7 +151,7 @@ def _unpack_data(data, return_size=3):
     return result
 
 
-def is_binary_image(data, unique_points=100):
+def is_binary_image(data, sample_cube_size=(10, 10, 10)):
     """Check if an image is binary image.
 
     Parameters
@@ -167,12 +167,19 @@ def is_binary_image(data, unique_points=100):
     """
     indices = []
 
-    rng = np.random.default_rng()
+    if data.ndim == 4:
+        sample_cube_size = (10, 10, 10, 10)
 
-    for dim in data.shape:
-        indices.append(rng.integers(0, dim - 1, size=unique_points))
+    for idx, dim in enumerate(data.shape):
+        if dim < sample_cube_size[idx]:
+            indices.append(np.arange(stop=dim))
+        else:
+            start = int(dim/2) - int(sample_cube_size[idx]/2)
+            stop = int(dim/2) + int(sample_cube_size[idx]/2)
+            indices.append(np.arange(start=start, stop=stop))
 
-    return np.unique(np.take(data, indices)).shape[0] <= 2
+    print(np.take(data, indices))
+    return np.unique(np.take(data, indices, axis=-1)).shape[0] <= 2
 
 
 def check_peak_size(pams, ref_img_shape=None, sync_imgs=False):

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -151,7 +151,7 @@ def _unpack_data(data, return_size=3):
     return result
 
 
-def is_binary_image(data, sample_cube_size=(10, 10, 10)):
+def is_binary_image(data, sample_cube_size=15):
     """Check if an image is binary image.
 
     Parameters
@@ -165,21 +165,18 @@ def is_binary_image(data, sample_cube_size=(10, 10, 10)):
     boolean
         Whether the image is binary or not
     """
-    indices = []
 
-    if data.ndim == 4:
-        sample_cube_size = (10, 10, 10, 10)
+    sample_cube = [sample_cube_size] * data.ndim
 
     for idx, dim in enumerate(data.shape):
-        if dim < sample_cube_size[idx]:
-            indices.append(np.arange(stop=dim))
+        if dim < sample_cube[idx]:
+            data = np.take(data, np.arange(stop=dim), axis=idx)
         else:
-            start = int(dim/2) - int(sample_cube_size[idx]/2)
-            stop = int(dim/2) + int(sample_cube_size[idx]/2)
-            indices.append(np.arange(start=start, stop=stop))
+            start = int(dim/2) - int(sample_cube[idx]/2)
+            stop = int(dim/2) + int(sample_cube[idx]/2)
+            data = np.take(data, np.arange(start=start, stop=stop), axis=idx)
 
-    print(np.take(data, indices))
-    return np.unique(np.take(data, indices, axis=-1)).shape[0] <= 2
+    return np.unique(data).shape[0] <= 2
 
 
 def check_peak_size(pams, ref_img_shape=None, sync_imgs=False):

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -151,14 +151,12 @@ def _unpack_data(data, return_size=3):
     return result
 
 
-def is_binary_image(data, sample_cube_size=15):
+def is_binary_image(data):
     """Check if an image is binary image.
 
     Parameters
     ----------
     data : ndarray
-    unique_points : int, optional
-        number of points to sample the check, by default 100
 
     Returns
     -------
@@ -166,6 +164,7 @@ def is_binary_image(data, sample_cube_size=15):
         Whether the image is binary or not
     """
 
+    sample_cube_size = int(max(data.shape) / 10.0)
     sample_cube = [sample_cube_size] * data.ndim
 
     for idx, dim in enumerate(data.shape):

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -14,7 +14,8 @@ if has_fury:
 
 class SlicesVisualizer:
     def __init__(self, interactor, scene, data, affine=None,
-                 world_coords=False, percentiles=[2, 98], rgb=False):
+                 world_coords=False, percentiles=[2, 98], rgb=False,
+                 is_binary=False):
 
         self._interactor = interactor
         self._scene = scene
@@ -29,19 +30,22 @@ class SlicesVisualizer:
         self._data_ndim = data.ndim
         self._data_shape = data.shape
         self._rgb = False
+        self._percentiles = percentiles
+        if is_binary:
+            self._percentiles = [0, 100]
 
         vol_data = self._data
 
         if ((self._data_ndim == 4 and rgb and self._data_shape[-1] == 3)
                 or self._data_ndim == 3):
             self._rgb = True and not self._data_ndim == 3
-            self._int_range = np.percentile(vol_data, percentiles)
+            self._int_range = np.percentile(vol_data, self._percentiles)
             _evaluate_intensities_range(self._int_range)
         else:
             if self._data_ndim == 4 and rgb and self._data_shape[-1] != 3:
                 warnings.warn('The rgb flag is enabled but the color '
                               + 'channel information is not provided')
-            vol_data = self._volume_calculations(percentiles)
+            vol_data = self._volume_calculations(self._percentiles)
 
         self._vol_max = np.max(vol_data)
         self._vol_min = np.min(vol_data)

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -169,7 +169,7 @@ def test_roi_images(rng):
     npt.assert_array_equal(report.colors_found, [True, True])
     show_m = horizon(images=images, roi_images=True, return_showm=True)
     analysis = window.analyze_scene(show_m.scene)
-    npt.assert_equal(analysis.actors, 2)
+    npt.assert_equal(analysis.actors, 3)
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")


### PR DESCRIPTION
### Bugfix of ROI option
This PR fixes the change of `--roi_images` option throwing an error.

### Fix Methodology
- Instead of checking entire dataset for unique data, we can pickup 3D box at the center of the 3D image, and check the box for binary values.
- For 4D images we are checking the values of the different 3D boxes.
- By default, the box is of size **(15, 15, 15)** and 15 volumes for 4D dataset.
- If the size of dimension less than the box the box will adjust to dimension.
![Screenshot from 2024-03-15 16-12-09](https://github.com/dipy/dipy/assets/39947025/935f73d2-f83f-4a88-ba2c-39127ac0dd31)

