### PR TITLE
[RF] PMF Gen: from memoryview to pointer

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pxd
+++ b/dipy/direction/closest_peak_direction_getter.pxd
@@ -22,14 +22,8 @@ cdef class BasePmfDirectionGetter(DirectionGetter):
         self,
         double[::1] point)
 
-    cdef double[:] _get_pmf(
-        self,
-        double[::1] point) nogil
-
-    cdef int get_direction_c(
-        self,
-        double[::1] point,
-        double[::1] direction)
+    cdef double* _get_pmf(self, double[::1] point) nogil
+    cdef int get_direction_c(self, double[::1] point, double[::1] direction)
 
 
 cdef class BaseDirectionGetter(BasePmfDirectionGetter):

--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -7,10 +7,10 @@ cdef class PmfGen:
         double[:, :] vertices
         object sphere
 
-    cdef double[:] get_pmf_c(self, double[::1] point) noexcept nogil
+    cdef double* get_pmf_c(self, double* point, double* out) noexcept nogil
     cdef int find_closest(self, double* xyz) noexcept nogil
-    cdef double get_pmf_value_c(self, double[::1] point, double[::1] xyz) noexcept nogil
-    cdef void __clear_pmf(self) noexcept nogil
+    cdef double get_pmf_value_c(self, double* point, double* xyz,
+                                double* out) noexcept nogil
     pass
 
 

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -82,7 +82,7 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         cdef:
             cnp.npy_intp i, idx, _len
             double[:] newdir
-            double[:] pmf
+            double* pmf
             double last_cdf, cos_sim
 
         _len = self.len_pmf
@@ -103,12 +103,12 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
                 if cos_sim < self.cos_similarity:
                     pmf[i] = 0
 
-            cumsum(&pmf[0], &pmf[0], _len)
+            cumsum(pmf, pmf, _len)
             last_cdf = pmf[_len - 1]
             if last_cdf == 0:
                 return 1
 
-        idx = where_to_insert(&pmf[0], random() * last_cdf, _len)
+        idx = where_to_insert(pmf, random() * last_cdf, _len)
 
         newdir = self.vertices[idx]
         # Update direction and return 0 for error
@@ -151,7 +151,7 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
         cdef:
             cnp.npy_intp _len, max_idx
             double[:] newdir
-            double[:] pmf
+            double* pmf
             double max_value, cos_sim
 
         pmf = self._get_pmf(point)

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -3,13 +3,10 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 
-from dipy.core.gradients import gradient_table
 from dipy.core.sphere import HemiSphere, unit_octahedron
 from dipy.data import default_sphere, get_sphere
 from dipy.direction.pmf import SHCoeffPmfGen, SimplePmfGen
 from dipy.reconst import shm
-from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
-from dipy.reconst.dti import TensorModel
 from dipy.testing.decorators import set_random_number_generator
 
 response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
@@ -25,8 +22,13 @@ def test_pmf_val(rng):
         pmfgen = SHCoeffPmfGen(rng.random([2, 2, 2, 28]), sphere, None)
     point = np.array([1, 1, 1], dtype='float')
 
+    out = np.ones(len(sphere.vertices))
     for idx in [0, 5, 15, -1]:
         pmf = pmfgen.get_pmf(point)
+        pmf_2 = pmfgen.get_pmf(point, out)
+
+        npt.assert_array_almost_equal(pmf, out)
+        npt.assert_array_almost_equal(pmf, pmf_2)
         # Create a direction vector close to the vertex idx
         xyz = sphere.vertices[idx] + rng.random([3]) / 100
         pmf_idx = pmfgen.get_pmf_value(point, xyz)
@@ -42,9 +44,12 @@ def test_pmf_from_sh():
             category=PendingDeprecationWarning)
         pmfgen = SHCoeffPmfGen(np.ones([2, 2, 2, 28]), sphere, None)
 
+    out = np.zeros(len(sphere.vertices))
     # Test that the pmf is greater than 0 for a valid point
     pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
+    out = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'), out)
     npt.assert_equal(np.sum(pmf) > 0, True)
+    npt.assert_array_almost_equal(pmf, out)
 
     # Test that the pmf is 0 for invalid Points
     npt.assert_array_equal(pmfgen.get_pmf(np.array([-1, 0, 0], dtype='float')),
@@ -57,14 +62,17 @@ def test_pmf_from_array():
     sphere = HemiSphere.from_sphere(unit_octahedron)
     pmfgen = SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]), sphere)
 
+    out = np.zeros(len(sphere.vertices))
     # Test that the pmf is greater than 0 for a valid point
     pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
+    out = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'), out)
     npt.assert_equal(np.sum(pmf) > 0, True)
+    npt.assert_array_almost_equal(pmf, out)
 
     # Test that the pmf is 0 for invalid Points
-    npt.assert_array_equal(pmfgen.get_pmf(np.array([-1, 0, 0], dtype='float')),
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([-1, 0, 0], dtype=float)),
                            np.zeros(len(sphere.vertices)))
-    npt.assert_array_equal(pmfgen.get_pmf(np.array([0, 0, 10], dtype='float')),
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([0, 0, 10], dtype=float)),
                            np.zeros(len(sphere.vertices)))
 
     # Test ValueError for negative pmf

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -1,6 +1,8 @@
 # cython: boundscheck=False
 # cython: initializedcheck=False
 # cython: wraparound=False
+from libc.stdio cimport printf
+
 
 cdef int where_to_insert(cnp.float_t* arr, cnp.float_t number, int size) noexcept nogil:
     cdef:
@@ -194,3 +196,10 @@ cpdef void seed(cnp.npy_uint32 s) noexcept nogil:
         random seed.
     """
     srand(s)
+
+
+cdef void print_c_array_pointer(double* arr, int size) noexcept nogil:
+    cdef int i
+    for i in range(size):
+        printf("%f, ", arr[i])
+    printf("\n\n\n")


### PR DESCRIPTION
To help the parallelization of the tracking framework, we needed to convert some memoryview to pointer and make sure that `nogil` is allowed. 

This change has no impact to the current tracking framework. This is a simple redesign. 

In a close future, we mightnneed to change the `pmf` object