### PR TITLE
[RF] from `os.fork` to `spawn` for multiprocessing

### DIFF
--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool
+import multiprocessing as mp
 import warnings
 
 import numpy as np
@@ -102,7 +102,8 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
                     _kwargs.update(kwargs)
                     params.append(_kwargs)
 
-                pool = Pool(num_processes)
+                mp.set_start_method('spawn', force=True)
+                pool = mp.Pool(num_processes)
 
                 for i, res in enumerate(pool.imap(_affine_transform, params)):
                     data2[..., i] = res

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -1,5 +1,5 @@
 from functools import partial
-from multiprocessing import Pool
+import multiprocessing as mp
 
 import numpy as np
 import scipy
@@ -319,7 +319,8 @@ def gibbs_removal(vol, slice_axis=2, n_points=3, inplace=True,
     if nd == 2:
         vol[:, :] = _gibbs_removal_2d(vol, n_points=n_points, G0=G0, G1=G1)
     else:
-        pool = Pool(num_processes)
+        mp.set_start_method('spawn', force=True)
+        pool = mp.Pool(num_processes)
 
         partial_func = partial(
             _gibbs_removal_2d, n_points=n_points, G0=G0, G1=G1

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -1,5 +1,5 @@
 from itertools import repeat
-from multiprocessing import Pool
+import multiprocessing as mp
 from os import path
 import tempfile
 
@@ -248,7 +248,8 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         else:
             mask_file_name = None
 
-        pool = Pool(num_processes)
+        mp.set_start_method('spawn', force=True)
+        pool = mp.Pool(num_processes)
 
         pam_res = pool.map(_peaks_from_model_parallel_sub,
                            zip(repeat((data_file_name, mask_file_name)),


### PR DESCRIPTION
`os.fork` is not recommended with multithread so forcing `spawn` on Linux. It was already the default setting for macOs and Windows. 

This should also remove the following warning for python3.12 on Linux:
```
=============================== warnings summary ===============================
align/tests/test_reslice.py: 8 warnings
denoise/tests/test_gibbs.py: 19 warnings
direction/tests/test_peaks.py: 22 warnings
workflows/tests/test_denoise.py: 1 warning
workflows/tests/test_reconst_csa_csd.py: 12 warnings
workflows/tests/test_reconst_rumba.py: 4 warnings
  /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2605) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()
```