### PR TITLE
BF: Rewrite list creation as `list()` instead of `[]`

### DIFF
--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -27,7 +27,7 @@ def test_default_weights_batch():
     file_path = get_fnames("evac_test_data")
     input_arr = np.load(file_path)["input"]
     output_arr = np.load(file_path)["output"]
-    input_arr = [input_arr]
+    input_arr = list(input_arr)
 
     evac_model = EVACPlus()
     fake_affine = np.array([np.eye(4), np.eye(4)])


### PR DESCRIPTION
Rewrite list creation as `list()` instead of `[]`: place each item as a separate item in the list instea of having a single item in the list.

Fixes:
```
__________________________ test_default_weights_batch __________________________
(...)
>       results_arr = evac_model.predict(
            input_arr, fake_affine, fake_voxsize, batch_size=2, return_prob=True
        )

../venv/lib/python3.10/site-packages/dipy/nn/tests/test_evac.py:35:
(...)
        if matrix.ndim == 2 and matrix.shape[1] != output.ndim:
>           raise RuntimeError('affine matrix has wrong number of columns')
E           RuntimeError: affine matrix has wrong number of columns
```

raised in:
https://github.com/dipy/dipy/actions/runs/9121652815/job/25081178023#step:10:7582

Inadvertently introudced in 23f978f.