### PR TITLE
ENH: Prefer `CLARABEL` over `ECOS` as the CVXPY solver

### DIFF
--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -101,7 +101,7 @@ class QtdmriModel(Cache):
         cvxpy_solver : str, optional
             cvxpy solver name. Optionally optimize the positivity constraint
             with a particular cvxpy solver. See See https://www.cvxpy.org/ for
-            details. Default: ECOS.
+            details.
 
         References
         ----------
@@ -135,7 +135,7 @@ class QtdmriModel(Cache):
                  constrain_q0=True,
                  bval_threshold=1e10,
                  eigenvalue_threshold=1e-04,
-                 cvxpy_solver="ECOS"
+                 cvxpy_solver="CLARABEL"
                  ):
 
         if radial_order % 2 or radial_order < 0:
@@ -1991,7 +1991,7 @@ def l1_crossvalidation(b0s_mask, E, M, weight_array=np.linspace(0, .4, 21)):
             )
             constraints = []
             prob = cvxpy.Problem(objective, constraints)
-            prob.solve(solver="ECOS", verbose=False)
+            prob.solve(solver="CLARABEL", verbose=False)
             errorlist[i, counter] = np.mean(
                 (E[sub] - np.asarray(recovered_signal.value).squeeze()) ** 2)
             cv_old = errorlist[i, counter - 1]
@@ -2053,7 +2053,7 @@ def elastic_crossvalidation(b0s_mask, E, M, L, lopt,
                 lopt * cvxpy.quad_form(c, L)
             )
             prob = cvxpy.Problem(objective, constraints)
-            prob.solve(solver="ECOS", verbose=False)
+            prob.solve(solver="CLARABEL", verbose=False)
             errorlist[i, counter] = np.mean(
                 (E[sub] - np.asarray(recovered_signal.value).squeeze()) ** 2)
             cv_old = errorlist[i, counter - 1]


### PR DESCRIPTION
Prefer `CLARABEL` over `ECOS` as the CVXPY solver: `ECOS` will no longer be installed starting CVXPY 1.6.0.

Fixes:
```
=============================== warnings summary ===============================
reconst/tests/test_qtdmri.py::test_q0_constraint_and_unity_of_ODFs
reconst/tests/test_qtdmri.py::test_q0_constraint_and_unity_of_ODFs
reconst/tests/test_qtdmri.py::test_laplacian_reduces_laplacian_norm
reconst/tests/test_qtdmri.py::test_spherical_laplacian_reduces_laplacian_norm
reconst/tests/test_qtdmri.py::test_laplacian_GCV_higher_weight_with_noise
reconst/tests/test_qtdmri.py::test_l1_increases_sparsity
reconst/tests/test_qtdmri.py::test_spherical_l1_increases_sparsity
reconst/tests/test_qtdmri.py::test_l1_CV
reconst/tests/test_qtdmri.py::test_elastic_GCV_CV
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/cvxpy/reductions/solvers/solving_chain.py:354: FutureWarning:
      You specified your problem should be solved by ECOS. Starting in
      CXVPY 1.6.0, ECOS will no longer be installed by default with CVXPY.
      Please either add an explicit dependency on ECOS or switch to our new
      default solver, Clarabel, by either not specifying a solver argument
      or specifying ``solver=cp.CLARABEL``.

    warnings.warn(ECOS_DEP_DEPRECATION_MSG, FutureWarning)
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/9047369878/job/24859232082#step:10:4671

Take advantage of the commit to remove the default value in the docstring and rely on the method signature to reduce the maintenance burden.