### PR TITLE
RF - remove buffer argument in pmf_gen.get_pmf_value(.)

### DIFF
--- a/dipy/direction/pmf.pxd
+++ b/dipy/direction/pmf.pxd
@@ -9,8 +9,7 @@ cdef class PmfGen:
 
     cdef double* get_pmf_c(self, double* point, double* out) noexcept nogil
     cdef int find_closest(self, double* xyz) noexcept nogil
-    cdef double get_pmf_value_c(self, double* point, double* xyz,
-                                double* out) noexcept nogil
+    cdef double get_pmf_value_c(self, double* point, double* xyz) noexcept nogil
     pass
 
 

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -162,8 +162,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
 
         if self.probe_count == 1:
             self.last_val = self.pmf_gen.get_pmf_value_c(self.position,
-                                                         self.frame[0],
-                                                         &self.pmf_gen.pmf[0])
+                                                         self.frame[0])
         else:
             for count in range(self.probe_count):
                 for i in range(3):
@@ -177,8 +176,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                                    * self.inv_voxel_size[i])
 
                 self.last_val += self.pmf_gen.get_pmf_value_c(position,
-                                                              self.frame[0],
-                                                              &self.pmf_gen.pmf[0])
+                                                              self.frame[0])
 
 
     cdef void prepare_propagator(self, double arclength) nogil:
@@ -272,8 +270,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                 copy_point(&binormal[0], &frame[2][0])
 
             if self.probe_count == 1:
-                fod_amp = self.pmf_gen.get_pmf_value_c(position, tangent,
-                                                       &self.pmf_gen.pmf[0])
+                fod_amp = self.pmf_gen.get_pmf_value_c(position, tangent)
                 fod_amp = fod_amp if fod_amp > self.pmf_threshold else 0
                 self.last_val_cand = fod_amp
                 likelihood += self.last_val_cand
@@ -295,8 +292,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                                            + binormal[i] * self.probe_radius
                                            * sin(c * self.angular_separation)
                                            * self.inv_voxel_size[i])
-                    fod_amp = self.pmf_gen.get_pmf_value_c(new_position, tangent,
-                                                           &self.pmf_gen.pmf[0])
+                    fod_amp = self.pmf_gen.get_pmf_value_c(new_position, tangent)
                     fod_amp = fod_amp if fod_amp > self.pmf_threshold else 0
                     self.last_val_cand += fod_amp
 


### PR DESCRIPTION
This PR removed an unnecessary argument `pmf_buffer` added in PR https://github.com/dipy/dipy/pull/3211

This is a speed and memory improvement. Because `get_pmf_value()` returns a double, the computation can be done for a single point on the sphere, rather than the whole sphere, thus removing the need for the buffer.