### PR TITLE
NF - initial directions from seed positions

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -614,6 +614,6 @@ def peaks_from_positions(positions, odfs, sphere, relative_peak_threshold=.5,
         peaks, _, _ = peak_directions(odf, sphere, relative_peak_threshold,
                                       min_separation_angle, is_symmetric)
         n = min(npeaks, peaks.shape[0])
-        peaks_arr[i,:n,:] = peaks[:n, :]
+        peaks_arr[i, :n, :] = peaks[:n, :]
 
     return peaks_arr

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -612,6 +612,9 @@ def peaks_from_positions(positions, odfs, sphere, *, relative_peak_threshold=.5,
 
     peaks_arr = np.zeros((len(positions), npeaks, 3))
 
+    if (positions.dtype not in [np.float64, float]):
+        positions = positions.astype(float)
+
     for i, s in enumerate(positions):
         odf = trilinear_interpolate4d(odfs, s)
         peaks, _, _ = peak_directions(odf, sphere, relative_peak_threshold,

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -615,7 +615,7 @@ def peaks_from_positions(positions, odfs, sphere, *, relative_peak_threshold=.5,
         odf = trilinear_interpolate4d(odfs, s)
         peaks, _, _ = peak_directions(odf, sphere, relative_peak_threshold,
                                       min_separation_angle, is_symmetric)
-        n = min(npeaks, peaks.shape[0])
-        peaks_arr[i, :n, :] = peaks[:n, :]
+        nbr_peaks = min(npeaks, peaks.shape[0])
+        peaks_arr[i, :nbr_peaks, :] = peaks[:nbr_peaks, :]
 
     return peaks_arr

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -604,6 +604,9 @@ def peaks_from_positions(positions, odfs, sphere, relative_peak_threshold=.5,
     -------
     peaks_arr : array (N, npeaks, 3)
     """
+    if positions.dtype is not np.float64:
+        positions = positions.astype(np.float64)
+
     peaks_arr = np.zeros((len(positions), npeaks, 3))
 
     for i, s in enumerate(positions):

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -1,7 +1,7 @@
-import tempfile
 from itertools import repeat
 from multiprocessing import Pool
 from os import path
+import tempfile
 
 import numpy as np
 import scipy.optimize as opt

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -1,21 +1,19 @@
+import tempfile
 from itertools import repeat
 from multiprocessing import Pool
 from os import path
-import tempfile
 
 import numpy as np
 import scipy.optimize as opt
 
+from dipy.core.interpolation import trilinear_interpolate4d
 from dipy.core.ndindex import ndindex
 from dipy.core.sphere import Sphere
 from dipy.data import default_sphere
 from dipy.reconst.eudx_direction_getter import EuDXDirectionGetter
 from dipy.reconst.odf import gfa
-from dipy.reconst.recspeed import (
-    local_maxima,
-    remove_similar_vertices,
-    search_descending,
-)
+from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
+                                   search_descending)
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.multiproc import determine_num_processes
@@ -573,3 +571,46 @@ def reshape_peaks_for_visualization(peaks):
         peaks = peaks.peak_dirs
 
     return peaks.reshape(np.append(peaks.shape[:-2], -1)).astype('float32')
+
+
+def peaks_from_positions(positions, odfs, sphere, relative_peak_threshold=.5,
+                         min_separation_angle=25, is_symmetric=True, npeaks=5):
+    """
+    Extract the peaks at each positions.
+
+    Parameters
+    ----------
+    position : array, (N, 3)
+        Voxel coordinates of the N positions.
+    odfs : array, (X, Y, Z, M)
+        Orientation distribution function (sphericla function) represented
+        on a sphere of M points.
+    sphere : Sphere
+        A discrete Sphere. The M points on the sphere correspond to the points
+        of the odfs.
+    relative_peak_threshold : float in [0., 1.]
+        Only peaks greater than ``min + relative_peak_threshold * scale`` are
+        kept, where ``min = max(0, odf.min())`` and
+        ``scale = odf.max() - min``.
+    min_separation_angle : float in [0, 90]
+        The minimum distance between directions. If two peaks are too close
+        only the larger of the two is returned.
+    is_symmetric : bool, optional
+        If True, v is considered equal to -v.
+    npeaks : int
+        The maximum number of peaks to extract at from each position.
+
+    Returns
+    -------
+    peaks_arr : array (N, npeaks, 3)
+    """
+    peaks_arr = np.zeros((len(positions), npeaks, 3))
+
+    for i, s in enumerate(positions):
+        odf = trilinear_interpolate4d(odfs, s)
+        peaks, _, _ = peak_directions(odf, sphere, relative_peak_threshold,
+                                      min_separation_angle, is_symmetric)
+        n = min(npeaks, peaks.shape[0])
+        peaks_arr[i,:n,:] = peaks[:n, :]
+
+    return peaks_arr

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -573,7 +573,7 @@ def reshape_peaks_for_visualization(peaks):
     return peaks.reshape(np.append(peaks.shape[:-2], -1)).astype('float32')
 
 
-def peaks_from_positions(positions, odfs, sphere, relative_peak_threshold=.5,
+def peaks_from_positions(positions, odfs, sphere, *, relative_peak_threshold=.5,
                          min_separation_angle=25, is_symmetric=True, npeaks=5):
     """
     Extract the peaks at each positions.
@@ -588,16 +588,18 @@ def peaks_from_positions(positions, odfs, sphere, relative_peak_threshold=.5,
     sphere : Sphere
         A discrete Sphere. The M points on the sphere correspond to the points
         of the odfs.
-    relative_peak_threshold : float in [0., 1.]
+    relative_peak_threshold : float, optional
         Only peaks greater than ``min + relative_peak_threshold * scale`` are
         kept, where ``min = max(0, odf.min())`` and
-        ``scale = odf.max() - min``.
-    min_separation_angle : float in [0, 90]
+        ``scale = odf.max() - min``. The ``relative_peak_threshold`` should
+        be in the range [0, 1].
+    min_separation_angle : float, optional
         The minimum distance between directions. If two peaks are too close
-        only the larger of the two is returned.
+        only the larger of the two is returned. The ``min_separation_angle``
+        should be in the range [0, 90].
     is_symmetric : bool, optional
         If True, v is considered equal to -v.
-    npeaks : int
+    npeaks : int, optional
         The maximum number of peaks to extract at from each position.
 
     Returns

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -12,8 +12,11 @@ from dipy.core.sphere import Sphere
 from dipy.data import default_sphere
 from dipy.reconst.eudx_direction_getter import EuDXDirectionGetter
 from dipy.reconst.odf import gfa
-from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
-                                   search_descending)
+from dipy.reconst.recspeed import (
+    local_maxima,
+    remove_similar_vertices,
+    search_descending,
+)
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.multiproc import determine_num_processes
@@ -606,8 +609,6 @@ def peaks_from_positions(positions, odfs, sphere, *, relative_peak_threshold=.5,
     -------
     peaks_arr : array (N, npeaks, 3)
     """
-    if positions.dtype is not np.float64:
-        positions = positions.astype(np.float64)
 
     peaks_arr = np.zeros((len(positions), npeaks, 3))
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -726,9 +726,29 @@ def test_peaks_from_positions():
                                relative_peak_threshold=thresh,
                                min_separation_angle=min_angle)
 
-    # test the peaks at each voxel
+    # test the peaks at each voxel using int coordinates
     positions = np.array(list(product(range(3), range(3), range(3))))
     peaks = peaks_from_positions(positions, pam.odf, default_sphere,
+                                 relative_peak_threshold=thresh,
+                                 min_separation_angle=min_angle,
+                                 npeaks=npeaks)
+    peaks = np.array(peaks).reshape((3, 3, 3, 5, 3))
+    assert_array_almost_equal(pam.peak_dirs, peaks)
+
+    # test the peaks at each voxel using float coordinates
+    positions = np.array(list(product(range(3), range(3), range(3))))
+    peaks = peaks_from_positions(positions.astype(float), pam.odf,
+                                 default_sphere,
+                                 relative_peak_threshold=thresh,
+                                 min_separation_angle=min_angle,
+                                 npeaks=npeaks)
+    peaks = np.array(peaks).reshape((3, 3, 3, 5, 3))
+    assert_array_almost_equal(pam.peak_dirs, peaks)
+
+    # test the peaks at each voxel using double coordinates
+    positions = np.array(list(product(range(3), range(3), range(3))))
+    peaks = peaks_from_positions(positions.astype(np.float64), pam.odf,
+                                 default_sphere,
                                  relative_peak_threshold=thresh,
                                  min_separation_angle=min_angle,
                                  npeaks=npeaks)

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -639,8 +639,6 @@ def test_peaks_shm_coeff():
     data, _ = multi_tensor(gtab, mevals, S0, angles=[(0, 0), (60, 0)],
                            fractions=[50, 50], snr=SNR)
 
-
-
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message=descoteaux07_legacy_msg,
@@ -695,9 +693,9 @@ def test_reshape_peaks_for_visualization(rng):
 
 def test_peaks_from_positions():
 
-    thresh=.5
-    min_angle=25
-    npeaks=5
+    thresh = .5
+    min_angle = 25
+    npeaks = 5
 
     _, fbvals, fbvecs = get_fnames('small_64D')
     bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
@@ -708,10 +706,10 @@ def test_peaks_from_positions():
     voxels = []
     for i in range(27):
         v, _ = multi_tensor(gtab, mevals, S0=100,
-                            angles=[(0, 0), (randint(0,90), randint(0,90))],
+                            angles=[(0, 0), (randint(0, 90), randint(0, 90))],
                             fractions=[50, 50], snr=10)
         voxels.append(v)
-    data = np.array(voxels).reshape((3,3,3,-1))
+    data = np.array(voxels).reshape((3, 3, 3, -1))
 
     pam = peaks_from_model(model, data, default_sphere, return_odf=True,
                            return_sh=False, legacy=False, npeaks=npeaks,
@@ -719,7 +717,7 @@ def test_peaks_from_positions():
                            min_separation_angle=min_angle)
 
     # test the peaks at each voxel
-    positions = np.array(list(product(range(3),range(3),range(3))))
+    positions = np.array(list(product(range(3), range(3), range(3))))
     peaks = peaks_from_positions(positions, pam.odf, default_sphere,
                                  relative_peak_threshold=thresh,
                                  min_separation_angle=min_angle,
@@ -727,10 +725,10 @@ def test_peaks_from_positions():
     peaks = np.array(peaks).reshape((3, 3, 3, 5, 3))
     assert_array_almost_equal(pam.peak_dirs, peaks)
 
-
     # test the peaks extraction at the mid point between 2 voxels
-    odfs = np.array([pam.odf[0,0,0],pam.odf[0,0,0]]).reshape((2,1,1,-1))
-    positions = np.array([[0.,0,0],[0.5,0,0], [1.,0,0]])
+    odfs = [pam.odf[0, 0, 0], pam.odf[0, 0, 0]]
+    odfs = np.array(odfs).reshape((2, 1, 1, -1))
+    positions = np.array([[0., 0, 0], [0.5, 0, 0], [1., 0, 0]])
     peaks = peaks_from_positions(positions, odfs, default_sphere,
                                  relative_peak_threshold=thresh,
                                  min_separation_angle=min_angle,

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -700,7 +700,6 @@ def test_peaks_from_positions():
     _, fbvals, fbvecs = get_fnames('small_64D')
     bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
     gtab = gradient_table(bvals, bvecs)
-    model = CsaOdfModel(gtab, 4)
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
     voxels = []
@@ -711,10 +710,15 @@ def test_peaks_from_positions():
         voxels.append(v)
     data = np.array(voxels).reshape((3, 3, 3, -1))
 
-    pam = peaks_from_model(model, data, default_sphere, return_odf=True,
-                           return_sh=False, legacy=False, npeaks=npeaks,
-                           relative_peak_threshold=thresh,
-                           min_separation_angle=min_angle)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning)
+        model = CsaOdfModel(gtab, 4)
+        pam = peaks_from_model(model, data, default_sphere, return_odf=True,
+                               return_sh=False, legacy=True, npeaks=npeaks,
+                               relative_peak_threshold=thresh,
+                               min_separation_angle=min_angle)
 
     # test the peaks at each voxel
     positions = np.array(list(product(range(3), range(3), range(3))))

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -1,27 +1,33 @@
-
-import pickle
-import warnings
 from io import BytesIO
 from itertools import product
+import pickle
 from random import randint
+import warnings
 
 import numpy as np
-from numpy.testing import (assert_, assert_almost_equal,
-                           assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
 
 from dipy.core.gradients import GradientTable, gradient_table
 from dipy.core.sphere import HemiSphere, unit_icosahedron
 from dipy.core.sphere_stats import angular_similarity
 from dipy.core.subdivide_octahedron import create_unit_hemisphere
 from dipy.data import default_sphere, get_fnames, get_sphere
-from dipy.direction.peaks import (peak_directions, peak_directions_nl,
-                                  peaks_from_model, peaks_from_positions,
-                                  reshape_peaks_for_visualization)
+from dipy.direction.peaks import (
+    peak_directions,
+    peak_directions_nl,
+    peaks_from_model,
+    peaks_from_positions,
+    reshape_peaks_for_visualization,
+)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.odf import OdfFit, OdfModel, gfa
-from dipy.reconst.shm import (CsaOdfModel, descoteaux07_legacy_msg,
-                              tournier07_legacy_msg)
+from dipy.reconst.shm import CsaOdfModel, descoteaux07_legacy_msg, tournier07_legacy_msg
 from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -9,24 +9,13 @@ from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking import metrics
 from dipy.tracking._utils import _to_voxel_coordinates
 from dipy.tracking.streamline import transform_streamlines
-from dipy.tracking.utils import (
-    _min_at,
-    connectivity_matrix,
-    density_map,
-    length,
-    max_angle_from_curvature,
-    min_radius_curvature_from_angle,
-    ndbincount,
-    near_roi,
-    path_length,
-    random_seeds_from_mask,
-    reduce_labels,
-    reduce_rois,
-    seeds_from_mask,
-    target,
-    target_line_based,
-    unique_rows,
-)
+from dipy.tracking.utils import (_min_at, connectivity_matrix, density_map,
+                                 length, max_angle_from_curvature,
+                                 min_radius_curvature_from_angle, ndbincount,
+                                 near_roi, path_length, random_seeds_from_mask,
+                                 reduce_labels, reduce_rois,
+                                 seeds_directions_pairs, seeds_from_mask,
+                                 target, target_line_based, unique_rows)
 from dipy.tracking.vox2track import streamline_mapping
 
 
@@ -713,3 +702,28 @@ def test_curvature_angle():
     with pytest.warns(UserWarning):
         npt.assert_equal(min_radius_curvature_from_angle(0, 1),
                          min_radius_curvature_from_angle(np.pi/2, 1))
+
+
+def test_seeds_directions_pairs():
+    positions = np.random.random((10, 3))
+    peaks = np.random.random((10, 5, 3))
+
+    # test various max_cross value
+    for i in range(-1, 7):
+        seeds, directions = seeds_directions_pairs(
+            positions, peaks, max_cross=i)
+        npt.assert_equal(seeds.shape, directions.shape)
+
+    # test it raise and error if the input array shapes don't match
+    npt.assert_raises(ValueError,
+                      seeds_directions_pairs,
+                      positions[:, :2], peaks)
+    npt.assert_raises(ValueError,
+                      seeds_directions_pairs,
+                      positions[:5, :], peaks)
+    npt.assert_raises(ValueError,
+                      seeds_directions_pairs,
+                      positions, peaks[:, :, :2])
+    npt.assert_raises(ValueError,
+                      seeds_directions_pairs,
+                      positions, peaks.flatten())

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -704,9 +704,10 @@ def test_curvature_angle():
                          min_radius_curvature_from_angle(np.pi/2, 1))
 
 
-def test_seeds_directions_pairs():
-    positions = np.random.random((10, 3))
-    peaks = np.random.random((10, 5, 3))
+@set_random_number_generator()
+def test_seeds_directions_pairs(rng):
+    positions = rng.random(size=(10, 3))
+    peaks = rng.random(size=(10, 5, 3))
 
     # test various max_cross value
     for i in range(-1, 7):

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -9,13 +9,25 @@ from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking import metrics
 from dipy.tracking._utils import _to_voxel_coordinates
 from dipy.tracking.streamline import transform_streamlines
-from dipy.tracking.utils import (_min_at, connectivity_matrix, density_map,
-                                 length, max_angle_from_curvature,
-                                 min_radius_curvature_from_angle, ndbincount,
-                                 near_roi, path_length, random_seeds_from_mask,
-                                 reduce_labels, reduce_rois,
-                                 seeds_directions_pairs, seeds_from_mask,
-                                 target, target_line_based, unique_rows)
+from dipy.tracking.utils import (
+    _min_at,
+    connectivity_matrix,
+    density_map,
+    length,
+    max_angle_from_curvature,
+    min_radius_curvature_from_angle,
+    ndbincount,
+    near_roi,
+    path_length,
+    random_seeds_from_mask,
+    reduce_labels,
+    reduce_rois,
+    seeds_directions_pairs,
+    seeds_from_mask,
+    target,
+    target_line_based,
+    unique_rows,
+)
 from dipy.tracking.vox2track import streamline_mapping
 
 

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -58,6 +58,7 @@ from scipy.spatial.distance import cdist
 
 from dipy.core.geometry import dist_to_corner
 from dipy.tracking import metrics
+
 # Import helper functions shared with vox2track
 from dipy.tracking._utils import _mapping_to_voxel, _to_voxel_coordinates
 from dipy.tracking.vox2track import _streamlines_in_mask

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -334,7 +334,7 @@ def subsegment(streamlines, max_segment_length):
             else:
                 # this should never happen because ns should be a positive
                 # int
-                assert(ns >= 0)
+                assert (ns >= 0)
         yield output_sl
 
 
@@ -1056,7 +1056,7 @@ def seeds_directions_pairs(positions, peaks, max_cross=-1):
 
     Parameters
     ----------
-    position : array, (N, 3)
+    positions : array, (N, 3)
         Voxel coordinates of the N positions.
     peaks : array (N, M, 3)
         Peaks at each position
@@ -1069,14 +1069,21 @@ def seeds_directions_pairs(positions, peaks, max_cross=-1):
     seeds : array (K, 3)
     directions : array (K, 3)
     """
+
+    if (not positions.shape[0] == peaks.shape[0]
+        or not positions.shape[1] == 3
+        or not peaks.shape[2] == 3):
+        raise ValueError("The array shapes of the positions and peaks should"
+                         " be (N,3) and (N,M,3), respectively.")
+
     seeds = []
     directions = []
 
     for i, s in enumerate(positions):
-        voxel_dirs_norm = np.linalg.norm(peaks[i, :max_cross, :], axis=1)
+        voxel_dirs_norm = np.linalg.norm(peaks[i, :, :], axis=1)
         voxel_dirs = peaks[i, voxel_dirs_norm > 0, :] \
             / voxel_dirs_norm[voxel_dirs_norm > 0, np.newaxis]
-        for d in voxel_dirs:
+        for d in voxel_dirs[:max_cross, :]:
             seeds.append(s)
             directions.append(d)
 

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -1070,9 +1070,12 @@ def seeds_directions_pairs(positions, peaks, max_cross=-1):
     directions : array (K, 3)
     """
 
-    if (not positions.shape[0] == peaks.shape[0]
-        or not positions.shape[1] == 3
-        or not peaks.shape[2] == 3):
+    if (not len(positions.shape) == 2
+            or not len(peaks.shape) == 3
+            or not positions.shape[0] == peaks.shape[0]
+            or not positions.shape[1] == 3
+            or not peaks.shape[2] == 3
+            or not peaks.shape[1] > 0):
         raise ValueError("The array shapes of the positions and peaks should"
                          " be (N,3) and (N,M,3), respectively.")
 

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -1049,7 +1049,7 @@ def min_radius_curvature_from_angle(max_angle, step_size):
     return min_radius_curvature
 
 
-def seeds_directions_pairs(positions, peaks, max_cross=-1):
+def seeds_directions_pairs(positions, peaks, *, max_cross=-1):
     """
     Pair each seed to the corresponding peaks. If multiple peaks are available
     the seed is repeated for each.
@@ -1060,7 +1060,7 @@ def seeds_directions_pairs(positions, peaks, max_cross=-1):
         Voxel coordinates of the N positions.
     peaks : array (N, M, 3)
         Peaks at each position
-    max_cross : int
+    max_cross : int, optional
         The maximum number of direction to track from each seed in crossing
         voxels. By default all voxel peaks are used.
 

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -52,8 +52,8 @@ from functools import wraps
 from itertools import combinations, groupby
 from warnings import warn
 
-import numpy as np
 from nibabel.affines import apply_affine
+import numpy as np
 from scipy.spatial.distance import cdist
 
 from dipy.core.geometry import dist_to_corner


### PR DESCRIPTION
This PR is related to #3089. It adds 2 functions:

- The function `dipy.direction.peaks.peaks_from_positions(.)` allows for extracting peaks at any 3D positions of an ODF image.
- The function `dipy.tracking.utils.seeds_directions_pairs(.)` allows matching seeds positions to the corresponding peaks. If more than 1 peak is available and selected at the position, the seed position is repeated for each peak. The output is 2 arrays of shape (N,3) corresponding to all selected peaks and their location.

Examples using those functions for tractography will be included in #3089.