### PR TITLE
DOC: Fix Cython method parameter type description

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -476,7 +476,7 @@ cdef inline cnp.npy_intp _bin_index(double normalized, int nbins,
 
     Parameters
     ----------
-    normalized : float
+    normalized : double
         normalized intensity
     nbins : int
         number of histogram bins


### PR DESCRIPTION
Fix Cython method parameter type description.