### PR TITLE
DOC: Fix documentation URLs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ conversation about the issue, by typing into the text box in the issue page.
 
 ## The development process
 
-Please refer to the [development section](https://dipy.org/documentation/latest/devel/)
+Please refer to the [development section](https://docs.dipy.org/stable/devel/index.html#development)
 of the documentation for the procedures we use in developing the code.
 
 ## When writing code, please pay attention to the following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ doc = [
 
 [project.urls]
 homepage = "https://dipy.org"
-documentation = "https://dipy.org/documentation/latest/documentation/"
+documentation = "https://docs.dipy.org/stable/"
 source = "https://github.com/dipy/dipy"
 download = "https://pypi.org/project/dipy/#files"
 tracker = "https://github.com/dipy/dipy/issues"


### PR DESCRIPTION
Fix documentation URLs: the DIPY documentation was moved from dipy.org/documentation to docs.dipy.org starting DIPY 1.8.0:
- Fix the project documentation URL in `pyproject.toml`.
- Fix the URL to the development documentation section in the `CONTRIBUTING.md` file.