### PR TITLE
Clean up for tabs and tab manager

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -454,13 +454,12 @@ class Horizon:
                 # It will be changed once all the elements wrapped in horizon
                 # elements.
                 text_block = build_label(HELP_MESSAGE, 18)
-                text_block.message = HELP_MESSAGE
 
                 self.help_panel = ui.Panel2D(
                     size=(300, 200), position=(1615, 875), color=(.8, .8, 1.),
                     opacity=.2, align='left')
 
-                self.help_panel.add_element(text_block, coords=(.02, .01))
+                self.help_panel.add_element(text_block.obj, coords=(.02, .01))
                 scene.add(self.help_panel)
                 self.__tabs.append(ClustersTab(
                     self.__clusters_visualizer, self.cluster_thr))

--- a/dipy/viz/horizon/tab/__init__.py
+++ b/dipy/viz/horizon/tab/__init__.py
@@ -1,7 +1,6 @@
 from dipy.viz.horizon.tab.base import (HorizonTab, TabManager, build_label,
                                        build_slider, build_checkbox,
-                                       build_switcher, color_double_slider,
-                                       color_single_slider, build_radio_button)
+                                       build_switcher, build_radio_button)
 from dipy.viz.horizon.tab.cluster import ClustersTab
 from dipy.viz.horizon.tab.peak import PeaksTab
 from dipy.viz.horizon.tab.roi import ROIsTab
@@ -11,5 +10,4 @@ from dipy.viz.horizon.tab.surface import SurfaceTab
 __all__ = [
     'HorizonTab', 'TabManager', 'ClustersTab', 'PeaksTab', 'ROIsTab',
     'SlicesTab', 'build_label', 'build_slider', 'build_checkbox',
-    'build_switcher', 'SurfaceTab', 'build_radio_button'
-    'color_double_slider', 'color_single_slider']
+    'build_switcher', 'SurfaceTab', 'build_radio_button']

--- a/dipy/viz/horizon/tab/cluster.py
+++ b/dipy/viz/horizon/tab/cluster.py
@@ -42,7 +42,7 @@ class ClustersTab(HorizonTab):
             on_handle_released=self._change_threshold
         )
 
-        self.register_elements(
+        self._register_elements(
             self._size_slider_label, self._size_slider,
             self._length_slider_label, self._length_slider,
             self._threshold_slider_label, self._threshold_slider
@@ -127,14 +127,13 @@ class ClustersTab(HorizonTab):
             else:
                 cluster['actor'].SetVisibility(True)
 
-    def build(self, tab_id, _tab_ui):
+    def build(self, tab_id):
         """Position the elements in the tab.
 
         Parameters
         ----------
         tab_id : int
-        _tab_ui : TabUI
-            Object for Tab from FURY.
+            Id of the tab.
         """
         self._tab_id = tab_id
 
@@ -181,16 +180,6 @@ class ClustersTab(HorizonTab):
             various properties of centroids.
         """
         return self._visualizer.centroid_actors
-
-    @property
-    def tab_id(self):
-        """Id of the tab. Reference for Tab Manager to identify the tab.
-
-        Returns
-        -------
-        int
-        """
-        return self._tab_id
 
     @property
     def actors(self):

--- a/dipy/viz/horizon/tab/peak.py
+++ b/dipy/viz/horizon/tab/peak.py
@@ -21,10 +21,10 @@ class PeaksTab(HorizonTab):
 
         self._tab_id = 0
 
-        self._opacity_toggle = build_checkbox(
+        self._actor_toggle = build_checkbox(
             labels=[''],
             checked_labels=[''],
-            on_change=self._toggle_opacity)
+            on_change=self._toggle_actors)
 
         self._opacity_label, self._opacity = build_slider(
             initial_value=1.,
@@ -113,16 +113,15 @@ class PeaksTab(HorizonTab):
             self._change_range, selected_range=self._range_z)
         self._range_z.obj.on_change = self._change_range_z
 
-        self._view_mode_label = build_label(
-            text='View Mode', is_horizon_label=True)
+        self._view_mode_label = build_label(text='View Mode')
 
         self._view_modes = ['Cross section', 'Range']
         self._view_mode_toggler = build_radio_button(
             self._view_modes, [self._view_modes[0]],
             padding=1.5, on_change=self._toggle_view_mode)
 
-        self.register_elements(
-            self._opacity_label, self._opacity_toggle, self._opacity,
+        self._register_elements(
+            self._opacity_label, self._opacity, self._actor_toggle,
             self._slice_x_label, self._slice_x,
             self._slice_y_label, self._slice_y,
             self._slice_z_label, self._slice_z,
@@ -131,19 +130,6 @@ class PeaksTab(HorizonTab):
             self._range_z_label, self._range_z,
             self._view_mode_label, self._view_mode_toggler,
         )
-
-    def _toggle_opacity(self, checkbox):
-        """Toggle Opacity of the peaks actor.
-
-        Parameters
-        ----------
-        checkbox : Checkbox
-            FURY checkbox UI element.
-        """
-        if '' in checkbox.checked_labels:
-            self._opacity.obj.value = 1
-        else:
-            self._opacity.obj.value = 0
 
     def _change_opacity(self, slider):
         """Update opacity of the peaks actor by adjusting the slider to
@@ -254,6 +240,7 @@ class PeaksTab(HorizonTab):
     def on_tab_selected(self):
         """Trigger when tab becomes active.
         """
+        super().on_tab_selected()
         self._toggle_view_mode(self._view_mode_toggler.obj)
 
     def update_slices(self, x_slice, y_slice, z_slice):
@@ -277,24 +264,18 @@ class PeaksTab(HorizonTab):
         if not self._slice_z.obj.value == z_slice:
             self._slice_z.obj.value = z_slice
 
-    def build(self, tab_id, tab_ui):
+    def build(self, tab_id):
         """Build all the elements under the tab.
 
         Parameters
         ----------
         tab_id : int
             Id of the tab.
-        tab_ui : TabUI
-            FURY TabUI object for tabs panel.
-
-        Notes
-        -----
-        tab_ui will removed once every all tabs adapt new build architecture.
         """
         self._tab_id = tab_id
 
         x_pos = .02
-        self._opacity_toggle.position = (x_pos, .85)
+        self._actor_toggle.position = (x_pos, .85)
 
         x_pos = .04
         self._opacity_label.position = (x_pos, .85)
@@ -346,13 +327,3 @@ class PeaksTab(HorizonTab):
             List of actors.
         """
         return [self._actor]
-
-    @property
-    def tab_id(self):
-        """Id of the tab. Reference for Tab Manager to identify the tab.
-
-        Returns
-        -------
-        int
-        """
-        return self._tab_id

--- a/dipy/viz/horizon/tab/roi.py
+++ b/dipy/viz/horizon/tab/roi.py
@@ -18,35 +18,20 @@ class ROIsTab(HorizonTab):
 
         self._tab_id = 0
 
-        self._opacity_toggle = build_checkbox(
+        self._actor_toggle = build_checkbox(
             labels=[''],
             checked_labels=[''],
-            on_change=self._toggle_opacity)
+            on_change=self._toggle_actors)
 
         self._opacity_slider_label, self._opacity_slider = build_slider(
             initial_value=1, max_value=1., text_template='{ratio:.0%}',
             on_change=self._change_opacity, label='Opacity'
         )
 
-        self.register_elements(
-            self._opacity_toggle,
+        self._register_elements(
+            self._actor_toggle,
             self._opacity_slider_label, self._opacity_slider
         )
-
-    def _toggle_opacity(self, checkbox):
-        """Toggle opacity of all ROIs. Changing the slider.obj.value will
-        trigger the _change_opacity function and adjust the opacity.
-
-        Parameters
-        ----------
-        checkbox : CheckBox2D
-        """
-        if '' in checkbox.checked_labels:
-            self._opacity_slider.selected_value = 1
-            self._opacity_slider.obj.value = 1
-        else:
-            self._opacity_slider.selected_value = 0
-            self._opacity_slider.obj.value = 0
 
     def _change_opacity(self, slider):
         """Change opacity of all ROIs.
@@ -60,21 +45,19 @@ class ROIsTab(HorizonTab):
         for contour in self._actors:
             contour.GetProperty().SetOpacity(opacity)
 
-    def build(self, tab_id, _tab_ui):
+    def build(self, tab_id):
         """Position the elements in the tab.
 
         Parameters
         ----------
         tab_id : int
             Identifier for the tab. Index of the tab in TabUI.
-        _tab_ui : TabUI
-            Object for Tab from FURY.
         """
 
         self._tab_id = tab_id
 
         y_pos = .85
-        self._opacity_toggle.position = (.02, y_pos)
+        self._actor_toggle.position = (.02, y_pos)
         self._opacity_slider_label.position = (.05, y_pos)
         self._opacity_slider.position = (.12, y_pos)
 
@@ -97,12 +80,3 @@ class ROIsTab(HorizonTab):
         list
         """
         return self._actors
-
-    @property
-    def tab_id(self):
-        """Id of the tab. Reference for Tab Manager to identify the tab.
-        Returns
-        -------
-        int
-        """
-        return self._tab_id

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -37,10 +37,10 @@ class SlicesTab(HorizonTab):
         self.on_slice_change = lambda _tab_id, _x, _y, _z: None
         self.on_volume_change = lambda _tab_id, v: None
 
-        self._opacity_toggle = build_checkbox(
+        self._actor_toggle = build_checkbox(
             labels=[''],
             checked_labels=[''],
-            on_change=self._toggle_opacity)
+            on_change=self._toggle_actors)
 
         self._slice_opacity_label, self._slice_opacity = build_slider(
             initial_value=1.,
@@ -125,19 +125,18 @@ class SlicesTab(HorizonTab):
             checked_labels=[''],
             on_change=self._change_slice_visibility_z)
 
-        self._voxel_label = build_label(text='Voxel', is_horizon_label=True)
-        self._voxel_data = build_label(text='', is_horizon_label=True)
+        self._voxel_label = build_label(text='Voxel')
+        self._voxel_data = build_label(text='')
 
         self._visualizer.register_picker_callback(self._change_picked_voxel)
 
         self._register_visualize_partials()
 
-        self._file_label = build_label(text='Filename', is_horizon_label=True)
-        self._file_name_label = build_label(text=self._file_name,
-                                            is_horizon_label=True)
+        self._file_label = build_label(text='Filename')
+        self._file_name_label = build_label(text=self._file_name)
 
-        self.register_elements(
-            self._opacity_toggle,
+        self._register_elements(
+            self._actor_toggle,
             self._slice_opacity_label,
             self._slice_opacity,
             self._slice_x_toggle,
@@ -186,7 +185,7 @@ class SlicesTab(HorizonTab):
                     on_value_changed=self._change_color_map
                 )
 
-            self.register_elements(
+            self._register_elements(
                 self._intensities_label,
                 self._intensities,
                 self._colormap_switcher_label,
@@ -204,7 +203,7 @@ class SlicesTab(HorizonTab):
                     text_template='{value:.0f}',
                     label='Volume'
                 )
-                self.register_elements(self._volume_label, self._volume)
+                self._register_elements(self._volume_label, self._volume)
 
     def _register_visualize_partials(self):
         self._visualize_slice_x = partial(
@@ -231,15 +230,6 @@ class SlicesTab(HorizonTab):
 
     def _change_opacity(self, slider):
         self._slice_opacity.selected_value = slider.value
-        self._update_opacities()
-
-    def _toggle_opacity(self, checkbox):
-        if '' in checkbox.checked_labels:
-            self._slice_opacity.selected_value = 1
-            self._slice_opacity.obj.value = 1
-        else:
-            self._slice_opacity.selected_value = 0
-            self._slice_opacity.obj.value = 0
         self._update_opacities()
 
     def _change_picked_voxel(self, message):
@@ -355,6 +345,7 @@ class SlicesTab(HorizonTab):
     def on_tab_selected(self):
         """Trigger when tab becomes active.
         """
+        super().on_tab_selected()
         self._slice_x.obj.set_visibility(self._slice_x.visibility)
         self._slice_y.obj.set_visibility(self._slice_y.visibility)
         self._slice_z.obj.set_visibility(self._slice_z.visibility)
@@ -395,24 +386,18 @@ class SlicesTab(HorizonTab):
         if not self._volume.obj.value == volume:
             self._volume.obj.value = volume
 
-    def build(self, tab_id, _tab_ui):
+    def build(self, tab_id):
         """Build all the elements under the tab.
 
         Parameters
         ----------
         tab_id : int
             Id of the tab.
-        tab_ui : TabUI
-            FURY TabUI object for tabs panel.
-
-        Notes
-        -----
-        tab_ui will removed once every all tabs adapt new build architecture.
         """
         self._tab_id = tab_id
 
         x_pos = .02
-        self._opacity_toggle.position = (x_pos, .85)
+        self._actor_toggle.position = (x_pos, .85)
         self._slice_x_toggle.position = (x_pos, .62)
         self._slice_y_toggle.position = (x_pos, .38)
         self._slice_z_toggle.position = (x_pos, .15)
@@ -472,12 +457,6 @@ class SlicesTab(HorizonTab):
         """Name of the file opened in the tab.
         """
         return self._file_name
-
-    @property
-    def tab_id(self):
-        """Id of the tab.
-        """
-        return self._tab_id
 
     @property
     def actors(self):

--- a/dipy/viz/horizon/tab/surface.py
+++ b/dipy/viz/horizon/tab/surface.py
@@ -20,10 +20,10 @@ class SurfaceTab(HorizonTab):
         self._name = tab_name
         self._file_name = Path(file_name or tab_name).name
 
-        self._opacity_toggle = build_checkbox(
+        self._actor_toggle = build_checkbox(
             labels=[''],
             checked_labels=[''],
-            on_change=self._toggle_opacity)
+            on_change=self._toggle_actors)
 
         self._surface_opacity_label, self._surface_opacity = build_slider(
             initial_value=1.,
@@ -33,14 +33,13 @@ class SurfaceTab(HorizonTab):
             label='Opacity'
         )
 
-        self._file_label = build_label(text='Filename', is_horizon_label=True)
-        self._file_name_label = build_label(text=self._file_name,
-                                            is_horizon_label=True)
+        self._file_label = build_label(text='Filename',)
+        self._file_name_label = build_label(text=self._file_name)
 
-        self.register_elements(self._opacity_toggle,
-                               self._surface_opacity_label,
-                               self._surface_opacity, self._file_label,
-                               self._file_name_label)
+        self._register_elements(self._actor_toggle,
+                                self._surface_opacity_label,
+                                self._surface_opacity, self._file_label,
+                                self._file_name_label)
 
     def _change_opacity(self, slider):
         """Change opacity value according to slider changed.
@@ -59,40 +58,18 @@ class SurfaceTab(HorizonTab):
             actor.GetProperty().SetOpacity(
                 self._surface_opacity.selected_value)
 
-    def _toggle_opacity(self, checkbox):
-        """Toggle opacity of the actor to 0% or 100%.
-
-        Parameters
-        ----------
-        checkbox : _type_
-            _description_
-        """
-        if '' in checkbox.checked_labels:
-            self._surface_opacity.selected_value = 1
-            self._surface_opacity.obj.value = 1
-        else:
-            self._surface_opacity.selected_value = 0
-            self._surface_opacity.obj.value = 0
-        self._update_opacities()
-
-    def build(self, tab_id, _tab_ui):
+    def build(self, tab_id):
         """Build all the elements under the tab.
 
         Parameters
         ----------
         tab_id : int
             Id of the tab.
-        tab_ui : TabUI
-            FURY TabUI object for tabs panel.
-
-        Notes
-        -----
-        tab_ui will removed once every all tabs adapt new build architecture.
         """
         self._tab_id = tab_id
 
         y_pos = .85
-        self._opacity_toggle.position = (.02, y_pos)
+        self._actor_toggle.position = (.02, y_pos)
         self._surface_opacity_label.position = (.05, y_pos)
         self._surface_opacity.position = (.10, y_pos)
 
@@ -109,12 +86,6 @@ class SurfaceTab(HorizonTab):
         str
         """
         return self._name
-
-    @property
-    def tab_id(self):
-        """Id of the tab.
-        """
-        return self._tab_id
 
     @property
     def actors(self):

--- a/dipy/viz/horizon/tab/tests/test_base.py
+++ b/dipy/viz/horizon/tab/tests/test_base.py
@@ -28,19 +28,7 @@ def check_label(label):
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 def test_build_label():
-    regular_label = build_label(text='Hello')
-    npt.assert_equal(regular_label.message, 'Hello')
-    npt.assert_equal(regular_label.font_size, 16)
-    npt.assert_equal(regular_label.bold, False)
-    check_label(regular_label)
-
-    regular_label = build_label(text='Hello', font_size=10, bold=True)
-    npt.assert_equal(regular_label.message, 'Hello')
-    npt.assert_equal(regular_label.font_size, 10)
-    npt.assert_equal(regular_label.bold, True)
-    check_label(regular_label)
-
-    horizon_label = build_label(text='Hello', is_horizon_label=True)
+    horizon_label = build_label(text='Hello')
     npt.assert_equal(horizon_label.obj.message, 'Hello')
     npt.assert_equal(horizon_label.obj.font_size, 16)
     npt.assert_equal(horizon_label.obj.bold, False)


### PR DESCRIPTION
### Clean up for tabs.

**Changes**

- This PR ensures that all the tabs do not have `tab_ui` while building the tab elements ensuring the **abstraction**.
- This PR ensures all the methods that are not used by any other class are kept private, ensuring the **encapsulation**.
- This PR replaces all the direct fury UI objects to the `HorizonUIElement` wrapper data class for maintaining the standard course of usage of the horizon.
- This PR moves methods common into the base `HorizonTab` class to ensure we are getting the benefits of **inheritance** and **polymorphism**.


**Goals**

- This PR aims to achieve intractability while having multiple visualizations in the window. The problem arises when you have an ROI, a Surface, or a Peak visualized. It creates problems in interacting with clusters or images. Both of them get placed behind the former objects and become non-interactable. Using show and hide methods in the toggler of the opacity makes it easier to remove and add the actors to the scene. If you use the toggle and turn the ROI off, the cluster or the image becomes intractable.