### PR TITLE
ENH: Specify the solver for the MAP-MRI positivity constraint test

### DIFF
--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -754,11 +754,14 @@ def test_positivity_constraint(radial_order=6, rng=None):
     pdf = mapfit_no_constraint.pdf(r_grad)
     pdf_negative_no_constraint = pdf[pdf < 0].sum()
 
+    # Set the cvxpy solver to CLARABEL as the one picked otherwise for this
+    # problem (OSQP) triggers a `Solution may be inaccurate` UserWarning
     mapmod_constraint = MapmriModel(gtab, radial_order=radial_order,
                                     laplacian_regularization=False,
                                     positivity_constraint=True,
                                     pos_grid=gridsize,
-                                    pos_radius='adaptive')
+                                    pos_radius='adaptive',
+                                    cvxpy_solver=mapmri.cvxpy.CLARABEL)
     mapfit_constraint = mapmod_constraint.fit(S_noise)
     pdf = mapfit_constraint.pdf(r_grad)
     pdf_negative_constraint = pdf[pdf < 0].sum()


### PR DESCRIPTION
Specify the solver for the MAP-MRI positivity constraint test: the solver picked up by `cvxpy` as the most appropriate one (`OSQP`) finds a solution that it suspects may be inaccurate, so set it to `CLARABEL`.

In either case, the optimal value found is 5.729e-01.

Fixes:
```
reconst/tests/test_mapmri.py::test_positivity_constraint
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/cvxpy/problems/problem.py:1403:
UserWarning: Solution may be inaccurate.
Try another solver, adjusting the solver settings, or solve with verbose=True for more information.
    warnings.warn(
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/8649253830/job/23715040118#step:10:4368