### PR TITLE
[RF] allow float and double for `trilinear_interpolate4d_c`

### DIFF
--- a/dipy/core/interpolation.pxd
+++ b/dipy/core/interpolation.pxd
@@ -3,9 +3,9 @@ cimport numpy as cnp
 from dipy.align.fused_types cimport floating, number
 
 
-cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
-                                   double* point,
-                                   double* result) noexcept nogil
+cdef int trilinear_interpolate4d_c(floating[:, :, :, :] data,
+                                   floating* point,
+                                   floating* result) noexcept nogil
 
 cdef int _interpolate_vector_2d(floating[:, :, :] field, double dii,
                                 double djj, floating* out) noexcept nogil

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -292,9 +292,9 @@ cdef void _trilinear_interpolation_iso(double *X,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
-                                   double* point,
-                                   double* result) noexcept nogil:
+cdef int trilinear_interpolate4d_c(floating[:, :, :, :] data,
+                                   floating* point,
+                                   floating* result) noexcept nogil:
     """Tri-linear interpolation along the last dimension of a 4d array
 
     Parameters
@@ -349,9 +349,9 @@ cdef int trilinear_interpolate4d_c(double[:, :, :, :] data,
     return 0
 
 
-def trilinear_interpolate4d(double[:, :, :, :] data,
-                            double[:] point,
-                            double[:] out=None):
+def trilinear_interpolate4d(floating[:, :, :, :] data,
+                            floating[:] point,
+                            floating[:] out=None):
     """Tri-linear interpolation along the last dimension of a 4d array
 
     Parameters

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -46,7 +46,7 @@ def test_trilinear_interpolate(rng):
 
     # Pass in out ourselves
     out[:] = -1
-    trilinear_interpolate4d(data, point, out)
+    trilinear_interpolate4d(data.astype(float), point.astype(float), out)
     npt.assert_array_almost_equal(out, expected)
 
     # use a point close to an edge


### PR DESCRIPTION
This PR should fix #3186.  It allows `float` and `double` for `trilinear_interpolate4d_c`.

To see the definition of `floating`, see https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html#built-in-fused-types