### PR TITLE
[ENH] Enable range for dipy_median_otsu workflow 

### DIFF
--- a/dipy/utils/convert.py
+++ b/dipy/utils/convert.py
@@ -1,0 +1,28 @@
+"""Module for different conversion functions."""
+
+
+def expand_range(range_str):
+    """Convert a string with ranges to a list of integers.
+
+    Parameters
+    ----------
+    range_str : str
+        string with ranges, e.g. '1,2,3-5,7'
+
+    Returns
+    -------
+    list(int)
+
+    """
+    range_str = range_str.strip()
+    range_str = range_str[:-1] if range_str.endswith(',') else range_str
+    result = []
+    for part in range_str.split(','):
+        if not part.replace('-', '').isdigit():
+            raise ValueError(f"Incorrect character found in input: {part}")
+        if '-' in part:
+            start, end = map(int, part.split('-'))
+            result += list(range(start, end + 1))
+        else:
+            result.append(int(part))
+    return result

--- a/dipy/utils/meson.build
+++ b/dipy/utils/meson.build
@@ -26,6 +26,7 @@ endforeach
 python_sources = [
   '__init__.py',
   'arrfuncs.py',
+  'convert.py',
   'deprecator.py',
   'multiproc.py',
   'optpkg.py',

--- a/dipy/utils/tests/meson.build
+++ b/dipy/utils/tests/meson.build
@@ -19,6 +19,7 @@ endforeach
 python_sources = [
   '__init__.py',
   'test_arrfuncs.py',
+  'test_convert.py',
   'test_deprecator.py',
   'test_multiproc.py',
   'test_omp.py',

--- a/dipy/utils/tests/test_convert.py
+++ b/dipy/utils/tests/test_convert.py
@@ -1,0 +1,33 @@
+"""Testing convert utilities."""
+
+import numpy as np
+
+from dipy.utils.convert import expand_range
+
+
+def test_expand_range():
+    test_cases = [
+        ("1,2,3,4", np.array([1, 2, 3, 4])),
+        ("5-7", np.array([5, 6, 7])),
+        ("0", np.array([0])),
+        ("0,", np.array([0])),
+        ("0, ", np.array([0])),
+        ("1,2,5-7,10", np.array([1, 2, 5, 6, 7, 10])),
+        ("1,2,5-7,10", [1, 2, 5, 6, 7, 10]),
+        ("1,2,5-7,10", (1, 2, 5, 6, 7, 10)),
+        ("1,a,3", ValueError),
+        ("1-2-3", ValueError)
+    ]
+
+    for input_string, expected_output in test_cases:
+        # print(f"Running test for input: {input_string}")
+        if not isinstance(expected_output, (np.ndarray, list, tuple)):
+            try:
+                expand_range(input_string)
+                assert False, f"Expected ValueError for input: {input_string}"
+            except ValueError:
+                assert True
+        else:
+            result = expand_range(input_string)
+            np.testing.assert_array_equal(result, expected_output)
+            # print(f"Test passed for input: {input_string}")

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -70,7 +70,6 @@ class MedianOtsuFlow(Workflow):
                          format(fpath))
 
             data, affine, img = load_nifti(fpath, return_img=True)
-
             masked_volume, mask_volume = median_otsu(
                 data,
                 vol_idx=vol_idx,

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -9,6 +9,7 @@ from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.tracking import Streamlines
 from dipy.segment.mask import median_otsu
 from dipy.segment.bundles import RecoBundles
+from dipy.utils.convert import expand_range
 from dipy.workflows.workflow import Workflow
 
 
@@ -42,11 +43,10 @@ class MedianOtsuFlow(Workflow):
             bounding box defined by the masked data. For example, if diffusion
             images are of 1x1x1 (mm^3) or higher resolution auto-cropping could
             reduce their size in memory and speed up some of the analysis.
-        vol_idx : variable int, optional
+        vol_idx : str, optional
             1D array representing indices of ``axis=-1`` of a 4D
             `input_volume`. From the command line use something like
-            `3 4 5 6`. From script use something like `[3, 4, 5, 6]`. This
-            input is required for 4D volumes.
+            '1,2,3-5,7'. This input is required for 4D volumes.
         dilate : int, optional
             number of iterations for binary dilation.
         out_dir : string, optional
@@ -58,7 +58,12 @@ class MedianOtsuFlow(Workflow):
         """
         io_it = self.get_io_iterator()
         if vol_idx is not None:
-            vol_idx = [int(idx) for idx in vol_idx]
+            if isinstance(vol_idx, str):
+                vol_idx = expand_range(vol_idx)
+            elif isinstance(vol_idx, int):
+                vol_idx = [vol_idx]
+            elif isinstance(vol_idx, (list, tuple)):
+                vol_idx = [int(idx) for idx in vol_idx]
 
         for fpath, mask_out_path, masked_out_path in io_it:
             logging.info('Applying median_otsu segmentation on {0}'.

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -25,7 +25,7 @@ def test_median_otsu_flow():
         median_radius = 3
         numpass = 3
         autocrop = False
-        vol_idx = [0]
+        vol_idx = '0,'
         dilate = 0
 
         mo_flow = MedianOtsuFlow()
@@ -36,7 +36,7 @@ def test_median_otsu_flow():
         mask_name = mo_flow.last_generated_outputs['out_mask']
         masked_name = mo_flow.last_generated_outputs['out_masked']
 
-        vol_idx = '0,'
+        vol_idx = [0, ]
         masked, mask = median_otsu(volume,
                                    vol_idx=vol_idx,
                                    median_radius=median_radius,

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -11,7 +11,7 @@ from dipy.segment.mask import median_otsu
 from dipy.tracking.streamline import Streamlines
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.io.image import load_nifti_data, save_nifti
+from dipy.io.image import load_nifti_data
 from dipy.tracking.streamline import set_number_of_points
 from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
@@ -36,6 +36,7 @@ def test_median_otsu_flow():
         mask_name = mo_flow.last_generated_outputs['out_mask']
         masked_name = mo_flow.last_generated_outputs['out_masked']
 
+        vol_idx = '0,'
         masked, mask = median_otsu(volume,
                                    vol_idx=vol_idx,
                                    median_radius=median_radius,

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,13 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 1.10.0 changes
+------------------
+
+**Workflows**
+- The `vol_idx` parameter datatype from ``dipy_median_otsu`` has been changed from `variable int` to `str`.
+  this change allows user to provide a range of values for the `vol_idx` parameter. e.g: `--vol_idx 0,1,2` or `--vol_idx 4,5,12-20,22`.
+
 DIPY 1.9.0 changes
 ------------------
 

--- a/doc/interfaces/basic_flow.rst
+++ b/doc/interfaces/basic_flow.rst
@@ -162,7 +162,7 @@ We can visualize the data using ``dipy_horizon`` ::
 
 We can use ``dipy_median_otsu`` to build a brain mask for the diffusion data::
 
-    dipy_median_otsu dwi.nii --median_radius 2 --numpass 1 --vol_idx 0 --out_dir out_work
+    dipy_median_otsu dwi.nii --median_radius 2 --numpass 1 --vol_idx 10-50 --out_dir out_work
 
 Visualize the mask using ``dipy_horizon``::
 

--- a/doc/interfaces/reconstruction_flow.rst
+++ b/doc/interfaces/reconstruction_flow.rst
@@ -48,7 +48,7 @@ output directory (``out_dir``).
 To get the mask file, we will use the median Otsu thresholding method by
 calling the ``dipy_median_otsu`` command::
 
-    dipy_median_otsu data/stanford_hardi/HARDI150.nii.gz --vol_idx 3 4 5 6 --out_dir "stanford_hardi_mask"
+    dipy_median_otsu data/stanford_hardi/HARDI150.nii.gz --vol_idx 10-50 --out_dir "stanford_hardi_mask"
 
 Then, to perform the CSD reconstruction we will run the ``dipy_fit_csd``
 command as::
@@ -187,7 +187,7 @@ directory (``out_dir``).
 To get the mask file, we will use the median Otsu thresholding method by calling
 the ``dipy_median_otsu`` command::
 
-    dipy_median_otsu data/cfin_multib/__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii --vol_idx 3 4 5 6 --out_dir "cfin_multib_mask"
+    dipy_median_otsu data/cfin_multib/__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii --vol_idx 3-6 --out_dir "cfin_multib_mask"
 
 To run the DKI reconstruction method on the data, execute the ``dipy_fit_dki``
 command, e.g.::
@@ -256,7 +256,7 @@ value to split the bvals to estimate D for the two-stage process of fitting
 To get the mask file, we will use the median Otsu thresholding method by calling
 the ``dipy_median_otsu`` command::
 
-    dipy_median_otsu data/ivim/HARDI150.nii.gz --vol_idx 3 4 5 6 --out_dir "ivim_mask"
+    dipy_median_otsu data/ivim/HARDI150.nii.gz --vol_idx 10-50 --out_dir "ivim_mask"
 
 Then, to perform the IVIM reconstruction we will run the command as::
 


### PR DESCRIPTION
This PR enable range to `vol_idx` parameter for `dipy_median_otsu`. here some examples:

- `dipy_median_otsu dwi.nii --vol_idx 10-50`
- `dipy_median_otsu dwi.nii --vol_idx 15-20,23-45,47,48,49,50`

This option can be enable for other workflows argumentS.