### PR TITLE
NF: Adding correct_mask to median_otsu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 default_language_version:
-  python: python3.10
+  python: python3
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.6.9
     hooks:
       # Run the linter
       - id: ruff

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage import affine_transform, label
+from scipy.ndimage import affine_transform
 
 from dipy.align.reslice import reslice
 from dipy.testing.decorators import warning_for_keywords
@@ -292,47 +292,3 @@ def pad_crop(image, target_shape):
     ]
 
     return image, pad_vs, crop_vs
-
-
-def correct_minor_errors(binary_img):
-    """
-    Remove any small mask chunks or holes
-    that could be in the segmentation output.
-
-    Parameters
-    ----------
-    binary_img : np.ndarray
-        Binary image
-
-    Returns
-    -------
-    largest_img : np.ndarray
-    """
-    largest_img = np.zeros_like(binary_img)
-    chunks, n_chunk = label(np.abs(1 - binary_img))
-    u, c = np.unique(chunks[chunks != 0], return_counts=True)
-    target = u[np.argmax(c)]
-    largest_img = np.where(chunks == target, 0, 1)
-
-    chunks, n_chunk = label(largest_img)
-    u, c = np.unique(chunks[chunks != 0], return_counts=True)
-    target = u[np.argmax(c)]
-    largest_img = np.where(chunks == target, 1, 0)
-
-    for x in range(largest_img.shape[0]):
-        chunks, n_chunk = label(np.abs(1 - largest_img[x]))
-        u, c = np.unique(chunks[chunks != 0], return_counts=True)
-        target = u[np.argmax(c)]
-        largest_img[x] = np.where(chunks == target, 0, 1)
-    for y in range(largest_img.shape[1]):
-        chunks, n_chunk = label(np.abs(1 - largest_img[:, y]))
-        u, c = np.unique(chunks[chunks != 0], return_counts=True)
-        target = u[np.argmax(c)]
-        largest_img[:, y] = np.where(chunks == target, 0, 1)
-    for z in range(largest_img.shape[2]):
-        chunks, n_chunk = label(np.abs(1 - largest_img[..., z]))
-        u, c = np.unique(chunks[chunks != 0], return_counts=True)
-        target = u[np.argmax(c)]
-        largest_img[..., z] = np.where(chunks == target, 0, 1)
-
-    return largest_img

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -1,17 +1,15 @@
 from warnings import warn
 
 import numpy as np
-from scipy.ndimage import median_filter
-
-from dipy.reconst.dti import color_fa, fractional_anisotropy
+from scipy.ndimage import binary_dilation, generate_binary_structure, median_filter
 
 try:
     from skimage.filters import threshold_otsu as otsu
 except Exception:
     from dipy.segment.threshold import otsu
 
-from scipy.ndimage import binary_dilation, generate_binary_structure
-
+from dipy.reconst.dti import color_fa, fractional_anisotropy
+from dipy.segment.utils import remove_holes_and_islands
 from dipy.testing.decorators import warning_for_keywords
 
 
@@ -137,6 +135,7 @@ def median_otsu(
     numpass=4,
     autocrop=False,
     dilate=None,
+    finalize_mask=False,
 ):
     """Simple brain extraction tool method for images from DWI data.
 
@@ -164,9 +163,11 @@ def median_otsu(
         if True, the masked input_volume will also be cropped using the
         bounding box defined by the masked data. Should be on if DWI is
         upsampled to 1x1x1 resolution.
-
     dilate : None or int, optional
         number of iterations for binary dilation
+    finalize_mask : bool, optional
+        Whether to remove potential holes or islands.
+        Useful for solving minor errors.
 
     Returns
     -------
@@ -223,6 +224,9 @@ def median_otsu(
         cross = generate_binary_structure(3, 1)
         mask = binary_dilation(mask, cross, iterations=dilate)
 
+    # Correct mask by removing islands and holes
+    if finalize_mask:
+        mask = remove_holes_and_islands(mask)
     # Auto crop the volumes using the mask as input_volume for bounding box
     # computing.
     if autocrop:

--- a/dipy/segment/meson.build
+++ b/dipy/segment/meson.build
@@ -37,6 +37,7 @@ python_sources = ['__init__.py',
   'metric.py',
   'threshold.py',
   'tissue.py',
+  'utils.py'
   ]
 
 py3.install_sources(

--- a/dipy/segment/tests/meson.build
+++ b/dipy/segment/tests/meson.build
@@ -10,6 +10,7 @@ python_sources = [
   'test_mrf.py',
   'test_qbx.py',
   'test_quickbundles.py',
+  'test_utils.py',
   ]
 
 

--- a/dipy/segment/tests/test_utils.py
+++ b/dipy/segment/tests/test_utils.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from dipy.segment.utils import remove_holes_and_islands
+from dipy.testing.decorators import set_random_number_generator
+
+
+@set_random_number_generator()
+def test_remove_holes_and_islands(rng=None):
+    # inefficient but more readable
+    temp = rng.choice([0, 1], size=(40, 40, 40), p=[0.8, 0.2])
+    temp[6:34, 6:34, 6:34] = 0
+    temp[7:33, 7:33, 7:33] = 1
+    temp[8:32, 8:32, 8:32] = rng.choice([0, 1], size=(24, 24, 24), p=[0.2, 0.8])
+    output = remove_holes_and_islands(temp)
+    ground_truth = np.zeros((40, 40, 40))
+    ground_truth[7:33, 7:33, 7:33] = 1
+    np.testing.assert_equal(output, ground_truth)
+
+
+def test_remove_holes_and_islands_warnings():
+    # Not binary test
+    non_binary_img = np.concatenate(
+        [np.zeros((30, 30, 10)), np.ones((30, 30, 10)), np.ones((30, 30, 10)) * 2],
+        axis=-1,
+    )
+    np.testing.assert_warns(UserWarning, remove_holes_and_islands, non_binary_img)
+
+    # No background test
+    no_background_img = np.ones((40, 40, 40))
+    np.testing.assert_warns(UserWarning, remove_holes_and_islands, no_background_img)
+
+    # No foreground test
+    no_foreground_img = np.zeros((40, 40, 40))
+    np.testing.assert_warns(UserWarning, remove_holes_and_islands, no_foreground_img)

--- a/dipy/segment/utils.py
+++ b/dipy/segment/utils.py
@@ -1,0 +1,78 @@
+import warnings
+
+import numpy as np
+from scipy.ndimage import label
+
+
+def remove_holes_and_islands(binary_img, *, slice_wise=False):
+    """
+    Remove any small mask chunks or holes
+    that could be in the segmentation output.
+
+    Parameters
+    ----------
+    binary_img : np.ndarray
+        Binary image
+    slice_wise : bool, optional
+        Whether to run slice wise background correction as well
+
+    Returns
+    -------
+    largest_img : np.ndarray
+    """
+    if len(np.unique(binary_img)) != 2:
+        warnings.warn(
+            "The mask is not binary. \
+                      Returning the original mask",
+            UserWarning,
+            stacklevel=2,
+        )
+        return binary_img
+
+    largest_img = np.zeros_like(binary_img)
+    chunks, _ = label(np.abs(1 - binary_img))
+    u, c = np.unique(chunks[chunks != 0], return_counts=True)
+    if len(u) == 0:
+        warnings.warn(
+            "The mask has no background. \
+                      Returning the original mask",
+            UserWarning,
+            stacklevel=2,
+        )
+        return binary_img
+    target = u[np.argmax(c)]
+
+    largest_img = np.where(chunks == target, 0, 1)
+
+    chunks, _ = label(largest_img)
+    u, c = np.unique(chunks[chunks != 0], return_counts=True)
+    if len(u) == 0:
+        warnings.warn(
+            "The mask has no foreground. \
+                      Returning the original mask",
+            UserWarning,
+            stacklevel=2,
+        )
+        return binary_img
+    target = u[np.argmax(c)]
+
+    largest_img = np.where(chunks == target, 1, 0)
+
+    if slice_wise:
+        for x in range(largest_img.shape[0]):
+            chunks, n_chunk = label(np.abs(1 - largest_img[x]))
+            u, c = np.unique(chunks[chunks != 0], return_counts=True)
+            target = u[np.argmax(c)]
+            largest_img[x] = np.where(chunks == target, 0, 1)
+        for y in range(largest_img.shape[1]):
+            chunks, n_chunk = label(np.abs(1 - largest_img[:, y]))
+            u, c = np.unique(chunks[chunks != 0], return_counts=True)
+            target = u[np.argmax(c)]
+            largest_img[:, y] = np.where(chunks == target, 0, 1)
+        for z in range(largest_img.shape[2]):
+            chunks, n_chunk = label(np.abs(1 - largest_img[..., z]))
+            u, c = np.unique(chunks[chunks != 0], return_counts=True)
+            target = u[np.argmax(c)]
+            largest_img[..., z] = np.where(chunks == target, 0, 1)
+
+    return largest_img

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -27,6 +27,7 @@ class MedianOtsuFlow(Workflow):
         autocrop=False,
         vol_idx=None,
         dilate=None,
+        finalize_mask=False,
         out_dir="",
         out_mask="brain_mask.nii.gz",
         out_masked="dwi_masked.nii.gz",
@@ -59,6 +60,9 @@ class MedianOtsuFlow(Workflow):
             '1,2,3-5,7'. This input is required for 4D volumes.
         dilate : int, optional
             number of iterations for binary dilation.
+        finalize_mask : bool, optional
+            Whether to remove potential holes or islands.
+            Useful for solving minor errors.
         out_dir : string, optional
             Output directory. (default current directory)
         out_mask : string, optional
@@ -80,6 +84,7 @@ class MedianOtsuFlow(Workflow):
                 numpass=numpass,
                 autocrop=autocrop,
                 dilate=dilate,
+                finalize_mask=finalize_mask,
             )
 
             save_nifti(mask_out_path, mask_volume.astype(np.float64), affine)

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -25,6 +25,7 @@ def test_median_otsu_flow():
         autocrop = False
         vol_idx = "0,"
         dilate = 0
+        finalize_mask = False
 
         mo_flow = MedianOtsuFlow()
         mo_flow.run(
@@ -36,6 +37,7 @@ def test_median_otsu_flow():
             autocrop=autocrop,
             vol_idx=vol_idx,
             dilate=dilate,
+            finalize_mask=finalize_mask,
         )
 
         mask_name = mo_flow.last_generated_outputs["out_mask"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,7 +25,8 @@ select = [
 ignore = [
   "B905",
   "C901",
-  "E203"
+  "E203",
+  "F811"
 ]
 
 [lint.extend-per-file-ignores]


### PR DESCRIPTION
This PR aims to add a function that removes holes or islands of a binary mask to median_otsu.

The function was already being used in
dipy/nn/utils.py, so it has been moved to dipy/segment/utils.py, as it makes more sense for mask correction to be in segmentation module.

Slice-wise hole removal was excluded from the function, since it can cause huge false positives if there is a lack of axial slices.

Finally, the function's name has been changed to
remove_holes_and_islands, to be more explicit about the functionality.

This PR is related to #3124 