### PR TITLE
[PEP8] fix pep8 and docstring style in `dti.py` file

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -31,7 +31,7 @@ def _roll_evals(evals, axis=-1):
     evals : array-like
         Eigenvalues of a diffusion tensor. shape should be (...,3).
 
-    axis : int
+    axis : int, optional
         The axis of the array which contains the 3 eigenvals. Default: -1
 
     Returns
@@ -57,7 +57,7 @@ def fractional_anisotropy(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -96,7 +96,7 @@ def geodesic_anisotropy(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -149,7 +149,6 @@ def geodesic_anisotropy(evals, axis=-1):
         tensors." Magnetic Resonance in Medecine, vol 56, pp. 411-421, 2006.
 
     """
-
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
 
@@ -177,7 +176,7 @@ def mean_diffusivity(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -208,7 +207,7 @@ def axial_diffusivity(evals, axis=-1):
     evals : array-like
         Eigenvalues of a diffusion tensor, must be sorted in descending order
         along `axis`.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -240,7 +239,7 @@ def radial_diffusivity(evals, axis=-1):
     evals : array-like
         Eigenvalues of a diffusion tensor, must be sorted in descending order
         along `axis`.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -269,7 +268,7 @@ def trace(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -316,8 +315,8 @@ def color_fa(fa, evecs):
     .. math::
 
         rgb = abs(max(\vec{e})) \times fa
-    """
 
+    """
     if (fa.shape != evecs[..., 0, 0].shape) or ((3, 3) != evecs.shape[-2:]):
         raise ValueError("Wrong number of dimensions for evecs")
 
@@ -339,8 +338,8 @@ def determinant(q_form):
     -------
     det : array
         The determinant of the tensor in each spatial coordinate
-    """
 
+    """
     # Following the conventions used here:
     # https://en.wikipedia.org/wiki/Determinant
     aei = q_form[..., 0, 0] * q_form[..., 1, 1] * q_form[..., 2, 2]
@@ -380,6 +379,7 @@ def isotropic(q_form):
         Invariants and the Analysis of Diffusion Tensor Magnetic Resonance
         Images", Magnetic Resonance in Medicine, vol. 55, no. 1, pp. 136-146,
         2006.
+
     """
     tr_A = q_form[..., 0, 0] + q_form[..., 1, 1] + q_form[..., 2, 2]
     my_I = np.eye(3)
@@ -418,6 +418,7 @@ def deviatoric(q_form):
         Invariants and the Analysis of Diffusion Tensor Magnetic Resonance
         Images", Magnetic Resonance in Medicine, vol. 55, no. 1, pp. 136-146,
         2006.
+
     """
     A_squiggle = q_form - isotropic(q_form)
     return A_squiggle
@@ -449,6 +450,7 @@ def norm(q_form):
     See Also
     --------
     np.linalg.norm
+
     """
     return np.sqrt(np.sum(np.sum(np.abs(q_form ** 2), -1), -1))
 
@@ -487,6 +489,7 @@ def mode(q_form):
         Invariants and the Analysis of Diffusion Tensor Magnetic Resonance
         Images", Magnetic Resonance in Medicine, vol. 55, no. 1, pp. 136-146,
         2006.
+
     """
     A_squiggle = deviatoric(q_form)
     A_s_norm = norm(A_squiggle)
@@ -512,7 +515,7 @@ def linearity(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -533,6 +536,7 @@ def linearity(evals, axis=-1):
     .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
         "Geometrical diffusion measures for MRI from tensor basis analysis" in
         Proc. 5th Annual ISMRM, 1997.
+
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
@@ -547,7 +551,7 @@ def planarity(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -569,6 +573,7 @@ def planarity(evals, axis=-1):
     .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
         "Geometrical diffusion measures for MRI from tensor basis analysis" in
         Proc. 5th Annual ISMRM, 1997.
+
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
@@ -583,7 +588,7 @@ def sphericity(evals, axis=-1):
     ----------
     evals : array-like
         Eigenvalues of a diffusion tensor.
-    axis : int
+    axis : int, optional
         Axis of `evals` which contains 3 eigenvalues.
 
     Returns
@@ -604,6 +609,7 @@ def sphericity(evals, axis=-1):
     .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
         "Geometrical diffusion measures for MRI from tensor basis analysis" in
         Proc. 5th Annual ISMRM, 1997.
+
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
@@ -667,6 +673,7 @@ def tensor_prediction(dti_params, gtab, S0):
     direction on the sphere for which a signal is to be predicted, $b$ is the b
     value provided in the GradientTable input for that direction, $Q$ is the
     quadratic form of the tensor determined by the input parameters.
+
     """
     evals = dti_params[..., :3]
     evecs = dti_params[..., 3:].reshape(dti_params.shape[:-1] + (3, 3))
@@ -691,7 +698,7 @@ class TensorModel(ReconstModel):
         ----------
         gtab : GradientTable class instance
 
-        fit_method : str or callable
+        fit_method : str or callable, optional
             str can be one of the following:
 
             'WLS' for weighted least squares
@@ -707,13 +714,13 @@ class TensorModel(ReconstModel):
             callable has to have the signature:
               fit_method(design_matrix, data, *args, **kwargs)
 
-        return_S0_hat : bool
+        return_S0_hat : bool, optional
             Boolean to return (True) or not (False) the S0 values for the fit.
 
         args, kwargs : arguments and key-word arguments passed to the
            fit_method. See dti.wls_fit_tensor, dti.ols_fit_tensor for details
 
-        min_signal : float
+        min_signal : float, optional
             The minimum signal value. Needs to be a strictly positive
             number. Default: minimal signal in the data provided to `fit`.
 
@@ -772,15 +779,15 @@ class TensorModel(ReconstModel):
         data : array
             The measured signal from one voxel.
 
-        mask : array
+        mask : array, optional
             A boolean array used to mark the coordinates in the data that
             should be analyzed that has the shape data.shape[:-1]
 
         adjacency : float, optional
             Calculate voxel adjacency accounting for mask, using this
             value as cutoff distance (measured in voxel coordinates)
-        """
 
+        """
         S0_params = None
 
         img_shape = data.shape[:-1]
@@ -866,9 +873,10 @@ class TensorModel(ReconstModel):
             The last dimension should have 12 tensor parameters: 3
             eigenvalues, followed by the 3 eigenvectors
 
-        S0 : float or ndarray
+        S0 : float or ndarray, optional
             The non diffusion-weighted signal in every voxel, or across all
-            voxels. Default: 1
+            voxels.
+
         """
         return tensor_prediction(dti_params, self.gtab, S0)
 
@@ -1213,12 +1221,12 @@ class TensorFit:
         gtab : a GradientTable class instance
             This encodes the directions for which a prediction is made
 
-        S0 : float array
+        S0 : float array, optional
            The mean non-diffusion weighted signal in each voxel. Default:
            The fitted S0 value in all voxels if it was fitted. Otherwise 1 in
            all voxels.
 
-        step : int
+        step : int, optional
             The chunk size as a number of voxels. Optional parameter with
             default value 10,000.
 
@@ -1281,7 +1289,7 @@ def iter_fit_tensor(step=1e4):
 
     Parameters
     ----------
-    step : int
+    step : int, optional
         The chunk size as a number of voxels. Optional parameter with default
         value 10,000.
 
@@ -1317,16 +1325,17 @@ def iter_fit_tensor(step=1e4):
             data : array ([X, Y, Z, ...], g)
                 Data or response variables holding the data. Note that the last
                 dimension should contain the data. It makes no copies of data.
-            return_S0_hat : bool
+            return_S0_hat : bool, optional
                 Boolean to return (True) or not (False) the S0 values for the
                 fit.
-            step : int
+            step : int, optional
                 The chunk size as a number of voxels. Overrides `step` value
                 of `iter_fit_tensor`.
             args : {list,tuple}
                 Any extra optional positional arguments passed to `fit_tensor`.
             kwargs : dict
                 Any extra optional keyword arguments passed to `fit_tensor`.
+
             """
             shape = data.shape[:-1]
             size = np.prod(shape)
@@ -1356,10 +1365,11 @@ def iter_fit_tensor(step=1e4):
 
                 if extra_i is not None:
                     for key in extra_i:
-                        if i == 0: extra[key] = np.empty(data.shape)
+                        if i == 0:
+                            extra[key] = np.empty(data.shape)
                         extra[key][i:i + step] = extra_i[key]
                 else:
-                    if i == 0: extra = None
+                    extra == i or None
 
             if extra is not None:
                 for key in extra:
@@ -1390,7 +1400,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     data : array ([X, Y, Z, ...], g)
         Data or response variables holding the data. Note that the last
         dimension should contain the data. It makes no copies of data.
-    return_S0_hat : bool
+    return_S0_hat : bool, optional
         Boolean to return (True) or not (False) the S0 values for the fit.
 
     Returns
@@ -1476,9 +1486,9 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
     data : array ([X, Y, Z, ...], g)
         Data or response variables holding the data. Note that the last
         dimension should contain the data. It makes no copies of data.
-    return_S0_hat : bool
+    return_S0_hat : bool, optional
         Boolean to return (True) or not (False) the S0 values for the fit.
-    return_lower_triangular : bool
+    return_lower_triangular : bool, optional
         Boolean to return (True) or not (False) the coefficients of the fit.
 
     Returns
@@ -1509,6 +1519,7 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
     ..  [1] Chung, SW., Lu, Y., Henry, R.G., 2006. Comparison of bootstrap
         approaches for estimation of uncertainties of DTI parameters.
         NeuroImage 33, 531-541.
+
     """
     tol = 1e-6
     data = np.asarray(data)
@@ -1523,8 +1534,8 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False,
                                 min_diffusivity=tol / -design_matrix.min()),
                 np.exp(-fit_result[:, -1])), None
     else:
-        return eig_from_lo_tri(fit_result,
-                               min_diffusivity=tol / -design_matrix.min()), None
+        return eig_from_lo_tri(
+            fit_result, min_diffusivity=tol / -design_matrix.min()), None
 
 
 def _ols_fit_matrix(design_matrix):
@@ -1541,8 +1552,8 @@ def _ols_fit_matrix(design_matrix):
     ---------
     ols_fit = _ols_fit_matrix(design_mat)
     ols_data = np.dot(ols_fit, data)
-    """
 
+    """
     U, S, V = np.linalg.svd(design_matrix, False)
     return np.dot(U, U.T)
 
@@ -1551,7 +1562,8 @@ class _NllsHelper():
     r"""Class with member functions to return nlls error and derivative.
     """
 
-    def err_func(self, tensor, design_matrix, data, weighting=None, sigma=None):
+    def err_func(self, tensor, design_matrix, data, weighting=None,
+                 sigma=None):
         r"""
         Error function for the non-linear least-squares fit of the tensor.
 
@@ -1566,11 +1578,11 @@ class _NllsHelper():
         data : array
             The voxel signal in all gradient directions
 
-        weighting : str (optional).
+        weighting : str, optional.
              Whether to use the Geman-McClure weighting criterion (see [1]_
              for details)
 
-        sigma : float, array (optional)
+        sigma : float, array, optional
             If 'sigma' weighting is used, we will weight the error function
             according to 1/sigma^2. If 'gmm', the Geman-Mclure
             M-estimator is used for weighting, in which case this value
@@ -1580,26 +1592,29 @@ class _NllsHelper():
         -----
         The Geman-McClure M-estimator is described as follows [1]_ (page 1089):
         "The scale factor C affects the shape of the GMM
-        [Geman-McClure M-estimator] weighting function and represents the expected
-        spread of the residuals (i.e., the SD of the residuals) due to Gaussian
-        distributed noise. The scale factor C can be estimated by many robust scale
-        estimators. We used the median absolute deviation (MAD) estimator because
-        it is very robust to outliers having a 50% breakdown point (6,7).
-        The explicit formula for C using the MAD estimator is:
+        [Geman-McClure M-estimator] weighting function and represents the
+        expected spread of the residuals (i.e., the SD of the residuals) due
+        to Gaussian distributed noise. The scale factor C can be estimated by
+        many robust scale estimators. We used the median absolute deviation
+        (MAD) estimator because it is very robust to outliers having a 50%
+        breakdown point (6,7). The explicit formula for C using the MAD
+        estimator is:
 
         .. math ::
 
-                C = 1.4826 x MAD = 1.4826 x median{|r1-\hat{r}|,... |r_n-\hat{r}|}
+            C = 1.4826 x MAD = 1.4826 x median{|r1-\hat{r}|,... |r_n-\hat{r}|}
 
-        where $\hat{r} = median{r_1, r_2, ..., r_3}$ and n is the number of data
-        points. The multiplicative constant 1.4826 makes this an approximately
-        unbiased estimate of scale when the error model is Gaussian."
+        where $\hat{r} = median{r_1, r_2, ..., r_3}$ and n is the number of
+        data points. The multiplicative constant 1.4826 makes this an
+        approximately unbiased estimate of scale when the error model is
+        Gaussian."
 
 
         References
         ----------
         .. [1] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust
         estimation of tensors by outlier rejection. MRM, 53: 1088-95.
+
         """
         # This is the predicted signal given the params:
         y = np.exp(np.dot(design_matrix, tensor))
@@ -1616,8 +1631,8 @@ class _NllsHelper():
 
         if weighting == 'sigma':
             if sigma is None:
-                e_s = "Must provide sigma float / array as input to use this weighting"
-                e_s += " method"
+                e_s = ("Must provide sigma float / array as input to use this "
+                       " weighting method")
                 raise ValueError(e_s)
             w = 1 / (sigma**2)
 
@@ -1642,8 +1657,31 @@ class _NllsHelper():
                 self.sqrt_w = np.sqrt(w)[:, None]
             return ans
 
-    def jacobian_func(self, tensor, design_matrix, data, weighting=None, sigma=None):
+    def jacobian_func(self, tensor, design_matrix, data, weighting=None,
+                      sigma=None):
         """The Jacobian is the first derivative of the error function [1]_.
+
+        Parameters
+        ----------
+        tensor : array (3, 3)
+            Hermitian matrix representing a diffusion tensor.
+        design_matrix : array (g, Npar)
+            Design matrix holding the covariants used to solve for the
+            regression coefficients. First six parameters of design matrix
+            should correspond to the six unique diffusion tensor elements in
+            the lower triangular order (Dxx, Dxy, Dyy, Dxz, Dyz, Dzz), while
+            last parameter to -log(S0)
+        data : array ([X, Y, Z, ...], g)
+            Data or response variables holding the data. Note that the last
+            dimension should contain the data. It makes no copies of data.
+        weighting: str, optional
+            the weighting scheme to use in considering the
+            squared-error. Default behavior is to use uniform weighting. Other
+            options: 'sigma' 'gmm'
+        sigma : array, optional
+            If 'sigma' weighting is used, we will weight the error function
+            according to 1/sigma^2. If 'gmm', the Geman-Mclure
+            M-estimator is used for weighting (see below).
 
         Notes
         -----
@@ -1683,7 +1721,7 @@ def _decompose_tensor_nan(tensor, tensor_alternative, min_diffusivity=0):
     tensor_alternative : array (3, 3)
         Hermitian matrix representing a diffusion tensor obtain from an
         approach that does not produce nan tensor elements
-    min_diffusivity : float
+    min_diffusivity : float, optional
         Because negative eigenvalues are not physical and small eigenvalues,
         much smaller than the diffusion weighting, cause quite a lot of noise
         in metrics such as fa, diffusivity values smaller than
@@ -1729,23 +1767,23 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
         Data or response variables holding the data. Note that the last
         dimension should contain the data. It makes no copies of data.
 
-    weighting: str
+    weighting: str, optional
            the weighting scheme to use in considering the
            squared-error. Default behavior is to use uniform weighting. Other
            options: 'sigma' 'gmm'
 
-    sigma : array (optional)
+    sigma : array, optional
         If 'sigma' weighting is used, we will weight the error function
         according to 1/sigma^2. If 'gmm', the Geman-Mclure
         M-estimator is used for weighting (see below).
 
-    jac : bool
+    jac : bool, optional
         Use the Jacobian? Default: True
 
-    return_S0_hat : bool
+    return_S0_hat : bool, optional
         Boolean to return (True) or not (False) the S0 values for the fit.
 
-    fail_is_nan : bool
+    fail_is_nan : bool, optional
         Boolean to set failed NL fitting to NaN (True) or LS (False, default).
 
     Returns
@@ -1764,7 +1802,8 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
     flat_data = data.reshape((-1, data.shape[-1]))
 
     # Use the OLS method parameters as the starting point for the optimization:
-    D, _ = ols_fit_tensor(design_matrix, flat_data, return_lower_triangular=True)
+    D, _ = ols_fit_tensor(design_matrix, flat_data,
+                          return_lower_triangular=True)
 
     # Flatten for the iteration over voxels:
     ols_params = np.reshape(D, (-1, D.shape[-1]))
@@ -1811,7 +1850,7 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
-        except (np.linalg.LinAlgError, TypeError) as e:
+        except (np.linalg.LinAlgError, TypeError):
             resort_to_OLS = True
             this_param = start_params
 
@@ -1873,10 +1912,10 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
         optimization procedure used to fit the tensor parameters (see also
         :func:`nlls_fit_tensor`). Default: True
 
-    return_S0_hat : bool
+    return_S0_hat : bool, optional
         Boolean to return (True) or not (False) the S0 values for the fit.
 
-    fail_is_nan : bool
+    fail_is_nan : bool, optional
         Boolean to set failed NL fitting to NaN (True) or LS (False, default).
 
     Returns
@@ -1903,7 +1942,8 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
             sigma = np.reshape(sigma, (-1, 1))
 
     # calculate OLS solution
-    D, _ = ols_fit_tensor(design_matrix, flat_data, return_lower_triangular=True)
+    D, _ = ols_fit_tensor(design_matrix, flat_data,
+                          return_lower_triangular=True)
 
     # Flatten for the iteration over voxels:
     ols_params = np.reshape(D, (-1, D.shape[-1]))
@@ -1961,7 +2001,8 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
                 rdx = 1
                 while rdx <= 10:  # NOTE: capped at 10 iterations
-                    C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
+                    C = 1.4826 * np.median(np.abs(
+                        residuals - np.median(residuals)))
                     denominator = (C**2 + residuals**2)**2
                     gmm = np.divide(C**2, denominator,
                                     out=np.zeros_like(denominator),
@@ -1984,22 +2025,24 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
                     # Recalculate residuals given gmm fit
                     pred_sig = np.exp(np.dot(design_matrix, this_param))
                     residuals = flat_data[vox] - pred_sig
-                    perc = 100 * np.linalg.norm(this_param - start_params) / np.linalg.norm(this_param)
+                    perc = 100 * np.linalg.norm(this_param - start_params)  \
+                        / np.linalg.norm(this_param)
                     start_params = this_param
-                    if perc < 0.1: break
+                    if perc < 0.1:
+                        break
                     rdx = rdx + 1
 
                 cond = np.abs(residuals) > 3 * sigma_vox
                 if np.any(cond):
                     # If you still have outliers, refit without those outliers:
-                    non_outlier_idx = np.where(cond == False)
+                    non_outlier_idx = np.where(np.logical_not(cond))
                     clean_design = design_matrix[non_outlier_idx]
                     clean_data = flat_data[vox][non_outlier_idx]
-                    robust[vox] = (cond == False)
+                    robust[vox] = (np.logical_not(cond))
 
                     # recalculate OLS solution with clean data
                     new_start, _ = ols_fit_tensor(clean_design, clean_data,
-                                               return_lower_triangular=True)
+                                                  return_lower_triangular=True)
 
                     if np.iterable(sigma_vox):
                         this_sigma = sigma_vox[non_outlier_idx]
@@ -2007,13 +2050,10 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
                         this_sigma = sigma_vox
 
                     if jac:
-                        this_param, status = opt.leastsq(nlls.err_func,
-                                                         new_start,
-                                                         args=(clean_design,
-                                                               clean_data,
-                                                               'sigma',
-                                                               this_sigma),
-                                                         Dfun=nlls.jacobian_func)
+                        this_param, status = opt.leastsq(
+                            nlls.err_func, new_start, args=(
+                                clean_design, clean_data, 'sigma', this_sigma),
+                            Dfun=nlls.jacobian_func)
                     else:
                         this_param, status = opt.leastsq(nlls.err_func,
                                                          new_start,
@@ -2030,7 +2070,7 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
-        except (np.linalg.LinAlgError, TypeError) as e:
+        except (np.linalg.LinAlgError, TypeError):
             resort_to_OLS = True
             this_param = start_params
 
@@ -2102,7 +2142,7 @@ def lower_triangular(tensor, b0=None):
     ----------
     tensor : array_like (..., 3, 3)
         a collection of 3, 3 diffusion tensors
-    b0 : float
+    b0 : float, optional
         if b0 is not none log(b0) is returned as the dummy variable
 
     Returns
@@ -2132,7 +2172,7 @@ def decompose_tensor(tensor, min_diffusivity=0):
     ----------
     tensor : array (..., 3, 3)
         Hermitian matrix representing a diffusion tensor.
-    min_diffusivity : float
+    min_diffusivity : float, optional
         Because negative eigenvalues are not physical and small eigenvalues,
         much smaller than the diffusion weighting, cause quite a lot of noise
         in metrics such as fa, diffusivity values smaller than
@@ -2185,7 +2225,7 @@ def design_matrix(gtab, dtype=None):
     ----------
     gtab : A GradientTable class instance
 
-    dtype : string
+    dtype : str, optional
         Parameter to control the dtype of returned designed matrix
 
     Returns
@@ -2193,6 +2233,7 @@ def design_matrix(gtab, dtype=None):
     design_matrix : array (g,7)
         Design matrix or B matrix assuming Gaussian distributed tensor model
         design_matrix[j, :] = (Bxx, Byy, Bzz, Bxy, Bxz, Byz, dummy)
+
     """
     if gtab.btens is None:
         B = np.zeros((gtab.gradients.shape[0], 7))
@@ -2222,13 +2263,14 @@ def quantize_evecs(evecs, odf_vertices=None):
     Parameters
     ----------
     evecs : ndarray
-    odf_vertices : None or ndarray
+    odf_vertices : ndarray, optional
         If None, then set vertices from symmetric362 sphere.  Otherwise use
         passed ndarray as vertices
 
     Returns
     -------
     IN : ndarray
+
     """
     max_evecs = evecs[..., :, 0]
     if odf_vertices is None:
@@ -2249,13 +2291,14 @@ def eig_from_lo_tri(data, min_diffusivity=0):
     ----------
     data : array_like (..., 6)
         diffusion tensors elements stored in lower triangular order
-    min_diffusivity : float
+    min_diffusivity : float, optional
         See decompose_tensor()
 
     Returns
     -------
     dti_params : array (..., 12)
         Eigen-values and eigen-vectors of the same array.
+
     """
     data = np.asarray(data)
     evals, evecs = decompose_tensor(from_lower_triangular(data),


### PR DESCRIPTION
This PR is just a clean up of `dti.py`. It fixes pep8 and docstring style.

I was looking for a function and all these issues disturbed me 😅 so [boy scout rule](https://www.linkedin.com/pulse/boy-scout-rule-simple-programming-principle-mudassar-saleem-rywlf/) and here is the PR