### PR TITLE
STYLE: Make module level import be at top of file

### DIFF
--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -1,29 +1,3 @@
-import numpy as np
-
-floating = np.float32
-
-
-class Bunch:
-    def __init__(self, **kwds):
-        r"""A 'bunch' of values (a replacement of Enum)
-
-        This is a temporary replacement of Enum, which is not available
-        on all versions of Python 2
-        """
-        self.__dict__.update(kwds)
-
-
-VerbosityLevels = Bunch(NONE=0, STATUS=1, DIAGNOSE=2, DEBUG=3)
-r""" VerbosityLevels
-This enum defines the four levels of verbosity we use in the align
-module.
-NONE : do not print anything
-STATUS : print information about the current status of the algorithm
-DIAGNOSE : print high level information of the components involved in the
-registration that can be used to detect a failing component.
-DEBUG : print as much information as possible to isolate the cause of a bug.
-"""
-
 from dipy.align._public import (
     affine,
     affine_registration,
@@ -60,4 +34,5 @@ __all__ = [
     "register_series",
     "register_dwi_series",
     "streamline_registration",
+    "utils",
 ]

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -40,25 +40,6 @@ from dipy.testing.decorators import warning_for_keywords
 from dipy.tracking.streamline import set_number_of_points
 from dipy.tracking.utils import transform_tracking_output
 
-__all__ = [
-    "syn_registration",
-    "register_dwi_to_template",
-    "write_mapping",
-    "read_mapping",
-    "resample",
-    "center_of_mass",
-    "translation",
-    "rigid_isoscaling",
-    "rigid_scaling",
-    "rigid",
-    "affine",
-    "motion_correction",
-    "affine_registration",
-    "register_series",
-    "register_dwi_series",
-    "streamline_registration",
-]
-
 # Global dicts for choosing metrics for registration:
 syn_metric_dict = {"CC": CCMetric, "EM": EMMetric, "SSD": SSDMetric}
 

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -49,7 +49,7 @@ import numpy as np
 import numpy.linalg as npl
 import scipy.ndimage as ndimage
 
-from dipy.align import VerbosityLevels, vector_fields as vf
+from dipy.align import vector_fields as vf
 from dipy.align.imwarp import ScaleSpace, get_direction_and_spacings
 from dipy.align.parzenhist import (
     ParzenJointHistogram,
@@ -60,6 +60,7 @@ from dipy.align.scalespace import IsotropicScaleSpace
 from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
 from dipy.core.optimize import Optimizer
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils import VerbosityLevels
 
 _interp_options = ["nearest", "linear"]
 _transform_method = {}

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -8,9 +8,11 @@ from nibabel.streamlines import ArraySequence as Streamlines
 import numpy as np
 import numpy.linalg as npl
 
-from dipy.align import Bunch, VerbosityLevels, floating, vector_fields as vfu
+from dipy.align import vector_fields as vfu
 from dipy.align.scalespace import ScaleSpace
+from dipy.align.utils import floating
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils import Bunch, VerbosityLevels
 
 RegistrationStages = Bunch(
     INIT_START=0,

--- a/dipy/align/meson.build
+++ b/dipy/align/meson.build
@@ -41,6 +41,7 @@ python_sources = ['__init__.py',
   'scalespace.py',
   'streamlinear.py',
   'streamwarp.py',
+  'utils.py',
   ]
 
 

--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -9,10 +9,10 @@ from scipy import ndimage
 from dipy.align import (
     crosscorr as cc,
     expectmax as em,
-    floating,
     sumsqdiff as ssd,
     vector_fields as vfu,
 )
+from dipy.align.utils import floating
 from dipy.testing.decorators import warning_for_keywords
 
 

--- a/dipy/align/scalespace.py
+++ b/dipy/align/scalespace.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.linalg as npl
 from scipy.ndimage import gaussian_filter
 
-from dipy.align import floating
+from dipy.align.utils import floating
 from dipy.testing.decorators import warning_for_keywords
 
 logger = logging.getLogger(__name__)

--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -1,7 +1,8 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from dipy.align import crosscorr as cc, floating
+from dipy.align import crosscorr as cc
+from dipy.align.utils import floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -6,7 +6,8 @@ from numpy.testing import (
     assert_raises,
 )
 
-from dipy.align import expectmax as em, floating
+from dipy.align import expectmax as em
+from dipy.align.utils import floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -8,17 +8,17 @@ from numpy.testing import (
 )
 
 from dipy.align import (
-    VerbosityLevels,
-    floating,
     imwarp as imwarp,
     metrics as metrics,
     vector_fields as vfu,
 )
 from dipy.align.imwarp import DiffeomorphicMap
+from dipy.align.utils import floating
 from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
 from dipy.data import get_fnames
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.streamline import deform_streamlines
+from dipy.utils import VerbosityLevels
 
 
 def test_mult_aff():

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -4,8 +4,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 from scipy import ndimage
 
-from dipy.align import floating
 from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
+from dipy.align.utils import floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_scalespace.py
+++ b/dipy/align/tests/test_scalespace.py
@@ -2,10 +2,10 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 import scipy as sp
 
-from dipy.align import floating
 from dipy.align.imwarp import get_direction_and_spacings
 from dipy.align.scalespace import IsotropicScaleSpace, ScaleSpace
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
+from dipy.align.utils import floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_sumsqdiff.py
+++ b/dipy/align/tests/test_sumsqdiff.py
@@ -6,7 +6,8 @@ from numpy.testing import (
     assert_equal,
 )
 
-from dipy.align import floating, sumsqdiff as ssd
+from dipy.align import sumsqdiff as ssd
+from dipy.align.utils import floating
 from dipy.testing.decorators import set_random_number_generator
 
 

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -9,9 +9,10 @@ from numpy.testing import (
 )
 from scipy.ndimage import map_coordinates
 
-from dipy.align import floating, imwarp, vector_fields as vfu
+from dipy.align import imwarp, vector_fields as vfu
 from dipy.align.parzenhist import sample_domain_regular
 from dipy.align.transforms import regtransforms
+from dipy.align.utils import floating
 from dipy.core import geometry
 from dipy.testing.decorators import set_random_number_generator
 

--- a/dipy/align/utils.py
+++ b/dipy/align/utils.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+floating = np.float32

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 from scipy.ndimage import map_coordinates
 
-from dipy.align import floating
+from dipy.align.utils import floating
 from dipy.core.interpolation import (
     NearestNeighborInterpolator,
     OutsideImage,

--- a/dipy/utils/__init__.py
+++ b/dipy/utils/__init__.py
@@ -1,1 +1,23 @@
 # code support utilities for dipy
+
+
+class Bunch:
+    def __init__(self, **kwds):
+        r"""A 'bunch' of values (a replacement of Enum)
+
+        This is a temporary replacement of Enum, which is not available
+        on all versions of Python 2
+        """
+        self.__dict__.update(kwds)
+
+
+VerbosityLevels = Bunch(NONE=0, STATUS=1, DIAGNOSE=2, DEBUG=3)
+r""" VerbosityLevels
+This enum defines the four levels of verbosity we use in the align
+module.
+NONE : do not print anything
+STATUS : print information about the current status of the algorithm
+DIAGNOSE : print high level information of the components involved in the
+registration that can be used to detect a failing component.
+DEBUG : print as much information as possible to isolate the cause of a bug.
+"""

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,6 @@ ignore = [
 ]
 
 [lint.extend-per-file-ignores]
-"dipy/align/__init__.py" = ["E402"]
 "dipy/reconst/*.py" = ["B026"]
 "dipy/viz/__init__.py" = ["F401"]
 "doc/examples/**" = ["E402"]


### PR DESCRIPTION
Make module level import be at top of file.

Fixes:
```
dipy/align/__init__.py:27:1: E402 Module level import not at top of file
```

Remove the corresponding rule from the `ruff` per-file ignore list.

Relocate the `np.float32` aliasing to an `align.utils.py` module to
avoid a circular import error.

Keep the list of semantically public names of the module (`__all__`) at
the `__init__.py` file, and avoid duplicating the list in the
`_public.py` file.

Relocate the `align.Bunch` class and the `align.VerbosityLevels` enum to
`utils` since they are general enough so as to be potentially used
elsewhere.