### PR TITLE
[NF] Add DiSCo challenge data fetcher

### DIFF
--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -64,11 +64,14 @@ from dipy.data.fetcher import (
     read_syn_data,
     read_taiwan_ntu_dsi,
     read_tissue_data,
+    fetch_disco1_dataset,
+    fetch_disco2_dataset,
+    fetch_disco3_dataset,
+    fetch_disco_dataset,
 )
 from dipy.io.image import load_nifti
 from dipy.tracking.streamline import relist_streamlines
-
-from ..utils.arrfuncs import as_native_array
+from dipy.utils.arrfuncs import as_native_array
 
 
 def loads_compat(byte_data):

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -18,6 +18,10 @@ from dipy.data.fetcher import (
     fetch_bundles_2_subjects,
     fetch_cenir_multib,
     fetch_cfin_multib,
+    fetch_disco1_dataset,
+    fetch_disco2_dataset,
+    fetch_disco3_dataset,
+    fetch_disco_dataset,
     fetch_evac_test,
     fetch_evac_weights,
     fetch_gold_standard_io,
@@ -64,10 +68,6 @@ from dipy.data.fetcher import (
     read_syn_data,
     read_taiwan_ntu_dsi,
     read_tissue_data,
-    fetch_disco1_dataset,
-    fetch_disco2_dataset,
-    fetch_disco3_dataset,
-    fetch_disco_dataset,
 )
 from dipy.io.image import load_nifti
 from dipy.tracking.streamline import relist_streamlines

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -5,10 +5,11 @@ import logging
 import os
 import os.path as op
 from os.path import join as pjoin
+import random
 from shutil import copyfileobj
 import tarfile
 import tempfile
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 import zipfile
 
 import nibabel as nib
@@ -36,6 +37,61 @@ UW_RW_URL = \
 
 
 boto3, has_boto3, _ = optional_package('boto3')
+
+HEADER_LIST = [
+    {
+        "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"
+    },
+    # Firefox 77 Mac
+    {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) Gecko/20100101 Firefox/77.0",  # noqa
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",  # noqa
+        "Accept-Language": "en-US,en;q=0.5",
+        "Referer": "https://www.google.com/",
+        "DNT": "1",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1"
+    },
+    # Firefox 77 Windows
+    {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0",  # noqa
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",  # noqa
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Referer": "https://www.google.com/",
+        "DNT": "1",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1"
+    },
+    # Chrome 83 Mac
+    {
+        "Connection": "keep-alive",
+        "DNT": "1",
+        "Upgrade-Insecure-Requests": "1",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",  # noqa
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",  # noqa
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Dest": "document",
+        "Referer": "https://www.google.com/",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8"
+    },
+    # Chrome 83 Windows
+    {
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",  # noqa
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",  # noqa
+        "Sec-Fetch-Site": "same-origin",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-User": "?1",
+        "Sec-Fetch-Dest": "document",
+        "Referer": "https://www.google.com/",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-US,en;q=0.9"
+    }
+]
 
 
 class FetcherError(Exception):
@@ -101,7 +157,9 @@ def check_md5(filename, stored_md5=None):
 
 
 def _get_file_data(fname, url):
-    with contextlib.closing(urlopen(url)) as opener:
+    hdr = random.choice(HEADER_LIST)
+    req = Request(url, headers=hdr)
+    with contextlib.closing(urlopen(req)) as opener:
         try:
             response_size = opener.headers['content-length']
         except KeyError:
@@ -152,6 +210,7 @@ def fetch_data(files, folder, data_size=None):
             continue
         all_skip = False
         _log('Downloading "%s" to %s' % (f, folder))
+        _log('From: %s' % url)
         _get_file_data(fullpath, url)
         check_md5(fullpath, md5)
     if all_skip:
@@ -720,6 +779,341 @@ fetch_bundle_warp_dataset = _make_fetcher(
     doc="Download Bundle Warp dataset")
 
 
+fetch_disco1_dataset = _make_fetcher(
+    "fetch_disco1_dataset",
+    pjoin(dipy_home, 'disco', 'disco_1'),
+    'https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/',
+    ['028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded',
+     'e714ff30-be78-4284-b282-84ed011885de/file_downloaded',
+     'a45ac785-4977-434b-b05e-c97ed4a1e6c7/file_downloaded',
+     'c3d1de3e-6dcf-4142-99bf-4dd42d445a0a/file_downloaded',
+     '35f025f6-d4ab-45e6-9f58-e7685862117f/file_downloaded',
+     '02ad744f-4910-40a2-870b-5507d6195926/file_downloaded',
+     'c030a2dc-6b80-43d7-a63c-87a28c77c73b/file_downloaded',
+     'c6a54096-d7ea-4d05-a921-6aeb0c1bc625/file_downloaded',
+     'd95bfd9a-8886-48ec-acc5-5526f3bca32c/file_downloaded',
+     '8ef464f7-e648-4583-a208-3ee87a08a2a1/file_downloaded',
+     'cbaa3708-7f39-46ec-8cea-51285956bf5a/file_downloaded',
+     '964040aa-e1f0-48f7-8eb7-87553f4190e5/file_downloaded',
+     'e8bea304-35ce-45de-95be-c51e2ed917f6/file_downloaded',
+     'ec5da4f1-53bd-4103-8722-ea3211223150/file_downloaded',
+     'c1ddba00-9ea1-435a-946a-bca43079eadf/file_downloaded',
+     '0aa2d1a0-ae07-4eff-af6a-22183249e9fa/file_downloaded',
+     '744d468f-bd0e-44a8-8395-893889c16462/file_downloaded',
+     '311afc50-9bf5-469a-a298-091d252940c9/file_downloaded',
+     '68f37ddf-8f06-4d3e-80c5-842b495516ba/file_downloaded',
+     'd272c9aa-85d9-40d1-9a87-1044d361da0c/file_downloaded',
+     '0ba92dbc-4489-4626-8bfd-5d56b7557699/file_downloaded',
+     '099c3f98-4574-4315-be5e-a2b183695e71/file_downloaded',
+     '231bbeac-bdec-4815-9238-9a2370bdca6b/file_downloaded',
+     'cd073c2f-c3b0-4a46-9c3d-63a853a8af49/file_downloaded',
+     '470f235c-04f5-4544-bf4b-f11ac0d8fbd2/file_downloaded',
+     '276b637b-6244-4927-b1af-8c1ca12b8a0c/file_downloaded',
+     '1c524b3f-ca6b-4f6f-9e6f-25431496000a/file_downloaded',
+     '24f8fe7c-8ab2-40c8-baec-4d1f29eba4f2/file_downloaded',
+     '5cc5fb58-6058-40dd-9969-019f7814a4a1/file_downloaded',
+     'aabcc286-b607-46e1-9229-80638630d518/file_downloaded',
+     '87b6cee7-0645-4405-b5b3-af89c04a2ac9/file_downloaded',
+     'ad47bf18-8b69-4b0c-8706-ada53365fd99/file_downloaded',
+     '417505fb-3a7a-4cbc-ac8a-92acc26bb958/file_downloaded',
+     '7708e776-f07c-47a9-9982-b5fbd9dd4390/file_downloaded',
+     '654863c6-6154-4da6-9f4c-3b0c76535dd7/file_downloaded',
+     '5f8d028c-82a1-4837-b34f-ad8251c0685b/file_downloaded',
+     'bd2fa6f3-f050-44a6-ad18-6c31bb037eb7/file_downloaded',
+     'b432035b-5429-4255-8e21-88184802d005/file_downloaded',
+     '1f1a4391-9740-4e17-89c3-79430aab0f91/file_downloaded',
+     '6c90c685-ae16-4f21-ae13-71e89ca9eb66/file_downloaded',
+     'f8878550-061b-40e0-a0c7-5aac5a33e542/file_downloaded',
+     ],
+    ['DiSCo_gradients.bvals', 'DiSCo_gradients_dipy.bvecs',
+     'DiSCo_gradients_fsl.bvecs', 'DiSCo_gradients_mrtrix.b',
+     'DiSCo_gradients.scheme', 'lowRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz',
+     'lowRes_DiSCo1_ROIs.nii.gz', 'lowRes_DiSCo1_mask.nii.gz',
+     'lowRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz',
+     'lowRes_DiSCo1_ROIs-mask.nii.gz', 'lowRes_DiSCo1_DWI_Intra.nii.gz',
+     'lowRes_DiSCo1_Strand_Bundle_Count.nii.gz',
+     'lowRes_DiSCo1_Strand_Count.nii.gz',
+     'lowRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz',
+     'lowRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz',
+     'lowRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz',
+     'lowRes_DiSCo1_DWI.nii.gz', 'lowRes_DiSCo1_Strand_ODFs.nii.gz',
+     'lowRes_DiSCo1_Strand_Average_Diameter.nii.gz',
+     'lowRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz',
+     'highRes_DiSCo1_Strand_ODFs.nii.gz',
+     'highRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz',
+     'highRes_DiSCo1_DWI.nii.gz',
+     'highRes_DiSCo1_ROIs.nii.gz',
+     'highRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz',
+     'highRes_DiSCo1_mask.nii.gz',
+     'highRes_DiSCo1_Strand_Bundle_Count.nii.gz',
+     'highRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz',
+     'highRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz',
+     'highRes_DiSCo1_Strand_Average_Diameter.nii.gz',
+     'highRes_DiSCo1_Strand_Streamline_Count.nii.gz',
+     'highRes_DiSCo1_DWI_Intra.nii.gz',
+     'highRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz',
+     'highRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz',
+     'highRes_DiSCo1_ROIs-mask.nii.gz',
+     'DiSCo1_Connectivity_Matrix_Strands_Count.txt',
+     'DiSCo1_Connectivity_Matrix_Cross-Sectional_Area.txt',
+     'DiSCo1_Strands_ROIs_Pairs.txt', 'DiSCo1_Strands_Diameters.txt',
+     'DiSCo1_Strands_Trajectories.tck', 'DiSCo1_Strands_Trajectories.trk'],
+    ['c03cfec8ee605a54866ef09c3c8ba31d', 'b8443aee0a2d2b60ee658a2342cccf0f',
+     '4ac749bb584e6963851ee170e137e3ec', '207d57a6c16cdf230b45d4df5b4e1dee',
+     '2346de6ad563a10e40b8ebec3ac4e0ff', '1981ac168ea76ce4d70e3dcd1d749f13',
+     '9a06a057df5b2ce5cb05e8c9f59be14f', 'ac9900538f4563c39032dcc289c36a51',
+     'beb0f999bc26cd32ba2079db77e7840a', '8d5659e78d7d028e3da8f5af89402669',
+     'db335f7d52b85c1d0de7ca61a2fca64b', 'f1c49868436e0beca3b7cc50416c664e',
+     'b967371fe44c4d736edcd65b8da12b93', 'd4da2df8cd7cbf24cdd0af09247ff0a2',
+     '80316e4e687ee3c2e2a9221929d1e826', '4c3580f512b325552302792a64da87f0',
+     '56ee11c59348f3a61079483bd249032d', '580d72144a5e19a119e6839d8f1c623d',
+     'f7bdfea9c3163cac7d4f67f49928b682', '7cf61f1088971a8799df80c29dc7a9f1',
+     'da762d46e6b7d513be0411ac66769c5c', '5d7bac8737a4543eee60f7aa26073df9',
+     '370bdf6571aa061daaa654a107eae6fd', '50fd6e201536b4a4815dd102d9c80974',
+     '8269aed23fc643bb98c36945462e866a', '86becb33b54a3c4291f0cd77ec87bb3e',
+     'd240cccd9d84e69bf146a5d06bb898bb', 'e75a1838ff8e5860bdbde1162e5aa80f',
+     'f7d9507884960f86918f6328962d98d2', 'be4f8221ccdd5a139f16ac18353d12c6',
+     'd8d33dbdc820289f5575b5c064c6dfe9', '53740e3d2851d5f301d93730268928f2',
+     'ed98e0f26abc85af5735fe228cb86b4c', '50a9385f567138c23df4ddf333c785c0',
+     '2d845131db87b6a2230a325e076bdd7f',
+     'c53f6e42cfd796a561b1af434a61c91d', 'f97730469c53deaa5b827effebef3e78',
+     'd34fd49147cd061b9417328118567d1c', 'f0d28f1d7eec1fad866607ee59686476',
+     'e475641a08ebafeecb79a21e618d7081', '8c2a338606c0cb7de6e34b8317f59cd6'],
+    doc=('Download DISCO 1 dataset: The Diffusion-Simulated Connectivity '
+         'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
+    data_size='1.05 GB')
+
+
+fetch_disco2_dataset = _make_fetcher(
+    "fetch_disco2_dataset",
+    pjoin(dipy_home, 'disco', 'disco_2'),
+    'https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/',
+    ['028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded',
+     'e714ff30-be78-4284-b282-84ed011885de/file_downloaded',
+     'a45ac785-4977-434b-b05e-c97ed4a1e6c7/file_downloaded',
+     'c3d1de3e-6dcf-4142-99bf-4dd42d445a0a/file_downloaded',
+     '35f025f6-d4ab-45e6-9f58-e7685862117f/file_downloaded',
+     'e7a50803-a58d-47dc-b026-6a6e20602546/file_downloaded',
+     '12158d68-0050-4528-88db-5fb606b2151d/file_downloaded',
+     '361df9ec-0542-4e05-8f2d-1c605a5a915a/file_downloaded',
+     '2bcf46ae-0b07-4dd0-baf8-654a05a4aca7/file_downloaded',
+     '6a514a78-8a8a-4cdf-947a-d1b01ced4b0d/file_downloaded',
+     'a387810f-54fe-4493-8842-f3fbeea687fe/file_downloaded',
+     '2401238c-ae37-4a99-81a8-50ba90110650/file_downloaded',
+     '980a6702-c192-4a4e-b706-f3ec2fb5e800/file_downloaded',
+     'c5691dae-5b10-4c67-8a58-2df8314c85ec/file_downloaded',
+     'd4eabb32-8b28-461c-8248-a0bacf4e44f2/file_downloaded',
+     'dd98fb48-c48f-4d72-85a9-38a2d8b2bb3f/file_downloaded',
+     'fed31d0d-7c75-4073-82e5-2c9ba30daa5a/file_downloaded',
+     '012853cb-0d7f-4135-8407-a99c4e022024/file_downloaded',
+     '46d0466f-75bd-4646-af10-5215477339d8/file_downloaded',
+     'd1adcbdd-1d11-43cd-a72a-6830e91b7c33/file_downloaded',
+     'f3e9d4a5-dc9d-4112-8a67-b63b40c87e5c/file_downloaded',
+     '825d2154-e892-474d-ae31-e490467dfa3c/file_downloaded',
+     'bf62b3fd-fff7-4658-b143-9ec948fc256f/file_downloaded',
+     '173dacc8-683c-42c0-b270-67f59c77d49d/file_downloaded',
+     'f981cbad-84c9-42bb-bf19-978f12e6c972/file_downloaded',
+     'd122bf02-98f7-46b2-9286-98473216d64e/file_downloaded',
+     '50b68dd1-1037-4cb4-8d1a-025cff38da55/file_downloaded',
+     '5f3e04b6-9bd5-4010-bc2f-ea16b7ac8b1c/file_downloaded',
+     'f8d7ac40-7d0e-41ba-9788-4f973be5968b/file_downloaded',
+     'd4adf4a7-1646-4530-85cb-66c2779e1cb6/file_downloaded',
+     '6b1f740e-2b20-440f-9bec-344540d80d1d/file_downloaded',
+     '7ea07af5-5cb8-4857-bf30-17a0d4f39f83/file_downloaded',
+     '7ad1c5ab-9606-481c-a08e-0770798b224f/file_downloaded',
+     '8d8c8fe9-7747-4ba2-b759-f27cf160b88f/file_downloaded',
+     '143de683-9bce-43b9-b08e-2e16fea05a53/file_downloaded',
+     'f3f5f798-0d01-41de-ad96-6a2e2d04eeb1/file_downloaded',
+     '0dc1a52f-7770-4492-8dc7-27da1f9d2ec9/file_downloaded',
+     'bba6f22f-1212-49c2-b07f-3b62ae435b4d/file_downloaded',
+     '5928d70c-01f3-47ab-8f29-0484f9a014a2/file_downloaded',
+     '6be306cb-1dfd-4fe8-912d-ec117ff0d70d/file_downloaded',
+     'e49d38af-e262-46ef-ad44-c51c29ee2178/file_downloaded',
+     ],
+    ['DiSCo_gradients.bvals', 'DiSCo_gradients_dipy.bvecs',
+     'DiSCo_gradients_fsl.bvecs', 'DiSCo_gradients_mrtrix.b',
+     'DiSCo_gradients.scheme', 'lowRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz',
+     'lowRes_DiSCo2_Strand_Average_Diameter.nii.gz',
+     'lowRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz',
+     'lowRes_DiSCo2_DWI.nii.gz', 'lowRes_DiSCo2_ROIs.nii.gz',
+     'lowRes_DiSCo2_mask.nii.gz', 'lowRes_DiSCo2_DWI_Intra.nii.gz',
+     'lowRes_DiSCo2_ROIs-mask.nii.gz', 'lowRes_DiSCo2_Strand_Count.nii.gz',
+     'lowRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz',
+     'lowRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz',
+     'lowRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz',
+     'lowRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz',
+     'lowRes_DiSCo2_Strand_ODFs.nii.gz',
+     'lowRes_DiSCo2_Strand_Bundle_Count.nii.gz',
+     'highRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz',
+     'highRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz',
+     'highRes_DiSCo2_ROIs-mask.nii.gz', 'highRes_DiSCo2_Strand_ODFs.nii.gz',
+     'highRes_DiSCo2_Strand_Count.nii.gz', 'highRes_DiSCo2_ROIs.nii.gz',
+     'highRes_DiSCo2_mask.nii.gz',
+     'highRes_DiSCo2_Strand_Average_Diameter.nii.gz',
+     'highRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz',
+     'highRes_DiSCo2_DWI_Intra.nii.gz',
+     'highRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz',
+     'highRes_DiSCo2_DWI.nii.gz', 'highRes_DiSCo2_Strand_Bundle_Count.nii.gz',
+     'highRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz',
+     'highRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz',
+     'DiSCo2_Strands_Diameters.txt',
+     'DiSCo2_Connectivity_Matrix_Strands_Count.txt',
+     'DiSCo2_Strands_Trajectories.trk',
+     'DiSCo2_Strands_ROIs_Pairs.txt',
+     'DiSCo2_Strands_Trajectories.tck',
+     'DiSCo2_Connectivity_Matrix_Cross-Sectional_Area.txt'],
+    ['c03cfec8ee605a54866ef09c3c8ba31d', 'b8443aee0a2d2b60ee658a2342cccf0f',
+     '4ac749bb584e6963851ee170e137e3ec', '207d57a6c16cdf230b45d4df5b4e1dee',
+     '2346de6ad563a10e40b8ebec3ac4e0ff', '425a97bce000265d9e4868fcb54a6bd7',
+     '7cb8fd4ae58973235903adfcf338cb87', 'bb5ba3ba1163f4335dae76f905e181d0',
+     '350fb02f7ceeaf95c5cd13a4721cef5f', 'a8476809cca854668ae4dd3bfd1366ec',
+     'e55bca1aef80039eafdadec4b8c3ff21', '5d9b46a5130a7734a2a0544ed1f5cc72',
+     '90869179977e2b78bd0a8c4f016ee7e3', 'c6207b65665f5b82a5413e65627156b3',
+     '1f7e32d2780bbc1a2b5f7b592c9fd53b', '36de56a359a67ec68c15cc484d79e1da',
+     '6ddfa6a7e5083cb71f3ae4d23711a6a8', '21f0cf235c8c1705e7bd9ebd9a39479a',
+     '660f549e8180f17ea69de82661b427e9', '19c037c7813c7574b809baedd9bb64fd',
+     '77a1f4111eefc01b26d7ec8b6473894d', 'cde18c2581ced8755958a153332c375a',
+     '88b12d4c24bd833430b3125340c96801', '4d70e9b246101f5f2ba8a44d92beb2e8',
+     'c01bb0a1d2bdb95565b92eb022ff2124', '31f664676e94280c5ebdf04b544d200f',
+     '41a3155f6fb44da50c515bb867006ab1', '9494f6a6f5c4e44b88051f0284757517',
+     '5d9f8bd4a540891082f2dda976f70478', '8e2e5900008ae6923fe56447d7b493c7',
+     'e961d27613acc250b6407d29d5020154', 'ef330fa395d4e48d0286652927116275',
+     '00c620b144253ef114fee1fe8e95a87f', '7e4cf83496996aefd9f27c6077c71d74',
+     'e6be6c73425337e331fda4e4bdcbe749', '0b6c1770d48f39f704986ba69970541e',
+     '69da5bb232b41dbeeea9d409ca94955f', '0b43ffcc46217da86a472a7b1e02ac06',
+     '4e774e280cc57b1336e4fa9e479ee4ee', 'cc5442ea2ff2ddfcd1330016e2a68399',
+     '7f276c0276561df13c86008776faf6b2'],
+    doc=('Download DISCO 2 dataset: The Diffusion-Simulated Connectivity '
+         'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
+    data_size='1.05 GB')
+
+
+fetch_disco3_dataset = _make_fetcher(
+    "fetch_disco3_dataset",
+    pjoin(dipy_home, 'disco', 'disco_3'),
+    'https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/',
+    ['028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded',
+     'e714ff30-be78-4284-b282-84ed011885de/file_downloaded',
+     'a45ac785-4977-434b-b05e-c97ed4a1e6c7/file_downloaded',
+     'c3d1de3e-6dcf-4142-99bf-4dd42d445a0a/file_downloaded',
+     '35f025f6-d4ab-45e6-9f58-e7685862117f/file_downloaded',
+     '3cc65986-2e64-4397-a34d-386dfe286a89/file_downloaded',
+     'ac384df6-8e9a-4c44-89db-624f89c12015/file_downloaded',
+     '7feb06e6-0bdc-4fba-b7df-c67c3cb43301/file_downloaded',
+     'c8bddc43-f1f2-404c-98d4-9ab34380fc8f/file_downloaded',
+     '00bdcd82-dde0-499d-9bef-581755ad7e57/file_downloaded',
+     '8abbc092-9368-4154-9e20-b28e3b6d03b4/file_downloaded',
+     'e0773f2f-7fbe-4139-8e71-2d3267360ab5/file_downloaded',
+     '8670b9c4-9275-4da6-adbf-398889a606d7/file_downloaded',
+     'ec2306f2-7d60-452a-82d8-66962ffb903d/file_downloaded',
+     '00cf30d9-14fa-484b-b6e1-3d484e43a840/file_downloaded',
+     'b61b83aa-522b-4239-9a7b-74c80aea3c07/file_downloaded',
+     '75176143-5ddf-4dfa-b2cd-b87da0abfc7b/file_downloaded',
+     'd5fe5abf-b72e-474a-9316-714e0739feec/file_downloaded',
+     '45a139fc-2d99-4832-8d95-7a7df2acf711/file_downloaded',
+     '68f30089-1bf9-45d9-82d8-d77855823229/file_downloaded',
+     '4162d753-0d7c-4492-aa4f-88554ee64fed/file_downloaded',
+     '5ca6e137-2e65-41cd-bb4b-e1d21dcb5a28/file_downloaded',
+     '8e88dccf-d7b3-4692-ab0f-26810ba168e0/file_downloaded',
+     'fd97249f-ab0b-4ffa-a3ba-c3d0b3b1c947/file_downloaded',
+     '73636f0f-7fc6-48c9-a140-7a11df9847f2/file_downloaded',
+     '186a2116-21a8-42fc-b6d1-f303b0ba0b69/file_downloaded',
+     'e087b436-d1be-4c8d-8c56-3de9ef7fb054/file_downloaded',
+     '305ae78b-725c-4bb1-b435-1bca70c18b6b/file_downloaded',
+     '2e62eb11-660b-4f09-920d-f5ee1e25b02a/file_downloaded',
+     'a35e33f5-f23a-48de-9c03-1560ce5fecbe/file_downloaded',
+     'f1737350-0b46-468e-b78a-af9731eac720/file_downloaded',
+     '86ba2b2c-2094-43ef-be3e-e286dca5c5bd/file_downloaded',
+     'c5a4a685-c3d6-4ef2-9ec9-956fce821c9b/file_downloaded',
+     'd84ec650-8c05-41a6-a4ef-a4e3a2f66dd3/file_downloaded',
+     '7648b6ce-2bc8-4753-8e8c-399978d4e187/file_downloaded',
+     '1b702c78-cbae-4ceb-a5f6-89c5cb0f4f88/file_downloaded',
+     '835af619-7447-4247-8e5b-2e2895480add/file_downloaded',
+     '99752985-840e-4ed2-b068-68f6be7af48f/file_downloaded',
+     'c07c7b51-1eab-4852-8b36-bd9901f15d7a/file_downloaded',
+     'af6f3bc0-a09a-461a-8e6b-6095d83110ea/file_downloaded',
+     '482bcf8f-52eb-4bf8-83b4-765ed935ad81/file_downloaded',
+     ],
+    ['DiSCo_gradients.bvals', 'DiSCo_gradients_dipy.bvecs',
+     'DiSCo_gradients_fsl.bvecs', 'DiSCo_gradients_mrtrix.b',
+     'DiSCo_gradients.scheme', 'lowRes_DiSCo3_Strand_ODFs.nii.gz',
+     'lowRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz',
+     'lowRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz',
+     'lowRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz',
+     'lowRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz',
+     'lowRes_DiSCo3_Strand_Average_Diameter.nii.gz',
+     'lowRes_DiSCo3_DWI_Intra.nii.gz',
+     'lowRes_DiSCo3_Strand_Count.nii.gz', 'lowRes_DiSCo3_DWI.nii.gz',
+     'lowRes_DiSCo3_Strand_Bundle_Count.nii.gz',
+     'lowRes_DiSCo3_ROIs-mask.nii.gz',
+     'lowRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz', 'lowRes_DiSCo3_mask.nii.gz',
+     'lowRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz', 'lowRes_DiSCo3_ROIs.nii.gz',
+     'highRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz',
+     'highRes_DiSCo3_Strand_Average_Diameter.nii.gz',
+     'highRes_DiSCo3_Strand_Count.nii.gz',
+     'highRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz',
+     'highRes_DiSCo3_DWI.nii.gz',
+     'highRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz',
+     'highRes_DiSCo3_ROIs-mask.nii.gz',
+     'highRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz',
+     'highRes_DiSCo3_Strand_Bundle_Count.nii.gz',
+     'highRes_DiSCo3_DWI_Intra.nii.gz',
+     'highRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz',
+     'highRes_DiSCo3_Strand_ODFs.nii.gz',
+     'highRes_DiSCo3_mask.nii.gz',
+     'highRes_DiSCo3_ROIs.nii.gz',
+     'highRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz',
+     'DiSCo3_Connectivity_Matrix_Cross-Sectional_Area.txt',
+     'DiSCo3_Strands_Trajectories.tck',
+     'DiSCo3_Strands_Trajectories.trk',
+     'DiSCo3_Strands_ROIs_Pairs.txt',
+     'DiSCo3_Connectivity_Matrix_Strands_Count.txt',
+     'DiSCo3_Strands_Diameters.txt'],
+    ['c03cfec8ee605a54866ef09c3c8ba31d', 'b8443aee0a2d2b60ee658a2342cccf0f',
+     '4ac749bb584e6963851ee170e137e3ec', '207d57a6c16cdf230b45d4df5b4e1dee',
+     '2346de6ad563a10e40b8ebec3ac4e0ff', 'acad92cebd780424280b5e38a5b41445',
+     'c5ce15ea50d02621d2a3f27cde7cd208', 'c827954b40279462b520edfb8cd2ced0',
+     'f4e8fca1a434436ffe8fc4392d2e635b', '62606109e8a96f41208b45bffbe94aae',
+     'a03bc8afe4d0348841c9fed5f03695b4', '85f60f649c6f3d4e6ae6bcf88053058d',
+     '7fdec9c4f4fb740f595191a4d0202de7', 'df04eb8f1ce0138f3c7f20488f4dbc00',
+     '0bde3cefd74e4c3b4d28ec0d90bcadc9', 'aa7bfbfc9ff454e7a466a01229b1377b',
+     '218561e3ebbee2f08d4f3040ec2f12a9', '577ae9e407bb225dae48482a7f88bafb',
+     'e85e6edf80bd07030f5a6c1769c84546', '49ed07d5fc60ee17a4a4019d7bea7d97',
+     'aa86d752bec702172a54c1e8efe51d78', 'df0dde6428f5c5146b5ce8f353865bca',
+     '0f0b68b956415bbe06766e497ee77388', '44adc18b39d03b8d83f48cc572aaab78',
+     '0460e6420739ae31b7076f5e1be5a1f1', '80c07379496d0f2aab66d8041a9c53b1',
+     '0e3763e51612b56fa8dc933efc8d1971', '676f88a792d9034015a9613001c9bf02',
+     '6f399bee3158613c74c1330cee5d9b0d', '534e64906cc2bf58ff4cf98ecd301dd5',
+     '7d0f7513c85d766c45581f9fa8ab34a5', '01b4fe6c6e6459eac293a62428680e3b',
+     '2bb5a0b24139f5448cdd51167ce33906', 'bf6c5a26cb1061be91bec7fa73153cec',
+     'e8911b580e7fc7e2d94d238f2c81c43b', '647714842c8dea4d192bdd7c2b41fd3b',
+     'bba1e4283ed853eb484497db4b6da460', 'd761384f8fed31c53197ce4916f32296',
+     '3b119c1b8487da71412f3275616003dc', '47c300fcb48b882c124d69086b224956',
+     '9e47185ae517f6f35daa1aa16c51ba45'],
+    doc=('Download DISCO 3 dataset: The Diffusion-Simulated Connectivity '
+         'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
+    data_size='1.05 GB')
+
+
+def fetch_disco_dataset():
+    """Download All DISCO datasets.
+
+    Notes
+    -----
+    see DOI: 10.17632/fgf86jdfg6.3
+
+    """
+    files_1, folder_1 = fetch_disco1_dataset()
+    files_2, folder_2 = fetch_disco2_dataset()
+    files_3, folder_3 = fetch_disco3_dataset()
+
+    all_path = [pjoin(folder_1, f) for f in files_1] + \
+        [pjoin(folder_2, f) for f in files_2] + \
+        [pjoin(folder_3, f) for f in files_3]
+
+    return all_path
+
+
 def get_fnames(name='small_64D'):
     """Provide full paths to example or test datasets.
 
@@ -985,6 +1379,10 @@ def get_fnames(name='small_64D'):
             streamlines_data = dict(json.load(json_file))
 
         return filepath_dix, points_data, streamlines_data
+    if name in ['disco', 'disco1', 'disco2', 'disco3']:
+        local_fetcher = globals().get(f'fetch_{name}_dataset')
+        files, folder = local_fetcher()
+        return [pjoin(folder, f) for f in files]
 
 
 def read_qtdMRI_test_retest_2subjects():

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -156,9 +156,23 @@ def check_md5(filename, stored_md5=None):
             raise FetcherError(msg)
 
 
-def _get_file_data(fname, url):
-    hdr = random.choice(HEADER_LIST)
-    req = Request(url, headers=hdr)
+def _get_file_data(fname, url, *, use_headers=False):
+    """Get data from url and write it to file.
+
+    Parameters
+    ----------
+    fname : str
+        The filename to write the data to.
+    url : str
+        The URL to get the data from.
+    use_headers : bool, optional
+        Whether to use headers when downloading files.
+
+    """
+    req = url
+    if use_headers:
+        hdr = random.choice(HEADER_LIST)
+        req = Request(url, headers=hdr)
     with contextlib.closing(urlopen(req)) as opener:
         try:
             response_size = opener.headers['content-length']
@@ -172,7 +186,7 @@ def _get_file_data(fname, url):
                 copyfileobj_withprogress(opener, data, response_size)
 
 
-def fetch_data(files, folder, data_size=None):
+def fetch_data(files, folder, data_size=None, use_headers=False):
     """Downloads files to folder and checks their md5 checksums
 
     Parameters
@@ -187,6 +201,9 @@ def fetch_data(files, folder, data_size=None):
     data_size : str, optional
         A string describing the size of the data (e.g. "91 MB") to be logged to
         the screen. Default does not produce any information about data size.
+    use_headers : bool, optional
+        Whether to use headers when downloading files.
+
     Raises
     ------
     FetcherError
@@ -194,7 +211,6 @@ def fetch_data(files, folder, data_size=None):
         value. The downloaded file is not deleted when this error is raised.
 
     """
-
     if not op.exists(folder):
         _log("Creating new folder %s" % folder)
         os.makedirs(folder)
@@ -211,7 +227,7 @@ def fetch_data(files, folder, data_size=None):
         all_skip = False
         _log('Downloading "%s" to %s' % (f, folder))
         _log('From: %s' % url)
-        _get_file_data(fullpath, url)
+        _get_file_data(fullpath, url, use_headers=use_headers)
         check_md5(fullpath, md5)
     if all_skip:
         _already_there_msg(folder)
@@ -221,7 +237,7 @@ def fetch_data(files, folder, data_size=None):
 
 def _make_fetcher(name, folder, baseurl, remote_fnames, local_fnames,
                   md5_list=None, doc="", data_size=None, msg=None,
-                  unzip=False):
+                  unzip=False, use_headers=False):
     """ Create a new fetcher
 
     Parameters
@@ -251,6 +267,9 @@ def _make_fetcher(name, folder, baseurl, remote_fnames, local_fnames,
     unzip : bool, optional
         Whether to unzip the file(s) after downloading them. Supports zip, gz,
         and tar.gz files.
+    use_headers : bool, optional
+        Whether to use headers when downloading files.
+
     returns
     -------
     fetcher : function
@@ -262,7 +281,7 @@ def _make_fetcher(name, folder, baseurl, remote_fnames, local_fnames,
         for i, (f, n), in enumerate(zip(remote_fnames, local_fnames)):
             files[n] = (baseurl + f, md5_list[i] if
                         md5_list is not None else None)
-        fetch_data(files, folder, data_size)
+        fetch_data(files, folder, data_size, use_headers=use_headers)
 
         if msg is not None:
             _log(msg)
@@ -881,7 +900,8 @@ fetch_disco1_dataset = _make_fetcher(
      'e475641a08ebafeecb79a21e618d7081', '8c2a338606c0cb7de6e34b8317f59cd6'],
     doc=('Download DISCO 1 dataset: The Diffusion-Simulated Connectivity '
          'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
-    data_size='1.05 GB')
+    data_size='1.05 GB',
+    use_headers=True,)
 
 
 fetch_disco2_dataset = _make_fetcher(
@@ -985,7 +1005,8 @@ fetch_disco2_dataset = _make_fetcher(
      '7f276c0276561df13c86008776faf6b2'],
     doc=('Download DISCO 2 dataset: The Diffusion-Simulated Connectivity '
          'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
-    data_size='1.05 GB')
+    data_size='1.05 GB',
+    use_headers=True,)
 
 
 fetch_disco3_dataset = _make_fetcher(
@@ -1092,7 +1113,8 @@ fetch_disco3_dataset = _make_fetcher(
      '9e47185ae517f6f35daa1aa16c51ba45'],
     doc=('Download DISCO 3 dataset: The Diffusion-Simulated Connectivity '
          'Dataset. DOI: 10.17632/fgf86jdfg6.3'),
-    data_size='1.05 GB')
+    data_size='1.05 GB',
+    use_headers=True,)
 
 
 def fetch_disco_dataset():

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -87,17 +87,16 @@ First, we import all relevant modules:
 """
 
 import numpy as np
-from scipy.ndimage import gaussian_filter
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
+from dipy.denoise.localpca import mppca
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 import dipy.reconst.dki as dki
 import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 from dipy.viz.plotting import compare_maps
-from dipy.denoise.localpca import mppca
 
 ###############################################################################
 # DKI requires multi-shell data, i.e. data acquired from more than one


### PR DESCRIPTION
This PR adds DiSCo challenge data fetcher for tractography tutorials, benchmarks and tests.

More information about this dataset in the following link: DOI: 10.17632/fgf86jdfg6.2

4 fetchers has been added:

- `fetch_disco_dataset`  -> 4.94 GB (contains disco1 + disco2+disco3)
- `fetch_disco1_dataset` -> 1.65 GB
- `fetch_disco2_dataset` -> 1.65 GB
-  `fetch_disco3_dataset` -> 1.65 GB

