### PR TITLE
ENH: Fix HDF5 key warning when saving BUAN profile data

### DIFF
--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -411,7 +411,7 @@ def create_nifti_header(affine, dimensions, voxel_sizes):
     return new_header
 
 
-def save_buan_profiles_hdf5(fname, dt):
+def save_buan_profiles_hdf5(fname, dt, key=None):
     """ Saves the given input dataframe to .h5 file
 
     Parameters
@@ -420,14 +420,21 @@ def save_buan_profiles_hdf5(fname, dt):
         file name for saving the hdf5 file
     dt : Pandas DataFrame
         DataFrame to be saved as .h5 file
+    key : str, optional
+        Key to retrieve the contents in the HDF5 file. The file rootname will
+        be used if not provided.
 
     """
 
     df = pd.DataFrame(dt)
     filename_hdf5 = fname + '.h5'
 
+    if key is None:
+        base_name_parts, _ = os.path.splitext(os.path.basename(fname))
+        key = base_name_parts.split('.')[0]
+
     store = pd.HDFStore(filename_hdf5, complevel=9)
-    store.append(fname, df, data_columns=True, complevel=9)
+    store.append(key, df, data_columns=True, complevel=9)
     store.close()
 
 


### PR DESCRIPTION
Fix HDF5 key warning when saving BUAN profile data: if a key is not provided, use the file's rootname (i.e. removing the extension to the file's basename) as the key.

Fix BUAN profile key warning when saving data to HDF5

Fixes:
```
workflows/tests/test_stats.py::test_buan_bundle_profiles
  C:\Miniconda\envs\venv\lib\site-packages\tables\path.py:137:
NaturalNameWarning: object name is not a valid Python identifier:
 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp6wee0ijp\\output\\temp_fa';
it does not match the pattern ``^[a-zA-Z_][a-zA-Z0-9_]*$``;
you will not be able to use natural naming to access this object;
 using ``getattr()`` will still work, though
    check_attribute_name(name)
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/8404604242/job/23016386753#step:10:4147