### PR TITLE
STYLE: Sort import statements using `ruff`

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,0 +1,29 @@
+name: code format
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  pre-commit:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+        requires: ['latest']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install and run pre-commit hooks
+      uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+default_language_version:
+  python: python3.10
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: [ --fix ]

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -11,6 +11,7 @@ from spin.cmds import meson
 def _set_mem_rlimit(max_mem=None):
     """Set address space rlimit."""
     import resource
+
     import psutil
 
     mem = psutil.virtual_memory()

--- a/benchmarks/benchmarks/bench_reconst.py
+++ b/benchmarks/benchmarks/bench_reconst.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from dipy.core.sphere import unique_edges
 from dipy.core.gradients import GradientTable
+from dipy.core.sphere import unique_edges
 from dipy.data import default_sphere, read_stanford_labels
 from dipy.io.image import load_nifti_data
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel

--- a/benchmarks/benchmarks/bench_segment.py
+++ b/benchmarks/benchmarks/bench_segment.py
@@ -4,10 +4,10 @@ import numpy as np
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
-from dipy.tracking.streamline import Streamlines, set_number_of_points
-from dipy.segment.metricspeed import Metric
 from dipy.segment.clustering import QuickBundles as QB_New
 from dipy.segment.mask import bounding_box
+from dipy.segment.metricspeed import Metric
+from dipy.tracking.streamline import Streamlines, set_number_of_points
 
 
 class BenchMask:

--- a/benchmarks/benchmarks/bench_tracking.py
+++ b/benchmarks/benchmarks/bench_tracking.py
@@ -5,11 +5,9 @@ import numpy as np
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
-
-from dipy.tracking.streamline import set_number_of_points, length
-from dipy.tracking.streamlinespeed import compress_streamlines
-
 from dipy.tracking import Streamlines
+from dipy.tracking.streamline import length, set_number_of_points
+from dipy.tracking.streamlinespeed import compress_streamlines
 
 
 class BenchStreamlines:

--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 floating = np.float32
 
 

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -5,37 +5,38 @@ streamlines.
 
 
 """
-from warnings import warn
-import re
 import collections.abc
 from functools import partial
 import numbers
-import numpy as np
+import re
+from warnings import warn
+
 import nibabel as nib
+import numpy as np
+
+from dipy.align.imaffine import (
+    AffineMap,
+    AffineRegistration,
+    MutualInformationMetric,
+    transform_centers_of_mass,
+)
+from dipy.align.imwarp import DiffeomorphicMap, SymmetricDiffeomorphicRegistration
 from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
-from dipy.align.imwarp import (SymmetricDiffeomorphicRegistration,
-                               DiffeomorphicMap)
-
-from dipy.align.imaffine import (transform_centers_of_mass,
-                                 AffineMap,
-                                 MutualInformationMetric,
-                                 AffineRegistration)
-
-from dipy.align.transforms import (TranslationTransform3D,
-                                   RigidTransform3D,
-                                   RigidScalingTransform3D,
-                                   RigidIsoScalingTransform3D,
-                                   AffineTransform3D)
-
-
+from dipy.align.streamlinear import StreamlineLinearRegistration
+from dipy.align.transforms import (
+    AffineTransform3D,
+    RigidIsoScalingTransform3D,
+    RigidScalingTransform3D,
+    RigidTransform3D,
+    TranslationTransform3D,
+)
 import dipy.core.gradients as dpg
 import dipy.data as dpd
-from dipy.align.streamlinear import StreamlineLinearRegistration
-from dipy.tracking.streamline import set_number_of_points
-from dipy.tracking.utils import transform_tracking_output
+from dipy.io.image import load_nifti, save_nifti
 from dipy.io.streamline import load_trk
 from dipy.io.utils import read_img_arr_or_path
-from dipy.io.image import load_nifti, save_nifti
+from dipy.tracking.streamline import set_number_of_points
+from dipy.tracking.utils import transform_tracking_output
 
 __all__ = ["syn_registration", "register_dwi_to_template",
            "write_mapping", "read_mapping", "resample",

--- a/dipy/align/cpd.py
+++ b/dipy/align/cpd.py
@@ -15,9 +15,10 @@ It remains licensed as the rest of PyCPD (MIT license as of October 2010).
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """
 
-import numpy as np
 import numbers
 from warnings import warn
+
+import numpy as np
 
 
 def gaussian_kernel(X, beta, Y=None):

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -48,16 +48,17 @@ from warnings import warn
 import numpy as np
 import numpy.linalg as npl
 import scipy.ndimage as ndimage
-from dipy.core.optimize import Optimizer
-from dipy.core.interpolation import (interpolate_scalar_2d,
-                                     interpolate_scalar_3d)
-from dipy.align import vector_fields as vf
-from dipy.align import VerbosityLevels
-from dipy.align.parzenhist import (ParzenJointHistogram,
-                                   sample_domain_regular,
-                                   compute_parzen_mi)
-from dipy.align.imwarp import (get_direction_and_spacings, ScaleSpace)
+
+from dipy.align import VerbosityLevels, vector_fields as vf
+from dipy.align.imwarp import ScaleSpace, get_direction_and_spacings
+from dipy.align.parzenhist import (
+    ParzenJointHistogram,
+    compute_parzen_mi,
+    sample_domain_regular,
+)
 from dipy.align.scalespace import IsotropicScaleSpace
+from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
+from dipy.core.optimize import Optimizer
 
 _interp_options = ['nearest', 'linear']
 _transform_method = dict()

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1,17 +1,14 @@
 """  Classes and functions for Symmetric Diffeomorphic Registration """
 
-import logging
 import abc
+import logging
 
-import numpy as np
-import numpy.linalg as npl
 import nibabel as nib
 from nibabel.streamlines import ArraySequence as Streamlines
+import numpy as np
+import numpy.linalg as npl
 
-from dipy.align import vector_fields as vfu
-from dipy.align import floating
-from dipy.align import VerbosityLevels
-from dipy.align import Bunch
+from dipy.align import Bunch, VerbosityLevels, floating, vector_fields as vfu
 from dipy.align.scalespace import ScaleSpace
 
 RegistrationStages = Bunch(INIT_START=0,

--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -1,14 +1,18 @@
 """  Metrics for Symmetric Diffeomorphic Registration """
 
 import abc
+
 import numpy as np
 from numpy import gradient
 from scipy import ndimage
-from dipy.align import vector_fields as vfu
-from dipy.align import sumsqdiff as ssd
-from dipy.align import crosscorr as cc
-from dipy.align import expectmax as em
-from dipy.align import floating
+
+from dipy.align import (
+    crosscorr as cc,
+    expectmax as em,
+    floating,
+    sumsqdiff as ssd,
+    vector_fields as vfu,
+)
 
 
 class SimilarityMetric(metaclass=abc.ABCMeta):

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -6,6 +6,7 @@ from scipy.ndimage import affine_transform
 
 from dipy.utils.multiproc import determine_num_processes
 
+
 def _affine_transform(kwargs):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*scipy.*18.*",

--- a/dipy/align/scalespace.py
+++ b/dipy/align/scalespace.py
@@ -1,8 +1,10 @@
 import logging
-from dipy.align import floating
+
 import numpy as np
 import numpy.linalg as npl
 from scipy.ndimage import gaussian_filter
+
+from dipy.align import floating
 
 logger = logging.getLogger(__name__)
 

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1,23 +1,27 @@
-import logging
 import abc
 from itertools import combinations
-import numpy as np
-from dipy.core.optimize import Optimizer
-from dipy.align.bundlemin import (_bundle_minimum_distance,
-                                  _bundle_minimum_distance_asymmetric,
-                                  distance_matrix_mdf)
-from dipy.tracking.streamline import (transform_streamlines,
-                                      unlist_streamlines,
-                                      center_streamlines,
-                                      set_number_of_points,
-                                      select_random_set_of_streamlines,
-                                      length,
-                                      Streamlines)
-from dipy.segment.clustering import qbx_and_merge
-from dipy.core.geometry import (compose_transformations,
-                                compose_matrix,
-                                decompose_matrix)
+import logging
 from time import time
+
+import numpy as np
+
+from dipy.align.bundlemin import (
+    _bundle_minimum_distance,
+    _bundle_minimum_distance_asymmetric,
+    distance_matrix_mdf,
+)
+from dipy.core.geometry import compose_matrix, compose_transformations, decompose_matrix
+from dipy.core.optimize import Optimizer
+from dipy.segment.clustering import qbx_and_merge
+from dipy.tracking.streamline import (
+    Streamlines,
+    center_streamlines,
+    length,
+    select_random_set_of_streamlines,
+    set_number_of_points,
+    transform_streamlines,
+    unlist_streamlines,
+)
 
 DEFAULT_BOUNDS = [(-35, 35), (-35, 35), (-35, 35),
                   (-45, 45), (-45, 45), (-45, 45),

--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -3,16 +3,14 @@ import warnings
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 
-from dipy.align.streamlinear import slr_with_qbx
-from dipy.align.cpd import DeformableRegistration
-from dipy.tracking.streamline import (unlist_streamlines,
-                                      Streamlines)
-from dipy.stats.analysis import assignment_map
-from dipy.tracking.streamline import length
 from dipy.align.bundlemin import distance_matrix_mdf
-from dipy.viz.plotting import bundle_shape_profile
+from dipy.align.cpd import DeformableRegistration
+from dipy.align.streamlinear import slr_with_qbx
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
+from dipy.stats.analysis import assignment_map
+from dipy.tracking.streamline import Streamlines, length, unlist_streamlines
+from dipy.viz.plotting import bundle_shape_profile
 
 
 def average_bundle_length(bundle):

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -1,29 +1,37 @@
 import os.path as op
-import pytest
 from tempfile import TemporaryDirectory
 
+import nibabel as nib
 import numpy as np
 import numpy.testing as npt
+import pytest
 
-import nibabel as nib
-
-import dipy.data as dpd
-import dipy.core.gradients as dpg
-
-from dipy.align import (syn_registration, register_series, register_dwi_series,
-                        center_of_mass, translation, rigid_isoscaling,
-                        rigid_scaling, rigid, affine, motion_correction,
-                        affine_registration, streamline_registration,
-                        write_mapping, read_mapping, register_dwi_to_template)
-
+from dipy.align import (
+    affine,
+    affine_registration,
+    center_of_mass,
+    motion_correction,
+    read_mapping,
+    register_dwi_series,
+    register_dwi_to_template,
+    register_series,
+    rigid,
+    rigid_isoscaling,
+    rigid_scaling,
+    streamline_registration,
+    syn_registration,
+    translation,
+    write_mapping,
+)
 from dipy.align.imwarp import DiffeomorphicMap
-
-from dipy.tracking.utils import transform_tracking_output
-from dipy.io.streamline import save_trk
-from dipy.io.stateful_tractogram import StatefulTractogram, Space
+import dipy.core.gradients as dpg
+import dipy.data as dpd
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import save_trk
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.utils import transform_tracking_output
 
 
 def setup_module():

--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from dipy.align import floating
-from dipy.align import crosscorr as cc
+
+from dipy.align import crosscorr as cc, floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -1,10 +1,12 @@
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
-from dipy.align import floating
-from dipy.align import expectmax as em
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from dipy.align import expectmax as em, floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -1,17 +1,23 @@
 import numpy as np
 import numpy.linalg as npl
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_equal,
-                           assert_raises,
-                           assert_warns)
-from dipy.core import geometry as geometry
-from dipy.align import vector_fields as vf
-from dipy.align import imaffine
-from dipy.align.imaffine import AffineInversionError, AffineInvalidValuesError, \
-    AffineMap, _number_dim_affine_matrix
-from dipy.align.transforms import regtransforms
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+    assert_warns,
+)
+
+from dipy.align import imaffine, vector_fields as vf
+from dipy.align.imaffine import (
+    AffineInvalidValuesError,
+    AffineInversionError,
+    AffineMap,
+    _number_dim_affine_matrix,
+)
 from dipy.align.tests.test_parzenhist import setup_random_transform
+from dipy.align.transforms import regtransforms
+from dipy.core import geometry as geometry
 from dipy.testing.decorators import set_random_number_generator
 
 # For each transform type, select a transform factor (indicating how large the

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -1,20 +1,24 @@
-import numpy as np
 import nibabel.eulerangles as eulerangles
-from numpy.testing import (assert_equal,
-                           assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
-from dipy.core.interpolation import (interpolate_scalar_2d,
-                                     interpolate_scalar_3d)
-from dipy.data import get_fnames
-from dipy.align import floating
-from dipy.align import imwarp as imwarp
-from dipy.align import metrics as metrics
-from dipy.align import vector_fields as vfu
-from dipy.align import VerbosityLevels
+import numpy as np
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from dipy.align import (
+    VerbosityLevels,
+    floating,
+    imwarp as imwarp,
+    metrics as metrics,
+    vector_fields as vfu,
+)
 from dipy.align.imwarp import DiffeomorphicMap
-from dipy.tracking.streamline import deform_streamlines
+from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
+from dipy.data import get_fnames
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.streamline import deform_streamlines
 
 
 def test_mult_aff():

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -1,11 +1,11 @@
 import itertools
+
 import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 from scipy import ndimage
+
 from dipy.align import floating
-from dipy.align.metrics import SSDMetric, CCMetric, EMMetric
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
+from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_parzenhist.py
+++ b/dipy/align/tests/test_parzenhist.py
@@ -1,22 +1,27 @@
-import numpy as np
-import scipy as sp
 from functools import reduce
 from operator import mul
-from dipy.core.ndindex import ndindex
-from dipy.core.interpolation import (interpolate_scalar_2d,
-                                     interpolate_scalar_3d)
-from dipy.data import get_fnames
+
+import numpy as np
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
+import scipy as sp
+
 from dipy.align import vector_fields as vf
+from dipy.align.parzenhist import (
+    ParzenJointHistogram,
+    cubic_spline,
+    cubic_spline_derivative,
+    sample_domain_regular,
+)
 from dipy.align.transforms import regtransforms
-from dipy.align.parzenhist import (ParzenJointHistogram,
-                                   cubic_spline,
-                                   cubic_spline_derivative,
-                                   sample_domain_regular)
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_almost_equal,
-                           assert_equal,
-                           assert_raises)
+from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
+from dipy.core.ndindex import ndindex
+from dipy.data import get_fnames
 from dipy.testing.decorators import set_random_number_generator
 
 factors = {('TRANSLATION', 2): 2.0,

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -1,13 +1,11 @@
-import numpy as np
 import nibabel as nib
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_almost_equal,
-                           assert_raises)
-from dipy.io.image import load_nifti
-from dipy.data import get_fnames
+import numpy as np
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
+
 from dipy.align.reslice import reslice
+from dipy.data import get_fnames
 from dipy.denoise.noise_estimate import estimate_sigma
+from dipy.io.image import load_nifti
 
 
 def test_resample():

--- a/dipy/align/tests/test_scalespace.py
+++ b/dipy/align/tests/test_scalespace.py
@@ -1,11 +1,10 @@
 import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 import scipy as sp
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
+
 from dipy.align import floating
 from dipy.align.imwarp import get_direction_and_spacings
-from dipy.align.scalespace import ScaleSpace, IsotropicScaleSpace
+from dipy.align.scalespace import IsotropicScaleSpace, ScaleSpace
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -1,33 +1,40 @@
 import numpy as np
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_almost_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
-from dipy.align.streamlinear import (compose_matrix44,
-                                     decompose_matrix44,
-                                     BundleSumDistanceMatrixMetric,
-                                     BundleMinDistanceMatrixMetric,
-                                     BundleMinDistanceMetric,
-                                     StreamlineLinearRegistration,
-                                     StreamlineDistanceMetric,
-                                     groupwise_slr,
-                                     get_unique_pairs)
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+)
 
-from dipy.tracking.streamline import (center_streamlines,
-                                      unlist_streamlines,
-                                      relist_streamlines,
-                                      transform_streamlines,
-                                      set_number_of_points,
-                                      Streamlines)
-from dipy.io.streamline import load_tractogram
+from dipy.align.bundlemin import (
+    _bundle_minimum_distance,
+    _bundle_minimum_distance_matrix,
+    distance_matrix_mdf,
+)
+from dipy.align.streamlinear import (
+    BundleMinDistanceMatrixMetric,
+    BundleMinDistanceMetric,
+    BundleSumDistanceMatrixMetric,
+    StreamlineDistanceMetric,
+    StreamlineLinearRegistration,
+    compose_matrix44,
+    decompose_matrix44,
+    get_unique_pairs,
+    groupwise_slr,
+)
 from dipy.core.geometry import compose_matrix
-
-from dipy.data import get_fnames, two_cingulum_bundles, read_five_af_bundles
-from dipy.align.bundlemin import (_bundle_minimum_distance_matrix,
-                                  _bundle_minimum_distance,
-                                  distance_matrix_mdf)
+from dipy.data import get_fnames, read_five_af_bundles, two_cingulum_bundles
+from dipy.io.streamline import load_tractogram
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.streamline import (
+    Streamlines,
+    center_streamlines,
+    relist_streamlines,
+    set_number_of_points,
+    transform_streamlines,
+    unlist_streamlines,
+)
 
 
 def simulated_bundle(no_streamlines=10, waves=False, no_pts=12):

--- a/dipy/align/tests/test_streamwarp.py
+++ b/dipy/align/tests/test_streamwarp.py
@@ -1,10 +1,12 @@
 from numpy.testing import assert_equal
-from dipy.align.streamwarp import (bundlewarp,
-                                   bundlewarp_shape_analysis,
-                                   bundlewarp_vector_filed)
 
+from dipy.align.streamwarp import (
+    bundlewarp,
+    bundlewarp_shape_analysis,
+    bundlewarp_vector_filed,
+)
 from dipy.data import two_cingulum_bundles
-from dipy.tracking.streamline import set_number_of_points, Streamlines
+from dipy.tracking.streamline import Streamlines, set_number_of_points
 
 
 def test_bundlewarp():

--- a/dipy/align/tests/test_sumsqdiff.py
+++ b/dipy/align/tests/test_sumsqdiff.py
@@ -1,10 +1,12 @@
 import numpy as np
-from dipy.align import floating
-from dipy.align import sumsqdiff as ssd
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_array_almost_equal,
-                           assert_allclose)
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+)
+
+from dipy.align import floating, sumsqdiff as ssd
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_transforms.py
+++ b/dipy/align/tests/test_transforms.py
@@ -1,10 +1,12 @@
 import numpy as np
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_equal,
-                           assert_raises)
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
-from dipy.align.transforms import regtransforms, Transform
+from dipy.align.transforms import Transform, regtransforms
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -1,17 +1,18 @@
-import numpy as np
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal,
-                           assert_almost_equal,
-                           assert_equal,
-                           assert_raises)
-from scipy.ndimage import map_coordinates
 from nibabel.affines import apply_affine, from_matvec
-from dipy.core import geometry
-from dipy.align import floating
-from dipy.align import imwarp
-from dipy.align import vector_fields as vfu
-from dipy.align.transforms import regtransforms
+import numpy as np
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
+from scipy.ndimage import map_coordinates
+
+from dipy.align import floating, imwarp, vector_fields as vfu
 from dipy.align.parzenhist import sample_domain_regular
+from dipy.align.transforms import regtransforms
+from dipy.core import geometry
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_whole_brain_slr.py
+++ b/dipy/align/tests/test_whole_brain_slr.py
@@ -1,14 +1,17 @@
 import numpy as np
-from numpy.testing import (assert_equal, assert_array_almost_equal,
-                           assert_raises)
+from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 
-from dipy.align.streamlinear import (compose_matrix44, decompose_matrix44,
-                                     transform_streamlines, whole_brain_slr,
-                                     slr_with_qbx)
-from dipy.io.streamline import load_tractogram
+from dipy.align.streamlinear import (
+    compose_matrix44,
+    decompose_matrix44,
+    slr_with_qbx,
+    transform_streamlines,
+    whole_brain_slr,
+)
 from dipy.data import get_fnames
-from dipy.tracking.streamline import Streamlines
+from dipy.io.streamline import load_tractogram
 from dipy.tracking.distances import bundles_distances_mam
+from dipy.tracking.streamline import Streamlines
 
 
 def test_whole_brain_slr():

--- a/dipy/conftest.py
+++ b/dipy/conftest.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 import pytest
 
-
 """ Set numpy print options to "legacy" for new versions of numpy
  If imported into a file, pytest will run this before any doctests.
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -2,6 +2,7 @@
 
 import itertools
 import math
+
 import numpy as np
 import numpy.linalg as npl
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -4,13 +4,11 @@ from warnings import warn
 import numpy as np
 from scipy.linalg import inv, polar
 
-from dipy.io import gradients as io
+from dipy.core.geometry import vec2vec_rotmat, vector_norm
 from dipy.core.onetime import auto_attr
-from dipy.core.geometry import vector_norm, vec2vec_rotmat
-from dipy.core.sphere import disperse_charges, HemiSphere
-
+from dipy.core.sphere import HemiSphere, disperse_charges
+from dipy.io import gradients as io
 from dipy.utils.deprecator import deprecate_with_version
-
 
 WATER_GYROMAGNETIC_RATIO = 267.513e6  # 1/(sT)
 

--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -2,10 +2,12 @@
 
 import abc
 import warnings
+
 import numpy as np
-import scipy.sparse as sps
 import scipy.optimize as opt
 from scipy.optimize import minimize
+import scipy.sparse as sps
+
 from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")

--- a/dipy/core/rng.py
+++ b/dipy/core/rng.py
@@ -2,6 +2,7 @@
 
 from math import floor
 from platform import architecture
+
 import numpy as np
 
 

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -1,6 +1,6 @@
-import numpy as np
 import warnings
 
+import numpy as np
 from scipy import optimize
 
 from dipy.core.geometry import cart2sphere, sphere2cart, vector_norm

--- a/dipy/core/sphere_stats.py
+++ b/dipy/core/sphere_stats.py
@@ -1,9 +1,11 @@
 """ Statistics on spheres
 """
 
-import numpy as np
-import dipy.core.geometry as geometry
 from itertools import permutations
+
+import numpy as np
+
+import dipy.core.geometry as geometry
 
 
 def random_uniform_on_sphere(n=1, coords='xyz'):

--- a/dipy/core/subdivide_octahedron.py
+++ b/dipy/core/subdivide_octahedron.py
@@ -10,7 +10,7 @@ This recursive method will avoid the common problem of the polar singularity,
 produced by 2d (lon-lat) parameterization methods.
 
 """
-from dipy.core.sphere import unit_octahedron, HemiSphere
+from dipy.core.sphere import HemiSphere, unit_octahedron
 
 
 def create_unit_sphere(recursion_level=2):

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -2,33 +2,39 @@
 
 """
 
-import numpy as np
-
+from itertools import permutations
 import random
 
-from dipy.core.geometry import (sphere2cart, cart2sphere,
-                                nearest_pos_semi_def,
-                                sphere_distance,
-                                cart_distance,
-                                vector_cosine,
-                                lambert_equal_area_projection_polar,
-                                circumradius,
-                                vec2vec_rotmat,
-                                vector_norm,
-                                compose_transformations,
-                                compose_matrix,
-                                decompose_matrix,
-                                perpendicular_directions,
-                                dist_to_corner,
-                                is_hemispherical)
+import numpy as np
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises, assert_almost_equal,)
-
-from dipy.testing.spherepoints import sphere_points
-from dipy.testing.decorators import set_random_number_generator
+from dipy.core.geometry import (
+    cart2sphere,
+    cart_distance,
+    circumradius,
+    compose_matrix,
+    compose_transformations,
+    decompose_matrix,
+    dist_to_corner,
+    is_hemispherical,
+    lambert_equal_area_projection_polar,
+    nearest_pos_semi_def,
+    perpendicular_directions,
+    sphere2cart,
+    sphere_distance,
+    vec2vec_rotmat,
+    vector_cosine,
+    vector_norm,
+)
 from dipy.core.sphere_stats import random_uniform_on_sphere
-from itertools import permutations
+from dipy.testing.decorators import set_random_number_generator
+from dipy.testing.spherepoints import sphere_points
 
 
 def test_vector_norm():

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -4,27 +4,36 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from dipy.data import get_fnames
-from dipy.core.gradients import (b0_threshold_empty_gradient_message,
-                                 b0_threshold_update_slicing_message,
-                                 gradient_table, GradientTable,
-                                 gradient_table_from_bvals_bvecs,
-                                 gradient_table_from_qvals_bvecs,
-                                 gradient_table_from_gradient_strength_bvecs,
-                                 WATER_GYROMAGNETIC_RATIO,
-                                 mask_non_weighted_bvals,
-                                 orientation_to_string,
-                                 reorient_bvecs, generate_bvecs,
-                                 check_multi_b, round_bvals, get_bval_indices,
-                                 unique_bvals_magnitude,
-                                 unique_bvals_tolerance, unique_bvals,
-                                 params_to_btens, btens_to_params,
-                                 orientation_from_string, reorient_vectors)
 from dipy.core.geometry import vec2vec_rotmat, vector_norm
+from dipy.core.gradients import (
+    WATER_GYROMAGNETIC_RATIO,
+    GradientTable,
+    b0_threshold_empty_gradient_message,
+    b0_threshold_update_slicing_message,
+    btens_to_params,
+    check_multi_b,
+    generate_bvecs,
+    get_bval_indices,
+    gradient_table,
+    gradient_table_from_bvals_bvecs,
+    gradient_table_from_gradient_strength_bvecs,
+    gradient_table_from_qvals_bvecs,
+    mask_non_weighted_bvals,
+    orientation_from_string,
+    orientation_to_string,
+    params_to_btens,
+    reorient_bvecs,
+    reorient_vectors,
+    round_bvals,
+    unique_bvals,
+    unique_bvals_magnitude,
+    unique_bvals_tolerance,
+)
+from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.testing import clear_and_catch_warnings
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.deprecator import ExpiredDeprecationError
 
 
 def test_unique_bvals_deprecated():

--- a/dipy/core/tests/test_graph.py
+++ b/dipy/core/tests/test_graph.py
@@ -1,6 +1,6 @@
-from dipy.core.graph import Graph
-
 from numpy.testing import assert_equal
+
+from dipy.core.graph import Graph
 
 
 def test_graph():

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -1,22 +1,25 @@
-import numpy as np
-import numpy.testing as npt
 import warnings
 
+import numpy as np
+import numpy.testing as npt
 from scipy.ndimage import map_coordinates
-from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.interpolation import (trilinear_interpolate4d,
-                                     interpolate_scalar_2d,
-                                     interpolate_scalar_3d,
-                                     interpolate_vector_2d,
-                                     interpolate_vector_3d,
-                                     interpolate_scalar_nn_2d,
-                                     interpolate_scalar_nn_3d,
-                                     NearestNeighborInterpolator,
-                                     TriLinearInterpolator,
-                                     OutsideImage,
-                                     map_coordinates_trilinear_iso,
-                                     interp_rbf)
+
 from dipy.align import floating
+from dipy.core.interpolation import (
+    NearestNeighborInterpolator,
+    OutsideImage,
+    TriLinearInterpolator,
+    interp_rbf,
+    interpolate_scalar_2d,
+    interpolate_scalar_3d,
+    interpolate_scalar_nn_2d,
+    interpolate_scalar_nn_3d,
+    interpolate_vector_2d,
+    interpolate_vector_3d,
+    map_coordinates_trilinear_iso,
+    trilinear_interpolate4d,
+)
+from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/core/tests/test_ndindex.py
+++ b/dipy/core/tests/test_ndindex.py
@@ -1,7 +1,7 @@
-from dipy.core.ndindex import ndindex
-
 import numpy as np
 from numpy.testing import assert_array_equal
+
+from dipy.core.ndindex import ndindex
 
 
 def test_ndindex():

--- a/dipy/core/tests/test_optimize.py
+++ b/dipy/core/tests/test_optimize.py
@@ -1,9 +1,9 @@
 import numpy as np
+import numpy.testing as npt
 import scipy.sparse as sps
 
-import numpy.testing as npt
-from dipy.core.optimize import Optimizer, sparse_nnls, spdot
 import dipy.core.optimize as opt
+from dipy.core.optimize import Optimizer, sparse_nnls, spdot
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/core/tests/test_rng.py
+++ b/dipy/core/tests/test_rng.py
@@ -1,8 +1,9 @@
 """File dedicated to test ``dipy.core.rng`` module."""
 
-from scipy.stats import chisquare
-from dipy.core import rng
 import numpy.testing as npt
+from scipy.stats import chisquare
+
+from dipy.core import rng
 
 
 def test_wichmann_hill2006():

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -1,14 +1,25 @@
+import warnings
+
 import numpy as np
 import numpy.testing as nt
 import pytest
-import warnings
 
-from dipy.core.sphere import (Sphere, HemiSphere, unique_edges, unique_sets,
-                              faces_from_sphere_vertices, disperse_charges,
-                              fibonacci_sphere, disperse_charges_alt,
-                              _get_forces, _get_forces_alt, unit_octahedron,
-                              unit_icosahedron, hemi_icosahedron)
 from dipy.core.geometry import cart2sphere, vector_norm
+from dipy.core.sphere import (
+    HemiSphere,
+    Sphere,
+    _get_forces,
+    _get_forces_alt,
+    disperse_charges,
+    disperse_charges_alt,
+    faces_from_sphere_vertices,
+    fibonacci_sphere,
+    hemi_icosahedron,
+    unique_edges,
+    unique_sets,
+    unit_icosahedron,
+    unit_octahedron,
+)
 from dipy.core.sphere_stats import random_uniform_on_sphere
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package

--- a/dipy/core/wavelet.py
+++ b/dipy/core/wavelet.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from dipy.denoise import nlmeans_block
 
 """

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -1,72 +1,74 @@
 """Read test or example data."""
 
+import gzip
 import json
+from os.path import dirname, exists, join as pjoin
 import pickle
 
-from os.path import join as pjoin, dirname, exists
-
-import gzip
 import numpy as np
 from scipy.sparse import load_npz
-from dipy.core.gradients import GradientTable, gradient_table
-from dipy.core.sphere import Sphere, HemiSphere
-from dipy.data.fetcher import (get_fnames,
-                               fetch_scil_b0,
-                               read_scil_b0,
-                               fetch_stanford_hardi,
-                               read_stanford_hardi,
-                               fetch_stanford_tracks,
-                               fetch_taiwan_ntu_dsi,
-                               read_taiwan_ntu_dsi,
-                               fetch_sherbrooke_3shell,
-                               read_sherbrooke_3shell,
-                               fetch_isbi2013_2shell,
-                               read_isbi2013_2shell,
-                               read_stanford_labels,
-                               fetch_stanford_labels,
-                               fetch_syn_data,
-                               read_syn_data,
-                               fetch_stanford_t1,
-                               read_stanford_t1,
-                               fetch_stanford_pve_maps,
-                               read_stanford_pve_maps,
-                               fetch_bundles_2_subjects,
-                               read_bundles_2_subjects,
-                               fetch_cenir_multib,
-                               read_cenir_multib,
-                               fetch_mni_template,
-                               read_mni_template,
-                               fetch_ivim,
-                               read_ivim,
-                               fetch_tissue_data,
-                               read_tissue_data,
-                               fetch_cfin_multib,
-                               read_cfin_dwi,
-                               read_cfin_t1,
-                               fetch_target_tractogram_hcp,
-                               fetch_bundle_atlas_hcp842,
-                               fetch_30_bundle_atlas_hcp842,
-                               get_bundle_atlas_hcp842,
-                               get_target_tractogram_hcp,
-                               get_two_hcp842_bundles,
-                               fetch_bundle_fa_hcp,
-                               fetch_gold_standard_io,
-                               fetch_resdnn_weights,
-                               fetch_synb0_weights,
-                               fetch_synb0_test,
-                               fetch_evac_weights,
-                               fetch_evac_test,
-                               read_qte_lte_pte,
-                               read_DiB_70_lte_pte_ste,
-                               read_DiB_217_lte_pte_ste,
-                               read_five_af_bundles,
-                               fetch_hbn,
-                               fetch_ptt_minimal_dataset,
-                               fetch_bundle_warp_dataset)
 
-from ..utils.arrfuncs import as_native_array
+from dipy.core.gradients import GradientTable, gradient_table
+from dipy.core.sphere import HemiSphere, Sphere
+from dipy.data.fetcher import (
+    fetch_30_bundle_atlas_hcp842,
+    fetch_bundle_atlas_hcp842,
+    fetch_bundle_fa_hcp,
+    fetch_bundle_warp_dataset,
+    fetch_bundles_2_subjects,
+    fetch_cenir_multib,
+    fetch_cfin_multib,
+    fetch_evac_test,
+    fetch_evac_weights,
+    fetch_gold_standard_io,
+    fetch_hbn,
+    fetch_isbi2013_2shell,
+    fetch_ivim,
+    fetch_mni_template,
+    fetch_ptt_minimal_dataset,
+    fetch_resdnn_weights,
+    fetch_scil_b0,
+    fetch_sherbrooke_3shell,
+    fetch_stanford_hardi,
+    fetch_stanford_labels,
+    fetch_stanford_pve_maps,
+    fetch_stanford_t1,
+    fetch_stanford_tracks,
+    fetch_syn_data,
+    fetch_synb0_test,
+    fetch_synb0_weights,
+    fetch_taiwan_ntu_dsi,
+    fetch_target_tractogram_hcp,
+    fetch_tissue_data,
+    get_bundle_atlas_hcp842,
+    get_fnames,
+    get_target_tractogram_hcp,
+    get_two_hcp842_bundles,
+    read_DiB_70_lte_pte_ste,
+    read_DiB_217_lte_pte_ste,
+    read_bundles_2_subjects,
+    read_cenir_multib,
+    read_cfin_dwi,
+    read_cfin_t1,
+    read_five_af_bundles,
+    read_isbi2013_2shell,
+    read_ivim,
+    read_mni_template,
+    read_qte_lte_pte,
+    read_scil_b0,
+    read_sherbrooke_3shell,
+    read_stanford_hardi,
+    read_stanford_labels,
+    read_stanford_pve_maps,
+    read_stanford_t1,
+    read_syn_data,
+    read_taiwan_ntu_dsi,
+    read_tissue_data,
+)
 from dipy.io.image import load_nifti
 from dipy.tracking.streamline import relist_streamlines
+
+from ..utils.arrfuncs import as_native_array
 
 
 def loads_compat(byte_data):

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -1,30 +1,28 @@
-import os
 import contextlib
-import logging
+from hashlib import md5
 import json
-
+import logging
+import os
 import os.path as op
 from os.path import join as pjoin
-from hashlib import md5
 from shutil import copyfileobj
-from tqdm.auto import tqdm
-import numpy as np
-import nibabel as nib
-
 import tarfile
 import tempfile
+from urllib.request import urlopen
 import zipfile
-from dipy.core.gradients import (gradient_table,
-                                 gradient_table_from_gradient_strength_bvecs)
+
+import nibabel as nib
+import numpy as np
+from tqdm.auto import tqdm
+
+from dipy.core.gradients import (
+    gradient_table,
+    gradient_table_from_gradient_strength_bvecs,
+)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data, save_nifti
-
 from dipy.io.streamline import load_trk
-
-from dipy.utils.optpkg import optional_package, TripWire
-
-
-from urllib.request import urlopen
+from dipy.utils.optpkg import TripWire, optional_package
 
 # Set a user-writeable file-system location to put files:
 if 'DIPY_HOME' in os.environ:

--- a/dipy/data/tests/test_data.py
+++ b/dipy/data/tests/test_data.py
@@ -1,6 +1,7 @@
-import numpy.testing as npt
-from dipy.data import SPHERE_FILES
 import numpy as np
+import numpy.testing as npt
+
+from dipy.data import SPHERE_FILES
 
 
 def test_sphere_dtypes():

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -1,8 +1,8 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import os
 import os.path as op
-from threading import Thread
 import tempfile
+from threading import Thread
 from urllib.request import pathname2url
 
 import numpy.testing as npt

--- a/dipy/denoise/adaptive_soft_matching.py
+++ b/dipy/denoise/adaptive_soft_matching.py
@@ -1,5 +1,7 @@
 import math
+
 import numpy as np
+
 from dipy.core import wavelet
 
 

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -3,10 +3,10 @@ from multiprocessing import Pool
 
 import numpy as np
 import scipy
+import scipy.fft
 
 from dipy.utils.multiproc import determine_num_processes
 
-import scipy.fft
 _fft = scipy.fft
 
 

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -2,8 +2,8 @@ import copy
 from warnings import warn
 
 import numpy as np
-from scipy.linalg.lapack import dgesvd as svd
 from scipy.linalg import eigh
+from scipy.linalg.lapack import dgesvd as svd
 
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from dipy.denoise.denspeed import nlmeans_3d
+
 # from warnings import warn
 # import warnings
 

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -1,7 +1,6 @@
 import numpy as np
-
-from scipy.special import gammainccinv
 from scipy.ndimage import convolve
+from scipy.special import gammainccinv
 
 
 def _inv_nchi_cdf(N, K, alpha):

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from dipy.denoise.nlmeans_block import nlmeans_block
 
 

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -1,8 +1,10 @@
-import numpy as np
-from warnings import warn
 import time
-from dipy.utils.optpkg import optional_package
+from warnings import warn
+
+import numpy as np
+
 import dipy.core.optimize as opt
+from dipy.utils.optpkg import optional_package
 
 sklearn, has_sklearn, _ = optional_package('sklearn')
 linear_model, _, _ = optional_package('sklearn.linear_model')

--- a/dipy/denoise/tests/test_ascm.py
+++ b/dipy/denoise/tests/test_ascm.py
@@ -1,12 +1,11 @@
-import numpy as np
-import dipy.data as dpd
 import nibabel as nib
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_array_almost_equal)
-from dipy.denoise.non_local_means import non_local_means
-from dipy.denoise.noise_estimate import estimate_sigma
+import numpy as np
+from numpy.testing import assert_, assert_array_almost_equal, assert_equal
+
+import dipy.data as dpd
 from dipy.denoise.adaptive_soft_matching import adaptive_soft_matching
+from dipy.denoise.noise_estimate import estimate_sigma
+from dipy.denoise.non_local_means import non_local_means
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/denoise/tests/test_denoise.py
+++ b/dipy/denoise/tests/test_denoise.py
@@ -1,6 +1,6 @@
-from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.denoise.nlmeans import nlmeans
 import dipy.data as dpd
+from dipy.denoise.nlmeans import nlmeans
+from dipy.denoise.noise_estimate import estimate_sigma
 from dipy.io.image import load_nifti
 
 

--- a/dipy/denoise/tests/test_gibbs.py
+++ b/dipy/denoise/tests/test_gibbs.py
@@ -1,7 +1,12 @@
 import numpy as np
-from dipy.denoise.gibbs import (_gibbs_removal_1d, _gibbs_removal_2d,
-                                gibbs_removal, _image_tv)
-from numpy.testing import (assert_, assert_array_almost_equal, assert_raises)
+from numpy.testing import assert_, assert_array_almost_equal, assert_raises
+
+from dipy.denoise.gibbs import (
+    _gibbs_removal_1d,
+    _gibbs_removal_2d,
+    _image_tv,
+    gibbs_removal,
+)
 
 
 def setup_module():

--- a/dipy/denoise/tests/test_kernel.py
+++ b/dipy/denoise/tests/test_kernel.py
@@ -1,12 +1,13 @@
 import warnings
 
-from dipy.denoise.enhancement_kernel import EnhancementKernel
-from dipy.denoise.shift_twist_convolution import convolve, convolve_sf
-from dipy.reconst.shm import sh_to_sf, sf_to_sh, descoteaux07_legacy_msg
-from dipy.core.sphere import Sphere
-
 import numpy as np
 import numpy.testing as npt
+
+from dipy.core.sphere import Sphere
+from dipy.denoise.enhancement_kernel import EnhancementKernel
+from dipy.denoise.shift_twist_convolution import convolve, convolve_sf
+from dipy.reconst.shm import descoteaux07_legacy_msg, sf_to_sh, sh_to_sf
+
 
 def test_enhancement_kernel():
     """ Test if the kernel values are correct by comparison against the values

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -1,18 +1,28 @@
 import warnings
 
 import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+    assert_warns,
+)
 import scipy.special as sps
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_raises,
-                           assert_array_almost_equal,
-                           assert_warns)
+
+from dipy.core.gradients import generate_bvecs, gradient_table
 from dipy.denoise.localpca import (
-    dimensionality_problem_message, create_patch_radius_arr, compute_patch_size,
-    compute_num_samples, compute_suggested_patch_radius, localpca, mppca,
-    genpca, _pca_classifier)
+    _pca_classifier,
+    compute_num_samples,
+    compute_patch_size,
+    compute_suggested_patch_radius,
+    create_patch_radius_arr,
+    dimensionality_problem_message,
+    genpca,
+    localpca,
+    mppca,
+)
 from dipy.sims.voxel import multi_tensor
-from dipy.core.gradients import gradient_table, generate_bvecs
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -1,17 +1,19 @@
 from time import time
 
 import numpy as np
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
+from numpy.testing import (
+    assert_,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+)
 import pytest
 
+from dipy.denoise.denspeed import add_padding_reflection, remove_padding
 from dipy.denoise.nlmeans import nlmeans
-from dipy.denoise.denspeed import (add_padding_reflection, remove_padding)
-from dipy.utils.omp import cpu_count, have_openmp
 from dipy.testing import assert_greater
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.omp import cpu_count, have_openmp
 
 
 @set_random_number_generator()

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -1,12 +1,21 @@
 import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_warns,
+)
 
-from numpy.testing import (assert_almost_equal, assert_equal, assert_,
-                           assert_array_almost_equal, assert_warns)
-from dipy.denoise.noise_estimate import _inv_nchi_cdf, piesno, estimate_sigma
-from dipy.denoise.noise_estimate import _piesno_3D
-from dipy.denoise.pca_noise_estimate import pca_noise_estimate
-import dipy.data as dpd
 import dipy.core.gradients as dpg
+import dipy.data as dpd
+from dipy.denoise.noise_estimate import (
+    _inv_nchi_cdf,
+    _piesno_3D,
+    estimate_sigma,
+    piesno,
+)
+from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 from dipy.io.image import load_nifti_data
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -1,8 +1,11 @@
 import numpy as np
-from numpy.testing import (assert_,
-                           assert_equal,
-                           assert_array_almost_equal,
-                           assert_raises)
+from numpy.testing import (
+    assert_,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
 from dipy.denoise.non_local_means import non_local_means
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -1,14 +1,18 @@
 import warnings
 
 import numpy as np
-from dipy.denoise import patch2self as p2s
-from dipy.testing import (assert_greater, assert_less,
-                          assert_greater_equal, assert_less_equal)
-from numpy.testing import (assert_array_almost_equal,
-                           assert_raises, assert_equal)
+from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 import pytest
+
+from dipy.core.gradients import generate_bvecs, gradient_table
+from dipy.denoise import patch2self as p2s
 from dipy.sims.voxel import multi_tensor
-from dipy.core.gradients import gradient_table, generate_bvecs
+from dipy.testing import (
+    assert_greater,
+    assert_greater_equal,
+    assert_less,
+    assert_less_equal,
+)
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 

--- a/dipy/direction/__init__.py
+++ b/dipy/direction/__init__.py
@@ -1,6 +1,8 @@
 from .bootstrap_direction_getter import BootDirectionGetter
 from .closest_peak_direction_getter import ClosestPeakDirectionGetter
-from .probabilistic_direction_getter import ProbabilisticDirectionGetter
-from .probabilistic_direction_getter import DeterministicMaximumDirectionGetter
-from .ptt_direction_getter import PTTDirectionGetter
 from .peaks import *
+from .probabilistic_direction_getter import (
+    DeterministicMaximumDirectionGetter,
+    ProbabilisticDirectionGetter,
+)
+from .ptt_direction_getter import PTTDirectionGetter

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -1,21 +1,22 @@
-import tempfile
-
-from multiprocessing import Pool
 from itertools import repeat
+from multiprocessing import Pool
 from os import path
-
+import tempfile
 
 import numpy as np
 import scipy.optimize as opt
 
-from dipy.reconst.odf import gfa
-from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
-                                   search_descending)
+from dipy.core.ndindex import ndindex
 from dipy.core.sphere import Sphere
 from dipy.data import default_sphere
-from dipy.core.ndindex import ndindex
-from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.reconst.eudx_direction_getter import EuDXDirectionGetter
+from dipy.reconst.odf import gfa
+from dipy.reconst.recspeed import (
+    local_maxima,
+    remove_similar_vertices,
+    search_descending,
+)
+from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.multiproc import determine_num_processes
 

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -3,16 +3,14 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 
-
 from dipy.core.geometry import cart2sphere
 from dipy.core.gradients import gradient_table
 from dipy.core.sphere import HemiSphere, unit_icosahedron
-from dipy.data import get_sphere, get_fnames
+from dipy.data import get_fnames, get_sphere
 from dipy.direction.bootstrap_direction_getter import BootDirectionGetter
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst import dti, shm
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   TensorModel)
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, TensorModel
 from dipy.sims.voxel import multi_tensor, single_tensor
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -1,27 +1,31 @@
+from io import BytesIO
+import pickle
 import warnings
 
 import numpy as np
-import pickle
-from io import BytesIO
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
 
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_almost_equal, assert_equal, assert_)
-from dipy.reconst.odf import (OdfFit, OdfModel, gfa)
-
-from dipy.direction.peaks import (peaks_from_model,
-                                  peak_directions,
-                                  peak_directions_nl,
-                                  reshape_peaks_for_visualization)
-
-from dipy.core.subdivide_octahedron import create_unit_hemisphere
-from dipy.core.sphere import unit_icosahedron
-from dipy.sims.voxel import multi_tensor, multi_tensor_odf
-from dipy.data import get_fnames, get_sphere, default_sphere
-from dipy.core.gradients import gradient_table, GradientTable
+from dipy.core.gradients import GradientTable, gradient_table
+from dipy.core.sphere import HemiSphere, unit_icosahedron
 from dipy.core.sphere_stats import angular_similarity
-from dipy.core.sphere import HemiSphere
+from dipy.core.subdivide_octahedron import create_unit_hemisphere
+from dipy.data import default_sphere, get_fnames, get_sphere
+from dipy.direction.peaks import (
+    peak_directions,
+    peak_directions_nl,
+    peaks_from_model,
+    reshape_peaks_for_visualization,
+)
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.reconst.odf import OdfFit, OdfModel, gfa
 from dipy.reconst.shm import descoteaux07_legacy_msg, tournier07_legacy_msg
+from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -1,12 +1,13 @@
 import warnings
+
 import numpy as np
 import numpy.testing as npt
 
 from dipy.core.gradients import gradient_table
 from dipy.core.sphere import HemiSphere, unit_octahedron
 from dipy.data import default_sphere, get_sphere
+from dipy.direction.pmf import SHCoeffPmfGen, SimplePmfGen
 from dipy.reconst import shm
-from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
 from dipy.testing.decorators import set_random_number_generator

--- a/dipy/direction/tests/test_prob_direction_getter.py
+++ b/dipy/direction/tests/test_prob_direction_getter.py
@@ -4,10 +4,16 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.core.sphere import unit_octahedron
+from dipy.direction import (
+    DeterministicMaximumDirectionGetter,
+    ProbabilisticDirectionGetter,
+)
 from dipy.reconst.shm import (
-    descoteaux07_legacy_msg, tournier07_legacy_msg, SphHarmFit, SphHarmModel)
-from dipy.direction import (DeterministicMaximumDirectionGetter,
-                            ProbabilisticDirectionGetter)
+    SphHarmFit,
+    SphHarmModel,
+    descoteaux07_legacy_msg,
+    tournier07_legacy_msg,
+)
 
 
 def test_ProbabilisticDirectionGetter():

--- a/dipy/direction/tests/test_ptt_direction_getter.py
+++ b/dipy/direction/tests/test_ptt_direction_getter.py
@@ -3,15 +3,16 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+
 from dipy.core.sphere import unit_octahedron
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.direction import PTTDirectionGetter
 from dipy.io.image import load_nifti
 from dipy.reconst.shm import (
     SphHarmFit,
     SphHarmModel,
-    sh_to_sf,
     descoteaux07_legacy_msg,
+    sh_to_sf,
     tournier07_legacy_msg,
 )
 from dipy.tracking.local_tracking import LocalTracking

--- a/dipy/io/__init__.py
+++ b/dipy/io/__init__.py
@@ -1,8 +1,8 @@
 # init for io routines
 
-from .gradients import read_bvals_bvecs
-from .dpy import Dpy
-from .pickles import save_pickle, load_pickle
 from . import utils
+from .dpy import Dpy
+from .gradients import read_bvals_bvecs
+from .pickles import load_pickle, save_pickle
 
 __all__ = ['read_bvals_bvecs', 'Dpy', 'save_pickle', 'load_pickle', 'utils']

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -8,10 +8,9 @@
     .. [1] http://www.hdfgroup.org/HDF5/doc/H5.intro.html
 """
 
-import numpy as np
 import h5py
-
 from nibabel.streamlines import ArraySequence as Streamlines
+import numpy as np
 
 # Make sure not to carry across setup module from * import
 __all__ = ['Dpy']

--- a/dipy/io/gradients.py
+++ b/dipy/io/gradients.py
@@ -1,8 +1,9 @@
+import io
 from os.path import splitext
 import re
-import io
 import tempfile
 import warnings
+
 import numpy as np
 
 

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -1,7 +1,6 @@
-from packaging.version import Version
-
 import nibabel as nib
 import numpy as np
+from packaging.version import Version
 
 
 def load_nifti_data(fname, as_ndarray=True):

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -1,11 +1,11 @@
 import os
+
+import h5py
 import numpy as np
 
-from dipy.direction.peaks import (PeaksAndMetrics,
-                                  reshape_peaks_for_visualization)
 from dipy.core.sphere import Sphere
+from dipy.direction.peaks import PeaksAndMetrics, reshape_peaks_for_visualization
 from dipy.io.image import save_nifti
-import h5py
 
 
 def _safe_save(group, array, name):

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -6,15 +6,19 @@ from itertools import product
 import logging
 
 from nibabel.affines import apply_affine
-from nibabel.streamlines.tractogram import (Tractogram,
-                                            PerArraySequenceDict,
-                                            PerArrayDict)
+from nibabel.streamlines.tractogram import (
+    PerArrayDict,
+    PerArraySequenceDict,
+    Tractogram,
+)
 import numpy as np
 
 from dipy.io.dpy import Streamlines
-from dipy.io.utils import (get_reference_info,
-                           is_reference_info_valid,
-                           is_header_compatible)
+from dipy.io.utils import (
+    get_reference_info,
+    is_header_compatible,
+    is_reference_info_valid,
+)
 
 logger = logging.getLogger('StatefulTractogram')
 logger.setLevel(level=logging.INFO)

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -9,11 +9,10 @@ from nibabel.streamlines.tractogram import Tractogram
 import numpy as np
 import trx.trx_file_memmap as tmm
 
-from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
-from dipy.io.vtk import save_vtk_streamlines, load_vtk_streamlines
 from dipy.io.dpy import Dpy
-from dipy.io.utils import (create_tractogram_header,
-                           is_header_compatible)
+from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
+from dipy.io.utils import create_tractogram_header, is_header_compatible
+from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines
 
 
 def save_tractogram(sft, filename, bbox_valid_check=True):

--- a/dipy/io/surface.py
+++ b/dipy/io/surface.py
@@ -1,4 +1,5 @@
 from warnings import warn
+
 import nibabel as nib
 
 

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -1,14 +1,15 @@
-import warnings
 import os.path as osp
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
+import warnings
 
 import numpy as np
 import numpy.testing as npt
-from dipy.testing import assert_true
+
+from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import gradient_table
+from dipy.testing import assert_true
 
 
 def test_read_bvals_bvecs():

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -5,9 +5,9 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import numpy.testing as npt
 
-from dipy.direction.peaks import PeaksAndMetrics
 from dipy.data import default_sphere
-from dipy.io.peaks import load_peaks, save_peaks, peaks_to_niftis
+from dipy.direction.peaks import PeaksAndMetrics
+from dipy.io.peaks import load_peaks, peaks_to_niftis, save_peaks
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -1,23 +1,22 @@
+from copy import deepcopy
 import os
 from os.path import join as pjoin
-from copy import deepcopy
 from tempfile import TemporaryDirectory
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
 
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_allclose, assert_array_equal, assert_
+from numpy.testing import assert_, assert_allclose, assert_array_equal
 import pytest
+import trx.trx_file_memmap as tmm
 
 from dipy.data import get_fnames
 from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.utils import is_header_compatible
 from dipy.testing.decorators import set_random_number_generator
-
-import trx.trx_file_memmap as tmm
-
 from dipy.utils.optpkg import optional_package
+
 fury, have_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -1,19 +1,19 @@
 import os
 from tempfile import TemporaryDirectory
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
 
-from dipy.data import get_fnames
-from dipy.io.streamline import (load_tractogram, save_tractogram,
-                                load_trk, save_trk)
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.utils import create_nifti_header
-from dipy.io.vtk import save_vtk_streamlines, load_vtk_streamlines
-from dipy.tracking.streamline import Streamlines
 import numpy as np
 import numpy.testing as npt
 import pytest
 
+from dipy.data import get_fnames
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import load_tractogram, load_trk, save_tractogram, save_trk
+from dipy.io.utils import create_nifti_header
+from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines
+from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
+
 fury, have_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 FILEPATH_DIX, STREAMLINE, STREAMLINES = None, None, None

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -1,20 +1,22 @@
 import tempfile
-from urllib.error import URLError, HTTPError
-
-import pytest
+from urllib.error import HTTPError, URLError
 
 import nibabel as nib
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal, assert_
+from numpy.testing import assert_, assert_allclose, assert_array_equal
+import pytest
 import trx.trx_file_memmap as tmm
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
-from dipy.io.utils import (create_nifti_header,
-                           decfa, decfa_to_float,
-                           get_reference_info,
-                           is_reference_info_valid,
-                           read_img_arr_or_path)
+from dipy.io.utils import (
+    create_nifti_header,
+    decfa,
+    decfa_to_float,
+    get_reference_info,
+    is_reference_info_valid,
+    read_img_arr_or_path,
+)
 from dipy.testing.decorators import set_random_number_generator
 
 FILEPATH_DIX = None

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -2,13 +2,15 @@
 import logging
 import numbers
 import os
-from dipy.utils.optpkg import optional_package
-import dipy
+
 import nibabel as nib
-from nibabel.streamlines import detect_format
 from nibabel import Nifti1Image
+from nibabel.streamlines import detect_format
 import numpy as np
 from trx import trx_file_memmap
+
+import dipy
+from dipy.utils.optpkg import optional_package
 
 pd, have_pd, _ = optional_package("pandas")
 

--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -1,11 +1,13 @@
 import numpy as np
+
 from dipy.tracking.streamline import transform_streamlines
 from dipy.utils.optpkg import optional_package
+
 fury, have_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 if have_fury:
-    import fury.utils
     import fury.io
+    import fury.utils
 
 
 def load_polydata(file_name):

--- a/dipy/nn/cnn_1d_denoising.py
+++ b/dipy/nn/cnn_1d_denoising.py
@@ -27,13 +27,15 @@ PLoS ONE 17(9): e0274396. https://doi.org/10.1371/journal.pone.0274396
 
 """
 
-from dipy.utils.optpkg import optional_package
 import numpy as np
+
+from dipy.utils.optpkg import optional_package
+
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import Input, Conv1D, Activation
     from tensorflow.keras.initializers import Orthogonal
+    from tensorflow.keras.layers import Activation, Conv1D, Input
+    from tensorflow.keras.models import Model
 
 sklearn, have_sklearn, _ = optional_package('sklearn.model_selection')
 

--- a/dipy/nn/deepn4.py
+++ b/dipy/nn/deepn4.py
@@ -3,21 +3,27 @@
 Class and helper functions for fitting the DeepN4 model.
 """
 import logging
+
 import numpy as np
 from scipy.ndimage import gaussian_filter
+
 from dipy.data import get_fnames
+from dipy.nn.utils import normalize, recover_img, set_logger_level, transform_img
 from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
-from dipy.nn.utils import set_logger_level
-from dipy.nn.utils import transform_img, recover_img, normalize
 
 tf, have_tf, _ = optional_package('tensorflow')
 if have_tf:
+    from tensorflow.keras.layers import (
+        Concatenate,
+        Conv3D,
+        Conv3DTranspose,
+        GroupNormalization,
+        Layer,
+        LeakyReLU,
+        MaxPool3D,
+    )
     from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import MaxPool3D, Conv3DTranspose
-    from tensorflow.keras.layers import Conv3D, LeakyReLU
-    from tensorflow.keras.layers import Concatenate, Layer
-    from tensorflow.keras.layers import GroupNormalization
 else:
     class Model:
         pass

--- a/dipy/nn/evac.py
+++ b/dipy/nn/evac.py
@@ -3,21 +3,35 @@
 Class and helper functions for fitting the EVAC+ model.
 """
 import logging
+
 import numpy as np
 
+from dipy.align.reslice import reslice
 from dipy.data import get_fnames
+from dipy.nn.utils import (
+    correct_minor_errors,
+    normalize,
+    recover_img,
+    set_logger_level,
+    transform_img,
+)
 from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
-from dipy.align.reslice import reslice
-from dipy.nn.utils import normalize, set_logger_level, transform_img
-from dipy.nn.utils import recover_img, correct_minor_errors
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
+    from tensorflow.keras.layers import (
+        Add,
+        Concatenate,
+        Conv3D,
+        Conv3DTranspose,
+        Dropout,
+        Layer,
+        LayerNormalization,
+        ReLU,
+        Softmax,
+    )
     from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import Softmax, Conv3DTranspose
-    from tensorflow.keras.layers import Conv3D, LayerNormalization, ReLU
-    from tensorflow.keras.layers import Concatenate, Layer, Dropout, Add
 else:
     class Model:
         pass

--- a/dipy/nn/histo_resdnn.py
+++ b/dipy/nn/histo_resdnn.py
@@ -3,21 +3,22 @@
 Class and helper functions for fitting the Histological ResDNN model.
 """
 import logging
+
 import numpy as np
 
-from dipy.core.gradients import unique_bvals_magnitude, get_bval_indices
+from dipy.core.gradients import get_bval_indices, unique_bvals_magnitude
 from dipy.core.sphere import HemiSphere
-from dipy.data import get_sphere, get_fnames
+from dipy.data import get_fnames, get_sphere
+from dipy.nn.utils import set_logger_level
 from dipy.reconst.shm import sf_to_sh, sh_to_sf, sph_harm_ind_list
 from dipy.testing.decorators import doctest_skip_parser
-from dipy.utils.optpkg import optional_package
-from dipy.nn.utils import set_logger_level
 from dipy.utils.deprecator import deprecated_params
+from dipy.utils.optpkg import optional_package
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
+    from tensorflow.keras.layers import Add, Dense, Input
     from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import Input, Dense, Add
 else:
     logging.warning('This model requires Tensorflow.\
                     Please install these packages using \

--- a/dipy/nn/synb0.py
+++ b/dipy/nn/synb0.py
@@ -3,20 +3,26 @@
 Class and helper functions for fitting the Synb0 model.
 """
 import logging
+
 import numpy as np
 
 from dipy.data import get_fnames
+from dipy.nn.utils import normalize, set_logger_level, unnormalize
 from dipy.testing.decorators import doctest_skip_parser
 from dipy.utils.optpkg import optional_package
-from dipy.nn.utils import normalize, unnormalize, set_logger_level
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 if have_tf:
+    from tensorflow.keras.layers import (
+        Concatenate,
+        Conv3D,
+        Conv3DTranspose,
+        GroupNormalization,
+        Layer,
+        LeakyReLU,
+        MaxPool3D,
+    )
     from tensorflow.keras.models import Model
-    from tensorflow.keras.layers import MaxPool3D, Conv3DTranspose
-    from tensorflow.keras.layers import Conv3D, LeakyReLU
-    from tensorflow.keras.layers import Concatenate, Layer
-    from tensorflow.keras.layers import GroupNormalization
 else:
     class Model:
         pass

--- a/dipy/nn/tests/test_cnn_1denoiser.py
+++ b/dipy/nn/tests/test_cnn_1denoiser.py
@@ -1,6 +1,8 @@
 import pytest
-from dipy.utils.optpkg import optional_package
+
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.optpkg import optional_package
+
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 sklearn, have_sklearn, _ = optional_package('sklearn.model_selection')
 if have_tf and have_sklearn:

--- a/dipy/nn/tests/test_deepn4.py
+++ b/dipy/nn/tests/test_deepn4.py
@@ -1,9 +1,9 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
 import pytest
 
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
-import numpy as np
-from numpy.testing import assert_almost_equal
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 

--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -1,7 +1,6 @@
-import pytest
-
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package

--- a/dipy/nn/tests/test_histo_resdnn.py
+++ b/dipy/nn/tests/test_histo_resdnn.py
@@ -1,16 +1,16 @@
 import warnings
 
+import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 import pytest
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
-from dipy.io.image import load_nifti
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti
 from dipy.nn.histo_resdnn import HistoResDNN
 from dipy.reconst.shm import tournier07_legacy_msg
 from dipy.utils.optpkg import optional_package
-import numpy as np
-from numpy.testing import assert_almost_equal, assert_raises, assert_equal
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 

--- a/dipy/nn/tests/test_synb0.py
+++ b/dipy/nn/tests/test_synb0.py
@@ -1,9 +1,9 @@
+import numpy as np
+from numpy.testing import assert_almost_equal
 import pytest
 
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
-import numpy as np
-from numpy.testing import assert_almost_equal
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 

--- a/dipy/nn/tests/test_tf.py
+++ b/dipy/nn/tests/test_tf.py
@@ -1,12 +1,12 @@
+from numpy.testing import assert_, assert_equal
 import pytest
-from numpy.testing import assert_equal, assert_
 
 from dipy.utils.optpkg import optional_package
 
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 if have_tf:
-    from dipy.nn.model import SingleLayerPerceptron, MultipleLayerPercepton
+    from dipy.nn.model import MultipleLayerPercepton, SingleLayerPerceptron
 
 
 @pytest.mark.skipif(not have_tf, reason='Requires TensorFlow')

--- a/dipy/nn/tests/test_utils.py
+++ b/dipy/nn/tests/test_utils.py
@@ -1,7 +1,8 @@
 import warnings
 
 import numpy as np
-from dipy.nn.utils import normalize, unnormalize, transform_img, recover_img
+
+from dipy.nn.utils import normalize, recover_img, transform_img, unnormalize
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.ndimage import affine_transform, label
+
 from dipy.align.reslice import reslice
 
 

--- a/dipy/pkg_info.py
+++ b/dipy/pkg_info.py
@@ -1,8 +1,7 @@
-import os
-import sys
-import subprocess
-
 import configparser
+import os
+import subprocess
+import sys
 
 COMMIT_INFO_FNAME = 'COMMIT_INFO.txt'
 
@@ -76,6 +75,7 @@ def get_pkg_info(pkg_path):
     """
     src, hsh = pkg_commit_hash(pkg_path)
     import numpy
+
     import dipy
     return dict(
         pkg_path=pkg_path,

--- a/dipy/reconst/cross_validation.py
+++ b/dipy/reconst/cross_validation.py
@@ -1,6 +1,7 @@
 """Cross-validation analysis of diffusion models."""
 
 import numpy as np
+
 import dipy.core.gradients as gt
 
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -1,29 +1,31 @@
+import numbers
 import warnings
 
 import numpy as np
-import numbers
 from scipy.integrate import quad
-from scipy.special import lpn, gamma
 import scipy.linalg as la
 import scipy.linalg.lapack as ll
+from scipy.special import gamma, lpn
 
-from dipy.data import small_sphere, get_sphere, default_sphere
-
-from dipy.core.geometry import cart2sphere
+from dipy.core.geometry import cart2sphere, vec2vec_rotmat
 from dipy.core.ndindex import ndindex
-from dipy.sims.voxel import single_tensor
-
-from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from dipy.reconst.shm import (sph_harm_ind_list, real_sh_descoteaux_from_index,
-                              sph_harm_lookup, lazy_index, SphHarmFit,
-                              real_sh_descoteaux, sh_to_rh,
-                              forward_sdeconv_mat, SphHarmModel)
-from dipy.reconst.utils import _roi_in_volume, _mask_from_roi
-
+from dipy.data import default_sphere, get_sphere, small_sphere
 from dipy.direction.peaks import peaks_from_model
-from dipy.core.geometry import vec2vec_rotmat
-
+from dipy.reconst.dti import TensorModel, fractional_anisotropy
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.shm import (
+    SphHarmFit,
+    SphHarmModel,
+    forward_sdeconv_mat,
+    lazy_index,
+    real_sh_descoteaux,
+    real_sh_descoteaux_from_index,
+    sh_to_rh,
+    sph_harm_ind_list,
+    sph_harm_lookup,
+)
+from dipy.reconst.utils import _mask_from_roi, _roi_in_volume
+from dipy.sims.voxel import single_tensor
 from dipy.utils.deprecator import deprecate_with_version, deprecated_params
 
 

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -2,18 +2,20 @@
 """ Classes and functions for fitting the correlation tensor model """
 
 import numpy as np
-from dipy.reconst.multi_voxel import multi_voxel_fit
+
+from dipy.core.onetime import auto_attr
 from dipy.reconst.base import ReconstModel
-from dipy.reconst.utils import cti_design_matrix as design_matrix
 from dipy.reconst.dki import (
     DiffusionKurtosisFit,
 )
 from dipy.reconst.dti import (
+    MIN_POSITIVE_SIGNAL,
     decompose_tensor,
     from_lower_triangular,
     lower_triangular,
-    MIN_POSITIVE_SIGNAL)
-from dipy.core.onetime import auto_attr
+)
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.utils import cti_design_matrix as design_matrix
 
 
 def from_qte_to_cti(C):

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1,26 +1,32 @@
 #!/usr/bin/python
 """ Classes and functions for fitting the diffusion kurtosis model """
 
-import numpy as np
 import warnings
+
+import numpy as np
 import scipy.optimize as opt
-import dipy.core.sphere as dps
-from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.dti import (TensorFit, mean_diffusivity,
-                              from_lower_triangular,
-                              lower_triangular, decompose_tensor,
-                              MIN_POSITIVE_SIGNAL, nlls_fit_tensor,
-                              restore_fit_tensor)
-from dipy.reconst.utils import dki_design_matrix as design_matrix
-from dipy.reconst.recspeed import local_maxima
-from dipy.reconst.base import ReconstModel
-from dipy.core.ndindex import ndindex
-from dipy.core.geometry import (sphere2cart, cart2sphere,
-                                perpendicular_directions)
-from dipy.core.optimize import PositiveDefiniteLeastSquares
-from dipy.data import get_sphere, get_fnames, load_sdp_constraints
-from dipy.reconst.vec_val_sum import vec_val_vect
+
+from dipy.core.geometry import cart2sphere, perpendicular_directions, sphere2cart
 from dipy.core.gradients import check_multi_b
+from dipy.core.ndindex import ndindex
+from dipy.core.optimize import PositiveDefiniteLeastSquares
+import dipy.core.sphere as dps
+from dipy.data import get_fnames, get_sphere, load_sdp_constraints
+from dipy.reconst.base import ReconstModel
+from dipy.reconst.dti import (
+    MIN_POSITIVE_SIGNAL,
+    TensorFit,
+    decompose_tensor,
+    from_lower_triangular,
+    lower_triangular,
+    mean_diffusivity,
+    nlls_fit_tensor,
+    restore_fit_tensor,
+)
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.recspeed import local_maxima
+from dipy.reconst.utils import dki_design_matrix as design_matrix
+from dipy.reconst.vec_val_sum import vec_val_vect
 
 
 def _positive_evals(L1, L2, L3, er=2e-7):

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -2,20 +2,31 @@
 """ Classes and functions for fitting the DKI-based microstructural model """
 
 import numpy as np
-from dipy.reconst.dti import (lower_triangular, from_lower_triangular,
-                              decompose_tensor, trace, mean_diffusivity,
-                              radial_diffusivity, axial_diffusivity,
-                              MIN_POSITIVE_SIGNAL)
 
-from dipy.reconst.dki import (split_dki_param, _positive_evals,
-                              directional_kurtosis,
-                              directional_diffusion, kurtosis_maximum,
-                              DiffusionKurtosisModel, DiffusionKurtosisFit)
-from dipy.reconst.dti import design_matrix as dti_design_matrix
 from dipy.core.ndindex import ndindex
-from dipy.reconst.vec_val_sum import vec_val_vect
-from dipy.data import get_sphere
 import dipy.core.sphere as dps
+from dipy.data import get_sphere
+from dipy.reconst.dki import (
+    DiffusionKurtosisFit,
+    DiffusionKurtosisModel,
+    _positive_evals,
+    directional_diffusion,
+    directional_kurtosis,
+    kurtosis_maximum,
+    split_dki_param,
+)
+from dipy.reconst.dti import (
+    MIN_POSITIVE_SIGNAL,
+    axial_diffusivity,
+    decompose_tensor,
+    design_matrix as dti_design_matrix,
+    from_lower_triangular,
+    lower_triangular,
+    mean_diffusivity,
+    radial_diffusivity,
+    trace,
+)
+from dipy.reconst.vec_val_sum import vec_val_vect
 
 
 def axonal_water_fraction(dki_params, sphere='repulsion100', gtol=1e-2,

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -1,9 +1,10 @@
 import numpy as np
-from scipy.ndimage import map_coordinates
 from scipy.fftpack import fftn, fftshift, ifftshift
-from dipy.reconst.odf import OdfModel, OdfFit
+from scipy.ndimage import map_coordinates
+
 from dipy.reconst.cache import Cache
 from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.odf import OdfFit, OdfModel
 
 
 class DiffusionSpectrumModel(OdfModel, Cache):

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1,19 +1,18 @@
 #!/usr/bin/python
 """ Classes and functions for fitting tensors """
-import warnings
 import functools
+import warnings
 
 import numpy as np
 import scipy.optimize as opt
 
-from dipy.data import get_sphere
-from dipy.core.gradients import gradient_table
 from dipy.core.geometry import vector_norm
-from dipy.reconst.vec_val_sum import vec_val_vect
+from dipy.core.gradients import gradient_table
 from dipy.core.onetime import auto_attr
+from dipy.data import get_sphere
 from dipy.reconst.base import ReconstModel
+from dipy.reconst.vec_val_sum import vec_val_vect
 from dipy.utils.volume import adjacency_calc
-
 
 MIN_POSITIVE_SIGNAL = 0.0001
 

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -1,18 +1,18 @@
 from warnings import warn
 
 import numpy as np
-
-from dipy.reconst.cache import Cache
-from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.csdeconv import csdeconv
-from dipy.reconst.shm import real_sh_descoteaux_from_index
+from scipy.optimize import leastsq
 from scipy.special import gamma, hyp1f1
+
 from dipy.core.geometry import cart2sphere
 from dipy.data import default_sphere
-from dipy.reconst.odf import OdfModel, OdfFit
-from scipy.optimize import leastsq
-from dipy.utils.optpkg import optional_package
+from dipy.reconst.cache import Cache
+from dipy.reconst.csdeconv import csdeconv
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.odf import OdfFit, OdfModel
+from dipy.reconst.shm import real_sh_descoteaux_from_index
 from dipy.utils.deprecator import deprecated_params
+from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -4,20 +4,22 @@ contamination """
 import warnings
 
 import numpy as np
-
 import scipy.optimize as opt
 
-from dipy.reconst.base import ReconstModel
-
-from dipy.reconst.dti import (TensorFit, design_matrix, decompose_tensor,
-                              _decompose_tensor_nan, from_lower_triangular,
-                              lower_triangular)
-from dipy.reconst.dki import _positive_evals
-
-from dipy.reconst.vec_val_sum import vec_val_vect
-from dipy.core.ndindex import ndindex
 from dipy.core.gradients import check_multi_b
+from dipy.core.ndindex import ndindex
+from dipy.reconst.base import ReconstModel
+from dipy.reconst.dki import _positive_evals
+from dipy.reconst.dti import (
+    TensorFit,
+    _decompose_tensor_nan,
+    decompose_tensor,
+    design_matrix,
+    from_lower_triangular,
+    lower_triangular,
+)
 from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.vec_val_sum import vec_val_vect
 
 
 def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -1,9 +1,11 @@
 """ Classes and functions for generalized q-sampling """
-import numpy as np
-from dipy.reconst.odf import OdfModel, OdfFit
-from dipy.reconst.cache import Cache
 import warnings
+
+import numpy as np
+
+from dipy.reconst.cache import Cache
 from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.odf import OdfFit, OdfModel
 
 
 class GeneralizedQSamplingModel(OdfModel, Cache):

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -2,7 +2,7 @@
 import warnings
 
 import numpy as np
-from scipy.optimize import least_squares, differential_evolution
+from scipy.optimize import differential_evolution, least_squares
 
 from dipy.reconst.base import ReconstModel
 from dipy.reconst.multi_voxel import multi_voxel_fit

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1,24 +1,24 @@
 import numpy as np
+from scipy.special import gamma, genlaguerre, hermite
 
-from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.base import ReconstModel, ReconstFit
+from dipy.reconst.base import ReconstFit, ReconstModel
 from dipy.reconst.cache import Cache
-from scipy.special import hermite, gamma, genlaguerre
+from dipy.reconst.multi_voxel import multi_voxel_fit
+
 try:  # preferred scipy >= 0.14, required scipy >= 1.0
-    from scipy.special import factorial as sfactorial
-    from scipy.special import factorial2
+    from scipy.special import factorial as sfactorial, factorial2
 except ImportError:
-    from scipy.misc import factorial as sfactorial
-    from scipy.misc import factorial2
+    from scipy.misc import factorial as sfactorial, factorial2
 from math import factorial as mfactorial
-from dipy.core.geometry import cart2sphere
-from dipy.reconst.shm import real_sh_descoteaux_from_index, sph_harm_ind_list
-import dipy.reconst.dti as dti
 from warnings import warn
+
+from dipy.core.geometry import cart2sphere
 from dipy.core.gradients import gradient_table
-from dipy.utils.optpkg import optional_package
 from dipy.core.optimize import Optimizer, PositiveDefiniteLeastSquares
 from dipy.data import load_sdp_constraints
+import dipy.reconst.dti as dti
+from dipy.reconst.shm import real_sh_descoteaux_from_index, sph_harm_ind_list
+from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -4,19 +4,22 @@ import warnings
 import numpy as np
 
 from dipy.core import geometry as geo
-from dipy.core.gradients import (GradientTable, gradient_table,
-                                 unique_bvals_tolerance, get_bval_indices)
+from dipy.core.gradients import (
+    GradientTable,
+    get_bval_indices,
+    gradient_table,
+    unique_bvals_tolerance,
+)
 from dipy.data import default_sphere
 from dipy.reconst import shm
 from dipy.reconst.csdeconv import response_from_mask_ssst
-from dipy.reconst.dti import (TensorModel, fractional_anisotropy,
-                              mean_diffusivity)
+from dipy.reconst.dti import TensorModel, fractional_anisotropy, mean_diffusivity
 from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.utils import _roi_in_volume, _mask_from_roi
+from dipy.reconst.utils import _mask_from_roi, _roi_in_volume
 from dipy.sims.voxel import single_tensor
 from dipy.utils.deprecator import deprecated_params
-
 from dipy.utils.optpkg import optional_package
+
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 
 SH_CONST = .5 / np.sqrt(np.pi)

--- a/dipy/reconst/msdki.py
+++ b/dipy/reconst/msdki.py
@@ -5,12 +5,11 @@ model """
 import numpy as np
 import scipy.optimize as opt
 
-from dipy.core.gradients import (check_multi_b, unique_bvals_magnitude,
-                                 round_bvals)
-from dipy.reconst.base import ReconstModel
-from dipy.reconst.dti import MIN_POSITIVE_SIGNAL
+from dipy.core.gradients import check_multi_b, round_bvals, unique_bvals_magnitude
 from dipy.core.ndindex import ndindex
 from dipy.core.onetime import auto_attr
+from dipy.reconst.base import ReconstModel
+from dipy.reconst.dti import MIN_POSITIVE_SIGNAL
 
 
 def mean_signal_bvalue(data, gtab, bmag=None):

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -4,8 +4,8 @@ from numpy.lib.stride_tricks import as_strided
 from tqdm import tqdm
 
 from dipy.core.ndindex import ndindex
-from dipy.reconst.quick_squash import quick_squash as _squash
 from dipy.reconst.base import ReconstFit
+from dipy.reconst.quick_squash import quick_squash as _squash
 
 
 def multi_voxel_fit(single_voxel_fit):

--- a/dipy/reconst/odf.py
+++ b/dipy/reconst/odf.py
@@ -1,5 +1,6 @@
-from dipy.reconst.base import ReconstModel, ReconstFit
 import numpy as np
+
+from dipy.reconst.base import ReconstFit, ReconstModel
 
 # Classes OdfModel and OdfFit are using API ReconstModel and ReconstFit from
 # .base

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1,22 +1,26 @@
-import numpy as np
-
-from dipy.reconst.cache import Cache
-from dipy.core.geometry import cart2sphere
-from dipy.reconst.multi_voxel import multi_voxel_fit
-from scipy.special import genlaguerre, gamma
-from dipy.core.gradients import gradient_table_from_gradient_strength_bvecs
-from scipy import special
 from warnings import warn
+
+import numpy as np
+from scipy import special
+from scipy.special import gamma, genlaguerre
+
+from dipy.core.geometry import cart2sphere
+from dipy.core.gradients import gradient_table_from_gradient_strength_bvecs
 from dipy.reconst import mapmri
+from dipy.reconst.cache import Cache
+from dipy.reconst.multi_voxel import multi_voxel_fit
+
 try:  # preferred scipy >= 0.14, required scipy >= 1.0
     from scipy.special import factorial, factorial2
 except ImportError:
     from scipy.misc import factorial, factorial2
-from scipy.optimize import fmin_l_bfgs_b
-from dipy.reconst.shm import real_sh_descoteaux_from_index
-import dipy.reconst.dti as dti
-from dipy.utils.optpkg import optional_package
 import random
+
+from scipy.optimize import fmin_l_bfgs_b
+
+import dipy.reconst.dti as dti
+from dipy.reconst.shm import real_sh_descoteaux_from_index
+from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")
 plt, have_plt, _ = optional_package("matplotlib.pyplot")

--- a/dipy/reconst/rumba.py
+++ b/dipy/reconst/rumba.py
@@ -5,16 +5,15 @@ import warnings
 import numpy as np
 
 from dipy.core.geometry import vec2vec_rotmat
-from dipy.core.gradients import gradient_table, unique_bvals_tolerance, \
-    get_bval_indices
+from dipy.core.gradients import get_bval_indices, gradient_table, unique_bvals_tolerance
 from dipy.core.onetime import auto_attr
 from dipy.core.sphere import Sphere
 from dipy.data import get_sphere
-from dipy.reconst.shm import lazy_index, normalize_data
-from dipy.reconst.odf import OdfModel, OdfFit
 from dipy.reconst.csdeconv import AxSymShResponse
+from dipy.reconst.odf import OdfFit, OdfModel
+from dipy.reconst.shm import lazy_index, normalize_data
 from dipy.segment.mask import bounding_box, crop
-from dipy.sims.voxel import single_tensor, all_tensor_evecs
+from dipy.sims.voxel import all_tensor_evecs, single_tensor
 
 # Machine precision for numerical stability in division
 _EPS = np.finfo(float).eps

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -15,26 +15,26 @@ This is an implementation of the sparse fascicle model described in
    Pestilli,  Brian A. Wandell (2014). Evaluating the accuracy of diffusion
    models at multiple b-values with cross-validation. ISMRM 2014.
 """
+from collections import OrderedDict
+import gc
 import warnings
 
 import numpy as np
-import gc
-from collections import OrderedDict
 
 try:
     from numpy import nanmean
 except ImportError:
     from scipy.stats import nanmean
 
-from dipy.utils.optpkg import optional_package
-from dipy.utils.multiproc import determine_num_processes
 import dipy.core.gradients as grad
-import dipy.core.optimize as opt
-import dipy.sims.voxel as sims
-import dipy.data as dpd
-from dipy.reconst.base import ReconstModel, ReconstFit
-from dipy.reconst.cache import Cache
 from dipy.core.onetime import auto_attr
+import dipy.core.optimize as opt
+import dipy.data as dpd
+from dipy.reconst.base import ReconstFit, ReconstModel
+from dipy.reconst.cache import Cache
+import dipy.sims.voxel as sims
+from dipy.utils.multiproc import determine_num_processes
+from dipy.utils.optpkg import optional_package
 
 joblib, has_joblib, _ = optional_package('joblib')
 sklearn, has_sklearn, _ = optional_package('sklearn')

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -26,18 +26,16 @@ where data is Y.T and sh_coef is x.T.
 """
 
 from warnings import warn
+
 import numpy as np
+from numpy.random import randint
 import scipy.special as sps
 
-from numpy.random import randint
-
-from dipy.utils.deprecator import deprecate_with_version
-from dipy.reconst.odf import OdfModel, OdfFit
 from dipy.core.geometry import cart2sphere
 from dipy.core.onetime import auto_attr
 from dipy.reconst.cache import Cache
-from dipy.utils.deprecator import deprecated_params
-
+from dipy.reconst.odf import OdfFit, OdfModel
+from dipy.utils.deprecator import deprecate_with_version, deprecated_params
 
 descoteaux07_legacy_msg = \
     "The legacy descoteaux07 SH basis uses absolute values for negative " \

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -1,15 +1,13 @@
-from warnings import warn
 from math import factorial
+from warnings import warn
 
 import numpy as np
+from scipy.special import gamma, genlaguerre, hyp2f1
 
-from scipy.special import genlaguerre, gamma, hyp2f1
-
+from dipy.core.geometry import cart2sphere
 from dipy.reconst.cache import Cache
 from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.shm import real_sh_descoteaux_from_index
-from dipy.core.geometry import cart2sphere
-
 from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")

--- a/dipy/reconst/tests/test_cache.py
+++ b/dipy/reconst/tests/test_cache.py
@@ -1,7 +1,7 @@
-from dipy.reconst.cache import Cache
-from dipy.core.sphere import Sphere
-
 from numpy.testing import assert_, assert_equal
+
+from dipy.core.sphere import Sphere
+from dipy.reconst.cache import Cache
 
 
 class DummyModel(Cache):

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -4,17 +4,17 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
-import dipy.reconst.cross_validation as xval
-import dipy.data as dpd
-import dipy.reconst.dti as dti
-import dipy.core.gradients as gt
-import dipy.sims.voxel as sims
-import dipy.reconst.csdeconv as csd
-import dipy.reconst.base as base
-from dipy.io.image import load_nifti_data
-from dipy.reconst.shm import descoteaux07_legacy_msg
-from dipy.testing.decorators import set_random_number_generator
 
+import dipy.core.gradients as gt
+import dipy.data as dpd
+from dipy.io.image import load_nifti_data
+import dipy.reconst.base as base
+import dipy.reconst.cross_validation as xval
+import dipy.reconst.csdeconv as csd
+import dipy.reconst.dti as dti
+from dipy.reconst.shm import descoteaux07_legacy_msg
+import dipy.sims.voxel as sims
+from dipy.testing.decorators import set_random_number_generator
 
 # We'll set these globally:
 fdata, fbval, fbvec = dpd.get_fnames('small_64D')

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -1,42 +1,54 @@
 import warnings
+
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import (assert_, assert_equal, assert_almost_equal,
-                           assert_array_almost_equal, assert_array_equal)
-from dipy.testing import assert_greater, assert_greater_equal
-from dipy.data import get_sphere, get_fnames, default_sphere, small_sphere
-from dipy.sims.voxel import (multi_tensor,
-                             single_tensor,
-                             multi_tensor_odf,
-                             all_tensor_evecs, single_tensor_odf)
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
+
 from dipy.core.gradients import gradient_table
-from dipy.core.sphere import Sphere, HemiSphere
+from dipy.core.sphere import HemiSphere, Sphere
 from dipy.core.sphere_stats import angular_similarity
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   ConstrainedSDTModel,
-                                   forward_sdeconv_mat,
-                                   odf_deconv,
-                                   odf_sh_to_sharp,
-                                   mask_for_response_ssst,
-                                   response_from_mask_ssst,
-                                   response_from_mask,
-                                   auto_response_ssst,
-                                   auto_response,
-                                   recursive_response)
+from dipy.data import default_sphere, get_fnames, get_sphere, small_sphere
 from dipy.direction.peaks import peak_directions
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.reconst.csdeconv import (
+    ConstrainedSDTModel,
+    ConstrainedSphericalDeconvModel,
+    auto_response,
+    auto_response_ssst,
+    forward_sdeconv_mat,
+    mask_for_response_ssst,
+    odf_deconv,
+    odf_sh_to_sharp,
+    recursive_response,
+    response_from_mask,
+    response_from_mask_ssst,
+)
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.reconst.shm import (
-    descoteaux07_legacy_msg,
     QballModel,
+    descoteaux07_legacy_msg,
+    lazy_index,
+    real_sh_descoteaux,
     sf_to_sh,
     sh_to_sf,
-    real_sh_descoteaux,
-    sph_harm_ind_list
+    sph_harm_ind_list,
 )
-from dipy.reconst.shm import lazy_index
-from dipy.utils.deprecator import ExpiredDeprecationError
-from dipy.io.gradients import read_bvals_bvecs
+from dipy.sims.voxel import (
+    all_tensor_evecs,
+    multi_tensor,
+    multi_tensor_odf,
+    single_tensor,
+    single_tensor_odf,
+)
+from dipy.testing import assert_greater, assert_greater_equal
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.deprecator import ExpiredDeprecationError
 
 
 def get_test_data():

--- a/dipy/reconst/tests/test_cti.py
+++ b/dipy/reconst/tests/test_cti.py
@@ -1,21 +1,28 @@
-import numpy as np
 import math
 
-from dipy.core.sphere import disperse_charges, HemiSphere
-from dipy.reconst.utils import cti_design_matrix as design_matrix
-from numpy.testing import (assert_array_almost_equal, assert_raises)
-from dipy.reconst.tests.test_qti import _anisotropic_DTD, _isotropic_DTD
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_raises
+
 from dipy.core.gradients import gradient_table
-import dipy.reconst.qti as qti
+from dipy.core.sphere import HemiSphere, disperse_charges
 import dipy.reconst.cti as cti
-from dipy.reconst.dti import (
-    decompose_tensor, mean_diffusivity)
-from dipy.reconst.cti import (split_cti_params, ls_fit_cti,
-                              multi_gaussian_k_from_c, from_qte_to_cti)
-from dipy.reconst.dki import (mean_kurtosis,
-                              axial_kurtosis, radial_kurtosis,
-                              mean_kurtosis_tensor,
-                              kurtosis_fractional_anisotropy)
+from dipy.reconst.cti import (
+    from_qte_to_cti,
+    ls_fit_cti,
+    multi_gaussian_k_from_c,
+    split_cti_params,
+)
+from dipy.reconst.dki import (
+    axial_kurtosis,
+    kurtosis_fractional_anisotropy,
+    mean_kurtosis,
+    mean_kurtosis_tensor,
+    radial_kurtosis,
+)
+from dipy.reconst.dti import decompose_tensor, mean_diffusivity
+import dipy.reconst.qti as qti
+from dipy.reconst.tests.test_qti import _anisotropic_DTD, _isotropic_DTD
+from dipy.reconst.utils import cti_design_matrix as design_matrix
 
 gtab1, gtab2, gtab, DTDs, S0 = None, None, None, None, None
 

--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -1,26 +1,35 @@
 """ Testing DKI """
 
-import numpy as np
 import random
 
-import dipy.reconst.dki as dki
-import dipy.reconst.dti as dti
-from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_almost_equal, assert_raises)
-from dipy.sims.voxel import multi_tensor_dki
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames
-from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
-from dipy.reconst.dki import (mean_kurtosis, carlson_rf,  carlson_rd,
-                              axial_kurtosis, radial_kurtosis,
-                              mean_kurtosis_tensor,
-                              _positive_evals, lower_triangular,
-                              kurtosis_fractional_anisotropy)
+import numpy as np
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_raises,
+)
 
-from dipy.core.sphere import Sphere
-from dipy.data import default_sphere
 from dipy.core.geometry import sphere2cart
+from dipy.core.gradients import gradient_table
+from dipy.core.sphere import Sphere
+from dipy.data import default_sphere, get_fnames
+from dipy.io.gradients import read_bvals_bvecs
+import dipy.reconst.dki as dki
+from dipy.reconst.dki import (
+    _positive_evals,
+    axial_kurtosis,
+    carlson_rd,
+    carlson_rf,
+    kurtosis_fractional_anisotropy,
+    lower_triangular,
+    mean_kurtosis,
+    mean_kurtosis_tensor,
+    radial_kurtosis,
+)
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import decompose_tensor, from_lower_triangular
+from dipy.sims.voxel import multi_tensor_dki
 from dipy.utils.optpkg import optional_package
 from dipy.utils.tripwire import TripWireError
 

--- a/dipy/reconst/tests/test_dki_micro.py
+++ b/dipy/reconst/tests/test_dki_micro.py
@@ -1,17 +1,22 @@
 """ Testing DKI microstructure """
 
-import numpy as np
 import random
-import dipy.reconst.dki_micro as dki_micro
-from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
-                           assert_, assert_raises, assert_allclose)
-from dipy.sims.voxel import (multi_tensor_dki, _check_directions, multi_tensor)
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames
-from dipy.reconst.dti import (eig_from_lo_tri)
 
-from dipy.data import default_sphere, get_sphere
+import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_raises,
+)
+
+from dipy.core.gradients import gradient_table
+from dipy.data import default_sphere, get_fnames, get_sphere
+from dipy.io.gradients import read_bvals_bvecs
+import dipy.reconst.dki_micro as dki_micro
+from dipy.reconst.dti import eig_from_lo_tri
+from dipy.sims.voxel import _check_directions, multi_tensor, multi_tensor_dki
 
 gtab_2s, DWIsim, DWIsim_all_taylor = None, None, None
 FIE, RDI, ADI, ADE, Tor, RDE = None, None, None, None, None, None

--- a/dipy/reconst/tests/test_dsi.py
+++ b/dipy/reconst/tests/test_dsi.py
@@ -1,15 +1,14 @@
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_raises)
-from dipy.data import get_fnames, dsi_voxels, default_sphere
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+
+from dipy.core.gradients import gradient_table
+from dipy.core.sphere_stats import angular_similarity
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.data import default_sphere, dsi_voxels, get_fnames
+from dipy.direction.peaks import peak_directions
 from dipy.reconst.dsi import DiffusionSpectrumModel
 from dipy.reconst.odf import gfa
-from dipy.direction.peaks import peak_directions
 from dipy.sims.voxel import sticks_and_ball
-from dipy.core.gradients import gradient_table
-from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.sphere_stats import angular_similarity
 
 
 def test_dsi():

--- a/dipy/reconst/tests/test_dsi_deconv.py
+++ b/dipy/reconst/tests/test_dsi_deconv.py
@@ -1,16 +1,15 @@
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_raises)
-from dipy.data import get_fnames, dsi_deconv_voxels, default_sphere
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+
+from dipy.core.gradients import gradient_table
+from dipy.core.sphere_stats import angular_similarity
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.data import default_sphere, dsi_deconv_voxels, get_fnames
+from dipy.direction.peaks import peak_directions
 from dipy.reconst.dsi import DiffusionSpectrumDeconvModel
 from dipy.reconst.odf import gfa
-from dipy.direction.peaks import peak_directions
-from dipy.sims.voxel import sticks_and_ball
-from dipy.core.gradients import gradient_table
-from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
+from dipy.sims.voxel import sticks_and_ball
 
 
 def test_dsi():

--- a/dipy/reconst/tests/test_dsi_metrics.py
+++ b/dipy/reconst/tests/test_dsi_metrics.py
@@ -1,9 +1,10 @@
 import numpy as np
-from dipy.reconst.dsi import DiffusionSpectrumModel
-from dipy.data import get_fnames
-from dipy.core.gradients import gradient_table
 from numpy.testing import assert_almost_equal
-from dipy.sims.voxel import sticks_and_ball, multi_tensor
+
+from dipy.core.gradients import gradient_table
+from dipy.data import get_fnames
+from dipy.reconst.dsi import DiffusionSpectrumModel
+from dipy.sims.voxel import multi_tensor, sticks_and_ball
 
 
 def test_dsi_metrics():

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -4,28 +4,35 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
-
 import scipy.optimize as opt
 
-import dipy.reconst.dti as dti
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.reconst.dti import (ols_resort_msg, axial_diffusivity, color_fa,
-                              fractional_anisotropy, from_lower_triangular,
-                              geodesic_anisotropy, lower_triangular,
-                              mean_diffusivity, radial_diffusivity,
-                              TensorModel, trace, linearity, planarity,
-                              sphericity, decompose_tensor,
-                              _decompose_tensor_nan, mode)
-
-from dipy.io.image import load_nifti_data
-from dipy.data import get_fnames, dsi_voxels, get_sphere
-
-from dipy.core.subdivide_octahedron import create_unit_sphere
 import dipy.core.gradients as grad
 import dipy.core.sphere as dps
-
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.data import dsi_voxels, get_fnames, get_sphere
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti_data
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import (
+    TensorModel,
+    _decompose_tensor_nan,
+    axial_diffusivity,
+    color_fa,
+    decompose_tensor,
+    fractional_anisotropy,
+    from_lower_triangular,
+    geodesic_anisotropy,
+    linearity,
+    lower_triangular,
+    mean_diffusivity,
+    mode,
+    ols_resort_msg,
+    planarity,
+    radial_diffusivity,
+    sphericity,
+    trace,
+)
 from dipy.sims.voxel import single_tensor
-
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -3,16 +3,15 @@
 import warnings
 
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 
-from dipy.data import get_sphere, default_sphere, get_3shell_gtab
+from dipy.core.sphere_stats import angular_similarity
+from dipy.data import default_sphere, get_3shell_gtab, get_sphere
+from dipy.direction.peaks import peak_directions
 from dipy.reconst.forecast import ForecastModel
 from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.sims.voxel import multi_tensor
-
-from numpy.testing import assert_almost_equal, assert_equal
-import pytest
-from dipy.direction.peaks import peak_directions
-from dipy.core.sphere_stats import angular_similarity
 from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -1,21 +1,31 @@
 """ Testing Free Water Elimination Model """
 
 import numpy as np
-import dipy.reconst.dti as dti
-import dipy.reconst.fwdti as fwdti
-from dipy.reconst.fwdti import fwdti_prediction
-from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
-                           assert_raises)
-from dipy.reconst.dti import (from_lower_triangular, decompose_tensor,
-                              fractional_anisotropy)
-from dipy.reconst.fwdti import (lower_triangular_to_cholesky,
-                                cholesky_to_lower_triangular,
-                                nls_fit_tensor, wls_fit_tensor)
-from dipy.sims.voxel import (multi_tensor, single_tensor,
-                             all_tensor_evecs, multi_tensor_dki)
-from dipy.io.gradients import read_bvals_bvecs
+from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_raises
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
+from dipy.io.gradients import read_bvals_bvecs
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import (
+    decompose_tensor,
+    fractional_anisotropy,
+    from_lower_triangular,
+)
+import dipy.reconst.fwdti as fwdti
+from dipy.reconst.fwdti import (
+    cholesky_to_lower_triangular,
+    fwdti_prediction,
+    lower_triangular_to_cholesky,
+    nls_fit_tensor,
+    wls_fit_tensor,
+)
+from dipy.sims.voxel import (
+    all_tensor_evecs,
+    multi_tensor,
+    multi_tensor_dki,
+    single_tensor,
+)
 
 
 def setup_module():

--- a/dipy/reconst/tests/test_gqi.py
+++ b/dipy/reconst/tests/test_gqi.py
@@ -1,16 +1,15 @@
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal
 
-from dipy.data import get_fnames, dsi_voxels, get_sphere, default_sphere
 from dipy.core.gradients import gradient_table
-from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.data import default_sphere, dsi_voxels, get_fnames, get_sphere
+from dipy.direction.peaks import peak_directions
 from dipy.reconst.gqi import GeneralizedQSamplingModel
+from dipy.reconst.odf import gfa
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
 from dipy.sims.voxel import sticks_and_ball
-from dipy.reconst.odf import gfa
-from dipy.direction.peaks import peak_directions
-
-from numpy.testing import assert_equal, assert_almost_equal
 
 
 def test_gqi():

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -12,17 +12,22 @@ References
        MR imaging." Radiology 265.3 (2012): 874-881.
 """
 import warnings
+
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_array_less, assert_,
-                           assert_equal)
-from dipy.testing import assert_greater_equal
+from numpy.testing import (
+    assert_,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_array_less,
+    assert_equal,
+    assert_raises,
+)
 import pytest
 
-from dipy.reconst.ivim import ivim_prediction, IvimModel
-from dipy.core.gradients import gradient_table, generate_bvecs
+from dipy.core.gradients import generate_bvecs, gradient_table
+from dipy.reconst.ivim import IvimModel, ivim_prediction
 from dipy.sims.voxel import multi_tensor
-
+from dipy.testing import assert_greater_equal
 from dipy.utils.optpkg import optional_package
 
 cvxpy, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -1,27 +1,36 @@
+from math import factorial
 import platform
 import time
-from math import factorial
-
-from scipy.special import gamma
-import scipy.integrate as integrate
 import warnings
+
 import numpy as np
-from numpy.testing import (assert_almost_equal,
-                           assert_array_almost_equal,
-                           assert_equal, assert_,
-                           assert_raises)
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+)
 import pytest
+import scipy.integrate as integrate
+from scipy.special import gamma
+
 from dipy.core.sphere_stats import angular_similarity
 from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.data import get_gtab_taiwan_dsi, default_sphere
+from dipy.data import default_sphere, get_gtab_taiwan_dsi
 from dipy.direction.peaks import peak_directions
-from dipy.reconst.mapmri import MapmriModel, mapmri_index_matrix
 from dipy.reconst import dti, mapmri
+from dipy.reconst.mapmri import MapmriModel, mapmri_index_matrix
 from dipy.reconst.odf import gfa
+from dipy.reconst.shm import descoteaux07_legacy_msg, sh_to_sf
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
-from dipy.reconst.shm import sh_to_sf, descoteaux07_legacy_msg
-from dipy.sims.voxel import (multi_tensor, multi_tensor_pdf, add_noise,
-                             single_tensor, cylinders_and_ball_soderman)
+from dipy.sims.voxel import (
+    add_noise,
+    cylinders_and_ball_soderman,
+    multi_tensor,
+    multi_tensor_pdf,
+    single_tensor,
+)
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -1,19 +1,21 @@
 import warnings
 
-from dipy.reconst.mcsd import (mask_for_response_msmt,
-                               response_from_mask_msmt,
-                               auto_response_msmt)
-from dipy.reconst.mcsd import MultiShellDeconvModel, multi_shell_fiber_response
 import numpy as np
 import numpy.testing as npt
 import pytest
 
-from dipy.sims.voxel import single_tensor, multi_tensor, add_noise
-from dipy.reconst import shm
-from dipy.data import default_sphere, get_3shell_gtab
 from dipy.core.gradients import GradientTable
+from dipy.data import default_sphere, get_3shell_gtab
+from dipy.reconst import shm
+from dipy.reconst.mcsd import (
+    MultiShellDeconvModel,
+    auto_response_msmt,
+    mask_for_response_msmt,
+    multi_shell_fiber_response,
+    response_from_mask_msmt,
+)
+from dipy.sims.voxel import add_noise, multi_tensor, single_tensor
 from dipy.testing.decorators import set_random_number_generator
-
 from dipy.utils.optpkg import optional_package
 
 cvx, have_cvxpy, _ = optional_package("cvxpy", min_version="1.4.1")

--- a/dipy/reconst/tests/test_msdki.py
+++ b/dipy/reconst/tests/test_msdki.py
@@ -1,16 +1,21 @@
 """ Testing Mean Signal DKI (MSDKI) """
 
-import numpy as np
 import random
-from numpy.testing import (assert_array_almost_equal, assert_raises,
-                           assert_almost_equal, assert_)
-from dipy.sims.voxel import (single_tensor, multi_tensor_dki)
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import (gradient_table, unique_bvals_magnitude,
-                                 round_bvals)
+
+import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_raises,
+)
+
+from dipy.core.gradients import gradient_table, round_bvals, unique_bvals_magnitude
 from dipy.data import get_fnames
+from dipy.io.gradients import read_bvals_bvecs
 import dipy.reconst.msdki as msdki
-from dipy.reconst.msdki import (msk_from_awf, awf_from_msk)
+from dipy.reconst.msdki import awf_from_msk, msk_from_awf
+from dipy.sims.voxel import multi_tensor_dki, single_tensor
 
 gtab_3s, signal_sph, msignal_sph, DWI, MDWI = None, None, None, None, None
 gtab, params_single, params_multi, MKgt_multi = None, None, None, None

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -3,8 +3,8 @@ from functools import reduce
 import numpy as np
 import numpy.testing as npt
 
-from dipy.reconst.multi_voxel import _squash, multi_voxel_fit, CallableArray
 from dipy.core.sphere import unit_icosahedron
+from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/reconst/tests/test_odf.py
+++ b/dipy/reconst/tests/test_odf.py
@@ -1,12 +1,11 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_
-from dipy.reconst.odf import (OdfFit, OdfModel, minmax_normalize, gfa)
+from numpy.testing import assert_, assert_almost_equal, assert_equal
 
+from dipy.core.gradients import GradientTable, gradient_table
 from dipy.core.subdivide_octahedron import create_unit_hemisphere
-from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 from dipy.data import get_sphere
-from dipy.core.gradients import gradient_table, GradientTable
-
+from dipy.reconst.odf import OdfFit, OdfModel, gfa, minmax_normalize
+from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 
 _sphere = create_unit_hemisphere(4)
 _odf = (_sphere.vertices * [1, 2, 3]).sum(-1)

--- a/dipy/reconst/tests/test_peak_finding.py
+++ b/dipy/reconst/tests/test_peak_finding.py
@@ -1,10 +1,14 @@
 
 import numpy as np
 import numpy.testing as npt
-from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
-                                   search_descending)
+
+from dipy.core.sphere import HemiSphere, unique_edges
 from dipy.data import default_sphere
-from dipy.core.sphere import unique_edges, HemiSphere
+from dipy.reconst.recspeed import (
+    local_maxima,
+    remove_similar_vertices,
+    search_descending,
+)
 
 
 def test_local_maxima():

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -1,19 +1,21 @@
 import warnings
 
 import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+import pytest
 import scipy.integrate as integrate
 
-from numpy.testing import (assert_,
-                           assert_almost_equal,
-                           assert_array_almost_equal,
-                           assert_equal,
-                           assert_raises,)
-import pytest
 from dipy.core.gradients import gradient_table_from_qvals_bvecs
 from dipy.data import get_gtab_taiwan_dsi, get_sphere
-from dipy.reconst import qtdmri, mapmri
+from dipy.reconst import mapmri, qtdmri
 from dipy.reconst.shm import descoteaux07_legacy_msg
-from dipy.sims.voxel import multi_tensor, add_noise
+from dipy.sims.voxel import add_noise, multi_tensor
 from dipy.testing.decorators import set_random_number_generator
 
 needs_cvxpy = pytest.mark.skipif(not qtdmri.have_cvxpy,

--- a/dipy/reconst/tests/test_qti.py
+++ b/dipy/reconst/tests/test_qti.py
@@ -3,11 +3,11 @@
 import numpy as np
 import numpy.testing as npt
 
-import dipy.reconst.qti as qti
 from dipy.core.gradients import gradient_table
-from dipy.sims.voxel import vec2vec_rotmat
-from dipy.core.sphere import disperse_charges, HemiSphere
+from dipy.core.sphere import HemiSphere, disperse_charges
 from dipy.reconst.dti import fractional_anisotropy
+import dipy.reconst.qti as qti
+from dipy.sims.voxel import vec2vec_rotmat
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 

--- a/dipy/reconst/tests/test_reco_utils.py
+++ b/dipy/reconst/tests/test_reco_utils.py
@@ -1,11 +1,9 @@
 """Testing reconstruction utilities."""
 
 import numpy as np
-
-from dipy.reconst.recspeed import (adj_to_countarrs,
-                                   argmax_from_countarrs)
-
 from numpy.testing import assert_array_equal, assert_equal
+
+from dipy.reconst.recspeed import adj_to_countarrs, argmax_from_countarrs
 
 
 def test_adj_countarrs():

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -1,24 +1,25 @@
 import warnings
 
 import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
-from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_array_equal,
-                           assert_allclose,
-                           assert_raises,)
-from numpy.testing import assert_
-
-from dipy.reconst.rumba import RumbaSDModel, generate_kernel
-from dipy.reconst.csdeconv import AxSymShResponse
-from dipy.data import get_fnames, dsi_voxels, default_sphere, get_sphere
-from dipy.core.gradients import gradient_table, unique_bvals_tolerance
 from dipy.core.geometry import cart2sphere
+from dipy.core.gradients import gradient_table, unique_bvals_tolerance
 from dipy.core.sphere_stats import angular_similarity
-from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
-from dipy.sims.voxel import sticks_and_ball, multi_tensor, single_tensor
+from dipy.data import default_sphere, dsi_voxels, get_fnames, get_sphere
 from dipy.direction.peaks import peak_directions
+from dipy.reconst.csdeconv import AxSymShResponse
+from dipy.reconst.rumba import RumbaSDModel, generate_kernel
 from dipy.reconst.shm import descoteaux07_legacy_msg
+from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
+from dipy.sims.voxel import multi_tensor, single_tensor, sticks_and_ball
 
 
 def test_rumba():

--- a/dipy/reconst/tests/test_sfm.py
+++ b/dipy/reconst/tests/test_sfm.py
@@ -1,15 +1,17 @@
 import warnings
+
 import numpy as np
 import numpy.testing as npt
 import pytest
-import dipy.reconst.sfm as sfm
-import dipy.data as dpd
+
 import dipy.core.gradients as grad
-import dipy.sims.voxel as sims
 import dipy.core.optimize as opt
-import dipy.reconst.cross_validation as xval
+import dipy.data as dpd
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
+import dipy.reconst.cross_validation as xval
+import dipy.reconst.sfm as sfm
+import dipy.sims.voxel as sims
 from dipy.utils.optpkg import optional_package
 
 warnings.filterwarnings('ignore')

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -1,40 +1,59 @@
 """Test spherical harmonic models and the tools associated with those models.
 """
 import warnings
+
 import numpy as np
 import numpy.linalg as npl
 import numpy.testing as npt
-
-from dipy.testing import assert_true
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_equal, assert_raises,)
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 from scipy.special import sph_harm as sph_harm_sp
 
-from dipy.core.sphere import hemi_icosahedron, Sphere
 from dipy.core.gradients import gradient_table
 from dipy.core.interpolation import NearestNeighborInterpolator
-from dipy.sims.voxel import single_tensor
-from dipy.direction.peaks import peak_directions
-from dipy.reconst.shm import sf_to_sh, sh_to_sf
-from dipy.sims.voxel import multi_tensor_odf
+from dipy.core.sphere import Sphere, hemi_icosahedron
 from dipy.data import mrtrix_spherical_functions
+from dipy.direction.peaks import peak_directions
 from dipy.reconst import odf
-
-
-from dipy.reconst.shm import (real_sh_descoteaux_from_index, real_sym_sh_basis,
-                              real_sym_sh_mrtrix, real_sh_descoteaux,
-                              real_sh_tournier, sph_harm_ind_list,
-                              order_from_ncoef, OpdtModel,
-                              normalize_data, hat, lcr_matrix,
-                              smooth_pinv, bootstrap_data_array,
-                              bootstrap_data_voxel, ResidualBootstrapWrapper,
-                              CsaOdfModel, QballModel, SphHarmFit,
-                              spherical_harmonics, anisotropic_power,
-                              calculate_max_order, sh_to_sf_matrix, gen_dirac,
-                              convert_sh_to_full_basis, convert_sh_from_legacy,
-                              convert_sh_to_legacy,
-                              convert_sh_descoteaux_tournier,
-                              descoteaux07_legacy_msg, tournier07_legacy_msg)
+from dipy.reconst.shm import (
+    CsaOdfModel,
+    OpdtModel,
+    QballModel,
+    ResidualBootstrapWrapper,
+    SphHarmFit,
+    anisotropic_power,
+    bootstrap_data_array,
+    bootstrap_data_voxel,
+    calculate_max_order,
+    convert_sh_descoteaux_tournier,
+    convert_sh_from_legacy,
+    convert_sh_to_full_basis,
+    convert_sh_to_legacy,
+    descoteaux07_legacy_msg,
+    gen_dirac,
+    hat,
+    lcr_matrix,
+    normalize_data,
+    order_from_ncoef,
+    real_sh_descoteaux,
+    real_sh_descoteaux_from_index,
+    real_sh_tournier,
+    real_sym_sh_basis,
+    real_sym_sh_mrtrix,
+    sf_to_sh,
+    sh_to_sf,
+    sh_to_sf_matrix,
+    smooth_pinv,
+    sph_harm_ind_list,
+    spherical_harmonics,
+    tournier07_legacy_msg,
+)
+from dipy.sims.voxel import multi_tensor_odf, single_tensor
+from dipy.testing import assert_true
 
 
 def test_order_from_ncoeff():

--- a/dipy/reconst/tests/test_shore.py
+++ b/dipy/reconst/tests/test_shore.py
@@ -1,12 +1,11 @@
 # Tests for shore fitting
-import warnings
 from math import factorial
+import warnings
 
 import numpy as np
 import numpy.testing as npt
-
-from scipy.special import genlaguerre, gamma
 import pytest
+from scipy.special import gamma, genlaguerre
 
 from dipy.data import get_gtab_taiwan_dsi
 from dipy.reconst.shm import descoteaux07_legacy_msg

--- a/dipy/reconst/tests/test_shore_metrics.py
+++ b/dipy/reconst/tests/test_shore_metrics.py
@@ -6,12 +6,13 @@ from scipy.special import genlaguerre
 
 from dipy.data import get_gtab_taiwan_dsi, get_sphere
 from dipy.reconst.shm import descoteaux07_legacy_msg
-from dipy.reconst.shore import (ShoreModel,
-                                shore_matrix,
-                                shore_indices,
-                                shore_order)
-from dipy.sims.voxel import (multi_tensor, multi_tensor_rtop,
-                             multi_tensor_msd, multi_tensor_pdf)
+from dipy.reconst.shore import ShoreModel, shore_indices, shore_matrix, shore_order
+from dipy.sims.voxel import (
+    multi_tensor,
+    multi_tensor_msd,
+    multi_tensor_pdf,
+    multi_tensor_rtop,
+)
 
 
 def test_shore_metrics():

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -3,15 +3,15 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 
-from dipy.data import default_sphere, get_isbi2013_2shell_gtab, get_3shell_gtab
-from dipy.reconst.shore import ShoreModel, shore_matrix
-from dipy.reconst.shm import sh_to_sf, descoteaux07_legacy_msg
+from dipy.core.sphere_stats import angular_similarity
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.data import default_sphere, get_3shell_gtab, get_isbi2013_2shell_gtab
 from dipy.direction.peaks import peak_directions
 from dipy.reconst.odf import gfa
-from dipy.sims.voxel import sticks_and_ball
-from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.sphere_stats import angular_similarity
+from dipy.reconst.shm import descoteaux07_legacy_msg, sh_to_sf
+from dipy.reconst.shore import ShoreModel, shore_matrix
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
+from dipy.sims.voxel import sticks_and_ball
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/reconst/tests/test_utils.py
+++ b/dipy/reconst/tests/test_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
-from dipy.reconst.utils import _roi_in_volume, _mask_from_roi, convert_tensors
+
+from dipy.reconst.utils import _mask_from_roi, _roi_in_volume, convert_tensors
 
 
 def test_roi_in_volume():

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -1,20 +1,25 @@
-from time import time
 from itertools import chain
 import logging
+from time import time
 
-import numpy as np
-from dipy.tracking.streamline import (set_number_of_points, nbytes,
-                                      select_random_set_of_streamlines)
-from dipy.segment.clustering import qbx_and_merge
-from dipy.tracking.distances import (bundles_distances_mdf,
-                                     bundles_distances_mam)
-from dipy.align.streamlinear import (StreamlineLinearRegistration,
-                                     BundleMinDistanceMetric,
-                                     BundleSumDistanceMatrixMetric,
-                                     BundleMinDistanceAsymmetricMetric)
-
-from dipy.tracking.streamline import Streamlines, length
 from nibabel.affines import apply_affine
+import numpy as np
+
+from dipy.align.streamlinear import (
+    BundleMinDistanceAsymmetricMetric,
+    BundleMinDistanceMetric,
+    BundleSumDistanceMatrixMetric,
+    StreamlineLinearRegistration,
+)
+from dipy.segment.clustering import qbx_and_merge
+from dipy.tracking.distances import bundles_distances_mam, bundles_distances_mdf
+from dipy.tracking.streamline import (
+    Streamlines,
+    length,
+    nbytes,
+    select_random_set_of_streamlines,
+    set_number_of_points,
+)
 
 
 def check_range(streamline, gt, lt):

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -1,15 +1,17 @@
-import operator
-import numpy as np
-from time import time
 from abc import ABCMeta, abstractmethod
 import logging
+import operator
+from time import time
+
+import numpy as np
 
 from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metricspeed import (
-    AveragePointwiseEuclideanMetric, Metric, MinimumAverageDirectFlipMetric,
+    AveragePointwiseEuclideanMetric,
+    Metric,
+    MinimumAverageDirectFlipMetric,
 )
-from dipy.tracking.streamline import set_number_of_points, nbytes
-
+from dipy.tracking.streamline import nbytes, set_number_of_points
 
 logger = logging.getLogger(__name__)
 

--- a/dipy/segment/fss.py
+++ b/dipy/segment/fss.py
@@ -1,11 +1,12 @@
 import warnings
+
 import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.spatial import cKDTree
 
-from dipy.tracking.streamline import set_number_of_points
-from dipy.segment.metric import mean_euclidean_distance
 from dipy.io.stateful_tractogram import StatefulTractogram
+from dipy.segment.metric import mean_euclidean_distance
+from dipy.tracking.streamline import set_number_of_points
 
 
 class FastStreamlineSearch:

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -1,10 +1,10 @@
 from warnings import warn
 
 import numpy as np
-
-from dipy.reconst.dti import fractional_anisotropy, color_fa
-
 from scipy.ndimage import median_filter
+
+from dipy.reconst.dti import color_fa, fractional_anisotropy
+
 try:
     from skimage.filters import threshold_otsu as otsu
 except Exception:

--- a/dipy/segment/metric.py
+++ b/dipy/segment/metric.py
@@ -4,11 +4,14 @@ __all__ = ["MinimumAverageDirectFlipMetric", "Metric", "CosineMetric",
 
 import numpy as np
 
-from dipy.segment.metricspeed import (SumPointwiseEuclideanMetric,
-                                      MinimumAverageDirectFlipMetric,
-                                      AveragePointwiseEuclideanMetric,
-                                      CosineMetric, Metric,
-                                      dist)
+from dipy.segment.metricspeed import (
+    AveragePointwiseEuclideanMetric,
+    CosineMetric,
+    Metric,
+    MinimumAverageDirectFlipMetric,
+    SumPointwiseEuclideanMetric,
+    dist,
+)
 
 # Creates aliases
 EuclideanMetric = SumPointwiseEuclideanMetric

--- a/dipy/segment/tests/test_adjustment.py
+++ b/dipy/segment/tests/test_adjustment.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numpy import zeros
-from dipy.segment.threshold import upper_bound_by_percent, upper_bound_by_rate
 from numpy.testing import assert_equal
+
+from dipy.segment.threshold import upper_bound_by_percent, upper_bound_by_rate
 
 
 def test_adjustment():

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,17 +1,17 @@
 import sys
-import pytest
 import warnings
 
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 from dipy.segment.bundles import RecoBundles
-from dipy.tracking.distances import bundles_distances_mam
-from dipy.tracking.streamline import Streamlines
 from dipy.segment.clustering import qbx_and_merge
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.distances import bundles_distances_mam
+from dipy.tracking.streamline import Streamlines
 
 is_big_endian = 'big' in sys.byteorder.lower()
 

--- a/dipy/segment/tests/test_clustering.py
+++ b/dipy/segment/tests/test_clustering.py
@@ -2,15 +2,17 @@ import copy
 import itertools
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_raises, assert_equal
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
-from dipy.segment.clustering import Cluster, ClusterCentroid
-from dipy.segment.clustering import ClusterMap, ClusterMapCentroid
-from dipy.segment.clustering import Clustering
-
-from dipy.testing import assert_true, assert_false, assert_arrays_equal
+from dipy.segment.clustering import (
+    Cluster,
+    ClusterCentroid,
+    ClusterMap,
+    ClusterMapCentroid,
+    Clustering,
+)
+from dipy.testing import assert_arrays_equal, assert_false, assert_true
 from dipy.testing.decorators import set_random_number_generator
-
 
 features_shape = (1, 10)
 dtype = "float32"

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -1,16 +1,19 @@
 import sys
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_equal,)
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
 import dipy.segment.featurespeed as dipysfeature
+from dipy.segment.featurespeed import extract
 import dipy.segment.metric as dipymetric
 import dipy.segment.metricspeed as dipysmetric
-from dipy.segment.featurespeed import extract
-from dipy.testing import assert_true, assert_false
+from dipy.testing import assert_false, assert_true
 from dipy.testing.decorators import set_random_number_generator
-
 
 dtype = "float32"
 rng = np.random.default_rng()

--- a/dipy/segment/tests/test_fss.py
+++ b/dipy/segment/tests/test_fss.py
@@ -1,17 +1,20 @@
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_raises
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
-from dipy.segment.fss import (FastStreamlineSearch,
-                              nearest_from_matrix_row,
-                              nearest_from_matrix_col)
+from dipy.segment.fss import (
+    FastStreamlineSearch,
+    nearest_from_matrix_col,
+    nearest_from_matrix_row,
+)
 from dipy.segment.metric import mean_euclidean_distance
-
-from dipy.testing import (assert_arrays_equal,
-                          assert_greater,
-                          assert_greater_equal,
-                          assert_true)
-from numpy.testing import assert_almost_equal, assert_raises
+from dipy.testing import (
+    assert_arrays_equal,
+    assert_greater,
+    assert_greater_equal,
+    assert_true,
+)
 
 
 def setup_module():

--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -1,15 +1,19 @@
 import warnings
 
 import numpy as np
-from scipy.ndimage import generate_binary_structure, binary_dilation
-from scipy.ndimage import median_filter
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+from scipy.ndimage import binary_dilation, generate_binary_structure, median_filter
 
-from dipy.segment.mask import (otsu, bounding_box, crop, applymask,
-                               multi_median, median_otsu)
-
-from numpy.testing import assert_equal, assert_almost_equal, assert_raises
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti_data
+from dipy.segment.mask import (
+    applymask,
+    bounding_box,
+    crop,
+    median_otsu,
+    multi_median,
+    otsu,
+)
 
 
 def test_mask():

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -1,14 +1,22 @@
 import itertools
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_raises,
-                           assert_almost_equal, assert_equal)
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
+)
 
 import dipy.segment.featurespeed as dipysfeature
 import dipy.segment.metric as dipymetric
 import dipy.segment.metricspeed as dipysmetric
-from dipy.testing import (assert_true, assert_false,
-                          assert_greater_equal, assert_less_equal)
+from dipy.testing import (
+    assert_false,
+    assert_greater_equal,
+    assert_less_equal,
+    assert_true,
+)
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -1,10 +1,10 @@
 import numpy as np
 import numpy.testing as npt
+
 from dipy.data import get_fnames
+from dipy.segment.mrf import ConstantObservationModel, IteratedConditionalModes
+from dipy.segment.tissue import TissueClassifierHMRF
 from dipy.sims.voxel import add_noise
-from dipy.segment.mrf import (ConstantObservationModel,
-                              IteratedConditionalModes)
-from dipy.segment.tissue import (TissueClassifierHMRF)
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -3,14 +3,14 @@ import itertools
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
-from dipy.segment.clustering import QuickBundlesX, QuickBundles, qbx_and_merge
+from dipy.segment.clustering import QuickBundles, QuickBundlesX, qbx_and_merge
 from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metricspeed import (
-    AveragePointwiseEuclideanMetric, MinimumAverageDirectFlipMetric,
+    AveragePointwiseEuclideanMetric,
+    MinimumAverageDirectFlipMetric,
 )
-from dipy.tracking.streamline import set_number_of_points
-from dipy.tracking.streamline import Streamlines
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.streamline import Streamlines, set_number_of_points
 
 
 def straight_bundle(nb_streamlines=1, nb_pts=30, step_size=1,

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -1,18 +1,16 @@
-import numpy as np
 import itertools
 
+import numpy as np
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
-from dipy.testing.memory import get_type_refcount
-from dipy.testing import assert_arrays_equal
 
 from dipy.segment.clustering import QuickBundles
-
+from dipy.segment.clustering_algorithms import quickbundles
 import dipy.segment.featurespeed as dipysfeature
 import dipy.segment.metricspeed as dipysmetric
-from dipy.segment.clustering_algorithms import quickbundles
-import dipy.tracking.streamline as streamline_utils
+from dipy.testing import assert_arrays_equal
 from dipy.testing.decorators import set_random_number_generator
-
+from dipy.testing.memory import get_type_refcount
+import dipy.tracking.streamline as streamline_utils
 
 dtype = "float32"
 threshold = 7

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -1,7 +1,7 @@
 import numpy as np
+
+from dipy.segment.mrf import ConstantObservationModel, IteratedConditionalModes
 from dipy.sims.voxel import add_noise
-from dipy.segment.mrf import (ConstantObservationModel,
-                              IteratedConditionalModes)
 
 
 class TissueClassifierHMRF:

--- a/dipy/sims/phantom.py
+++ b/dipy/sims/phantom.py
@@ -1,11 +1,12 @@
 import numpy as np
-# import scipy.stats as stats
 
-from dipy.sims.voxel import single_tensor, diffusion_evals
-import dipy.sims.voxel as vox
 from dipy.core.geometry import vec2vec_rotmat
-from dipy.data import get_fnames
 from dipy.core.gradients import gradient_table
+from dipy.data import get_fnames
+import dipy.sims.voxel as vox
+
+# import scipy.stats as stats
+from dipy.sims.voxel import diffusion_evals, single_tensor
 
 
 def add_noise(vol, snr=1.0, S0=None, noise_type='rician', rng=None):

--- a/dipy/sims/tests/test_phantom.py
+++ b/dipy/sims/tests/test_phantom.py
@@ -1,14 +1,12 @@
 import numpy as np
-
 from numpy.testing import assert_, assert_array_almost_equal
 
+from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
+from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.dti import TensorModel
 from dipy.sims.phantom import orbital_phantom
-from dipy.core.gradients import gradient_table
-from dipy.io.gradients import read_bvals_bvecs
 from dipy.testing.decorators import set_random_number_generator
-
 
 fimg, fbvals, fbvecs = get_fnames('small_64D')
 bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -1,15 +1,27 @@
 import numpy as np
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+)
 
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_, assert_almost_equal)
+from dipy.core.gradients import gradient_table
 
-from dipy.sims.voxel import (_check_directions, all_tensor_evecs, add_noise,
-                             single_tensor, sticks_and_ball, multi_tensor_dki,
-                             kurtosis_element, dki_signal, multi_tensor)
 # from dipy.core.geometry import vec2vec_rotmat
 from dipy.data import get_fnames
-from dipy.core.gradients import gradient_table
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.sims.voxel import (
+    _check_directions,
+    add_noise,
+    all_tensor_evecs,
+    dki_signal,
+    kurtosis_element,
+    multi_tensor,
+    multi_tensor_dki,
+    single_tensor,
+    sticks_and_ball,
+)
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -1,10 +1,10 @@
 import numpy as np
 from numpy import dot
-from dipy.core.geometry import sphere2cart
-from dipy.core.geometry import vec2vec_rotmat
+from scipy.special import jn
+
+from dipy.core.geometry import sphere2cart, vec2vec_rotmat
 from dipy.core.gradients import GradientTable
 from dipy.reconst.utils import dki_design_matrix
-from scipy.special import jn
 
 # Diffusion coefficients for white matter tracts, in mm^2/s
 #

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -1,16 +1,19 @@
 import os
+
 import numpy as np
-from scipy.spatial import cKDTree
 from scipy.ndimage import map_coordinates
+from scipy.spatial import cKDTree
 from scipy.spatial.distance import mahalanobis
 
 from dipy.io.utils import save_buan_profiles_hdf5
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
-from dipy.tracking.streamline import (set_number_of_points,
-                                      values_from_volume,
-                                      orient_by_streamline,
-                                      Streamlines)
+from dipy.tracking.streamline import (
+    Streamlines,
+    orient_by_streamline,
+    set_number_of_points,
+    values_from_volume,
+)
 
 
 def peak_values(

--- a/dipy/stats/qc.py
+++ b/dipy/stats/qc.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from dipy.core.geometry import cart_distance
 
 

--- a/dipy/stats/tests/test_analysis.py
+++ b/dipy/stats/tests/test_analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 
-from dipy.stats.analysis import (gaussian_weights, afq_profile)
+from dipy.stats.analysis import afq_profile, gaussian_weights
 from dipy.tracking.streamline import Streamlines
 
 

--- a/dipy/stats/tests/test_qc.py
+++ b/dipy/stats/tests/test_qc.py
@@ -1,7 +1,8 @@
 import numpy as np
-from dipy.stats.qc import neighboring_dwi_correlation
-from dipy.core.gradients import gradient_table
+
 from dipy.core.geometry import normalized_vector
+from dipy.core.gradients import gradient_table
+from dipy.stats.qc import neighboring_dwi_correlation
 
 rng = np.random.default_rng()
 

--- a/dipy/stats/tests/test_resampling.py
+++ b/dipy/stats/tests/test_resampling.py
@@ -1,5 +1,5 @@
-from numpy.testing import assert_almost_equal
 import numpy as np
+from numpy.testing import assert_almost_equal
 import pytest
 
 from dipy.stats.resampling import bootstrap, jackknife

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -1,12 +1,11 @@
 """Utilities for testing."""
 from functools import partial
 import operator
-from os.path import dirname, abspath, join as pjoin
+from os.path import abspath, dirname, join as pjoin
 import warnings
 
-from numpy.testing import assert_array_equal
 import numpy.testing as npt
-
+from numpy.testing import assert_array_equal
 
 # set path to example data
 IO_DATA_PATH = abspath(pjoin(dirname(__file__),

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -4,10 +4,11 @@
 Decorators for dipy tests
 """
 
-import re
+import inspect
 import os
 import platform
-import inspect
+import re
+
 import numpy as np
 
 SKIP_RE = re.compile(r"(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")

--- a/dipy/testing/memory.py
+++ b/dipy/testing/memory.py
@@ -1,5 +1,5 @@
-import gc
 from collections import defaultdict
+import gc
 
 
 def get_type_refcount(pattern=None):

--- a/dipy/testing/tests/test_decorators.py
+++ b/dipy/testing/tests/test_decorators.py
@@ -1,6 +1,7 @@
 """Testing decorators module."""
 
-from numpy.testing import assert_raises, assert_equal
+from numpy.testing import assert_equal, assert_raises
+
 from dipy.testing import assert_true
 from dipy.testing.decorators import doctest_skip_parser
 

--- a/dipy/testing/tests/test_testing.py
+++ b/dipy/testing/tests/test_testing.py
@@ -2,10 +2,11 @@
 
 import sys
 import warnings
+
 import numpy as np
+import numpy.testing as npt
 
 import dipy.testing as dt
-import numpy.testing as npt
 
 
 def test_assert():

--- a/dipy/tests/scriptrunner.py
+++ b/dipy/tests/scriptrunner.py
@@ -12,11 +12,10 @@ Then, in the tests, something like::
     assert_equal(code, 0)
     assert_equal(stdout, b'This script ran OK')
 """
-import sys
 import os
-from os.path import (dirname, join as pjoin, isfile, isdir, realpath, pathsep)
-
-from subprocess import Popen, PIPE
+from os.path import dirname, isdir, isfile, join as pjoin, pathsep, realpath
+from subprocess import PIPE, Popen
+import sys
 
 try:  # Python 2
     string_types = basestring,

--- a/dipy/tracking/learning.py
+++ b/dipy/tracking/learning.py
@@ -1,5 +1,6 @@
 """ Learning algorithms for tractography"""
 import numpy as np
+
 import dipy.tracking.distances as pf
 
 

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -7,15 +7,15 @@ and statistical inference in living connectomes. Nature Methods 11:
 1058-1063. doi:10.1038/nmeth.3098
 """
 import numpy as np
-import scipy.sparse as sps
 import scipy.linalg as la
+import scipy.sparse as sps
 
-from dipy.reconst.base import ReconstModel, ReconstFit
-from dipy.tracking.utils import unique_rows
-from dipy.tracking.streamline import transform_streamlines
-from dipy.tracking.vox2track import _voxel2streamline
-import dipy.data as dpd
 import dipy.core.optimize as opt
+import dipy.data as dpd
+from dipy.reconst.base import ReconstFit, ReconstModel
+from dipy.tracking.streamline import transform_streamlines
+from dipy.tracking.utils import unique_rows
+from dipy.tracking.vox2track import _voxel2streamline
 
 
 def gradient(f):

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -1,12 +1,15 @@
-import random
 from collections.abc import Iterable
+import random
 from warnings import warn
+
 import numpy as np
 
-from dipy.tracking.localtrack import local_tracker, pft_tracker
-from dipy.tracking.stopping_criterion import (AnatomicalStoppingCriterion,
-                                              StreamlineStatus)
 from dipy.tracking import utils
+from dipy.tracking.localtrack import local_tracker, pft_tracker
+from dipy.tracking.stopping_criterion import (
+    AnatomicalStoppingCriterion,
+    StreamlineStatus,
+)
 from dipy.utils import fast_numpy
 
 

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -1,9 +1,10 @@
 """ Metrics for tracks, where tracks are arrays of points """
 
-from dipy.utils.deprecator import deprecate_with_version
-from dipy.tracking.streamline import set_number_of_points
 import numpy as np
-from scipy.interpolate import splprep, splev
+from scipy.interpolate import splev, splprep
+
+from dipy.tracking.streamline import set_number_of_points
+from dipy.utils.deprecator import deprecate_with_version
 
 
 def winding(xyz):

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -1,18 +1,17 @@
 from copy import deepcopy
-from warnings import warn
 import types
+from warnings import warn
 
-from scipy.spatial.distance import cdist
-
-import numpy as np
 from nibabel.affines import apply_affine
 from nibabel.streamlines import ArraySequence as Streamlines
-from dipy.tracking.streamlinespeed import length, set_number_of_points
-from dipy.tracking.distances import bundles_distances_mdf
-import dipy.tracking.utils as ut
+import numpy as np
+from scipy.spatial.distance import cdist
+
 from dipy.core.geometry import dist_to_corner
-from dipy.core.interpolation import (interpolate_vector_3d,
-                                     interpolate_scalar_3d)
+from dipy.core.interpolation import interpolate_scalar_3d, interpolate_vector_3d
+from dipy.tracking.distances import bundles_distances_mdf
+from dipy.tracking.streamlinespeed import length, set_number_of_points
+import dipy.tracking.utils as ut
 
 
 def unlist_streamlines(streamlines):

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -1,16 +1,19 @@
 import warnings
 
 import numpy as np
-from numpy.testing import (assert_array_almost_equal,
-                           assert_equal, assert_almost_equal,
-                           assert_array_equal)
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+)
 
+from dipy.data import get_fnames
+from dipy.io.streamline import load_tractogram
 from dipy.testing import assert_true
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking import distances as pf
 from dipy.tracking.streamline import set_number_of_points
-from dipy.data import get_fnames
-from dipy.io.streamline import load_tractogram
 
 
 @set_random_number_generator()

--- a/dipy/tracking/tests/test_fbc.py
+++ b/dipy/tracking/tests/test_fbc.py
@@ -1,11 +1,9 @@
-from dipy.denoise.enhancement_kernel import EnhancementKernel
-from dipy.tracking.fbcmeasures import FBCMeasures
-
-
-from dipy.core.sphere import Sphere
-
 import numpy as np
 import numpy.testing as npt
+
+from dipy.core.sphere import Sphere
+from dipy.denoise.enhancement_kernel import EnhancementKernel
+from dipy.tracking.fbcmeasures import FBCMeasures
 
 
 def test_fbc():

--- a/dipy/tracking/tests/test_learning.py
+++ b/dipy/tracking/tests/test_learning.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from numpy.testing import assert_array_equal
+
 from dipy.tracking import learning as tl
 
 

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -1,15 +1,17 @@
 import os.path as op
-import dipy.core.gradients as grad
-import dipy.core.optimize as opt
-import dipy.data as dpd
-from dipy.io.image import load_nifti_data
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
-import dipy.tracking.life as life
+
 import nibabel as nib
 import numpy as np
 import numpy.testing as npt
 import scipy.linalg as la
+
+import dipy.core.gradients as grad
+import dipy.core.optimize as opt
+import dipy.data as dpd
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti_data
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+import dipy.tracking.life as life
 
 THIS_DIR = op.dirname(__file__)
 

--- a/dipy/tracking/tests/test_mesh.py
+++ b/dipy/tracking/tests/test_mesh.py
@@ -1,10 +1,12 @@
 import numpy as np
 import numpy.testing as npt
 
-from dipy.tracking.mesh import (triangles_area,
-                                random_coordinates_from_surface,
-                                seeds_from_surface_coordinates,
-                                vertices_to_triangles_values)
+from dipy.tracking.mesh import (
+    random_coordinates_from_surface,
+    seeds_from_surface_coordinates,
+    triangles_area,
+    vertices_to_triangles_values,
+)
 
 
 def create_cube():

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -1,12 +1,11 @@
 """ Testing track_metrics module """
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_equal, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_equal
 
-from dipy.tracking import metrics as tm
-from dipy.tracking import distances as pf
-from dipy.utils.deprecator import ExpiredDeprecationError
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking import distances as pf, metrics as tm
+from dipy.utils.deprecator import ExpiredDeprecationError
 
 
 def test_downsample_deprecated():

--- a/dipy/tracking/tests/test_propagation.py
+++ b/dipy/tracking/tests/test_propagation.py
@@ -1,9 +1,8 @@
 import numpy as np
+from numpy.testing import assert_equal, assert_raises
 
 from dipy.data import default_sphere
-from dipy.tracking.propspeed import ndarray_offset, eudx_both_directions
-
-from numpy.testing import assert_equal, assert_raises
+from dipy.tracking.propspeed import eudx_both_directions, ndarray_offset
 
 
 def stepped_1d(arr_1d):

--- a/dipy/tracking/tests/test_stopping_criterion.py
+++ b/dipy/tracking/tests/test_stopping_criterion.py
@@ -3,12 +3,14 @@ import numpy.testing as npt
 import scipy.ndimage
 
 from dipy.core.ndindex import ndindex
-from dipy.tracking.stopping_criterion import (ActStoppingCriterion,
-                                              BinaryStoppingCriterion,
-                                              CmcStoppingCriterion,
-                                              ThresholdStoppingCriterion,
-                                              StreamlineStatus)
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.stopping_criterion import (
+    ActStoppingCriterion,
+    BinaryStoppingCriterion,
+    CmcStoppingCriterion,
+    StreamlineStatus,
+    ThresholdStoppingCriterion,
+)
 
 
 @set_random_number_generator()

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -1,34 +1,40 @@
-import warnings
 import types
+import warnings
 
 import numpy as np
 from numpy.linalg import norm
 import numpy.testing as npt
-from dipy.testing.memory import get_type_refcount
-from dipy.testing import assert_arrays_equal
-from dipy.testing.decorators import set_random_number_generator
-
-from dipy.testing import assert_true
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_raises, assert_allclose,
-                           assert_almost_equal, assert_equal)
-
-from dipy.tracking.streamlinespeed import (
-    compress_streamlines, length, set_number_of_points,
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_equal,
+    assert_raises,
 )
-from dipy.tracking.streamline import Streamlines
-from dipy.tracking.streamline import (relist_streamlines,
-                                      unlist_streamlines,
-                                      center_streamlines,
-                                      transform_streamlines,
-                                      select_random_set_of_streamlines,
-                                      select_by_rois,
-                                      orient_by_rois,
-                                      orient_by_streamline,
-                                      values_from_volume,
-                                      deform_streamlines,
-                                      cluster_confidence)
 
+from dipy.testing import assert_arrays_equal, assert_true
+from dipy.testing.decorators import set_random_number_generator
+from dipy.testing.memory import get_type_refcount
+from dipy.tracking.streamline import (
+    Streamlines,
+    center_streamlines,
+    cluster_confidence,
+    deform_streamlines,
+    orient_by_rois,
+    orient_by_streamline,
+    relist_streamlines,
+    select_by_rois,
+    select_random_set_of_streamlines,
+    transform_streamlines,
+    unlist_streamlines,
+    values_from_volume,
+)
+from dipy.tracking.streamlinespeed import (
+    compress_streamlines,
+    length,
+    set_number_of_points,
+)
 
 streamline = np.array([[82.20181274,  91.36505890,  43.15737152],
                        [82.38442230,  91.79336548,  43.87036514],

--- a/dipy/tracking/tests/test_track_volumes.py
+++ b/dipy/tracking/tests/test_track_volumes.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
+
 import dipy.tracking.vox2track as tvo
 
 

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -8,24 +8,27 @@ import numpy.testing as npt
 from dipy.core.gradients import gradient_table
 from dipy.core.sphere import HemiSphere, unit_octahedron
 from dipy.data import get_fnames, get_sphere
-from dipy.direction import (BootDirectionGetter,
-                            ClosestPeakDirectionGetter,
-                            DeterministicMaximumDirectionGetter,
-                            PeaksAndMetrics,
-                            ProbabilisticDirectionGetter,
-                            PTTDirectionGetter)
+from dipy.direction import (
+    BootDirectionGetter,
+    ClosestPeakDirectionGetter,
+    DeterministicMaximumDirectionGetter,
+    PTTDirectionGetter,
+    PeaksAndMetrics,
+    ProbabilisticDirectionGetter,
+)
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.shm import descoteaux07_legacy_msg
-from dipy.tracking.local_tracking import (LocalTracking,
-                                          ParticleFilteringTracking)
-from dipy.tracking.streamline import Streamlines
-from dipy.tracking.stopping_criterion import (ActStoppingCriterion,
-                                              BinaryStoppingCriterion,
-                                              ThresholdStoppingCriterion,
-                                              StreamlineStatus)
-from dipy.tracking.utils import random_seeds_from_mask, seeds_from_mask
-from dipy.sims.voxel import single_tensor, multi_tensor
+from dipy.sims.voxel import multi_tensor, single_tensor
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.local_tracking import LocalTracking, ParticleFilteringTracking
+from dipy.tracking.stopping_criterion import (
+    ActStoppingCriterion,
+    BinaryStoppingCriterion,
+    StreamlineStatus,
+    ThresholdStoppingCriterion,
+)
+from dipy.tracking.streamline import Streamlines
+from dipy.tracking.utils import random_seeds_from_mask, seeds_from_mask
 
 
 def allclose(x, y, atol=None):

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -1,23 +1,33 @@
 import warnings
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 
-from dipy.tracking import metrics
-from dipy.tracking.streamline import transform_streamlines
-from dipy.tracking.utils import (connectivity_matrix, density_map, length,
-                                 ndbincount, reduce_labels, seeds_from_mask,
-                                 random_seeds_from_mask, target,
-                                 target_line_based, unique_rows, near_roi,
-                                 reduce_rois, path_length, _min_at,
-                                 max_angle_from_curvature,
-                                 min_radius_curvature_from_angle)
-
-from dipy.tracking._utils import _to_voxel_coordinates
-from dipy.tracking.vox2track import streamline_mapping
-import numpy.testing as npt
 from dipy.testing import assert_true
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking import metrics
+from dipy.tracking._utils import _to_voxel_coordinates
+from dipy.tracking.streamline import transform_streamlines
+from dipy.tracking.utils import (
+    _min_at,
+    connectivity_matrix,
+    density_map,
+    length,
+    max_angle_from_curvature,
+    min_radius_curvature_from_angle,
+    ndbincount,
+    near_roi,
+    path_length,
+    random_seeds_from_mask,
+    reduce_labels,
+    reduce_rois,
+    seeds_from_mask,
+    target,
+    target_line_based,
+    unique_rows,
+)
+from dipy.tracking.vox2track import streamline_mapping
 
 
 def make_streamlines(return_seeds=False):

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -47,21 +47,21 @@ And the letters A-D represent the following points in
 
 """
 
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from functools import wraps
 from itertools import combinations, groupby
 from warnings import warn
 
-import numpy as np
 from nibabel.affines import apply_affine
+import numpy as np
 from scipy.spatial.distance import cdist
 
 from dipy.core.geometry import dist_to_corner
 from dipy.tracking import metrics
-from dipy.tracking.vox2track import _streamlines_in_mask
 
 # Import helper functions shared with vox2track
-from dipy.tracking._utils import (_mapping_to_voxel, _to_voxel_coordinates)
+from dipy.tracking._utils import _mapping_to_voxel, _to_voxel_coordinates
+from dipy.tracking.vox2track import _streamlines_in_mask
 
 
 def density_map(streamlines, affine, vol_dims):

--- a/dipy/utils/arrfuncs.py
+++ b/dipy/utils/arrfuncs.py
@@ -1,7 +1,7 @@
 """ Utilities to manipulate numpy arrays """
 
-import numpy as np
 from nibabel.volumeutils import endian_codes, native_code
+import numpy as np
 
 
 def as_native_array(arr):

--- a/dipy/utils/deprecator.py
+++ b/dipy/utils/deprecator.py
@@ -9,11 +9,13 @@ the Nibabel package for the copyright and license terms.
 """
 
 import functools
-import warnings
-import re
 from inspect import signature
-from dipy import __version__
+import re
+import warnings
+
 from packaging.version import parse as version_cmp
+
+from dipy import __version__
 
 _LEADING_WHITE = re.compile(r'^(\s*)')
 

--- a/dipy/utils/optpkg.py
+++ b/dipy/utils/optpkg.py
@@ -1,6 +1,7 @@
 """ Routines to support optional packages """
 
 import importlib
+
 from packaging.version import Version
 
 try:

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -1,6 +1,8 @@
-import numpy as np
 import multiprocessing
+
+import numpy as np
 from tqdm.auto import tqdm
+
 from dipy.utils.optpkg import optional_package
 
 joblib, has_joblib, _ = optional_package('joblib')

--- a/dipy/utils/tests/test_arrfuncs.py
+++ b/dipy/utils/tests/test_arrfuncs.py
@@ -3,13 +3,11 @@
 import sys
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_equal
 
-from dipy.utils.arrfuncs import as_native_array, pinv
-
-from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_array_equal)
-from dipy.testing import assert_true, assert_false
+from dipy.testing import assert_false, assert_true
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.arrfuncs import as_native_array, pinv
 
 NATIVE_ORDER = '<' if sys.byteorder == 'little' else '>'
 SWAPPED_ORDER = '>' if sys.byteorder == 'little' else '<'

--- a/dipy/utils/tests/test_deprecator.py
+++ b/dipy/utils/tests/test_deprecator.py
@@ -10,14 +10,21 @@ the Nibabel package for the copyright and license terms.
 
 import sys
 import warnings
+
 import numpy.testing as npt
 import pytest
+
 import dipy
-from dipy.testing import clear_and_catch_warnings, assert_true
-from dipy.utils.deprecator import (cmp_pkg_version, _add_dep_doc,
-                                   _ensure_cr, deprecate_with_version,
-                                   deprecated_params, ArgsDeprecationWarning,
-                                   ExpiredDeprecationError)
+from dipy.testing import assert_true, clear_and_catch_warnings
+from dipy.utils.deprecator import (
+    ArgsDeprecationWarning,
+    ExpiredDeprecationError,
+    _add_dep_doc,
+    _ensure_cr,
+    cmp_pkg_version,
+    deprecate_with_version,
+    deprecated_params,
+)
 
 
 def test_cmp_pkg_version():

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -1,8 +1,9 @@
 """ Testing multiproc utilities
 """
 
-from dipy.utils.multiproc import determine_num_processes
 from numpy.testing import assert_equal, assert_raises
+
+from dipy.utils.multiproc import determine_num_processes
 
 
 def test_determine_num_processes():

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -2,13 +2,20 @@
 """
 
 import os
-from dipy.utils.omp import (cpu_count, thread_count, default_threads,
-                            _set_omp_threads, _restore_omp_threads,
-                            have_openmp, determine_num_threads)
 
-import pytest
-from dipy.utils.parallel import has_ray, has_joblib
 from numpy.testing import assert_equal, assert_raises
+import pytest
+
+from dipy.utils.omp import (
+    _restore_omp_threads,
+    _set_omp_threads,
+    cpu_count,
+    default_threads,
+    determine_num_threads,
+    have_openmp,
+    thread_count,
+)
+from dipy.utils.parallel import has_joblib, has_ray
 
 
 def test_set_omp_threads():

--- a/dipy/utils/tests/test_optpkg.py
+++ b/dipy/utils/tests/test_optpkg.py
@@ -1,8 +1,8 @@
 import pytest
 
+from dipy.testing import assert_false, assert_true
 from dipy.utils.optpkg import optional_package
 from dipy.utils.tripwire import TripWireError
-from dipy.testing import assert_true, assert_false
 
 
 def test_optional_package():

--- a/dipy/utils/tests/test_parallel.py
+++ b/dipy/utils/tests/test_parallel.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+
 import dipy.utils.parallel as para
 
 

--- a/dipy/utils/tests/test_tripwire.py
+++ b/dipy/utils/tests/test_tripwire.py
@@ -1,10 +1,10 @@
 """ Testing tripwire module.
 """
 
-from dipy.utils.tripwire import TripWire, is_tripwire, TripWireError
-
-from dipy.testing import assert_true, assert_false
 from numpy.testing import assert_raises
+
+from dipy.testing import assert_false, assert_true
+from dipy.utils.tripwire import TripWire, TripWireError, is_tripwire
 
 
 def test_is_tripwire():

--- a/dipy/utils/tests/test_volume.py
+++ b/dipy/utils/tests/test_volume.py
@@ -3,7 +3,8 @@
 import numpy as np
 import numpy.testing as npt
 
-from dipy.utils.volume import (adjacency_calc)
+from dipy.utils.volume import adjacency_calc
+
 
 def test_adjacency_calc():
     """

--- a/dipy/utils/tractogram.py
+++ b/dipy/utils/tractogram.py
@@ -1,7 +1,7 @@
 
 """This module is dedicated to the handling of tractograms."""
-import os
 import logging
+import os
 
 import numpy as np
 import trx.trx_file_memmap as tmm

--- a/dipy/viz/__init__.py
+++ b/dipy/viz/__init__.py
@@ -1,9 +1,9 @@
 # Init file for visualization package
 import warnings
 
+from dipy.utils.optpkg import optional_package
 from dipy.viz.horizon.app import horizon
 
-from dipy.utils.optpkg import optional_package
 # Allow import, but disable doctests if we don't have fury
 fury, has_fury, _ = optional_package(
     'fury',
@@ -13,10 +13,8 @@ fury, has_fury, _ = optional_package(
 
 
 if has_fury:
-    from fury import actor, window, colormap, lib
-    from fury import interactor, ui, utils, shaders
-    from fury.data import (fetch_viz_icons, read_viz_icons,
-                           DATA_DIR as FURY_DATA_DIR)
+    from fury import actor, colormap, interactor, lib, shaders, ui, utils, window
+    from fury.data import DATA_DIR as FURY_DATA_DIR, fetch_viz_icons, read_viz_icons
 
 else:
     warnings.warn(

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -1,7 +1,7 @@
 from warnings import warn
-from packaging.version import Version
 
 import numpy as np
+from packaging.version import Version
 
 from dipy import __version__ as horizon_version
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
@@ -9,19 +9,34 @@ from dipy.io.streamline import save_tractogram
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
 from dipy.viz.gmem import GlobalHorizon
-from dipy.viz.horizon.tab import (ClustersTab, PeaksTab, ROIsTab, SlicesTab,
-                                  TabManager, build_label, SurfaceTab)
-from dipy.viz.horizon.visualizer import (ClustersVisualizer, SlicesVisualizer,
-                                         SurfaceVisualizer, PeaksVisualizer)
-from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
-                                   unpack_image, is_binary_image,
-                                   unpack_surface, check_peak_size)
+from dipy.viz.horizon.tab import (
+    ClustersTab,
+    PeaksTab,
+    ROIsTab,
+    SlicesTab,
+    SurfaceTab,
+    TabManager,
+    build_label,
+)
+from dipy.viz.horizon.util import (
+    check_img_dtype,
+    check_img_shapes,
+    check_peak_size,
+    is_binary_image,
+    unpack_image,
+    unpack_surface,
+)
+from dipy.viz.horizon.visualizer import (
+    ClustersVisualizer,
+    PeaksVisualizer,
+    SlicesVisualizer,
+    SurfaceVisualizer,
+)
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 if has_fury:
-    from fury import __version__ as fury_version
-    from fury import actor, ui, window
+    from fury import __version__ as fury_version, actor, ui, window
     from fury.colormap import distinguishable_colormap
 
 

--- a/dipy/viz/horizon/tab/__init__.py
+++ b/dipy/viz/horizon/tab/__init__.py
@@ -1,6 +1,12 @@
-from dipy.viz.horizon.tab.base import (HorizonTab, TabManager, build_label,
-                                       build_slider, build_checkbox,
-                                       build_switcher, build_radio_button)
+from dipy.viz.horizon.tab.base import (
+    HorizonTab,
+    TabManager,
+    build_checkbox,
+    build_label,
+    build_radio_button,
+    build_slider,
+    build_switcher,
+)
 from dipy.viz.horizon.tab.cluster import ClustersTab
 from dipy.viz.horizon.tab.peak import PeaksTab
 from dipy.viz.horizon.tab.roi import ROIsTab

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -1,7 +1,7 @@
-from typing import Any
-from dataclasses import dataclass
-import warnings
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+import warnings
 
 import numpy as np
 

--- a/dipy/viz/horizon/tab/cluster.py
+++ b/dipy/viz/horizon/tab/cluster.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from dipy.viz.horizon.tab import (HorizonTab, build_slider)
+from dipy.viz.horizon.tab import HorizonTab, build_slider
 
 
 class ClustersTab(HorizonTab):

--- a/dipy/viz/horizon/tab/peak.py
+++ b/dipy/viz/horizon/tab/peak.py
@@ -1,8 +1,14 @@
 from functools import partial
+
 import numpy as np
 
-from dipy.viz.horizon.tab import (HorizonTab, build_label, build_slider,
-                                  build_radio_button, build_checkbox)
+from dipy.viz.horizon.tab import (
+    HorizonTab,
+    build_checkbox,
+    build_label,
+    build_radio_button,
+    build_slider,
+)
 
 
 class PeaksTab(HorizonTab):

--- a/dipy/viz/horizon/tab/roi.py
+++ b/dipy/viz/horizon/tab/roi.py
@@ -1,4 +1,4 @@
-from dipy.viz.horizon.tab import (HorizonTab, build_slider, build_checkbox)
+from dipy.viz.horizon.tab import HorizonTab, build_checkbox, build_slider
 
 
 class ROIsTab(HorizonTab):

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -1,14 +1,18 @@
+from functools import partial
+from pathlib import Path
 import warnings
 
-from functools import partial
 import numpy as np
-from pathlib import Path
-
-from dipy.utils.optpkg import optional_package
-from dipy.viz.horizon.tab import (HorizonTab, build_label, build_slider,
-                                  build_switcher, build_checkbox)
 
 from dipy.testing.decorators import is_macOS
+from dipy.utils.optpkg import optional_package
+from dipy.viz.horizon.tab import (
+    HorizonTab,
+    build_checkbox,
+    build_label,
+    build_slider,
+    build_switcher,
+)
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 

--- a/dipy/viz/horizon/tab/surface.py
+++ b/dipy/viz/horizon/tab/surface.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
-from dipy.viz.horizon.tab import (HorizonTab, build_slider, build_checkbox,
-                                  build_label)
+from dipy.viz.horizon.tab import HorizonTab, build_checkbox, build_label, build_slider
 
 
 class SurfaceTab(HorizonTab):

--- a/dipy/viz/horizon/tab/tests/test_base.py
+++ b/dipy/viz/horizon/tab/tests/test_base.py
@@ -1,14 +1,18 @@
-import pytest
 import warnings
 
 import numpy.testing as npt
-from dipy.testing import check_for_warnings
+import pytest
 
-from dipy.utils.optpkg import optional_package
+from dipy.testing import check_for_warnings
 from dipy.testing.decorators import use_xvfb
-from dipy.viz.horizon.tab.base import (build_checkbox, build_label,
-                                       build_radio_button,
-                                       build_slider, build_switcher)
+from dipy.utils.optpkg import optional_package
+from dipy.viz.horizon.tab.base import (
+    build_checkbox,
+    build_label,
+    build_radio_button,
+    build_slider,
+    build_switcher,
+)
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -1,4 +1,5 @@
 import warnings
+
 import numpy as np
 
 

--- a/dipy/viz/horizon/visualizer/__init__.py
+++ b/dipy/viz/horizon/visualizer/__init__.py
@@ -1,7 +1,7 @@
 from dipy.viz.horizon.visualizer.cluster import ClustersVisualizer
+from dipy.viz.horizon.visualizer.peak import PeaksVisualizer
 from dipy.viz.horizon.visualizer.slice import SlicesVisualizer
 from dipy.viz.horizon.visualizer.surface import SurfaceVisualizer
-from dipy.viz.horizon.visualizer.peak import PeaksVisualizer
 
 __all__ = ['ClustersVisualizer', 'SlicesVisualizer', 'SurfaceVisualizer',
            'PeaksVisualizer']

--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -1,5 +1,5 @@
-import warnings
 from os.path import join as pjoin
+import warnings
 
 import numpy as np
 
@@ -24,11 +24,7 @@ if has_fury:
         import_fury_shader,
         shader_to_actor,
     )
-    from fury.utils import (
-        apply_affine,
-        numpy_to_vtk_colors,
-        numpy_to_vtk_points
-    )
+    from fury.utils import apply_affine, numpy_to_vtk_colors, numpy_to_vtk_points
 else:
     class Actor:
         pass

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -1,13 +1,15 @@
-import warnings
-import numpy as np
-from dipy.utils.optpkg import optional_package
 import itertools
+import warnings
+
+import numpy as np
+
+from dipy.utils.optpkg import optional_package
 from dipy.viz.gmem import GlobalHorizon
 
 fury, have_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 if have_fury:
-    from dipy.viz import actor, ui, colormap
+    from dipy.viz import actor, colormap, ui
 
 
 def build_label(text, font_size=18, bold=False):

--- a/dipy/viz/plotting.py
+++ b/dipy/viz/plotting.py
@@ -2,9 +2,12 @@
 plotting functions
 """
 
-import numpy as np
 from warnings import warn
+
+import numpy as np
+
 from dipy.utils.optpkg import optional_package
+
 plt, have_plt, _ = optional_package("matplotlib.pyplot")
 
 

--- a/dipy/viz/projections.py
+++ b/dipy/viz/projections.py
@@ -7,9 +7,10 @@ ODFs.
 
 import numpy as np
 import scipy.interpolate as interp
-from dipy.utils.optpkg import optional_package
+
 import dipy.core.geometry as geo
 from dipy.testing.decorators import doctest_skip_parser
+from dipy.utils.optpkg import optional_package
 
 matplotlib, has_mpl, setup_module = optional_package("matplotlib")
 plt, _, _ = optional_package("matplotlib.pyplot")

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from dipy.utils.optpkg import optional_package
+
 matplotlib, has_mpl, setup_module = optional_package("matplotlib")
 plt, _, _ = optional_package("matplotlib.pyplot")
 

--- a/dipy/viz/streamline.py
+++ b/dipy/viz/streamline.py
@@ -1,8 +1,9 @@
 from dipy.utils.optpkg import optional_package
+
 plt, have_plt, _ = optional_package("matplotlib.pyplot")
 fury, has_fury, _ = optional_package('fury', min_version="0.10.0")
 if has_fury:
-    from dipy.viz import window, actor
+    from dipy.viz import actor, window
 
 
 def show_bundles(bundles, interactive=True, view='sagital', colors=None,

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -10,10 +10,9 @@ from dipy.direction.peaks import PeaksAndMetrics
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.utils import create_nifti_header
 from dipy.testing import check_for_warnings
-from dipy.testing.decorators import use_xvfb
+from dipy.testing.decorators import set_random_number_generator, use_xvfb
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
-from dipy.testing.decorators import set_random_number_generator
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -1,30 +1,26 @@
 import warnings
 
-import pytest
 import numpy as np
 import numpy.testing as npt
-from dipy.testing.decorators import use_xvfb, set_random_number_generator
-from dipy.utils.optpkg import optional_package
-from dipy.data import get_sphere
+import pytest
+
 from dipy.align.reslice import reslice
-from dipy.data import read_stanford_labels
-from dipy.reconst.shm import CsaOdfModel
-from dipy.data import default_sphere
-from dipy.direction import peaks_from_model
-from dipy.tracking import utils
-from dipy.tracking.stopping_criterion import \
-    ThresholdStoppingCriterion
-from dipy.tracking.local_tracking import LocalTracking
-from dipy.reconst.shm import descoteaux07_legacy_msg, sh_to_sf_matrix
 from dipy.align.tests.test_streamlinear import fornix_streamlines
-from dipy.tracking.streamline import (center_streamlines,
-                                      transform_streamlines)
+from dipy.data import default_sphere, get_sphere, read_stanford_labels
+from dipy.direction import peaks_from_model
 from dipy.reconst.dti import color_fa, fractional_anisotropy
+from dipy.reconst.shm import CsaOdfModel, descoteaux07_legacy_msg, sh_to_sf_matrix
+from dipy.testing.decorators import set_random_number_generator, use_xvfb
+from dipy.tracking import utils
+from dipy.tracking.local_tracking import LocalTracking
+from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
+from dipy.tracking.streamline import center_streamlines, transform_streamlines
+from dipy.utils.optpkg import optional_package
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 if has_fury:
-    from dipy.viz import actor, window, colormap
+    from dipy.viz import actor, colormap, window
 
 skip_it = use_xvfb == 'skip'
 

--- a/dipy/viz/tests/test_regtools.py
+++ b/dipy/viz/tests/test_regtools.py
@@ -1,13 +1,14 @@
 import numpy as np
-from dipy.viz import regtools
 import numpy.testing as npt
 import pytest
-from dipy.align.metrics import SSDMetric
+
 from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
+from dipy.align.metrics import SSDMetric
 from dipy.testing.decorators import set_random_number_generator
 
 # Conditional import machinery for matplotlib
 from dipy.utils.optpkg import optional_package
+from dipy.viz import regtools
 
 _, have_matplotlib, _ = optional_package('matplotlib')
 

--- a/dipy/viz/tests/test_streamline.py
+++ b/dipy/viz/tests/test_streamline.py
@@ -1,21 +1,28 @@
-import tempfile
 import os
-from numpy.testing import assert_raises, assert_equal
+import tempfile
+
+from numpy.testing import assert_equal, assert_raises
 import pytest
 
 from dipy.align.streamwarp import bundlewarp, bundlewarp_vector_filed
 from dipy.data import read_five_af_bundles, two_cingulum_bundles
-from dipy.tracking.streamline import (set_number_of_points, unlist_streamlines,
-                                      Streamlines)
+from dipy.tracking.streamline import (
+    Streamlines,
+    set_number_of_points,
+    unlist_streamlines,
+)
 from dipy.utils.optpkg import optional_package
-
 
 _, have_matplotlib, _ = optional_package("matplotlib")
 fury, have_fury, _ = optional_package('fury', min_version="0.10.0")
 if have_fury:
-    from dipy.viz.streamline import (show_bundles, viz_two_bundles,
-                                     viz_displacement_mag, viz_vector_field)
     from dipy.viz import window
+    from dipy.viz.streamline import (
+        show_bundles,
+        viz_displacement_mag,
+        viz_two_bundles,
+        viz_vector_field,
+    )
 
 bundles = read_five_af_bundles()
 

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -1,12 +1,19 @@
 import warnings
+
 import numpy as np
 import numpy.testing as npt
+
 from dipy.direction.peaks import PeaksAndMetrics
 from dipy.testing import check_for_warnings
 from dipy.testing.decorators import set_random_number_generator
-from dipy.viz.horizon.util import (check_img_dtype, check_img_shapes,
-                                   check_peak_size, is_binary_image,
-                                   show_ellipsis, unpack_surface)
+from dipy.viz.horizon.util import (
+    check_img_dtype,
+    check_img_shapes,
+    check_peak_size,
+    is_binary_image,
+    show_ellipsis,
+    unpack_surface,
+)
 
 
 @set_random_number_generator()

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1,22 +1,22 @@
 import logging
-from warnings import warn
-import numpy as np
-import nibabel as nib
 from os.path import join as pjoin
-from dipy.utils.optpkg import optional_package
-from dipy.align.imaffine import AffineMap
-from dipy.align.imwarp import (SymmetricDiffeomorphicRegistration,
-                               DiffeomorphicMap)
-from dipy.align.metrics import CCMetric, SSDMetric, EMMetric
-from dipy.align.reslice import reslice
+from warnings import warn
+
+import nibabel as nib
+import numpy as np
+
 from dipy.align import affine_registration, motion_correction
+from dipy.align.imaffine import AffineMap
+from dipy.align.imwarp import DiffeomorphicMap, SymmetricDiffeomorphicRegistration
+from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
+from dipy.align.reslice import reslice
 from dipy.align.streamlinear import slr_with_qbx
-from dipy.tracking.streamline import set_number_of_points
 from dipy.align.streamwarp import bundlewarp
-from dipy.core.gradients import mask_non_weighted_bvals, gradient_table
-from dipy.io.image import save_nifti, load_nifti, save_qa_metric
+from dipy.core.gradients import gradient_table, mask_non_weighted_bvals
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.tracking.streamline import transform_streamlines
+from dipy.io.image import load_nifti, save_nifti, save_qa_metric
+from dipy.tracking.streamline import set_number_of_points, transform_streamlines
+from dipy.utils.optpkg import optional_package
 from dipy.workflows.workflow import Workflow
 
 pd, have_pd, _ = optional_package("pandas")

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -1,16 +1,17 @@
 import logging
 import shutil
+
 import numpy as np
 
 from dipy.core.gradients import gradient_table
+from dipy.denoise.gibbs import gibbs_removal
+from dipy.denoise.localpca import localpca, mppca
+from dipy.denoise.nlmeans import nlmeans
+from dipy.denoise.noise_estimate import estimate_sigma
+from dipy.denoise.patch2self import patch2self
+from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
-from dipy.denoise.patch2self import patch2self
-from dipy.denoise.nlmeans import nlmeans
-from dipy.denoise.localpca import localpca, mppca
-from dipy.denoise.gibbs import gibbs_removal
-from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 from dipy.workflows.workflow import Workflow
 
 

--- a/dipy/workflows/flow_runner.py
+++ b/dipy/workflows/flow_runner.py
@@ -1,6 +1,7 @@
 #  Disabling the FutureWarning from h5py below.
 #  This disables the FutureWarning warning for all the workflows.
 import warnings
+
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 import logging

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -1,12 +1,12 @@
 import importlib
+from inspect import getmembers, isfunction
+import logging
 import os
 import sys
-import logging
-from inspect import getmembers, isfunction
 import warnings
 
-import trx.trx_file_memmap as tmm
 import numpy as np
+import trx.trx_file_memmap as tmm
 
 from dipy.io.image import load_nifti, save_nifti
 from dipy.io.streamline import load_tractogram, save_tractogram

--- a/dipy/workflows/mask.py
+++ b/dipy/workflows/mask.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import logging
+
 import numpy as np
 
 from dipy.io.image import load_nifti, save_nifti

--- a/dipy/workflows/multi_io.py
+++ b/dipy/workflows/multi_io.py
@@ -1,8 +1,9 @@
+from glob import glob
 import inspect
 import itertools
-import numpy as np
 import os
-from glob import glob
+
+import numpy as np
 
 from dipy.workflows.base import get_args_default
 

--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 
-from dipy.io.image import save_nifti, load_nifti
+from dipy.io.image import load_nifti, save_nifti
 from dipy.nn.evac import EVACPlus
 from dipy.workflows.workflow import Workflow
 

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -1,33 +1,38 @@
-import logging
-import numpy as np
-import os.path
 from ast import literal_eval
+import logging
+import os.path
 from warnings import warn
 
 import nibabel as nib
+import numpy as np
 
-from dipy.core.gradients import mask_non_weighted_bvals, gradient_table
+from dipy.core.gradients import gradient_table, mask_non_weighted_bvals
 from dipy.data import default_sphere, get_sphere
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.peaks import save_peaks, peaks_to_niftis
-from dipy.io.image import load_nifti, save_nifti, load_nifti_data
-from dipy.io.utils import nifti1_symmat
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
-from dipy.reconst.dti import (TensorModel, color_fa, fractional_anisotropy,
-                              geodesic_anisotropy, mean_diffusivity,
-                              axial_diffusivity, radial_diffusivity,
-                              lower_triangular, mode as get_mode)
 from dipy.direction.peaks import peaks_from_model
-from dipy.reconst.shm import CsaOdfModel
-from dipy.reconst.dsi import DiffusionSpectrumModel
-from dipy.workflows.workflow import Workflow
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
+from dipy.io.peaks import peaks_to_niftis, save_peaks
+from dipy.io.utils import nifti1_symmat
+from dipy.reconst import mapmri
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.dki import DiffusionKurtosisModel, split_dki_param
+from dipy.reconst.dsi import DiffusionSpectrumModel
+from dipy.reconst.dti import (
+    TensorModel,
+    axial_diffusivity,
+    color_fa,
+    fractional_anisotropy,
+    geodesic_anisotropy,
+    lower_triangular,
+    mean_diffusivity,
+    mode as get_mode,
+    radial_diffusivity,
+)
 from dipy.reconst.ivim import IvimModel
 from dipy.reconst.rumba import RumbaSDModel
-
-from dipy.reconst import mapmri
+from dipy.reconst.shm import CsaOdfModel
 from dipy.utils.deprecator import deprecated_params
+from dipy.workflows.workflow import Workflow
 
 
 class ReconstMAPMRIFlow(Workflow):

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -3,12 +3,12 @@ from time import time
 
 import numpy as np
 
-from dipy.io.image import save_nifti, load_nifti
+from dipy.io.image import load_nifti, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.tracking import Streamlines
-from dipy.segment.mask import median_otsu
 from dipy.segment.bundles import RecoBundles
+from dipy.segment.mask import median_otsu
+from dipy.tracking import Streamlines
 from dipy.utils.convert import expand_range
 from dipy.workflows.workflow import Workflow
 

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -1,26 +1,25 @@
-import logging
-import numpy as np
-import os
+from glob import glob
 import json
-import warnings
+import logging
+import os
 from time import time
+import warnings
+
+import numpy as np
 from scipy.ndimage import binary_dilation
-from dipy.utils.optpkg import optional_package
+
+from dipy.core.gradients import gradient_table
 from dipy.io import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
-from dipy.core.gradients import gradient_table
-from dipy.reconst.dti import TensorModel
 from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
-from dipy.segment.mask import segment_from_cfa
-from dipy.segment.mask import bounding_box
-from dipy.tracking.streamline import transform_streamlines
-from glob import glob
-from dipy.workflows.workflow import Workflow
+from dipy.reconst.dti import TensorModel
 from dipy.segment.bundles import bundle_shape_similarity
-from dipy.stats.analysis import assignment_map
-from dipy.stats.analysis import anatomical_measures
-from dipy.stats.analysis import peak_values
+from dipy.segment.mask import bounding_box, segment_from_cfa
+from dipy.stats.analysis import anatomical_measures, assignment_map, peak_values
+from dipy.tracking.streamline import transform_streamlines
+from dipy.utils.optpkg import optional_package
+from dipy.workflows.workflow import Workflow
 
 pd, have_pd, _ = optional_package("pandas")
 smf, have_smf, _ = optional_package("statsmodels.formula.api")

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -1,25 +1,31 @@
-from os.path import join as pjoin
 import os.path
+from os.path import join as pjoin
 from tempfile import TemporaryDirectory
 
-import numpy.testing as npt
-import numpy as np
 import nibabel as nib
+import numpy as np
+import numpy.testing as npt
 import pytest
-from dipy.utils.optpkg import optional_package
+
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
 from dipy.align.tests.test_parzenhist import setup_random_transform
 from dipy.align.transforms import regtransforms
 from dipy.data import get_fnames
-from dipy.io.image import save_nifti, load_nifti_data
+from dipy.io.image import load_nifti_data, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.tracking.streamline import Streamlines
-from dipy.workflows.align import (ImageRegistrationFlow, SynRegistrationFlow,
-                                  ApplyTransformFlow, ResliceFlow,
-                                  SlrWithQbxFlow, MotionCorrectionFlow,
-                                  BundleWarpFlow)
 from dipy.testing.decorators import set_random_number_generator
+from dipy.tracking.streamline import Streamlines
+from dipy.utils.optpkg import optional_package
+from dipy.workflows.align import (
+    ApplyTransformFlow,
+    BundleWarpFlow,
+    ImageRegistrationFlow,
+    MotionCorrectionFlow,
+    ResliceFlow,
+    SlrWithQbxFlow,
+    SynRegistrationFlow,
+)
 
 _, have_pd, _ = optional_package("pandas")
 

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -1,19 +1,22 @@
 import os
 from tempfile import TemporaryDirectory
 
-import pytest
 import numpy as np
 import numpy.testing as npt
-from dipy.utils.optpkg import optional_package
+import pytest
 
 from dipy.data import get_fnames
-from dipy.io.image import save_nifti, load_nifti, load_nifti_data
-
-from dipy.testing import (assert_true, assert_false, assert_greater,
-                          assert_less)
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
+from dipy.testing import assert_false, assert_greater, assert_less, assert_true
 from dipy.testing.decorators import set_random_number_generator
-from dipy.workflows.denoise import (NLMeansFlow, LPCAFlow, MPPCAFlow,
-                                    GibbsRingingFlow, Patch2SelfFlow)
+from dipy.utils.optpkg import optional_package
+from dipy.workflows.denoise import (
+    GibbsRingingFlow,
+    LPCAFlow,
+    MPPCAFlow,
+    NLMeansFlow,
+    Patch2SelfFlow,
+)
 
 sklearn, has_sklearn, _ = optional_package('sklearn')
 needs_sklearn = pytest.mark.skipif(

--- a/dipy/workflows/tests/test_docstring_parser.py
+++ b/dipy/workflows/tests/test_docstring_parser.py
@@ -32,9 +32,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 import textwrap
 
-from dipy.workflows.docstring_parser import NumpyDocString
 import numpy.testing as npt
 
+from dipy.workflows.docstring_parser import NumpyDocString
 
 doc_txt = """\
   numpy.multivariate_normal(mean, cov, shape=None, spam=None)

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,5 +1,5 @@
-import sys
 from os.path import join as pjoin
+import sys
 from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
@@ -7,8 +7,13 @@ import numpy.testing as npt
 from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import (
-    DummyFlow, DummyCombinedWorkflow, DummyWorkflow1, DummyWorkflowOptionalStr,
-    DummyVariableTypeWorkflow, DummyVariableTypeErrorWorkflow)
+    DummyCombinedWorkflow,
+    DummyFlow,
+    DummyVariableTypeErrorWorkflow,
+    DummyVariableTypeWorkflow,
+    DummyWorkflow1,
+    DummyWorkflowOptionalStr,
+)
 
 
 def test_none_or_dtype():

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from tempfile import mkstemp, TemporaryDirectory
+from tempfile import TemporaryDirectory, mkstemp
 
 import numpy as np
 import numpy.testing as npt
@@ -11,12 +11,18 @@ from dipy.data.fetcher import dipy_home
 from dipy.io.image import load_nifti, save_nifti
 from dipy.io.streamline import load_tractogram
 from dipy.io.utils import nifti1_symmat
-from dipy.testing import assert_true
 from dipy.reconst import dti, utils as reconst_utils
 from dipy.reconst.shm import convert_sh_descoteaux_tournier
-from dipy.workflows.io import (IoInfoFlow, FetchFlow, SplitFlow,
-                               ConcatenateTractogramFlow, ConvertSHFlow,
-                               ConvertTractogramFlow, ConvertTensorsFlow)
+from dipy.testing import assert_true
+from dipy.workflows.io import (
+    ConcatenateTractogramFlow,
+    ConvertSHFlow,
+    ConvertTensorsFlow,
+    ConvertTractogramFlow,
+    FetchFlow,
+    IoInfoFlow,
+    SplitFlow,
+)
 
 fname_log = mkstemp()[1]
 

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -1,10 +1,10 @@
 from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
-from dipy.testing import assert_false
 
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti
+from dipy.testing import assert_false
 from dipy.workflows.mask import MaskFlow
 
 

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -11,7 +11,6 @@ from dipy.nn.evac import EVACPlus
 from dipy.utils.optpkg import optional_package
 from dipy.workflows.nn import EVACPlusFlow
 
-
 tf, have_tf, _ = optional_package('tensorflow', min_version='2.0.0')
 
 

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -6,14 +6,13 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 
-from dipy.io.peaks import load_peaks
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti, save_nifti, load_nifti_data
 from dipy.core.gradients import generate_bvecs
-
 from dipy.data import get_fnames
-from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
+from dipy.io.peaks import load_peaks
 from dipy.reconst.shm import descoteaux07_legacy_msg, sph_harm_ind_list
+from dipy.workflows.reconst import ReconstCSAFlow, ReconstCSDFlow
 
 logging.getLogger().setLevel(logging.INFO)
 

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -2,15 +2,14 @@ from os.path import join as pjoin
 from tempfile import TemporaryDirectory
 
 import numpy as np
-
 import numpy.testing as npt
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
+from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti_data, load_nifti, save_nifti
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.peaks import load_peaks
-from dipy.core.gradients import generate_bvecs
 from dipy.reconst.shm import sph_harm_ind_list
 from dipy.workflows.reconst import ReconstDkiFlow
 

--- a/dipy/workflows/tests/test_reconst_dsi.py
+++ b/dipy/workflows/tests/test_reconst_dsi.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.data import get_fnames
-from dipy.io.image import load_nifti, save_nifti, load_nifti_data
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.workflows.reconst import ReconstDsiFlow
 

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -2,10 +2,10 @@ from os.path import join
 from tempfile import TemporaryDirectory
 
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from dipy.data import get_fnames
-from dipy.io.image import load_nifti_data, load_nifti, save_nifti
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.peaks import load_peaks
 from dipy.reconst.shm import sph_harm_ind_list
 from dipy.workflows.reconst import ReconstDtiFlow

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -3,12 +3,11 @@ from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
-
 from numpy.testing import assert_equal
 
-from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import generate_bvecs, gradient_table
 from dipy.io.image import load_nifti_data, save_nifti
+from dipy.sims.voxel import multi_tensor
 from dipy.workflows.reconst import ReconstIvimFlow
 
 

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -6,10 +6,10 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+from dipy.core.gradients import generate_bvecs
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
-from dipy.core.gradients import generate_bvecs
 from dipy.reconst import mapmri
 from dipy.workflows.reconst import ReconstMAPMRIFlow
 

--- a/dipy/workflows/tests/test_reconst_rumba.py
+++ b/dipy/workflows/tests/test_reconst_rumba.py
@@ -7,8 +7,8 @@ import numpy as np
 
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti, save_nifti
-from dipy.workflows.reconst import ReconstRUMBAFlow
 from dipy.reconst.shm import descoteaux07_legacy_msg
+from dipy.workflows.reconst import ReconstRUMBAFlow
 
 logging.getLogger().setLevel(logging.INFO)
 

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -1,20 +1,18 @@
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
 
-import numpy.testing as npt
-import numpy as np
 import nibabel as nib
+import numpy as np
+import numpy.testing as npt
 
 from dipy.align.streamlinear import BundleMinDistanceMetric
 from dipy.data import get_fnames
-from dipy.segment.mask import median_otsu
-from dipy.tracking.streamline import Streamlines
+from dipy.io.image import load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.io.image import load_nifti_data
-from dipy.tracking.streamline import set_number_of_points
-from dipy.workflows.segment import MedianOtsuFlow
-from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
+from dipy.segment.mask import median_otsu
+from dipy.tracking.streamline import Streamlines, set_number_of_points
+from dipy.workflows.segment import LabelsBundlesFlow, MedianOtsuFlow, RecoBundlesFlow
 
 
 def test_median_otsu_flow():

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -9,18 +9,20 @@ import numpy.testing as npt
 import pytest
 
 from dipy.data import get_fnames
-from dipy.io.image import save_nifti, load_nifti
+from dipy.io.image import load_nifti, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.testing import assert_true
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
-from dipy.workflows.stats import SNRinCCFlow
-from dipy.workflows.stats import BundleAnalysisTractometryFlow
-from dipy.workflows.stats import LinearMixedModelsFlow
-from dipy.workflows.stats import BundleShapeAnalysis
-from dipy.workflows.stats import buan_bundle_profiles
+from dipy.workflows.stats import (
+    BundleAnalysisTractometryFlow,
+    BundleShapeAnalysis,
+    LinearMixedModelsFlow,
+    SNRinCCFlow,
+    buan_bundle_profiles,
+)
 
 pd, have_pandas, _ = optional_package("pandas")
 _, have_statsmodels, _ = optional_package("statsmodels", min_version="0.14.0")

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -5,17 +5,15 @@ import warnings
 import nibabel as nib
 import numpy as np
 from numpy.testing import assert_equal
-from dipy.testing import assert_false, assert_true
-
 
 from dipy.data import get_fnames
-from dipy.io.image import save_nifti, load_nifti
+from dipy.io.image import load_nifti, save_nifti
 from dipy.io.streamline import load_tractogram
 from dipy.reconst.shm import descoteaux07_legacy_msg
+from dipy.testing import assert_false, assert_true
 from dipy.workflows.mask import MaskFlow
 from dipy.workflows.reconst import ReconstCSDFlow
-from dipy.workflows.tracking import (LocalFiberTrackingPAMFlow,
-                                     PFTrackingPAMFlow)
+from dipy.workflows.tracking import LocalFiberTrackingPAMFlow, PFTrackingPAMFlow
 
 
 def test_particle_filtering_tracking_workflows():

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -9,15 +9,15 @@ from dipy.io.image import save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
 from dipy.io.utils import create_nifti_header
+from dipy.testing.decorators import set_random_number_generator, use_xvfb
 from dipy.tracking.streamline import Streamlines
-from dipy.testing.decorators import use_xvfb, set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 if has_fury:
-    from dipy.workflows.viz import HorizonFlow
     from dipy.viz.horizon.app import horizon
+    from dipy.workflows.viz import HorizonFlow
 
 
 skip_it = use_xvfb == 'skip'

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -1,7 +1,7 @@
 import os
-import time
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
+import time
 
 import numpy.testing as npt
 

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -1,5 +1,5 @@
-from dipy.workflows.workflow import Workflow
 from dipy.workflows.combined_workflow import CombinedWorkflow
+from dipy.workflows.workflow import Workflow
 
 
 class DummyWorkflow1(Workflow):

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -2,19 +2,22 @@
 
 import logging
 
-from dipy.direction import (DeterministicMaximumDirectionGetter,
-                            ProbabilisticDirectionGetter,
-                            ClosestPeakDirectionGetter)
+from dipy.direction import (
+    ClosestPeakDirectionGetter,
+    DeterministicMaximumDirectionGetter,
+    ProbabilisticDirectionGetter,
+)
 from dipy.io.image import load_nifti
 from dipy.io.peaks import load_peaks
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_tractogram
 from dipy.tracking import utils
-from dipy.tracking.local_tracking import (LocalTracking,
-                                          ParticleFilteringTracking)
-from dipy.tracking.stopping_criterion import (BinaryStoppingCriterion,
-                                              CmcStoppingCriterion,
-                                              ThresholdStoppingCriterion)
+from dipy.tracking.local_tracking import LocalTracking, ParticleFilteringTracking
+from dipy.tracking.stopping_criterion import (
+    BinaryStoppingCriterion,
+    CmcStoppingCriterion,
+    ThresholdStoppingCriterion,
+)
 from dipy.workflows.workflow import Workflow
 
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -1,24 +1,25 @@
-from warnings import warn
-import numpy as np
 from os.path import join as pjoin
-from dipy.io.surface import load_gifti, load_pial
-from dipy.workflows.workflow import Workflow
+from warnings import warn
+
+import numpy as np
+
 from dipy.io.image import load_nifti
-from dipy.viz import horizon
 from dipy.io.peaks import load_peaks
 from dipy.io.streamline import load_tractogram
+from dipy.io.surface import load_gifti, load_pial
 from dipy.io.utils import create_nifti_header
 from dipy.stats.analysis import assignment_map
 from dipy.utils.optpkg import optional_package
-
+from dipy.viz import horizon
+from dipy.workflows.workflow import Workflow
 
 fury, has_fury, setup_module = optional_package('fury', min_version="0.10.0")
 
 
 if has_fury:
     from fury.colormap import line_colors
-    from fury.utils import numpy_to_vtk_colors
     from fury.lib import numpy_support
+    from fury.utils import numpy_to_vtk_colors
 
 
 class HorizonFlow(Workflow):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,10 +9,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from datetime import datetime
 import os
 import re
 import sys
-from datetime import datetime
 
 # Doc generation depends on being able to import dipy
 try:
@@ -518,8 +518,8 @@ latex_preamble = r"""
 
 # -- Options for sphinx gallery -------------------------------------------
 from docimage_scrap import ImageFileScraper
-from sphinx_gallery.sorting import ExplicitOrder
 from prepare_gallery import folder_explicit_order
+from sphinx_gallery.sorting import ExplicitOrder
 
 sc = ImageFileScraper()
 ordered_folders = [f'examples_revamped/{f}' for f in folder_explicit_order()]

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -14,19 +14,25 @@ interface.
 """
 
 from os.path import join as pjoin
+
 import numpy as np
-from dipy.viz import regtools
+
+from dipy.align import affine_registration, register_dwi_to_template
+from dipy.align.imaffine import (
+    AffineMap,
+    AffineRegistration,
+    MutualInformationMetric,
+    transform_centers_of_mass,
+)
+from dipy.align.transforms import (
+    AffineTransform3D,
+    RigidTransform3D,
+    TranslationTransform3D,
+)
 from dipy.data import fetch_stanford_hardi
 from dipy.data.fetcher import fetch_syn_data
 from dipy.io.image import load_nifti
-from dipy.align.imaffine import (transform_centers_of_mass,
-                                 AffineMap,
-                                 MutualInformationMetric,
-                                 AffineRegistration)
-from dipy.align.transforms import (TranslationTransform3D,
-                                   RigidTransform3D,
-                                   AffineTransform3D)
-from dipy.align import affine_registration, register_dwi_to_template
+from dipy.viz import regtools
 
 ###############################################################################
 # Let's fetch two b0 volumes, the static image will be the b0 from the Stanford

--- a/doc/examples/affine_registration_masks.py
+++ b/doc/examples/affine_registration_masks.py
@@ -19,20 +19,16 @@ with respect to the heart.
 """
 
 from os.path import join as pjoin
-import numpy as np
+
 import matplotlib.pyplot as plt
-from dipy.viz import regtools
+import numpy as np
+
+from dipy.align import affine_registration, register_series, rigid, translation
+from dipy.align.imaffine import AffineMap, AffineRegistration, MutualInformationMetric
+from dipy.align.transforms import RigidTransform3D, TranslationTransform3D
 from dipy.data import fetch_stanford_hardi
 from dipy.io.image import load_nifti
-from dipy.align.imaffine import (AffineMap,
-                                 MutualInformationMetric,
-                                 AffineRegistration)
-from dipy.align.transforms import (TranslationTransform3D,
-                                   RigidTransform3D)
-
-from dipy.align import (affine_registration, translation,
-                        rigid, register_series)
-
+from dipy.viz import regtools
 
 ###############################################################################
 # Let's fetch a single b0 volume from the Stanford HARDI dataset.

--- a/doc/examples/afq_tract_profiles.py
+++ b/doc/examples/afq_tract_profiles.py
@@ -16,18 +16,20 @@ trajectory of the bundle at that location.
 
 """
 
-import dipy.stats.analysis as dsa
-import dipy.tracking.streamline as dts
-from dipy.segment.clustering import QuickBundles
-from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
-from dipy.segment.featurespeed import ResampleFeature
-from dipy.data.fetcher import get_two_hcp842_bundles
-import dipy.data as dpd
-from dipy.io.streamline import load_trk
-from dipy.io.image import load_nifti
+import os.path as op
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os.path as op
+
+import dipy.data as dpd
+from dipy.data.fetcher import get_two_hcp842_bundles
+from dipy.io.image import load_nifti
+from dipy.io.streamline import load_trk
+from dipy.segment.clustering import QuickBundles
+from dipy.segment.featurespeed import ResampleFeature
+from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
+import dipy.stats.analysis as dsa
+import dipy.tracking.streamline as dts
 
 ###############################################################################
 # To get started, we will grab the bundles.

--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -8,8 +8,8 @@ We show how to extract brain information and mask from a b0 image using DIPY_'s
 
 First import the necessary modules:
 """
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from dipy.core.histeq import histeq
 from dipy.data import get_fnames

--- a/doc/examples/bundle_assignment_maps.py
+++ b/doc/examples/bundle_assignment_maps.py
@@ -12,8 +12,7 @@ First import the necessary modules.
 
 import numpy as np
 
-from dipy.data import get_two_hcp842_bundles
-from dipy.data import fetch_bundle_atlas_hcp842
+from dipy.data import fetch_bundle_atlas_hcp842, get_two_hcp842_bundles
 from dipy.io.streamline import load_trk
 from dipy.stats.analysis import assignment_map
 from dipy.viz import actor, window

--- a/doc/examples/bundle_extraction.py
+++ b/doc/examples/bundle_extraction.py
@@ -12,11 +12,13 @@ First import the necessary modules.
 import numpy as np
 
 from dipy.align.streamlinear import whole_brain_slr
-from dipy.data import get_two_hcp842_bundles
-from dipy.data import (fetch_target_tractogram_hcp,
-                       fetch_bundle_atlas_hcp842,
-                       get_bundle_atlas_hcp842,
-                       get_target_tractogram_hcp)
+from dipy.data import (
+    fetch_bundle_atlas_hcp842,
+    fetch_target_tractogram_hcp,
+    get_bundle_atlas_hcp842,
+    get_target_tractogram_hcp,
+    get_two_hcp842_bundles,
+)
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_trk, save_trk
 from dipy.io.utils import create_tractogram_header

--- a/doc/examples/bundle_group_registration.py
+++ b/doc/examples/bundle_group_registration.py
@@ -33,11 +33,12 @@ Example
 We start by importing and creating the necessary functions:
 """
 
+import logging
+
 from dipy.align.streamlinear import groupwise_slr
 from dipy.data import read_five_af_bundles
 from dipy.viz.streamline import show_bundles
 
-import logging
 logging.basicConfig(level=logging.INFO)
 
 ###############################################################################

--- a/doc/examples/bundle_registration.py
+++ b/doc/examples/bundle_registration.py
@@ -16,7 +16,7 @@ from time import sleep
 from dipy.align.streamlinear import StreamlineLinearRegistration
 from dipy.data import two_cingulum_bundles
 from dipy.tracking.streamline import set_number_of_points
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # Let's download and load the two bundles.

--- a/doc/examples/bundle_shape_similarity.py
+++ b/doc/examples/bundle_shape_similarity.py
@@ -18,10 +18,13 @@ First import the necessary modules.
 """
 
 import numpy as np
-from dipy.viz import window, actor
-from dipy.segment.bundles import bundle_shape_similarity
-from dipy.segment.bundles import select_random_set_of_streamlines
+
 from dipy.data import two_cingulum_bundles
+from dipy.segment.bundles import (
+    bundle_shape_similarity,
+    select_random_set_of_streamlines,
+)
+from dipy.viz import actor, window
 
 ###############################################################################
 # To show the concept we will use two pre-saved cingulum bundle.

--- a/doc/examples/bundlewarp_registration.py
+++ b/doc/examples/bundlewarp_registration.py
@@ -13,17 +13,22 @@ registration of white matter tracts [Chandio23]_.
 
 """
 from os.path import join as pjoin
+from time import time
 
-from dipy.align.streamwarp import (bundlewarp, bundlewarp_vector_filed,
-                                   bundlewarp_shape_analysis)
+from dipy.align.streamwarp import (
+    bundlewarp,
+    bundlewarp_shape_analysis,
+    bundlewarp_vector_filed,
+)
 from dipy.data import fetch_bundle_warp_dataset
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_tractogram, load_trk
-from dipy.tracking.streamline import (set_number_of_points, unlist_streamlines,
-                                      Streamlines)
-from dipy.viz.streamline import (viz_two_bundles, viz_vector_field,
-                                 viz_displacement_mag)
-from time import time
+from dipy.io.streamline import load_trk, save_tractogram
+from dipy.tracking.streamline import (
+    Streamlines,
+    set_number_of_points,
+    unlist_streamlines,
+)
+from dipy.viz.streamline import viz_displacement_mag, viz_two_bundles, viz_vector_field
 
 ###############################################################################
 # Let's download and load two uncinate fasciculus bundles in the left

--- a/doc/examples/cluster_confidence.py
+++ b/doc/examples/cluster_confidence.py
@@ -9,21 +9,20 @@ have similar pathways. The details can be found in [Jordan_2018_plm]_.
 
 """
 
+import matplotlib.pyplot as plt
+
 from dipy.core.gradients import gradient_table
 from dipy.data import default_sphere, get_fnames
 from dipy.direction import peaks_from_model
-from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, load_nifti_data
 from dipy.reconst.shm import CsaOdfModel
-from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
+from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.tracking.streamline import Streamlines, cluster_confidence
 from dipy.tracking.utils import length
 from dipy.viz import actor, window
-
-import matplotlib.pyplot as plt
-
 
 ###############################################################################
 # First, we need to generate some streamlines. For a more complete

--- a/doc/examples/combined_workflow_creation.py
+++ b/doc/examples/combined_workflow_creation.py
@@ -15,7 +15,6 @@ from dipy.workflows.combined_workflow import CombinedWorkflow
 ###############################################################################
 # ``CombinedWorkflow`` is the base class that will be extended to create our
 # combined workflow.
-
 from dipy.workflows.denoise import NLMeansFlow
 from dipy.workflows.segment import MedianOtsuFlow
 

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -79,20 +79,22 @@ are unknown, we use the approximation given in [Portegies2015b]_.
 """
 
 import numpy as np
+
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.denoise.shift_twist_convolution import convolve
-from dipy.io.image import load_nifti_data
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti_data
+from dipy.reconst.csdeconv import (
+    ConstrainedSphericalDeconvModel,
+    auto_response_ssst,
+    odf_sh_to_sharp,
+)
+from dipy.reconst.shm import sf_to_sh, sh_to_sf
 from dipy.segment.mask import median_otsu
 from dipy.sims.voxel import add_noise
-from dipy.reconst.csdeconv import odf_sh_to_sharp
-from dipy.reconst.shm import sf_to_sh, sh_to_sf
-from dipy.reconst.csdeconv import (
-   auto_response_ssst, ConstrainedSphericalDeconvModel)
-
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # The enhancement is evaluated on the Stanford HARDI dataset

--- a/doc/examples/denoise_ascm.py
+++ b/doc/examples/denoise_ascm.py
@@ -26,16 +26,18 @@ of the image features.
 Let us load the necessary modules
 """
 
-import numpy as np
+from time import time
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
-from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.io.image import load_nifti, save_nifti
-from dipy.io.gradients import read_bvals_bvecs
-from time import time
-from dipy.denoise.non_local_means import non_local_means
 from dipy.denoise.adaptive_soft_matching import adaptive_soft_matching
+from dipy.denoise.noise_estimate import estimate_sigma
+from dipy.denoise.non_local_means import non_local_means
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################
 # Choose one of the data from the datasets in dipy_

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -23,8 +23,8 @@ module of dipy:
 import matplotlib.pyplot as plt
 import numpy as np
 
-from dipy.denoise.gibbs import gibbs_removal
 from dipy.data import get_fnames, read_cenir_multib
+from dipy.denoise.gibbs import gibbs_removal
 from dipy.io.image import load_nifti_data
 import dipy.reconst.msdki as msdki
 from dipy.segment.mask import median_otsu

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -27,15 +27,17 @@ please see the following example instead:
 Let's load the necessary modules
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
 from time import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.core.gradients import gradient_table
+from dipy.data import get_fnames
 from dipy.denoise.localpca import localpca
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
-from dipy.data import get_fnames
-from dipy.io.image import load_nifti, save_nifti
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################
 # Load one of the datasets. These data were acquired with 63 gradients and 1

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -26,22 +26,23 @@ Let's load the necessary modules
 """
 
 # load general modules
-import numpy as np
-import matplotlib.pyplot as plt
 from time import time
 
-# load main pca function using Marcenko-Pastur distribution
-from dipy.denoise.localpca import mppca
+import matplotlib.pyplot as plt
+import numpy as np
+
+# load other dipy's functions that will be used for auxiliary analysis
+from dipy.core.gradients import gradient_table
 
 # load functions to fetch data for this example
 from dipy.data import get_fnames
 
-# load other dipy's functions that will be used for auxiliary analysis
-from dipy.core.gradients import gradient_table
-from dipy.io.image import load_nifti, save_nifti
+# load main pca function using Marcenko-Pastur distribution
+from dipy.denoise.localpca import mppca
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.segment.mask import median_otsu
+from dipy.io.image import load_nifti, save_nifti
 import dipy.reconst.dki as dki
+from dipy.segment.mask import median_otsu
 
 ###############################################################################
 # For this example, we use fetch to download a multi-shell dataset which was

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -10,12 +10,14 @@ modeling the noise as Gaussian or Rician (default).
 We start by loading the necessary modules
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
 from time import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from dipy.data import get_fnames
 from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.data import get_fnames
 from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################

--- a/doc/examples/denoise_patch2self.py
+++ b/doc/examples/denoise_patch2self.py
@@ -56,12 +56,12 @@ denoised output in (B).
 Let's load the necessary modules:
 """
 
-import numpy as np
-from dipy.data import get_fnames
-from dipy.io.image import load_nifti, save_nifti
 import matplotlib.pyplot as plt
+import numpy as np
 
+from dipy.data import get_fnames
 from dipy.denoise.patch2self import patch2self
+from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################
 # Now let's load an example dataset and denoise it with Patch2Self. Patch2Self

--- a/doc/examples/fast_streamline_search.py
+++ b/doc/examples/fast_streamline_search.py
@@ -11,8 +11,12 @@ First import the necessary modules.
 
 import numpy as np
 
-from dipy.data import (get_target_tractogram_hcp, get_two_hcp842_bundles,
-                       fetch_bundle_atlas_hcp842, fetch_target_tractogram_hcp)
+from dipy.data import (
+    fetch_bundle_atlas_hcp842,
+    fetch_target_tractogram_hcp,
+    get_target_tractogram_hcp,
+    get_two_hcp842_bundles,
+)
 from dipy.io.streamline import load_trk
 from dipy.segment.fss import FastStreamlineSearch, nearest_from_matrix_row
 from dipy.viz import actor, window

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -42,20 +42,19 @@ datasets in DIPY_.
 import numpy as np
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.denoise.enhancement_kernel import EnhancementKernel
-from dipy.direction import peaks_from_model, ProbabilisticDirectionGetter
-from dipy.io.image import load_nifti_data, load_nifti
+from dipy.direction import ProbabilisticDirectionGetter, peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, load_nifti_data
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.shm import CsaOdfModel
-from dipy.reconst.csdeconv import (
-  auto_response_ssst, ConstrainedSphericalDeconvModel)
 from dipy.tracking import utils
+from dipy.tracking.fbcmeasures import FBCMeasures
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.tracking.streamline import Streamlines
-from dipy.tracking.fbcmeasures import FBCMeasures
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -25,9 +25,10 @@ Let's start by importing the necessary modules.
 """
 
 import numpy as np
+
 from dipy.core.gradients import gradient_table
-from dipy.core.sphere import disperse_charges, Sphere, HemiSphere
-from dipy.viz import window, actor
+from dipy.core.sphere import HemiSphere, Sphere, disperse_charges
+from dipy.viz import actor, window
 
 ###############################################################################
 # We can first create some random points on a ``HemiSphere`` using spherical

--- a/doc/examples/histology_resdnn.py
+++ b/doc/examples/histology_resdnn.py
@@ -18,13 +18,12 @@ import scipy.ndimage as ndi
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, get_sphere
-from dipy.io.image import load_nifti, save_nifti
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, save_nifti
 from dipy.nn.histo_resdnn import HistoResDNN
 from dipy.reconst.shm import sh_to_sf_matrix
 from dipy.segment.mask import median_otsu
-from dipy.viz import window, actor
-
+from dipy.viz import actor, window
 
 # Disable oneDNN warning
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'

--- a/doc/examples/kfold_xval.py
+++ b/doc/examples/kfold_xval.py
@@ -34,17 +34,17 @@ First, we import that modules needed for this example. In particular, the
 
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-
-import dipy.data as dpd
-import dipy.reconst.cross_validation as xval
-import dipy.reconst.dti as dti
-import dipy.reconst.csdeconv as csd
+import numpy as np
 import scipy.stats as stats
+
 from dipy.core.gradients import gradient_table
-from dipy.io.image import load_nifti
+import dipy.data as dpd
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti
+import dipy.reconst.cross_validation as xval
+import dipy.reconst.csdeconv as csd
+import dipy.reconst.dti as dti
 
 np.random.seed(2014)
 

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -21,22 +21,20 @@ created in that example:
 """
 from os.path import join as pjoin
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import AxesGrid
-
-import dipy.core.optimize as opt
-from dipy.data import fetch_stanford_tracks
-from dipy.io.streamline import load_trk
-import dipy.tracking.life as life
-from dipy.viz import window, actor, colormap as cmap
+import numpy as np
 
 # We'll need to know where the corpus callosum is from these variables:
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames
+import dipy.core.optimize as opt
+from dipy.data import fetch_stanford_tracks, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti_data, load_nifti
+from dipy.io.image import load_nifti, load_nifti_data
+from dipy.io.streamline import load_trk
+import dipy.tracking.life as life
+from dipy.viz import actor, colormap as cmap, window
 
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 label_fname = get_fnames('stanford_labels')

--- a/doc/examples/motion_correction.py
+++ b/doc/examples/motion_correction.py
@@ -19,8 +19,8 @@ Let's import some essential functions.
 from dipy.align import motion_correction
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
-from dipy.io.image import load_nifti, save_nifti
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################
 # We choose one of the data from the datasets in dipy_. However, you can

--- a/doc/examples/path_length_map.py
+++ b/doc/examples/path_length_map.py
@@ -20,21 +20,22 @@ on a tractography model of the local white matter anatomy, as described in
 Let's start by importing the necessary modules.
 """
 
-from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
-from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti_data, load_nifti, save_nifti
-from dipy.reconst.shm import CsaOdfModel
-from dipy.direction import peaks_from_model
-from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.tracking import utils
-from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import Streamlines
-from dipy.viz import actor, window, colormap as cmap
-from dipy.tracking.utils import path_length
-import numpy as np
 import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import AxesGrid
+import numpy as np
+
+from dipy.core.gradients import gradient_table
+from dipy.data import default_sphere, get_fnames
+from dipy.direction import peaks_from_model
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
+from dipy.reconst.shm import CsaOdfModel
+from dipy.tracking import utils
+from dipy.tracking.local_tracking import LocalTracking
+from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
+from dipy.tracking.streamline import Streamlines
+from dipy.tracking.utils import path_length
+from dipy.viz import actor, colormap as cmap, window
 
 ###############################################################################
 # First, we need to generate some streamlines and visualize. For a more

--- a/doc/examples/piesno.py
+++ b/doc/examples/piesno.py
@@ -34,11 +34,11 @@ In this example, we will demonstrate the use of PIESNO with a 3-shell data-set.
 We start by importing necessary modules and functions:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-from dipy.denoise.noise_estimate import piesno
 from dipy.data import get_fnames
+from dipy.denoise.noise_estimate import piesno
 from dipy.io.image import load_nifti, save_nifti
 
 ###############################################################################

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -12,13 +12,13 @@ First import the necessary modules:
 import numpy as np
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
+from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 from dipy.reconst.shm import CsaOdfModel
-from dipy.direction import peaks_from_model
 from dipy.segment.mask import median_otsu
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # Download and read the data for this tutorial and load the raw diffusion data

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -10,14 +10,14 @@ Import modules, fetch and read data, and compute the mask.
 """
 
 import time
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, get_sphere
+from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 from dipy.reconst.shm import CsaOdfModel
-from dipy.direction import peaks_from_model
 from dipy.segment.mask import median_otsu
-
 
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -28,19 +28,20 @@ with b-value 2000.
 import numpy as np
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
-from dipy.reconst.dti import (
-    TensorModel, fractional_anisotropy, mean_diffusivity)
-from dipy.reconst.csdeconv import (auto_response_ssst,
-                                   mask_for_response_ssst,
-                                   response_from_mask_ssst,
-                                   recursive_response,
-                                   ConstrainedSphericalDeconvModel)
+from dipy.reconst.csdeconv import (
+    ConstrainedSphericalDeconvModel,
+    auto_response_ssst,
+    mask_for_response_ssst,
+    recursive_response,
+    response_from_mask_ssst,
+)
+from dipy.reconst.dti import TensorModel, fractional_anisotropy, mean_diffusivity
 from dipy.sims.voxel import single_tensor_odf
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -16,14 +16,12 @@ import multiprocessing
 import time
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
-from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
-from dipy.reconst.csdeconv import auto_response_ssst
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.segment.mask import median_otsu
-
 
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 

--- a/doc/examples/reconst_cti.py
+++ b/doc/examples/reconst_cti.py
@@ -55,11 +55,11 @@ First, we'll import all relevant modules.
 
 import matplotlib.pyplot as plt
 
-import dipy.reconst.cti as cti
-from dipy.io import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
-from dipy.io.image import load_nifti
 from dipy.data import get_fnames
+from dipy.io import read_bvals_bvecs
+from dipy.io.image import load_nifti
+import dipy.reconst.cti as cti
 
 ###############################################################################
 # For CTI analysis, data must be acquired using double diffusion encoding,

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -62,15 +62,16 @@ First, we import all relevant modules:
 """
 
 import numpy as np
-import dipy.reconst.dki as dki
-import dipy.reconst.dti as dti
+from scipy.ndimage import gaussian_filter
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+import dipy.reconst.dki as dki
+import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 from dipy.viz.plotting import compare_maps
-from scipy.ndimage import gaussian_filter
 
 ###############################################################################
 # DKI requires multi-shell data, i.e. data acquired from more than one

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -21,16 +21,17 @@ the WMTI model.
 First, we import all relevant modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-import dipy.reconst.dki as dki
-import dipy.reconst.dki_micro as dki_micro
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+import dipy.reconst.dki as dki
+import dipy.reconst.dki_micro as dki_micro
 from dipy.segment.mask import median_otsu
-from scipy.ndimage import gaussian_filter
 
 ###############################################################################
 # As the standard DKI, WMTI requires multi-shell data, i.e. data acquired from

--- a/doc/examples/reconst_dsi.py
+++ b/doc/examples/reconst_dsi.py
@@ -9,8 +9,8 @@ diffusion MRI datasets of Cartesian keyhole diffusion gradients.
 First import the necessary modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from dipy.core.gradients import gradient_table
 from dipy.core.ndindex import ndindex

--- a/doc/examples/reconst_dsi_metrics.py
+++ b/doc/examples/reconst_dsi_metrics.py
@@ -10,8 +10,9 @@ probability (RTOP) [Descoteaux2011]_ and mean square displacement (MSD)
 First import the necessary modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -13,12 +13,12 @@ performs against standard DSI ODF and a ground truth multi tensor ODF.
 """
 
 import numpy as np
-from dipy.sims.voxel import multi_tensor, multi_tensor_odf
-from dipy.data import get_fnames, get_sphere
+
 from dipy.core.gradients import gradient_table
-from dipy.reconst.dsi import (DiffusionSpectrumDeconvModel,
-                              DiffusionSpectrumModel)
-from dipy.viz import window, actor
+from dipy.data import get_fnames, get_sphere
+from dipy.reconst.dsi import DiffusionSpectrumDeconvModel, DiffusionSpectrumModel
+from dipy.sims.voxel import multi_tensor, multi_tensor_odf
+from dipy.viz import actor, window
 
 ###############################################################################
 # For the simulation we will use a standard DSI acquisition scheme with 514

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -55,9 +55,9 @@ import numpy as np
 ``dipy.io.gradients`` is for loading / saving our bvals and bvecs
 """
 
-from dipy.io.image import load_nifti, save_nifti
-from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti, save_nifti
 
 """
 ``dipy.reconst`` is for the reconstruction algorithms which we use to create
@@ -156,7 +156,7 @@ or where more than one population of white matter fibers crosses.
 """
 
 print('Computing anisotropy measures (FA, MD, RGB)')
-from dipy.reconst.dti import fractional_anisotropy, color_fa
+from dipy.reconst.dti import color_fa, fractional_anisotropy
 
 FA = fractional_anisotropy(tenfit.evals)
 
@@ -222,9 +222,10 @@ area in an axial slice of the splenium of the corpus callosum (CC).
 print('Computing tensor ellipsoids in a part of the splenium of the CC')
 
 from dipy.data import get_sphere
+
 sphere = get_sphere('repulsion724')
 
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -10,14 +10,16 @@ axially symmetric tensor and the fODF using the FORECAST model from
 First import the necessary modules:
 """
 
-import numpy as np
+import os.path as op
+
 import matplotlib.pyplot as plt
+import nibabel as nib
+import numpy as np
+
+from dipy.core.gradients import gradient_table
+from dipy.data import fetch_hbn, get_sphere
 from dipy.reconst.forecast import ForecastModel
 from dipy.viz import actor, window
-from dipy.data import fetch_hbn, get_sphere
-import nibabel as nib
-import os.path as op
-from dipy.core.gradients import gradient_table
 
 ###############################################################################
 # Download and read the data for this tutorial. Our implementation of FORECAST

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -40,14 +40,16 @@ The full details of Dipy's free water DTI implementation was published in
 Let's start by importing the relevant modules:
 """
 
-import numpy as np
-import dipy.reconst.fwdti as fwdti
-import dipy.reconst.dti as dti
-import matplotlib.pyplot as plt
-from dipy.data import fetch_hbn
 import os.path as op
+
+import matplotlib.pyplot as plt
 import nibabel as nib
+import numpy as np
+
 from dipy.core.gradients import gradient_table
+from dipy.data import fetch_hbn
+import dipy.reconst.dti as dti
+import dipy.reconst.fwdti as fwdti
 
 ###############################################################################
 # Without spatial constrains the free water elimination model cannot be solved

--- a/doc/examples/reconst_gqi.py
+++ b/doc/examples/reconst_gqi.py
@@ -11,12 +11,13 @@ First import the necessary modules:
 """
 
 import numpy as np
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, get_sphere
+from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 from dipy.reconst.gqi import GeneralizedQSamplingModel
-from dipy.direction import peaks_from_model
 
 ###############################################################################
 # Download and get the data filenames for this tutorial.

--- a/doc/examples/reconst_ivim.py
+++ b/doc/examples/reconst_ivim.py
@@ -35,11 +35,11 @@ coefficients. First, we import all relevant modules:
 
 import matplotlib.pyplot as plt
 
-from dipy.reconst.ivim import IvimModel
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
+from dipy.reconst.ivim import IvimModel
 
 ###############################################################################
 # We get an IVIM dataset using DIPY_'s data fetcher ``read_ivim``.

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -25,12 +25,12 @@ regularization (MAPL) [Fick2016a]_.
 First import the necessary modules:
 """
 
-from dipy.reconst import mapmri
-from dipy.viz import window, actor
-from dipy.data import get_fnames, get_sphere
 from dipy.core.gradients import gradient_table
-from dipy.io.image import load_nifti
+from dipy.data import get_fnames, get_sphere
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti
+from dipy.reconst import mapmri
+from dipy.viz import actor, window
 from dipy.viz.plotting import compare_maps
 
 ###############################################################################

--- a/doc/examples/reconst_mcsd.py
+++ b/doc/examples/reconst_mcsd.py
@@ -29,24 +29,27 @@ The reconstruction of the fiber orientation distribution function
 First, we import all the modules we need from dipy as follows:
 """
 
-import numpy as np
-import dipy.reconst.shm as shm
-import dipy.direction.peaks as dp
 import matplotlib.pyplot as plt
+import numpy as np
 
-from dipy.denoise.localpca import mppca
 from dipy.core.gradients import gradient_table, unique_bvals_tolerance
+from dipy.data import get_fnames, get_sphere
+from dipy.denoise.localpca import mppca
+import dipy.direction.peaks as dp
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+from dipy.reconst.mcsd import (
+    MultiShellDeconvModel,
+    auto_response_msmt,
+    mask_for_response_msmt,
+    multi_shell_fiber_response,
+    response_from_mask_msmt,
+)
+import dipy.reconst.shm as shm
 from dipy.segment.mask import median_otsu
-from dipy.reconst.mcsd import (auto_response_msmt,
-                               mask_for_response_msmt,
-                               response_from_mask_msmt)
 from dipy.segment.tissue import TissueClassifierHMRF
-from dipy.reconst.mcsd import MultiShellDeconvModel, multi_shell_fiber_response
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
-from dipy.data import get_sphere, get_fnames
 sphere = get_sphere('symmetric724')
 
 ###############################################################################

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -35,23 +35,24 @@ technique [NetoHe2019]_, [Kaden2016b]_.
 Let's import all relevant modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-# Reconstruction modules
-import dipy.reconst.dki as dki
-import dipy.reconst.msdki as msdki
-
-# For simulations
-from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import gradient_table
-from dipy.core.sphere import disperse_charges, HemiSphere
+from dipy.core.sphere import HemiSphere, disperse_charges
 
 # For in-vivo data
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+
+# Reconstruction modules
+import dipy.reconst.dki as dki
+import dipy.reconst.msdki as msdki
 from dipy.segment.mask import median_otsu
+
+# For simulations
+from dipy.sims.voxel import multi_tensor
 
 ###############################################################################
 # Testing MSDKI in synthetic data

--- a/doc/examples/reconst_qtdmri.py
+++ b/doc/examples/reconst_qtdmri.py
@@ -33,11 +33,14 @@ time-dependent q-space indices from a :math:`q\tau`-acquisition of a mouse.
 First import the necessary modules:
 """
 
-from dipy.data.fetcher import (fetch_qtdMRI_test_retest_2subjects,
-                               read_qtdMRI_test_retest_2subjects)
-from dipy.reconst import qtdmri, dti
 import matplotlib.pyplot as plt
 import numpy as np
+
+from dipy.data.fetcher import (
+    fetch_qtdMRI_test_retest_2subjects,
+    read_qtdMRI_test_retest_2subjects,
+)
+from dipy.reconst import dti, qtdmri
 
 ###############################################################################
 # Download and read the data for this tutorial.

--- a/doc/examples/reconst_qti.py
+++ b/doc/examples/reconst_qti.py
@@ -82,12 +82,13 @@ QTI can be fit to data using the module `dipy.reconst.qti`. Let's start by
 importing the required modules and functions:
 """
 
+import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
-import matplotlib.pyplot as plt
-import numpy as np
 import dipy.reconst.qti as qti
 
 ###############################################################################

--- a/doc/examples/reconst_qtiplus.py
+++ b/doc/examples/reconst_qtiplus.py
@@ -136,7 +136,7 @@ In DIPY, the constrained estimation routine is available as part of the
 First we import all the necessary modules to perform the QTI fit:
 """
 
-from dipy.data import read_DiB_217_lte_pte_ste, read_DiB_70_lte_pte_ste
+from dipy.data import read_DiB_70_lte_pte_ste, read_DiB_217_lte_pte_ste
 import dipy.reconst.qti as qti
 from dipy.viz.plotting import compare_qti_maps
 

--- a/doc/examples/reconst_rumba.py
+++ b/doc/examples/reconst_rumba.py
@@ -33,20 +33,19 @@ To begin, we will load the data, consisting of 10 b0s and 150 non-b0s with a
 b-value of 2000.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, get_sphere
-from dipy.direction import peaks_from_model, peak_directions
+from dipy.direction import peak_directions, peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
-from dipy.reconst.rumba import RumbaSDModel
 from dipy.reconst.csdeconv import auto_response_ssst, recursive_response
+from dipy.reconst.rumba import RumbaSDModel
 from dipy.segment.mask import median_otsu
 from dipy.sims.voxel import single_tensor_odf
-from dipy.viz import window, actor
-
+from dipy.viz import actor, window
 
 hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 data, affine = load_nifti(hardi_fname)

--- a/doc/examples/reconst_sfm.py
+++ b/doc/examples/reconst_sfm.py
@@ -11,14 +11,14 @@ reconstruct the fiber Orientation Distribution Function (fODF) in every voxel.
 First, we import the modules we will use in this example:
 """
 
-import dipy.reconst.sfm as sfm
+from dipy.core.gradients import gradient_table
 import dipy.data as dpd
 import dipy.direction.peaks as dpp
-from dipy.io.image import load_nifti
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import gradient_table
+from dipy.io.image import load_nifti
 from dipy.reconst.csdeconv import auto_response_ssst
-from dipy.viz import window, actor
+import dipy.reconst.sfm as sfm
+from dipy.viz import actor, window
 
 ###############################################################################
 # For the purpose of this example, we will use the Stanford HARDI dataset (150

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -11,11 +11,12 @@ Let's import some standard packages.
 """
 
 import numpy as np
-from dipy.core.sphere import disperse_charges, Sphere, HemiSphere
+
+from dipy.core.sphere import HemiSphere, Sphere, disperse_charges
 from dipy.data import get_sphere
 from dipy.reconst.shm import sf_to_sh, sh_to_sf
 from dipy.sims.voxel import multi_tensor_odf
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # We can first create some random points on a ``HemiSphere`` using spherical

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -11,12 +11,12 @@ Function (ODF).
 First import the necessary modules:
 """
 
-from dipy.reconst.shore import ShoreModel
-from dipy.viz import window, actor
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, get_sphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
+from dipy.reconst.shore import ShoreModel
+from dipy.viz import actor, window
 
 ###############################################################################
 # Download and read the data for this tutorial.

--- a/doc/examples/reconst_shore_metrics.py
+++ b/doc/examples/reconst_shore_metrics.py
@@ -11,8 +11,9 @@ dataset like multi-shell or DSI.
 First import the necessary modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs

--- a/doc/examples/register_binary_fuzzy.py
+++ b/doc/examples/register_binary_fuzzy.py
@@ -8,9 +8,10 @@ This could be seen as aligning a fuzzy (sensed) image to a binary
 (e.g., template) image.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from skimage import draw, filters
+
 from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
 from dipy.align.metrics import SSDMetric
 from dipy.viz import regtools

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -36,16 +36,16 @@ We start by importing a few of the libraries we will use.
   visualizations:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from dipy.core.gradients import gradient_table
 import dipy.data as dpd
 import dipy.denoise.noise_estimate as ne
-from dipy.io.image import load_nifti
 from dipy.io.gradients import read_bvals_bvecs
+from dipy.io.image import load_nifti
 import dipy.reconst.dti as dti
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/segment_clustering_features.py
+++ b/doc/examples/segment_clustering_features.py
@@ -19,13 +19,21 @@ Let's import the necessary modules.
 import numpy as np
 
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import (
-    AveragePointwiseEuclideanMetric, EuclideanMetric, CosineMetric)
 from dipy.segment.featurespeed import (
-    IdentityFeature, ResampleFeature, CenterOfMassFeature, MidpointFeature,
-    ArcLengthFeature, VectorOfEndpointsFeature)
+    ArcLengthFeature,
+    CenterOfMassFeature,
+    IdentityFeature,
+    MidpointFeature,
+    ResampleFeature,
+    VectorOfEndpointsFeature,
+)
+from dipy.segment.metric import (
+    AveragePointwiseEuclideanMetric,
+    CosineMetric,
+    EuclideanMetric,
+)
 from dipy.tracking.streamline import set_number_of_points
-from dipy.viz import window, actor, colormap as cmap
+from dipy.viz import actor, colormap as cmap, window
 
 ###############################################################################
 # .. note::

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -18,11 +18,14 @@ Let's start by importing the necessary modules.
 import numpy as np
 
 from dipy.segment.clustering import QuickBundles
-from dipy.segment.metric import (
-    AveragePointwiseEuclideanMetric, SumPointwiseEuclideanMetric, CosineMetric)
 from dipy.segment.featurespeed import VectorOfEndpointsFeature
+from dipy.segment.metric import (
+    AveragePointwiseEuclideanMetric,
+    CosineMetric,
+    SumPointwiseEuclideanMetric,
+)
 from dipy.tracking.streamline import set_number_of_points
-from dipy.viz import window, actor, colormap
+from dipy.viz import actor, colormap, window
 
 ###############################################################################
 # .. note::

--- a/doc/examples/segment_extending_clustering_framework.py
+++ b/doc/examples/segment_extending_clustering_framework.py
@@ -64,12 +64,11 @@ import numpy as np
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
-from dipy.tracking.streamline import Streamlines
-from dipy.viz import window, actor, colormap
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.featurespeed import Feature, VectorOfEndpointsFeature
 from dipy.segment.metric import Metric, SumPointwiseEuclideanMetric
-from dipy.tracking.streamline import length
+from dipy.tracking.streamline import Streamlines, length
+from dipy.viz import actor, colormap, window
 
 ###############################################################################
 # We now define the class ``ArcLengthFeature`` that will perform the desired

--- a/doc/examples/segment_quickbundles.py
+++ b/doc/examples/segment_quickbundles.py
@@ -10,11 +10,12 @@ First import the necessary modules.
 """
 
 import numpy as np
+
+from dipy.data import get_fnames
+from dipy.io.pickles import save_pickle
 from dipy.io.streamline import load_tractogram
 from dipy.segment.clustering import QuickBundles
-from dipy.io.pickles import save_pickle
-from dipy.data import get_fnames
-from dipy.viz import window, actor, colormap
+from dipy.viz import actor, colormap, window
 
 ###############################################################################
 # For educational purposes we will try to cluster a small streamline bundle

--- a/doc/examples/simulate_dki.py
+++ b/doc/examples/simulate_dki.py
@@ -17,13 +17,14 @@ performed according to [RNH2015]_.
 We first import all relevant modules.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-from dipy.sims.voxel import (multi_tensor_dki, single_tensor)
+import numpy as np
+
+from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.core.gradients import gradient_table
-from dipy.reconst.dti import (decompose_tensor, from_lower_triangular)
+from dipy.reconst.dti import decompose_tensor, from_lower_triangular
+from dipy.sims.voxel import multi_tensor_dki, single_tensor
 
 ###############################################################################
 # For the simulation we will need a GradientTable with the b-values and

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -10,11 +10,11 @@ single voxel using a MultiTensor.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from dipy.core.sphere import disperse_charges, HemiSphere
 from dipy.core.gradients import gradient_table
+from dipy.core.sphere import HemiSphere, disperse_charges
 from dipy.data import get_sphere
 from dipy.sims.voxel import multi_tensor, multi_tensor_odf
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # For the simulation we will need a GradientTable with the b-values and

--- a/doc/examples/snr_in_cc.py
+++ b/doc/examples/snr_in_cc.py
@@ -30,16 +30,16 @@ example for further explanations).
 Let's load the necessary modules:
 """
 
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.ndimage import binary_dilation
-import matplotlib.pyplot as plt
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
-from dipy.segment.mask import median_otsu, segment_from_cfa, bounding_box
 from dipy.reconst.dti import TensorModel
+from dipy.segment.mask import bounding_box, median_otsu, segment_from_cfa
 
 ###############################################################################
 # Then, we fetch and load a specific dataset with 64 gradient directions:

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -20,15 +20,13 @@ import os
 
 import nibabel as nib
 import numpy as np
+
+from dipy.data.fetcher import fetch_file_formats, get_file_formats
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.io.utils import (create_nifti_header, get_reference_info,
-                           is_header_compatible)
+from dipy.io.utils import create_nifti_header, get_reference_info, is_header_compatible
 from dipy.tracking.streamline import select_random_set_of_streamlines
 from dipy.tracking.utils import density_map
-
-from dipy.data.fetcher import (fetch_file_formats,
-                               get_file_formats)
 
 ###############################################################################
 # First fetch the dataset that contains 5 tractography file of 5 file formats:

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -14,12 +14,13 @@ numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where $M$ is the
 number of streamlines in the set.
 """
 
+import matplotlib.pyplot as plt
 import numpy as np
+
 from dipy.tracking.distances import approx_polygon_track
 from dipy.tracking.streamline import set_number_of_points
 from dipy.tracking.utils import length
-import matplotlib.pyplot as plt
-from dipy.viz import window, actor
+from dipy.viz import actor, window
 
 ###############################################################################
 # Let's first create a simple simulation of a bundle of streamlines using

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -27,15 +27,15 @@ import numpy as np
 from dipy.align import affine_registration, syn_registration
 from dipy.align.reslice import reslice
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, fetch_stanford_tracks
-from dipy.data.fetcher import (fetch_mni_template, read_mni_template)
+from dipy.data import fetch_stanford_tracks, get_fnames
+from dipy.data.fetcher import fetch_mni_template, read_mni_template
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_tractogram, load_tractogram
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.segment.mask import median_otsu
 from dipy.tracking.streamline import transform_streamlines
-from dipy.viz import regtools, has_fury, horizon
+from dipy.viz import has_fury, horizon, regtools
 
 ###############################################################################
 # In order to get the deformation field, we will first use two b0 volumes. Both

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -20,23 +20,23 @@ modules and download the data we'll be using.
 Let's load the necessary modules:
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.ndimage import binary_dilation
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
+from dipy.direction import peaks
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti_data, load_nifti, save_nifti
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
-from dipy.direction import peaks
 from dipy.reconst import shm
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
-from dipy.viz import window, actor, colormap as cmap
+from dipy.viz import actor, colormap as cmap, window
 
 ###############################################################################
 # We'll be using the Stanford HARDI dataset which consists of a single

--- a/doc/examples/surface_seed.py
+++ b/doc/examples/surface_seed.py
@@ -7,16 +7,21 @@ Surface seeding is a way to generate initial position for tractography
 from cortical surfaces position [Stonge2018]_.
 """
 
+from fury.io import load_polydata
+from fury.utils import (
+    get_actor_from_polydata,
+    get_polydata_triangles,
+    get_polydata_vertices,
+    normals_from_v_f,
+)
 import numpy as np
 
-from dipy.viz import window, actor
 from dipy.data import get_fnames
-from dipy.tracking.mesh import (random_coordinates_from_surface,
-                                seeds_from_surface_coordinates)
-
-from fury.io import load_polydata
-from fury.utils import (get_polydata_triangles, get_polydata_vertices,
-                        get_actor_from_polydata, normals_from_v_f)
+from dipy.tracking.mesh import (
+    random_coordinates_from_surface,
+    seeds_from_surface_coordinates,
+)
+from dipy.viz import actor, window
 
 ###############################################################################
 # Fetch and load a surface

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -11,14 +11,14 @@ registration
 """
 
 import numpy as np
-from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
-from dipy.align.metrics import SSDMetric, CCMetric
+
 import dipy.align.imwarp as imwarp
+from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
+from dipy.align.metrics import CCMetric, SSDMetric
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti_data
 from dipy.segment.mask import median_otsu
 from dipy.viz import regtools
-
 
 fname_moving = get_fnames('reg_o')
 fname_static = get_fnames('reg_c')

--- a/doc/examples/tissue_classification.py
+++ b/doc/examples/tissue_classification.py
@@ -16,12 +16,14 @@ Here we will use a T1-weighted image, that has been previously skull-stripped
 and bias field corrected.
 """
 
-import numpy as np
+import time
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti_data
 from dipy.segment.tissue import TissueClassifierHMRF
-import time
 
 ###############################################################################
 # First we fetch the T1 volume from the Syn dataset and determine its shape.

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -22,14 +22,13 @@ from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import Streamlines
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.viz import window, actor, colormap, has_fury
+from dipy.tracking.streamline import Streamlines
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_deterministic.py
+++ b/doc/examples/tracking_deterministic.py
@@ -32,14 +32,13 @@ from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.tracking.streamline import Streamlines
-from dipy.viz import window, actor, colormap, has_fury
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_pft.py
+++ b/doc/examples/tracking_pft.py
@@ -24,23 +24,21 @@ Deconvolution (CSD) reconstruction model, creating the probabilistic direction
 getter and defining the seeds.
 """
 
-from dipy.tracking.stopping_criterion import CmcStoppingCriterion
 import numpy as np
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.direction import ProbabilisticDirectionGetter
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
-from dipy.tracking.local_tracking import (LocalTracking,
-                                          ParticleFilteringTracking)
-from dipy.tracking.streamline import Streamlines
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking import utils
-from dipy.viz import window, actor, colormap, has_fury
+from dipy.tracking.local_tracking import LocalTracking, ParticleFilteringTracking
+from dipy.tracking.stopping_criterion import CmcStoppingCriterion
+from dipy.tracking.streamline import Streamlines
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_probabilistic.py
+++ b/doc/examples/tracking_probabilistic.py
@@ -21,20 +21,19 @@ data and fitting a Constrained Spherical Deconvolution (CSD) model.
 """
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, small_sphere, default_sphere
+from dipy.data import default_sphere, get_fnames, small_sphere
 from dipy.direction import ProbabilisticDirectionGetter, peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import Streamlines
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.viz import window, actor, colormap, has_fury
+from dipy.tracking.streamline import Streamlines
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_ptt.py
+++ b/doc/examples/tracking_ptt.py
@@ -7,23 +7,20 @@ Parallel Transport Tractography (PTT) [Aydogan2021]_
 Let's start by importing the necessary modules.
 """
 
-from dipy.io.streamline import save_trk
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.data import get_sphere
-from dipy.direction import PTTDirectionGetter
-from dipy.reconst.shm import CsaOdfModel
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames
+from dipy.data import get_fnames, get_sphere
+from dipy.direction import PTTDirectionGetter
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import save_trk
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
+from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import Streamlines
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.viz import window, actor, colormap, has_fury
-
+from dipy.tracking.streamline import Streamlines
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_rumba.py
+++ b/doc/examples/tracking_rumba.py
@@ -15,8 +15,8 @@ tutorial is an extension on
 We start by loading sample data and identifying a fiber response function.
 """
 
-from numpy.linalg import inv
 import matplotlib.pyplot as plt
+from numpy.linalg import inv
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames, small_sphere
@@ -26,13 +26,12 @@ from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import save_trk
 from dipy.reconst.csdeconv import auto_response_ssst
+from dipy.reconst.rumba import RumbaSDModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import Streamlines, transform_streamlines
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.viz import window, actor, colormap
-from dipy.reconst.rumba import RumbaSDModel
-
+from dipy.tracking.streamline import Streamlines, transform_streamlines
+from dipy.viz import actor, colormap, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_sfm.py
+++ b/doc/examples/tracking_sfm.py
@@ -11,23 +11,26 @@ signal as a combination of the signals from different fascicles (see also
 :ref:`sphx_glr_examples_built_reconstruction_reconst_sfm.py`).
 """
 
+from numpy.linalg import inv
+
 from dipy.core.gradients import gradient_table
-from dipy.data import get_sphere, get_fnames
+from dipy.data import get_fnames, get_sphere
+from dipy.direction.peaks import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.direction.peaks import peaks_from_model
-from dipy.io.streamline import save_trk
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.reconst.csdeconv import auto_response_ssst
+from dipy.io.streamline import save_trk
 from dipy.reconst import sfm
+from dipy.reconst.csdeconv import auto_response_ssst
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
-from dipy.tracking.streamline import (select_random_set_of_streamlines,
-                                      transform_streamlines,
-                                      Streamlines)
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
-from dipy.viz import window, actor, colormap, has_fury
-from numpy.linalg import inv
+from dipy.tracking.streamline import (
+    Streamlines,
+    select_random_set_of_streamlines,
+    transform_streamlines,
+)
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/tracking_stopping_criterion.py
+++ b/doc/examples/tracking_stopping_criterion.py
@@ -29,23 +29,23 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere, get_fnames
 from dipy.direction import DeterministicMaximumDirectionGetter
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.io.streamline import save_trk
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response_ssst)
-from dipy.reconst.dti import fractional_anisotropy, TensorModel
+from dipy.io.streamline import save_trk
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
+from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
+from dipy.tracking.stopping_criterion import (
+    ActStoppingCriterion,
+    BinaryStoppingCriterion,
+    ThresholdStoppingCriterion,
+)
 from dipy.tracking.streamline import Streamlines
-from dipy.tracking.stopping_criterion import (ActStoppingCriterion,
-                                              BinaryStoppingCriterion,
-                                              ThresholdStoppingCriterion)
-from dipy.viz import window, actor, colormap, has_fury
-
+from dipy.viz import actor, colormap, has_fury, window
 
 # Enables/disables interactive visualization
 interactive = False

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from dipy.data.fetcher import fetch_bundles_2_subjects, read_bundles_2_subjects
 from dipy.tracking.streamline import Streamlines
-from dipy.viz import actor, window, ui
+from dipy.viz import actor, ui, window
 
 ###############################################################################
 # In ``window`` we have all the objects that connect what needs to be rendered

--- a/doc/examples/viz_bundles.py
+++ b/doc/examples/viz_bundles.py
@@ -8,9 +8,10 @@ which provides metrics and bundles.
 """
 
 import numpy as np
-from dipy.viz import window, actor
+
 from dipy.data import fetch_bundles_2_subjects, read_bundles_2_subjects
-from dipy.tracking.streamline import transform_streamlines, length
+from dipy.tracking.streamline import length, transform_streamlines
+from dipy.viz import actor, window
 
 fetch_bundles_2_subjects()
 dix = read_bundles_2_subjects(subj_id='subj_1', metrics=['fa'],

--- a/doc/examples/viz_roi_contour.py
+++ b/doc/examples/viz_roi_contour.py
@@ -11,16 +11,16 @@ Let's start by importing the relevant modules.
 """
 
 from dipy.core.gradients import gradient_table
-from dipy.reconst.shm import CsaOdfModel
 from dipy.data import default_sphere, get_fnames
 from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
+from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
+from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.tracking.streamline import Streamlines
-from dipy.viz import actor, window, colormap as cmap
+from dipy.viz import actor, colormap as cmap, window
 
 ###############################################################################
 # First, we need to generate some streamlines. For a more complete

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -12,7 +12,7 @@ import os
 
 from dipy.data import fetch_bundles_2_subjects
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.viz import window, actor, ui
+from dipy.viz import actor, ui, window
 
 ###############################################################################
 # Let's download and load a T1.

--- a/doc/examples/workflow_creation.py
+++ b/doc/examples/workflow_creation.py
@@ -19,7 +19,6 @@ import shutil
 
 ###############################################################################
 # ``shutil`` Will be used for sample file manipulation.
-
 from dipy.workflows.workflow import Workflow
 
 ###############################################################################

--- a/doc/sphinxext/docimage_scrap.py
+++ b/doc/sphinxext/docimage_scrap.py
@@ -1,7 +1,8 @@
-import os
 import glob
+import os
 import shutil
 import time
+
 from sphinx_gallery.scrapers import figure_rst
 
 

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -1,12 +1,13 @@
 """Extract reference documentation from the NumPy source tree."""
 
-import inspect
-import textwrap
-import re
-import pydoc
-from warnings import warn
 import collections
+import inspect
+import pydoc
+import re
 import sys
+import textwrap
+from warnings import warn
+
 from packaging.version import Version
 
 python_version = '.'.join(str(x) for x in sys.version_info[:2])

--- a/doc/sphinxext/docscrape_sphinx.py
+++ b/doc/sphinxext/docscrape_sphinx.py
@@ -1,6 +1,11 @@
-import re, inspect, textwrap, pydoc
+import inspect
+import pydoc
+import re
+import textwrap
+
+from docscrape import ClassDoc, FunctionDoc, NumpyDocString
 import sphinx
-from docscrape import NumpyDocString, FunctionDoc, ClassDoc
+
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):

--- a/doc/sphinxext/math_dollar.py
+++ b/doc/sphinxext/math_dollar.py
@@ -1,5 +1,6 @@
 import re
 
+
 def dollars_to_math(source):
     r"""
     Replace dollar signs with backticks.

--- a/doc/sphinxext/numpydoc.py
+++ b/doc/sphinxext/numpydoc.py
@@ -17,11 +17,12 @@ It will:
 
 """
 
-import re
-import pydoc
-import sphinx
-import inspect
 import collections
+import inspect
+import pydoc
+import re
+
+import sphinx
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")

--- a/doc/sphinxext/prepare_gallery.py
+++ b/doc/sphinxext/prepare_gallery.py
@@ -1,10 +1,10 @@
-import fnmatch
-import sys
-import os
-import shutil
-from os.path import join as pjoin
 from dataclasses import dataclass, field
+import fnmatch
+import os
+from os.path import join as pjoin
 from pathlib import Path
+import shutil
+import sys
 
 from sphinx.util import logging
 

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -17,12 +17,11 @@ is an MIT-licensed project.
 """
 
 import ast
+from importlib import import_module
+from inspect import getmodule, ismethod
 import os
 import re
-from importlib import import_module
-
 from types import BuiltinFunctionType, FunctionType
-from inspect import ismethod, getmodule
 
 # suppress print statements (warnings for empty files)
 DEBUG = True

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -3,9 +3,9 @@
 """
 
 # stdlib imports
-import sys
-import re
 from os.path import join as pjoin
+import re
+import sys
 
 # local imports
 from apigen import ApiDocWriter

--- a/doc/tools/docgen_cmd.py
+++ b/doc/tools/docgen_cmd.py
@@ -2,12 +2,12 @@
 """
 Script to generate documentation for command line utilities
 """
-import os
-from os.path import join as pjoin
-from subprocess import Popen, PIPE, CalledProcessError
-import sys
 import importlib
 import inspect
+import os
+from os.path import join as pjoin
+from subprocess import PIPE, CalledProcessError, Popen
+import sys
 
 # version comparison
 # from packaging.version import Version

--- a/doc/upload_docs.py
+++ b/doc/upload_docs.py
@@ -2,10 +2,10 @@
 # Script to upload docs to gh-pages branch of dipy_web that will be
 # automatically detected by the dipy website.
 import os
-import re
-import sys
 from os import chdir as cd
+import re
 from subprocess import check_call
+import sys
 
 
 def sh(cmd):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
     # Developer UI
     'spin>=0.5',
     'build',
+    'ruff',
 ]
 
 extra = ["dipy[viz, ml]",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+target-version = "py310"
+
+lint.select = [
+  "I",   # isort
+]
+
+[lint.isort]
+case-sensitive = true
+combine-as-imports = true
+force-sort-within-sections = true
+no-sections = false
+order-by-type = true
+relative-imports-order = "closest-to-furthest"
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]

--- a/tools/build_dmgs.py
+++ b/tools/build_dmgs.py
@@ -9,15 +9,14 @@ Note quotes around the globber first argument to protect it from shell
 globbing.
 
 """
-import os
-from os.path import join as pjoin, isfile, isdir
-import shutil
-from glob import glob
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from functools import partial
+from glob import glob
+import os
+from os.path import isdir, isfile, join as pjoin
+import shutil
 from subprocess import check_call
 import warnings
-
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 my_call = partial(check_call, shell=True)
 

--- a/tools/build_release
+++ b/tools/build_release
@@ -2,7 +2,8 @@
 """dipy release build script.
 """
 import os
-from toollib import (c, get_dipydir, compile_tree, cd, pjoin, remove_tree)
+
+from toollib import c, cd, compile_tree, get_dipydir, pjoin, remove_tree
 
 # Get main dipy dir, this will raise if it doesn't pass some checks
 dipydir = get_dipydir()

--- a/tools/dipnost
+++ b/tools/dipnost
@@ -12,8 +12,10 @@ To reproduce a standard test run::
 """
 
 import sys
+
 import nose
 from nose.plugins import doctests
+
 
 # We were getting errors for the extension modules.  See:
 # https://github.com/nose-devs/nose/pull/661

--- a/tools/doc_mod.py
+++ b/tools/doc_mod.py
@@ -6,8 +6,9 @@ Depends on some guessed filepaths
 Filepaths guessed by importing
 """
 
+from os.path import abspath, dirname, join as pjoin
 import sys
-from os.path import join as pjoin, dirname, abspath
+
 ROOT_DIR = abspath(pjoin(dirname(__file__), '..'))
 DOC_SDIR = pjoin(ROOT_DIR, 'doc', 'reference')
 

--- a/tools/doctest_extmods.py
+++ b/tools/doctest_extmods.py
@@ -10,14 +10,12 @@ Examples
     %prog dipy
 """
 
-import sys
-import os
-from os.path import dirname, relpath, sep, join as pjoin, abspath
-
 from distutils.sysconfig import get_config_vars
-
 import doctest
 from optparse import OptionParser
+import os
+from os.path import abspath, dirname, join as pjoin, relpath, sep
+import sys
 
 EXT_EXT = get_config_vars('SO')[0]
 

--- a/tools/ex2rst
+++ b/tools/ex2rst
@@ -13,11 +13,12 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 """Helper to automagically generate ReST versions of examples"""
-import os
-import sys
-import re
+
 import glob
 from optparse import OptionParser
+import os
+import re
+import sys
 
 __docformat__ = 'restructuredtext'
 

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -8,14 +8,12 @@ Taken from ipython
 # Imports
 # -----------------------------------------------------------------------------
 
+from datetime import datetime, timedelta
 import json
 import re
-import sys
-
-from datetime import datetime, timedelta
 from subprocess import check_output
+import sys
 from urllib.request import urlopen
-
 
 # -----------------------------------------------------------------------------
 # Globals

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """ Checkout gitwash repo into directory and do search replace on name """
 
+import fnmatch
+import glob
+from optparse import OptionParser
 import os
 from os.path import join as pjoin
-import shutil
-import sys
 import re
-import glob
-import fnmatch
-import tempfile
+import shutil
 from subprocess import call
-from optparse import OptionParser
+import sys
+import tempfile
 
 verbose = False
 

--- a/tools/osxbuild.py
+++ b/tools/osxbuild.py
@@ -11,12 +11,12 @@ user system.  Script will prompt for sudo pwd.
 
 """
 
+from getpass import getuser
+from optparse import OptionParser
 import os
-import sys
 import shutil
 import subprocess
-from optparse import OptionParser
-from getpass import getuser
+import sys
 
 # USER_README = 'docs/README.rst'
 # DEV_README = SRC_DIR + 'README.rst'

--- a/tools/version_utils.py
+++ b/tools/version_utils.py
@@ -13,10 +13,9 @@ It remains licensed as the rest of scipy (BSD-3 license as of October 2023).
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """
+import argparse
 import os
 import subprocess
-import argparse
-
 
 MAJOR = 1
 MINOR = 10


### PR DESCRIPTION
Sort import statements using `ruff`.

Add a pre-commit hook to apply the import sorting to local files prior to commits.

Add a GHA workflow to apply the pre-commit hooks in order to ensure that files modified across commits/in PRs comply with the expected formatting.