### PR TITLE
BF: Declare variables holding integers as `cnp.npy_intp` over `double`

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -146,8 +146,7 @@ cdef double process_block(double[:, :, ::1] arr,
     """
 
     cdef:
-        cnp.npy_intp m, n, o, M, N, O, a, b, c, cnt, step
-        double patch_vol_size
+        cnp.npy_intp m, n, o, M, N, O, patch_vol_size, a, b, c, cnt, step
         double summ, d, w, sumw, sum_out, x, sigm
         double * W
         double * cache

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -103,7 +103,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         cnp.npy_intp prx = patch_radius if n0 > 1 else 0
         cnp.npy_intp pry = patch_radius if n1 > 1 else 0
         cnp.npy_intp prz = patch_radius if n2 > 1 else 0
-        double norm = (2 * prx + 1) * (2 * pry + 1) * (2 * prz + 1)
+        cnp.npy_intp norm = (2 * prx + 1) * (2 * pry + 1) * (2 * prz + 1)
         double sum_reg, temp1
         double[:, :, :] I = np.zeros((n0, n1, n2))
 


### PR DESCRIPTION
Declare variables holding the result of an integer product as `cnp.npy_intp` instead of `double` in denoising Cython code.

Fixes:
```
dipy/denoise/denspeed.cp39-win_amd64.pyd.p/denspeed.c(21239):
 warning C4244: '=': conversion from 'npy_intp' to 'double', possible loss of data
```

and
```
dipy/denoise/pca_noise_estimate.cp39-win_amd64.pyd.p/pca_noise_estimate.c(20299):
 warning C4244: '=': conversion from 'npy_intp' to 'double', possible loss of data
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/8822497881/job/24220827033#step:8:268
https://github.com/dipy/dipy/actions/runs/8822497881/job/24220827033#step:8:319