### PR TITLE
Python 3.13: Fix tests for next Python release

### DIFF
--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -1,4 +1,4 @@
-from logging import warn
+from logging import warning
 import warnings
 
 import nibabel as nib


### PR DESCRIPTION
Python 3.13 will remove the deprecated alias `warn` from `logging`.
