### PR TITLE
Loading Peaks faster with complete range and synchronization functionality.

### DIFF
--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -99,7 +99,7 @@ class PeakActor(Actor):
 
         valid_dirs = directions[indices]
 
-        num_dirs = len(np.where(valid_dirs >= 0)[0])
+        num_dirs = len(np.nonzero(np.abs(valid_dirs).max(axis=-1) > 0)[0])
 
         pnts_per_line = 2
 
@@ -112,7 +112,8 @@ class PeakActor(Actor):
                 xyz = np.asarray(center)
             else:
                 xyz = w_pos[idx, :]
-            valid_peaks = np.where(valid_dirs[idx, :, :] >= 0)[0]
+            valid_peaks = np.nonzero(np.abs(valid_dirs[idx, :, :])
+                                     .max(axis=-1) > 0.0)[0]
             for direction in valid_peaks:
                 if values is not None:
                     pv = values[center][direction]
@@ -223,8 +224,8 @@ class PeakActor(Actor):
         if self.__global_opacity >= 0:
             self.GetProperty().SetOpacity(self.__global_opacity)
 
-        self.__min_centers = np.min(indices, axis=1)
-        self.__max_centers = np.max(indices, axis=1)
+        self.__min_centers = np.zeros(shape=(3, ))
+        self.__max_centers = np.array(directions.shape[:3])
 
         self.__is_range = True
         self.__low_ranges = self.__min_centers
@@ -386,7 +387,7 @@ def peak(
             )
         else:
             valid_mask = np.logical_and(valid_mask, mask)
-    indices = np.where(valid_mask >= 0)
+    indices = np.where(valid_mask)
 
     return PeakActor(
         peaks_dirs,


### PR DESCRIPTION
### Loading the peaks faster with a complete range.

**Changes**

- This PR changes the functionality back to FURY where we avoid calculating voxels that don't contain any peaks.
- Ensuring the sizes will still correspond to the actual image.

**Goals**

- This PR makes much faster than the current Horizon peaks loading time.

**Speed Up**

- Measuring the speedup on a Linux machine with below given specifications
![Screenshot from 2024-04-10 11-51-18](https://github.com/dipy/dipy/assets/39947025/13d471c2-0349-443e-98c7-0f92ee79136e)

- Measuring was done using peaks generated from stanford_hardi data.

| Before | After |
|--------|--------|
| 63s | 5s | 