### PR TITLE
[RF] Add peaks generation to reconst workflows

### DIFF
--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -57,7 +57,6 @@ def reconst_flow_core(flow):
                     out_dir=out_dir,
                     extract_pam_values=True,
                 )
-
             elif flow.get_short_name() == "csa":
                 reconst_flow.run(
                     data_path,

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -5,8 +5,9 @@ import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
+from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
-from dipy.io.gradients import generate_bvecs, read_bvals_bvecs
+from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.peaks import load_peaks
 from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -5,9 +5,8 @@ import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
-from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.gradients import generate_bvecs, read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.peaks import load_peaks
 from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list


### PR DESCRIPTION
All in the title. 

Many of our reconstruction workflows were not saving the peaks which could be problematic if the user want to generate a tractogram. This PR fix mainly this issue.