### PR TITLE
BF: Removed allow_break

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -15,7 +15,7 @@ numpydoc
 sphinx!=4.4
 sphinx-gallery>=0.10.0
 tomli>=2.0.1
-pydata-sphinx-theme==0.13.3
+grg-sphinx-theme>=0.3
 Jinja2
 sphinx-design>=0.5.0
 boto3


### PR DESCRIPTION
# Removed allow_break from TissueClassifierHMRF

## Overview
This PR introduces removal of 'allow_break' from the TissueClassifierHMRF as mentioned in issue #3096. 

## Changes
- Removed the `allow_break` variable to simplify loop exit logic.
- The `tolerance` parameter now explicitly disables the early stopping condition when set to `0`, allowing for clear differentiation between using and not using the tolerance check for loop control.
- Clarified documentation for the `tolerance` parameter to indicate how users can disable the tolerance check.

## Related Issues
* #3096 

## Screenshots
I ran this [tutorial](https://docs.dipy.org/stable/examples_built/segmentation/tissue_classification.html#sphx-glr-examples-built-segmentation-tissue-classification-py) to check if the changes were functional. Here are the results.

Old Code

![Screenshot 2024-03-18 at 7 12 32 PM](https://github.com/dipy/dipy/assets/116963260/e0c31050-d80b-4504-a4d2-fe0a66257140)

New Code

![Screenshot 2024-03-18 at 7 09 19 PM](https://github.com/dipy/dipy/assets/116963260/93233a4d-e86b-4402-9eb7-6ed344040cff)

## Additional Comments
* I also ran the test mentioned in `test_mrf.py` by running the function `test_classify`, the test was successful.
```python
pytest -svv -k 'test_classify'
```
* Based on my understanding I have put the changes, but please let me know if this is the right way or any other changes are required. Any feedbacks would be helpful.

## Checklist
- [x] I have reviewed my own code changes.
- [x] I have tested my changes locally.
- [x] My code follows the project's coding standards.

