### PR TITLE
ENH: Ensure that `arccos` argument is in the [-1,1] range

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -128,7 +128,8 @@ def cart2sphere(x, y, z):
 
     """
     r = np.sqrt(x * x + y * y + z * z)
-    theta = np.arccos(np.divide(z, r, where=r > 0))
+    cos = np.divide(z, r, where=r > 0)
+    theta = np.arccos(cos, where=(cos >= -1) & (cos <= 1))
     theta = np.where(r > 0, theta, 0.)
     phi = np.arctan2(y, x)
     r, theta, phi = np.broadcast_arrays(r, theta, phi)


### PR DESCRIPTION
Ensure that the argument to `arccos` in `cart2sphere` is in the [-1,1] range. Rather than clipping the values to the [-1,1] range, leave them uninitialized to keep the previous behavior.

Fixes:
```
reconst/tests/test_forecast.py::test_forecast_predict
reconst/tests/test_mapmri.py::test_mapmri_isotropic_static_scale_factor
reconst/tests/test_mapmri.py::test_mapmri_isotropic_design_matrix_separability
  C:\Miniconda\envs\venv\lib\site-packages\dipy\core\geometry.py:131: RuntimeWarning: invalid value encountered in arccos
    theta = np.arccos(np.divide(z, r, where=r > 0))
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/8767689276/job/24061232823?pr=3197#step:10:4212