### PR TITLE
BF: Cast operation explicitly to `cnp.npy_intp` in denoising Cython

### DIFF
--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -174,7 +174,8 @@ cdef class EnhancementKernel:
             cnp.npy_intp OR1 = orientations.shape[0]
             cnp.npy_intp OR2 = orientations.shape[0]
             cnp.npy_intp N = self.kernelsize
-            cnp.npy_intp hn = (N-1)/2
+            # kernelsize (N) is always odd, so casting is lossless
+            cnp.npy_intp hn = <cnp.npy_intp> ((N-1)/2)
             cnp.npy_intp angv, angr, xp, yp, zp
             double [:] x
             double [:] y


### PR DESCRIPTION
Cast operation explicitly to `cnp.npy_intp` in denoising kernel enhancement Cython code.

Fixes:
```
dipy/denoise/enhancement_kernel.cp39-win_amd64.pyd.p/enhancement_kernel.c(21799):
 warning C4244: '=': conversion from 'npy_intp' to 'double', possible loss of data
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/8822497881/job/24220827033#step:8:281