### PR TITLE
ENH: Fix miscellaneous warnings in `dki` reconstruction module

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1198,7 +1198,7 @@ def axial_kurtosis(dki_params, min_kurtosis=-3./7, max_kurtosis=10,
         dt = lower_triangular(vec_val_vect(evecs, evals))
         for vox in range(len(kt)):
             AKi[vox] = directional_kurtosis(dt[vox], md[vox], kt[vox],
-                                            np.array([evecs[vox, :, 0]]))
+                                            np.array([evecs[vox, :, 0]])).item()
 
     # reshape data according to input data
     AK[rel_i] = AKi
@@ -1792,7 +1792,7 @@ class DiffusionKurtosisModel(ReconstModel):
         tol = 1e-6
         self.min_diffusivity = tol / -self.design_matrix.min()
 
-        self.convexity_constraint = fit_method in {'CLS', 'CWLS'}
+        self.convexity_constraint = fit_method in {'CLS', 'CWLS', 'NLS'}
         if self.convexity_constraint:
             self.cvxpy_solver = self.kwargs.pop('cvxpy_solver', None)
             self.convexity_level = self.kwargs.pop('convexity_level', 'full')

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -91,13 +91,13 @@ from scipy.ndimage import gaussian_filter
 
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
+from dipy.denoise.localpca import mppca
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 import dipy.reconst.dki as dki
 import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 from dipy.viz.plotting import compare_maps
-from dipy.denoise.localpca import mppca
 
 ###############################################################################
 # DKI requires multi-shell data, i.e. data acquired from more than one


### PR DESCRIPTION
Fix miscellaneous warnings in `dki` reconstruction module:
- Add the `NLS` fit method to the list of methods that understand the `cvxpy_solver` keyword argument when instantiating DKI objects.
  Require `cvxpy` when instantiating a DKI model with the `NLS` fit method in `test_dki_errors`.
- Use the `CLARABEL` `cvxpy` solver.
- Extract the single element in the retuned directional kurtosis array.
- Capture and test the convexity level warning.

Fixes:
```
reconst/tests/test_dki.py::test_dki_fits
  /dipy/venv/lib/python3.10/site-packages/cvxpy/reductions/solvers/solving_chain.py:336:
 FutureWarning:
      Your problem is being solved with the ECOS solver by default. Starting in
      CVXPY 1.5.0, Clarabel will be used as the default solver instead. To continue
      using ECOS, specify the ECOS solver explicitly using the ``solver=cp.ECOS``
      argument to the ``problem.solve`` method.

    warnings.warn(ECOS_DEPRECATION_MSG, FutureWarning)
```

```
reconst/tests/test_dki.py::test_compare_analytical_and_numerical_methods
  /dipy/venv/lib/python3.10/site-packages/dipy/reconst/dki.py:1200:
 DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated,
 and will error in future.
 Ensure you extract a single element from your array before performing this operation.
 (Deprecated NumPy 1.25.)
    AKi[vox] = directional_kurtosis(dt[vox], md[vox], kt[vox],
```

and
```
reconst/tests/test_dki.py::test_dki_errors
  /dipy/venv/lib/python3.10/site-packages/dipy/reconst/dki.py:1810:
 UserWarning: Maximum convexity_level supported is 4.
    warnings.warn(msg)
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/8740100731/job/23982974793#step:10:4426