### PR TITLE
Add support for tensor-valued spherical functions in `interp_rbf`

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -16,8 +16,8 @@ from dipy.utils.deprecator import deprecate_with_version
     "dipy.core.interpolation.interp_rbf is deprecated, "
     "Please use "
     "dipy.core.interpolation.rbf_interpolation instead",
-    since="1.9",
-    until="2.0",
+    since="1.10.0",
+    until="1.12.0",
 )
 def interp_rbf(data, sphere_origin, sphere_target,
                function='multiquadric', epsilon=None, smooth=0.1,
@@ -93,7 +93,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     return rbfi(sphere_target.x, sphere_target.y, sphere_target.z)
 
 
-def rbf_interpolation(data, sphere_origin, sphere_target,
+def rbf_interpolation(data, sphere_origin, sphere_target, *,
                       function='multiquadric', epsilon=None, smoothing=0.1):
     """Interpolate `data` on the sphere, using radial basis functions,
     where `data` can be scalar- (1D), vector- (2D), or tensor-valued (3D and beyond).
@@ -107,14 +107,15 @@ def rbf_interpolation(data, sphere_origin, sphere_target,
     sphere_target : Sphere
         M positions on the unit sphere where the spherical function is interpolated.
 
-    function : {'linear', 'thin_plate_spline', 'cubic', 'quintic', 'multiquadric', 'inverse_multiquadric',
-    'inverse_quadratic', 'gaussian'}
-        Radial basis function. Default: `thin_plate_spline`.
-    epsilon : float
+    function: str, optional
+        Radial basis function.
+        Possible values: {'linear', 'thin_plate_spline', 'cubic', 'quintic',
+        'multiquadric', 'inverse_multiquadric', 'inverse_quadratic', 'gaussian'}.
+    epsilon : float, optional
         Radial basis function spread parameter.
         Defaults to 1 when `function` is 'linear', 'thin_plate_spline', 'cubic', or 'quintic'.
         Otherwise, `epsilon` must be specified.
-    smoothing : float
+    smoothing : float, optional
         Smoothing parameter. When `smoothing` is 0, the interpolation is exact.
         As `smoothing` increases, the interpolation approaches a least-squares fit of `data`
         using the supplied radial basis function. Default: 0.
@@ -131,7 +132,7 @@ def rbf_interpolation(data, sphere_origin, sphere_target,
     """
     from scipy.interpolate import RBFInterpolator
 
-    last_dim_idx = len(data.shape) - 1
+    last_dim_idx = data.ndim - 1
     if not data.shape[last_dim_idx] == sphere_origin.vertices.shape[0]:
         raise ValueError("The last dimension of `data` must be equal to the number of "
                          "vertices in `sphere_origin`.")

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -57,9 +57,10 @@ def interp_rbf(data, sphere_origin, sphere_target,
     from scipy.interpolate import Rbf, RBFInterpolator
 
     if legacy:
-        assert len(data.shape) == 1, \
-            "The data array must be 1D when using the legacy mode, " \
-            "set `legacy=False` to interpolate tensor-valued spherical functions."
+        if not len(data.shape) == 1:
+            raise ValueError("The data array must be 1D when using the legacy mode, "
+                             "set `legacy=False` to interpolate tensor-valued spherical functions.")
+
         def angle(x1, x2):
             xx = np.arccos(np.clip((x1 * x2).sum(axis=0), -1, 1))
             return np.nan_to_num(xx)
@@ -94,9 +95,9 @@ def interp_rbf(data, sphere_origin, sphere_target,
 
     else:
         last_dim_idx = len(data.shape) - 1
-        assert data.shape[last_dim_idx] == sphere_origin.vertices.shape[0], \
-            "The last dimension of `data` must be equal to the number of " \
-            "vertices in `sphere_origin`."
+        if not data.shape[last_dim_idx] == sphere_origin.vertices.shape[0]:
+            raise ValueError("The last dimension of `data` must be equal to the number of "
+                             "vertices in `sphere_origin`.")
 
         rbfi = RBFInterpolator(sphere_origin.vertices, np.moveaxis(data, last_dim_idx, 0),
                                smoothing=smooth, kernel=function, epsilon=epsilon)

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -8,6 +8,8 @@ import warnings
 
 from libc.math cimport floor
 
+from scipy.interpolate import Rbf, RBFInterpolator
+
 from dipy.align.fused_types cimport floating, number
 from dipy.utils.deprecator import deprecate_with_version
 
@@ -58,8 +60,6 @@ def interp_rbf(data, sphere_origin, sphere_target,
     scipy.interpolate.Rbf
 
     """
-    from scipy.interpolate import Rbf
-
     def angle(x1, x2):
         xx = np.arccos(np.clip((x1 * x2).sum(axis=0), -1, 1))
         return np.nan_to_num(xx)
@@ -130,8 +130,6 @@ def rbf_interpolation(data, sphere_origin, sphere_target, *,
     scipy.interpolate.RBFInterpolator
 
     """
-    from scipy.interpolate import RBFInterpolator
-
     last_dim_idx = data.ndim - 1
     if not data.shape[last_dim_idx] == sphere_origin.vertices.shape[0]:
         raise ValueError("The last dimension of `data` must be equal to the number of "

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -76,7 +76,7 @@ def test_interpolate_scalar_2d(rng):
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
 
     extended_image = np.zeros((sz + 2, sz + 2), dtype=floating)
-    extended_image[1: sz + 1, 1: sz + 1] = image[...]
+    extended_image[1 : sz + 1, 1 : sz + 1] = image[...]
 
     # Select some coordinates inside the image to interpolate at
     nsamples = 200
@@ -131,7 +131,7 @@ def test_interpolate_scalar_nn_2d(rng):
     # Test the 'inside' flag
     for i in range(nsamples):
         if (locations[i, 0] < 0 or locations[i, 0] > (sz - 1)) or (
-                locations[i, 1] < 0 or locations[i, 1] > (sz - 1)
+            locations[i, 1] < 0 or locations[i, 1] > (sz - 1)
         ):
             npt.assert_equal(inside[i], 0)
         else:
@@ -174,7 +174,7 @@ def test_interpolate_scalar_3d(rng):
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
 
     extended_image = np.zeros((sz + 2, sz + 2, sz + 2), dtype=floating)
-    extended_image[1: sz + 1, 1: sz + 1, 1: sz + 1] = image[...]
+    extended_image[1 : sz + 1, 1 : sz + 1, 1 : sz + 1] = image[...]
 
     # Select some coordinates inside the image to interpolate at
     nsamples = 800
@@ -218,7 +218,7 @@ def test_interpolate_vector_3d(rng):
     field[...] = rng.integers(0, 10, np.size(field)).reshape(target_shape + (3,))
 
     extended_field = np.zeros((sz + 2, sz + 2, sz + 2, 3), dtype=floating)
-    extended_field[1: sz + 1, 1: sz + 1, 1: sz + 1] = field
+    extended_field[1 : sz + 1, 1 : sz + 1, 1 : sz + 1] = field
     # Select some coordinates to interpolate at
     nsamples = 800
     locations = rng.random(3 * nsamples).reshape((nsamples, 3)) * (sz + 2) - 1.0
@@ -267,7 +267,7 @@ def test_interpolate_vector_2d(rng):
     field = np.empty(target_shape + (2,), dtype=floating)
     field[...] = rng.integers(0, 10, np.size(field)).reshape(target_shape + (2,))
     extended_field = np.zeros((sz + 2, sz + 2, 2), dtype=floating)
-    extended_field[1: sz + 1, 1: sz + 1] = field
+    extended_field[1 : sz + 1, 1 : sz + 1] = field
     # Select some coordinates to interpolate at
     nsamples = 200
     locations = rng.random(2 * nsamples).reshape((nsamples, 2)) * (sz + 2) - 1.0

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -439,7 +439,7 @@ def test_interp_rbf():
         interp_data = interp_rbf(data, s0, s1, legacy=False, epsilon=10)
         npt.assert_(np.mean(np.abs(interp_data - expected)) < 0.1)
 
-    # Test that interpolating 3D data when `legacy=False` raises an error
+    # Test that interpolating 3D data when `legacy=True` raises an error
     with npt.assert_raises(ValueError):
         interp_rbf(data, s0, s1, legacy=True, epsilon=10)
 

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -429,11 +429,49 @@ def test_interp_rbf():
 
 
 def test_rbf_interpolation():
-    def data_func_3d(s, a, b, i, j, k):
-        return a * np.cos(s.theta) + b * np.sin(s.phi) + i + j + k
-
     s0 = create_unit_sphere(3)
     s1 = create_unit_sphere(4)
+
+    def data_func(s, a, b):
+        return a * np.cos(s.theta) + b * np.sin(s.phi)
+
+    # Test 1D case
+    def data_func_1d(s, a, b, i):
+        return data_func(s, a, b) + i
+
+    for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
+        data = np.empty([3, len(s0.vertices)])
+        for i in range(3):
+            data[i] = data_func_1d(s0, a, b, i)
+
+        expected = np.empty([3, len(s1.vertices)])
+        for i in range(3):
+            expected[i] = data_func_1d(s1, a, b, i)
+
+        interp_data = rbf_interpolation(data, s0, s1, epsilon=10)
+        npt.assert_(np.mean(np.abs(interp_data - expected)) < 0.1)
+
+    # Test 2D case
+    def data_func_2d(s, a, b, i, j):
+        return data_func(s, a, b) + i + j
+
+    for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
+        data = np.empty([3, 4, len(s0.vertices)])
+        for i in range(3):
+            for j in range(4):
+                data[i, j] = data_func_2d(s0, a, b, i, j)
+
+        expected = np.empty([3, 4, len(s1.vertices)])
+        for i in range(3):
+            for j in range(4):
+                expected[i, j] = data_func_2d(s1, a, b, i, j)
+
+        interp_data = rbf_interpolation(data, s0, s1, epsilon=10)
+        npt.assert_(np.mean(np.abs(interp_data - expected)) < 0.1)
+
+    # Test 3D case
+    def data_func_3d(s, a, b, i, j, k):
+        return data_func(s, a, b) + i + j + k
 
     for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
         data = np.empty([3, 4, 5, len(s0.vertices)])
@@ -441,11 +479,13 @@ def test_rbf_interpolation():
             for j in range(4):
                 for k in range(5):
                     data[i, j, k] = data_func_3d(s0, a, b, i, j, k)
+
         expected = np.empty([3, 4, 5, len(s1.vertices)])
         for i in range(3):
             for j in range(4):
                 for k in range(5):
                     expected[i, j, k] = data_func_3d(s1, a, b, i, j, k)
+
         interp_data = rbf_interpolation(data, s0, s1, epsilon=10)
         npt.assert_(np.mean(np.abs(interp_data - expected)) < 0.1)
 


### PR DESCRIPTION
Fixes #3236.

This PR adds support for tensor-valued spherical functions in `interp_rbf`. When the user calls this function, specifying `legacy=True` internally uses `scipy.interpolate.Rbf` which is the original behavior; specifying `legacy=False` internally uses `scipy.interpolate.RBFInterpolator`, which allows `data` to have arbitrary dimensions. 

It would be great if I could get some feedbacks on the following questions:
* I saw the kwarg `norm` is already pending deprecation and is not used in `scipy.interpolate.RBFInterpolator`. As of my initial commit, `norm` is ignored when `legacy=False`. Do we still want to keep `norm`?
* In the docstring, `function` is said to be one of `{'multiquadric', 'inverse', 'gaussian'}`, but both `scipy.interpolate.Rbf` and `scipy.interpolate.RBFInterpolator` support a little bit more than that (see [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RBFInterpolator.html#scipy.interpolate.RBFInterpolator) and [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.Rbf.html#scipy-interpolate-rbf)). Should I change the docstring?
* In `Rbf`, when `epsilon=None`, it internally estimate the average distance between nodes. However, in `RBFInterpolator`, this behavior is gone. The user has to specify `epsilon` when `kernel` is not one of `{'linear', 'thin_plate_spline', 'cubic', or 'quintic'}`. Should I change the docstring to reflect this new behavior? 