### PR TITLE
STYLE: Do not allow running unintended modules as scripts

### DIFF
--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -130,7 +130,3 @@ class Dpy:
 
     def close(self):
         self.f.close()
-
-
-if __name__ == "__main__":
-    pass

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -676,7 +676,3 @@ def LR_deconv(prop, psf, numit=5, acc_factor=1):
         # Enforce positivity
         prop_deconv = np.clip(prop_deconv, 0, np.inf)
     return prop_deconv / prop_deconv.sum()
-
-
-if __name__ == "__main__":
-    pass

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -854,7 +854,3 @@ def midpoint2point(xyz, p):
     """
     mid = midpoint(xyz)
     return np.sqrt(np.sum((xyz - mid) ** 2))
-
-
-if __name__ == "__main__":
-    pass


### PR DESCRIPTION
Do not allow running as scripts modules that are not intended for that: remove the `if __name__ == "__main__": pass` statements.