### PR TITLE
ENH: Add `pre-commit` to project `dev` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
     # Developer UI
     'spin>=0.5',
     'build',
+    'pre-commit',
     'ruff',
 ]
 


### PR DESCRIPTION
Add `pre-commit` to project `dev` dependencies: will allow to run `ruff` as a pre-commit hook when installing DIPY in development mode.

Left behind in commit 91fd582.