### PR TITLE
BF: Use `cnp.npy_intp` instead of `int` as counter

### DIFF
--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -2,6 +2,7 @@ cimport cython
 from cython.view cimport array as cvarray
 from libc.math cimport sqrt, exp
 import numpy as np
+cimport numpy as cnp
 
 __all__ = ['firdn', 'upfir', 'nlmeans_block']
 
@@ -401,7 +402,7 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
     cdef double[:, :, :] variances = np.zeros_like(image)
     cdef double[:, :, :] Estimate = np.zeros_like(image)
     cdef double[:, :, :] Label = np.zeros_like(image)
-    cdef int i, j, k, ni, nj, nk
+    cdef cnp.npy_intp i, j, k, ni, nj, nk
     cdef double t1, t2
     cdef double epsilon = 0.00001
     cdef double mu1 = 0.95

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -147,7 +147,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         """
         cdef double[3] position
         cdef int count
-        cdef int i
+        cdef cnp.npy_intp i
 
         # Initialize Frame
         self.frame[0][0] = init_dir[0]
@@ -364,7 +364,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         cdef double data_support = 0
         cdef double[3] tangent
         cdef int tries
-        cdef int i
+        cdef cnp.npy_intp i
 
         self.prepare_propagator(self.step_size)
 

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -41,7 +41,7 @@ cdef print_node(CentroidNode* node, prepend=""):
     txt += " thres({})".format(node.threshold)
     txt += "\n"
 
-    cdef int i
+    cdef cnp.npy_intp i
     for i in range(node.nb_children):
         txt += prepend
         if i == node.nb_children-1:
@@ -129,7 +129,7 @@ cdef class QuickBundlesX:
         self.nb_levels = len(levels_thresholds)
         self.thresholds = <double*> malloc(self.nb_levels*sizeof(double))
 
-        cdef int i
+        cdef cnp.npy_intp i
         for i in range(self.nb_levels):
             self.thresholds[i] = levels_thresholds[i]
 
@@ -257,7 +257,7 @@ cdef class QuickBundlesX:
         return print_node(self.root)
 
     cdef void traverse_postorder(self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*)):
-        cdef int i
+        cdef cnp.npy_intp i
         for i in range(node.nb_children):
             self.traverse_postorder(node.children[i], visit)
         visit(self, node)
@@ -281,7 +281,7 @@ cdef class QuickBundlesX:
         tree_cluster = TreeCluster(threshold=node.threshold,
                                    centroid=np.asarray(centroid),
                                    indices=np.asarray(<int[:node.size]> node.indices).copy())
-        cdef int i
+        cdef cnp.npy_intp i
         for i in range(node.nb_children):
             tree_cluster.add(self._build_tree_clustermap(node.children[i]))
 

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -25,7 +25,7 @@ cdef Shape shape_from_memview(Data data) noexcept nogil:
         structure containing information about the shape of `data`
     """
     cdef Shape shape
-    cdef int i
+    cdef cnp.npy_intp i
     shape.ndim = 0
     shape.size = 1
     for i in range(MAX_NDIM):
@@ -52,7 +52,7 @@ cdef Shape tuple2shape(dims) except *:
     """
     assert len(dims) < MAX_NDIM
     cdef Shape shape
-    cdef int i
+    cdef cnp.npy_intp i
     shape.ndim = len(dims)
     shape.size = np.prod(dims)
     for i in range(shape.ndim):
@@ -74,7 +74,7 @@ cdef shape2tuple(Shape shape):
     dims : tuple of int
         size of each dimension
     """
-    cdef int i
+    cdef cnp.npy_intp i
     dims = []
     for i in range(shape.ndim):
         dims.append(shape.dims[i])
@@ -101,7 +101,7 @@ cdef int same_shape(Shape shape1, Shape shape2) noexcept nogil:
         tells if the shape are equals
     """
 
-    cdef int i
+    cdef cnp.npy_intp i
     cdef int same_shape = True
 
     same_shape &= shape1.ndim == shape2.ndim

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -235,7 +235,7 @@ cdef class CenterOfMassFeature(CythonFeature):
 
     cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) noexcept nogil:
         cdef int N = datum.shape[0], D = datum.shape[1]
-        cdef int i, d
+        cdef cnp.npy_intp i, d
 
         for d in range(D):
             out[0, d] = 0
@@ -356,7 +356,7 @@ cpdef infer_shape(Feature feature, data):
         return []
 
     shapes = []
-    cdef int i
+    cdef cnp.npy_intp i
     for i in range(0, len(data)):
         datum = data[i] if data[i].flags.writeable else data[i].astype(np.float32)
         shapes.append(shape2tuple(feature.c_infer_shape(datum)))
@@ -393,7 +393,7 @@ cpdef extract(Feature feature, data):
     shapes = infer_shape(feature, data)
     features = [np.empty(shape, dtype=np.float32) for shape in shapes]
 
-    cdef int i
+    cdef cnp.npy_intp i
     for i in range(len(data)):
         datum = data[i] if data[i].flags.writeable else data[i].astype(np.float32)
         feature.c_extract(datum, features[i])

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -1,6 +1,7 @@
 # cython: wraparound=False, cdivision=True, boundscheck=False
 
 import numpy as np
+cimport numpy as cnp
 
 from libc.math cimport sqrt, acos
 
@@ -389,7 +390,7 @@ cpdef distance_matrix(Metric metric, data1, data2=None):
     2D array (double)
         Distance matrix.
     """
-    cdef int i, j
+    cdef cnp.npy_intp i, j
     if data2 is None:
         data2 = data1
 

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -264,7 +264,7 @@ cdef void _initialize_param_uniform(double[:, :, :] image, double[:] mu,
         cnp.npy_intp ny = image.shape[1]
         cnp.npy_intp nz = image.shape[2]
         cnp.npy_intp nclasses = mu.shape[0]
-        int i
+        cnp.npy_intp i
         double min_val
         double max_val
     min_val = image[0, 0, 0]

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -105,7 +105,7 @@ cdef inline void cnormalized_3vec(float *vec_in, float *vec_out):
 
     """
     cdef float norm = cnorm_3vec(vec_in)
-    cdef int i
+    cdef cnp.npy_intp i
     for i in range(3):
         vec_out[i] = vec_in[i] / norm
 
@@ -117,7 +117,7 @@ def inner_3vecs(vec1, vec2):
 
 
 cdef inline float cinner_3vecs(float *vec1, float *vec2) noexcept nogil:
-    cdef int i
+    cdef cnp.npy_intp i
     cdef float ip = 0
     for i from 0<=i<3:
         ip += vec1[i]*vec2[i]
@@ -135,7 +135,7 @@ def sub_3vecs(vec1, vec2):
 
 
 cdef inline void csub_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
-    cdef int i
+    cdef cnp.npy_intp i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]-vec2[i]
 
@@ -151,7 +151,7 @@ def add_3vecs(vec1, vec2):
 
 
 cdef inline void cadd_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
-    cdef int i
+    cdef cnp.npy_intp i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]+vec2[i]
 
@@ -165,7 +165,7 @@ def mul_3vecs(vec1, vec2):
     return vec_out
 
 cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
-    cdef int i
+    cdef cnp.npy_intp i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]*vec2[i]
 
@@ -177,7 +177,7 @@ def mul_3vec(a, vec):
     return vec_out
 
 cdef inline void cmul_3vec(float a, float *vec, float *vec_out) noexcept nogil:
-    cdef int i
+    cdef cnp.npy_intp i
     for i from 0<=i<3:
         vec_out[i] = a*vec[i]
 
@@ -1517,7 +1517,7 @@ cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *
     """
 
     cdef:
-        int i
+        cnp.npy_intp i
         float tmp1=0,tmp2=0,tmp3=0,tmp1f=0,tmp3f=0
 
     #for i in range(3):
@@ -1852,7 +1852,7 @@ cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float  *c1,floa
     """
 
     cdef:
-        int i
+        cnp.npy_intp i
         float tmp1=0,tmp2=0,tmp3=0,tmp1f=0,tmp3f=0
     #for i in range(3):
     for i from 0<=i<3:
@@ -2071,7 +2071,7 @@ def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
         int tlen = len(track)
         int curr = 0
         float dist = 0
-        int i
+        cnp.npy_intp i
         int intersects = 0
 
     with nogil:
@@ -2127,7 +2127,7 @@ def track_roi_intersection_check(cnp.ndarray[float,ndim=2] track, cnp.ndarray[fl
         int curr = 0
         int currp = 0
         float dist = 0
-        int i,j
+        cnp.npy_intp i,j
         int intersects=0
 
     with nogil:

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -16,7 +16,7 @@ cdef int where_to_insert(cnp.float_t* arr, cnp.float_t number, int size) noexcep
 
 cdef void cumsum(cnp.float_t* arr_in, cnp.float_t* arr_out, int N) noexcept nogil:
     cdef:
-        int i = 0
+        cnp.npy_intp i = 0
         cnp.float_t csum = 0
     for i in range(N):
         csum += arr_in[i]
@@ -25,14 +25,14 @@ cdef void cumsum(cnp.float_t* arr_in, cnp.float_t* arr_out, int N) noexcept nogi
 
 cdef void copy_point(double * a, double * b) noexcept nogil:
     cdef:
-        int i = 0
+        cnp.npy_intp i = 0
     for i in range(3):
         b[i] = a[i]
 
 
 cdef void scalar_muliplication_point(double * a, double scalar) noexcept nogil:
     cdef:
-        int i = 0
+        cnp.npy_intp i = 0
     for i in range(3):
         a[i] *= scalar
 


### PR DESCRIPTION
Use `cnp.npy_intp` instead of `int` to as a counter/to iterate over arrays/as.