### PR TITLE
Update affine_registration to clarify returns and make them consistent with docstring

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -433,9 +433,9 @@ def affine_registration(moving, static,
 
     Returns
     -------
-    transformed : array with moving data resampled to the static space
-    after computing the affine transformation
-    affine : the affine 4x4 associated with the transformation.
+    resampled : array with moving data resampled to the static space
+    after computing the affine transformation.
+    final_affine : the affine 4x4 associated with the transformation.
     xopt : the value of the optimized coefficients.
     fopt : the value of the optimization quality metric.
 
@@ -513,9 +513,12 @@ def affine_registration(moving, static,
                                   static_mask=static_mask,
                                   moving_mask=moving_mask)
             starting_affine = xform.affine
-
+            
+    # Copy the final affine into a final variable
+    final_affine = starting_affine.copy()
+                            
     # After doing all that, resample once at the end:
-    affine_map = AffineMap(starting_affine,
+    affine_map = AffineMap(final_affine,
                            static.shape, static_affine,
                            moving.shape, moving_affine)
 
@@ -523,8 +526,8 @@ def affine_registration(moving, static,
 
     # Return the optimization metric only if requested
     if ret_metric:
-        return resampled, starting_affine, xopt, fopt
-    return resampled, starting_affine
+        return resampled, final_affine, xopt, fopt
+    return resampled, final_affine
 
 
 center_of_mass = partial(affine_registration, pipeline=['center_of_mass'])

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -513,10 +513,10 @@ def affine_registration(moving, static,
                                   static_mask=static_mask,
                                   moving_mask=moving_mask)
             starting_affine = xform.affine
-            
+    
     # Copy the final affine into a final variable
     final_affine = starting_affine.copy()
-                            
+    
     # After doing all that, resample once at the end:
     affine_map = AffineMap(final_affine,
                            static.shape, static_affine,


### PR DESCRIPTION
Changed name of return variable in the docstring to match the actual function return. Added a copy of starting_affine named final_affine after registrations to clarify the flow of data.