### PR TITLE
STYLE: Set `stacklevel` argument explicitly to warning messages

### DIFF
--- a/dipy/testing/tests/test_testing.py
+++ b/dipy/testing/tests/test_testing.py
@@ -49,19 +49,19 @@ def test_clear_and_catch_warnings():
     npt.assert_equal(getattr(my_mod, "__warningregistry__", {}), {})
     with dt.clear_and_catch_warnings(modules=[my_mod]):
         warnings.simplefilter("ignore")
-        warnings.warn("Some warning")
+        warnings.warn("Some warning", stacklevel=1)
     npt.assert_equal(my_mod.__warningregistry__, {})
     # Without specified modules, don't clear warnings during context
     with dt.clear_and_catch_warnings():
-        warnings.warn("Some warning")
+        warnings.warn("Some warning", stacklevel=1)
     assert_warn_len_equal(my_mod, 1)
     # Confirm that specifying module keeps old warning, does not add new
     with dt.clear_and_catch_warnings(modules=[my_mod]):
-        warnings.warn("Another warning")
+        warnings.warn("Another warning", stacklevel=1)
     assert_warn_len_equal(my_mod, 1)
     # Another warning, no module spec does add to warnings dict, except on
     # Python 3 (see comments in `assert_warn_len_equal`)
     with dt.clear_and_catch_warnings():
-        warnings.warn("Another warning")
+        warnings.warn("Another warning", stacklevel=1)
     assert_warn_len_equal(my_mod, 2)
     warnings.simplefilter("always", category=UserWarning)

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,7 +32,6 @@ ignore = [
 "dipy/align/__init__.py" = ["E402"]
 "dipy/direction/__init__.py" = ["F401", "F403"]
 "dipy/reconst/*.py" = ["B026"]
-"dipy/testing/tests/test_testing.py" = ["B028"]
 "dipy/viz/__init__.py" = ["F401"]
 "doc/examples/**" = ["E402"]
 "doc/conf.py" = ["E402"]


### PR DESCRIPTION
Set `stacklevel` argument explicitly to warning messages in
`testing.tests.test_testing.py` module. Set its value to 1, as opposed
to the `ruff` recommendation of using 2 [1], since otherwise the tests
do not pass: the `__warningregistry__` seems not to be created (and
cannot be queried) otherwise. This is related to the fact that the
`stacklevel` option to warnings causes the attribute to be set for the
module the warning was issued "in the name of", not necessarily the one
where `warn()` was called, e.g. if we specify a value larger than 1.

Fixes:
```
dipy/testing/tests/test_testing.py:52:9:
 B028 No explicit `stacklevel` keyword argument found
dipy/testing/tests/test_testing.py:56:9:
 B028 No explicit `stacklevel` keyword argument found
dipy/testing/tests/test_testing.py:60:9:
 B028 No explicit `stacklevel` keyword argument found
dipy/testing/tests/test_testing.py:65:9:
 B028 No explicit `stacklevel` keyword argument found
```

Remove the corresponding rule from the `ruff` per-file ignore list.

[1] https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/