### PR TITLE
STYLE: Simplify implicitly concatenated strings

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -529,7 +529,7 @@ def affine_registration(
 
     if pipeline == ["center_of_mass"] and ret_metric:
         raise ValueError(
-            "center of mass registration cannot return any " "quality metric."
+            "center of mass registration cannot return any quality metric."
         )
 
     # Go through the selected transformation:
@@ -585,29 +585,29 @@ def affine_registration(
 
 center_of_mass = partial(affine_registration, pipeline=["center_of_mass"])
 center_of_mass.__doc__ = (
-    "Implements a center of mass transform. " "Based on `affine_registration()`."
+    "Implements a center of mass transform. Based on `affine_registration()`."
 )
 
 translation = partial(affine_registration, pipeline=["translation"])
 translation.__doc__ = (
-    "Implements a translation transform. " "Based on `affine_registration()`."
+    "Implements a translation transform. Based on `affine_registration()`."
 )
 
 rigid = partial(affine_registration, pipeline=["rigid"])
-rigid.__doc__ = "Implements a rigid transform. " "Based on `affine_registration()`."
+rigid.__doc__ = "Implements a rigid transform. Based on `affine_registration()`."
 
 rigid_isoscaling = partial(affine_registration, pipeline=["rigid_isoscaling"])
 rigid_isoscaling.__doc__ = (
-    "Implements a rigid isoscaling transform. " "Based on `affine_registration()`."
+    "Implements a rigid isoscaling transform. Based on `affine_registration()`."
 )
 
 rigid_scaling = partial(affine_registration, pipeline=["rigid_scaling"])
 rigid_scaling.__doc__ = (
-    "Implements a rigid scaling transform. " "Based on `affine_registration()`."
+    "Implements a rigid scaling transform. Based on `affine_registration()`."
 )
 
 affine = partial(affine_registration, pipeline=["affine"])
-affine.__doc__ = "Implements an affine transform. " "Based on `affine_registration()`."
+affine.__doc__ = "Implements an affine transform. Based on `affine_registration()`."
 
 
 _METHOD_DICT = {  # mapping from str key -> (callable, class) tuple

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -190,12 +190,10 @@ class AffineMap:
             raise AffineInversionError("Affine transform must be 2D")
 
         if not affine.shape[0] == affine.shape[1]:
-            raise AffineInversionError("Affine transform must be a square " "matrix")
+            raise AffineInversionError("Affine transform must be a square matrix")
 
         if not np.all(np.isfinite(affine)):
-            raise AffineInvalidValuesError(
-                "Affine transform contains invalid" " elements"
-            )
+            raise AffineInvalidValuesError("Affine transform contains invalid elements")
 
         # checking on proper augmentation
         # First n-1 columns in last row in matrix contain non-zeros

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -415,7 +415,7 @@ class DiffeomorphicMap:
         if out_shape is None:
             if self.domain_shape is None:
                 raise ValueError(
-                    "Unable to infer sampling info. " "Provide a valid out_shape."
+                    "Unable to infer sampling info. Provide a valid out_shape."
                 )
             out_shape = self.domain_shape
         else:

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -175,7 +175,7 @@ class Sphere:
 
         if edges is not None and faces is None:
             raise ValueError(
-                "Either specify both faces and " "edges, only faces, or neither."
+                "Either specify both faces and edges, only faces, or neither."
             )
 
         if edges is not None:

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -160,7 +160,7 @@ class StatefulTractogram:
         self._space = space
 
         if origin not in Origin:
-            raise ValueError("Origin MUST be from Origin enum, " "e.g Origin.NIFTI.")
+            raise ValueError("Origin MUST be from Origin enum, e.g Origin.NIFTI.")
         self._origin = origin
 
         logger.debug(self)

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -148,7 +148,7 @@ def load_tractogram(
 
     if trk_header_check and extension == ".trk":
         if not is_header_compatible(filename, reference):
-            logging.error("Trk file header does not match the provided " "reference.")
+            logging.error("Trk file header does not match the provided reference.")
             return False
 
     timer = time.time()

--- a/dipy/nn/cnn_1d_denoising.py
+++ b/dipy/nn/cnn_1d_denoising.py
@@ -81,11 +81,11 @@ class Cnn1DDenoiser:
         """
         if not have_tf:
             raise ImportError(
-                "TensorFlow is not available. Please install " "TensorFlow 2+."
+                "TensorFlow is not available. Please install TensorFlow 2+."
             )
         if not have_sklearn:
             raise ImportError(
-                "scikit-learn is not available. Please install " "scikit-learn."
+                "scikit-learn is not available. Please install scikit-learn."
             )
         input_layer = Input(shape=(sig_length, 1))
         x = Conv1D(

--- a/dipy/nn/evac.py
+++ b/dipy/nn/evac.py
@@ -453,7 +453,7 @@ class EVACPlus:
             voxsize = np.expand_dims(voxsize, 0)
         else:
             raise ValueError(
-                "T1 data should be a np.ndarray of dimension 3 " "or a list/tuple of it"
+                "T1 data should be a np.ndarray of dimension 3 or a list/tuple of it"
             )
 
         input_data = np.zeros((128, 128, 128, len(T1)))

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -266,7 +266,7 @@ class MapmriModel(ReconstModel, Cache):
 
         if positivity_constraint:
             if not have_cvxpy:
-                raise ImportError("CVXPY package needed to enforce " "constraints.")
+                raise ImportError("CVXPY package needed to enforce constraints.")
             if cvxpy_solver is not None:
                 if cvxpy_solver not in cvxpy.installed_solvers():
                     installed_solvers = ", ".join(cvxpy.installed_solvers())
@@ -879,7 +879,7 @@ class MapmriFit(ReconstFit):
             )
         if not self.model.anisotropic_scaling:
             raise ValueError(
-                "Parallel non-Gaussianity is not defined using " "isotropic scaling."
+                "Parallel non-Gaussianity is not defined using isotropic scaling."
             )
 
         coef = self._mapmri_coef
@@ -909,7 +909,7 @@ class MapmriFit(ReconstFit):
             )
         if not self.model.anisotropic_scaling:
             raise ValueError(
-                "Parallel non-Gaussianity is not defined using " "isotropic scaling."
+                "Parallel non-Gaussianity is not defined using isotropic scaling."
             )
 
         ind_mat = self.model.ind_mat
@@ -954,7 +954,7 @@ class MapmriFit(ReconstFit):
             )
         if not self.model.anisotropic_scaling:
             raise ValueError(
-                "Parallel non-Gaussianity is not defined using " "isotropic scaling."
+                "Parallel non-Gaussianity is not defined using isotropic scaling."
             )
 
         ind_mat = self.model.ind_mat

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -385,7 +385,7 @@ class ParticleFilteringTracking(LocalTracking):
 
         if not 0 <= min_wm_pve_before_stopping <= 1:
             raise ValueError(
-                "The min_wm_pve_before_stopping value must be " "between 0 and 1."
+                "The min_wm_pve_before_stopping value must be between 0 and 1."
             )
 
         self.min_wm_pve_before_stopping = min_wm_pve_before_stopping

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -772,7 +772,7 @@ def arbitrarypoint(xyz, distance):
     cumlen = np.zeros(n_pts)
     cumlen[1:] = length(xyz, along=True)
     if cumlen[-1] < distance:
-        raise ValueError("Given distance is bigger than " "the length of the curve")
+        raise ValueError("Given distance is bigger than the length of the curve")
     ind = np.where((cumlen - distance) > 0)[0][0]
     len0 = cumlen[ind - 1]
     len1 = cumlen[ind]

--- a/dipy/utils/tractogram.py
+++ b/dipy/utils/tractogram.py
@@ -83,9 +83,7 @@ def concatenate_tractogram(
                 raise ValueError("Wrong space attributes.")
 
     if preallocation and not delete_groups:
-        raise ValueError(
-            "Groups are variables, cannot be handled with " "preallocation"
-        )
+        raise ValueError("Groups are variables, cannot be handled with preallocation")
 
     # Verifying the validity of fixed-size arrays, coherence between inputs
     for curr_trx in trx_list:
@@ -98,7 +96,7 @@ def concatenate_tractogram(
                     logging.debug(
                         "{} dpv key does not exist in all TrxFile.".format(key)
                     )
-                    raise ValueError("TrxFile must be sharing identical dpv " "keys.")
+                    raise ValueError("TrxFile must be sharing identical dpv keys.")
             elif (
                 ref_trx.data_per_vertex[key]._data.dtype
                 != curr_trx.data_per_vertex[key]._data.dtype
@@ -119,7 +117,7 @@ def concatenate_tractogram(
                     logging.debug(
                         "{} dps key does not exist in all " "TrxFile.".format(key)
                     )
-                    raise ValueError("TrxFile must be sharing identical dps " "keys.")
+                    raise ValueError("TrxFile must be sharing identical dps keys.")
             elif (
                 ref_trx.data_per_streamline[key].dtype
                 != curr_trx.data_per_streamline[key].dtype

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -163,7 +163,7 @@ class Horizon:
         """
         if not has_fury:
             raise ImportError(
-                "Horizon requires FURY. Please install it " "with pip install fury"
+                "Horizon requires FURY. Please install it with pip install fury"
             )
         if Version(fury_version) < Version("0.10.0"):
             ValueError(

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -51,7 +51,7 @@ def check_dimensions(static, moving):
 
     if len(static.shape) > 3 and len(moving.shape) > 3:
         raise ValueError(
-            "Dimension mismatch: One of the input should " "be 2D or 3D dimensions."
+            "Dimension mismatch: One of the input should be 2D or 3D dimensions."
         )
 
 

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -529,7 +529,7 @@ class ConvertTractogramFlow(Workflow):
 
             if in_extension == out_extension:
                 warnings.warn(
-                    "Input and output are the same file format, " "Skipping...",
+                    "Input and output are the same file format. Skipping...",
                     stacklevel=2,
                 )
                 continue

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -118,7 +118,7 @@ def test_buan_bundle_profiles(rng):
 
 @pytest.mark.skipif(
     not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
-    reason="Requires Pandas, StatsModels, PyTables, and " "matplotlib",
+    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
 )
 @set_random_number_generator()
 def test_bundle_analysis_tractometry_flow(rng):
@@ -192,7 +192,7 @@ def test_bundle_analysis_tractometry_flow(rng):
 
 @pytest.mark.skipif(
     not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
-    reason="Requires Pandas, StatsModels, PyTables, and " "matplotlib",
+    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
 )
 def test_linear_mixed_models_flow():
     with TemporaryDirectory() as dirpath:
@@ -282,7 +282,7 @@ def test_linear_mixed_models_flow():
 
 @pytest.mark.skipif(
     not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
-    reason="Requires Pandas, StatsModels, PyTables, and " "matplotlib",
+    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
 )
 @set_random_number_generator()
 def test_bundle_shape_analysis_flow(rng):

--- a/doc/examples/reconst_ivim.py
+++ b/doc/examples/reconst_ivim.py
@@ -310,19 +310,19 @@ plot_map(
 )
 plot_map(
     ivimfit_vp.perfusion_fraction,
-    "Heatmap of perfusion fraction values " "predicted from the fit",
+    "Heatmap of perfusion fraction values predicted from the fit",
     (0, 1),
     "perfusion_fraction.png",
 )
 plot_map(
     ivimfit_vp.D_star,
-    "D* - Heatmap of perfusion coefficients predicted " "from the fit",
+    "D* - Heatmap of perfusion coefficients predicted from the fit",
     (0, 0.01),
     "perfusion_coeff.png",
 )
 plot_map(
     ivimfit_vp.D,
-    "D - Heatmap of diffusion coefficients predicted from " "the fit",
+    "D - Heatmap of diffusion coefficients predicted from the fit",
     (0, 0.001),
     "diffusion_coeff.png",
 )

--- a/doc/examples/snr_in_cc.py
+++ b/doc/examples/snr_in_cc.py
@@ -147,9 +147,9 @@ axis_Z = np.argmin(np.sum((gtab.bvecs - np.array([0, 0, 1])) ** 2, axis=-1))
 for direction in [0, axis_X, axis_Y, axis_Z]:
     SNR = mean_signal[direction] / noise_std
     if direction == 0:
-        print("SNR for the b=0 image is :", SNR)
+        print(f"SNR for the b=0 image is : {SNR}")
     else:
-        print("SNR for direction", direction, " ", gtab.bvecs[direction], "is :", SNR)
+        print(f"SNR for direction {direction} {gtab.bvecs[direction]} is : {SNR}")
 
 ###############################################################################
 # Since the CC is aligned with the X axis, the lowest SNR is for that gradient


### PR DESCRIPTION
Simplify implicitly concatenated strings of the form:
```
msg = "first part of string " + "second part of string"
```

to a single string, i.e.
```
msg = "first part of string second part of string"
```

Related to the `ISC001` `ruff` rule.