### PR TITLE
STYLE: Fix function definition loop variable binding warning

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -528,7 +528,7 @@ def forward_sdt_deconv_mat(ratio, l_values, r2_term=False):
     for j in np.arange(0, n_orders * 2, 2):
         if r2_term:
             sharp = quad(
-                lambda z: lpn(j, z)[0][-1]
+                lambda z, j=j: lpn(j, z)[0][-1]
                 * gamma(1.5)
                 * np.sqrt(ratio / (4 * np.pi**3))
                 / np.power((1 - (1 - ratio) * z**2), 1.5),
@@ -537,7 +537,8 @@ def forward_sdt_deconv_mat(ratio, l_values, r2_term=False):
             )
         else:
             sharp = quad(
-                lambda z: lpn(j, z)[0][-1] * np.sqrt(1 / (1 - (1 - ratio) * z * z)),
+                lambda z, j=j: lpn(j, z)[0][-1]
+                * np.sqrt(1 / (1 - (1 - ratio) * z * z)),
                 -1.0,
                 1.0,
             )


### PR DESCRIPTION
Fix function definition loop variable binding warning.

Fixes:
```
dipy/reconst/csdeconv.py:531:31:
 B023 Function definition does not bind loop variable `j`
dipy/reconst/csdeconv.py:540:31:
 B023 Function definition does not bind loop variable `j`
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/9141052535/job/25135036670?pr=3228#step:4:114