### PR TITLE
NF: Decorator for keyword-only argument

### DIFF
--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -8,6 +8,7 @@ from scipy.spatial.distance import mahalanobis
 from dipy.io.utils import save_buan_profiles_hdf5
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
+from dipy.testing.decorators import warning_for_keywords
 from dipy.tracking.streamline import (
     Streamlines,
     orient_by_streamline,
@@ -150,7 +151,8 @@ def assignment_map(target_bundle, model_bundle, no_disks):
     return indx
 
 
-def gaussian_weights(bundle, n_points=100, return_mahalnobis=False, stat=np.mean):
+@warning_for_keywords()
+def gaussian_weights(bundle, *, n_points=100, return_mahalnobis=False, stat=np.mean):
     """
     Calculate weights for each streamline/node in a bundle, based on a
     Mahalanobis distance from the core the bundle, at that node (mean, per
@@ -228,10 +230,12 @@ def gaussian_weights(bundle, n_points=100, return_mahalnobis=False, stat=np.mean
     return w / np.sum(w, 0)
 
 
+@warning_for_keywords()
 def afq_profile(
     data,
     bundle,
     affine,
+    *,
     n_points=100,
     profile_stat=np.average,
     orient_by=None,

--- a/dipy/stats/qc.py
+++ b/dipy/stats/qc.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from dipy.core.geometry import cart_distance
+from dipy.testing.decorators import warning_for_keywords
 
 
 def find_qspace_neighbors(gtab):
@@ -65,7 +66,8 @@ def find_qspace_neighbors(gtab):
     return dwi_neighbors
 
 
-def neighboring_dwi_correlation(dwi_data, gtab, mask=None):
+@warning_for_keywords()
+def neighboring_dwi_correlation(dwi_data, gtab, *, mask=None):
     """Calculate the Neighboring DWI Correlation (NDC) from dMRI data.
 
     Using a mask is highly recommended, otherwise the FOV will influence the

--- a/dipy/stats/tests/test_qc.py
+++ b/dipy/stats/tests/test_qc.py
@@ -96,7 +96,7 @@ def test_neighboring_dwi_correlation():
     real_r, dwi_data, mask, gtab = create_test_data(
         test_r=0.3, cube_size=10, mask_size=6, num_dwi_vols=10, num_b0s=2
     )
-    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask)
+    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask=mask)
     assert np.allclose(real_r, estimated_ndc)
 
     maskless_ndc = neighboring_dwi_correlation(dwi_data, gtab)
@@ -106,19 +106,19 @@ def test_neighboring_dwi_correlation():
     real_r, dwi_data, mask, gtab = create_test_data(
         test_r=0.3, cube_size=10, mask_size=6, num_dwi_vols=10, num_b0s=0
     )
-    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask)
+    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask=mask)
     assert np.allclose(real_r, estimated_ndc)
 
     # Try with realistic correlation value
     real_r, dwi_data, mask, gtab = create_test_data(
         test_r=0.8, cube_size=10, mask_size=6, num_dwi_vols=10, num_b0s=2
     )
-    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask)
+    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask=mask)
     assert np.allclose(real_r, estimated_ndc)
 
     # Try with a bigger volume, lower correlation
     real_r, dwi_data, mask, gtab = create_test_data(
         test_r=0.5, cube_size=100, mask_size=49, num_dwi_vols=160, num_b0s=2
     )
-    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask)
+    estimated_ndc = neighboring_dwi_correlation(dwi_data, gtab, mask=mask)
     assert np.allclose(real_r, estimated_ndc)

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -4,12 +4,18 @@
 Decorators for dipy tests
 """
 
+from functools import wraps
 import inspect
+from inspect import Parameter, signature
 import os
 import platform
 import re
+import warnings
 
 import numpy as np
+from packaging import version
+
+import dipy
 
 SKIP_RE = re.compile(r"(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")
 
@@ -103,3 +109,109 @@ def set_random_number_generator(seed_v=1234):
         return _set_random_number_generator_wrapper
 
     return _set_random_number_generator
+
+
+def warning_for_keywords(from_version="1.10.0", until_version="2.0.0"):
+    """
+    Decorator to warn about keyword arguments passed as positional arguments
+    and handle version-based deprecation of functions.
+
+    Parameters
+    ----------
+    from_version : str, optional
+        The version from which the warning should start.
+    until_version : str, optional
+        The version until which the warning is applicable.
+
+    Returns
+    -------
+    function
+        The wrapped function that will issue a warning based
+        on the version.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            current_version = dipy.__version__
+
+            def convert_positional_to_keyword(func, args, kwargs):
+                """
+                Converts excess positional arguments to keyword arguments.
+
+                Parameters
+                ----------
+                func : function
+                    The original function to be called.
+                args : tuple
+                    The positional arguments passed to the function.
+                kwargs : dict
+                    The keyword arguments passed to the function.
+
+                Returns
+                -------
+                result
+                    The result of the function call with corrected arguments.
+                """
+                sig = signature(func)
+                params = sig.parameters
+                max_positional_args = sum(
+                    1
+                    for param in params.values()
+                    if param.kind
+                    in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+                )
+
+                if len(args) > max_positional_args:
+                    # Split positional arguments into valid positional and
+                    # those needing conversion
+                    positional_args = list(args[:max_positional_args])
+                    corrected_kwargs = dict(kwargs)
+                    positionally_passed_kwonly_args = []
+                    for param, arg in zip(
+                        list(params.values())[max_positional_args:],
+                        args[max_positional_args:],
+                    ):
+                        corrected_kwargs[param.name] = arg
+                        positionally_passed_kwonly_args.append(param.name)
+
+                    if positionally_passed_kwonly_args and version.parse(
+                        from_version
+                    ) <= version.parse(current_version) <= version.parse(until_version):
+                        warnings.warn(
+                            f"Pass {positionally_passed_kwonly_args} as keyword args. "
+                            f"From version {until_version} passing these as positional "
+                            f"arguments will result in an error. ",
+                            UserWarning,
+                            stacklevel=3,
+                        )
+
+                    return func(*positional_args, **corrected_kwargs)
+
+                return func(*args, **kwargs)
+
+            # Check if the current version is within the warning range
+            if (
+                version.parse(from_version)
+                <= version.parse(current_version)
+                <= version.parse(until_version)
+            ):
+                # Convert positional to keyword arguments and issue a warning
+                return convert_positional_to_keyword(func, args, kwargs)
+
+            # If the version is greater than the until_version,
+            # pass the arguments as they are
+            elif version.parse(current_version) > version.parse(until_version):
+                return func(*args, **kwargs)
+
+            # Convert positional to keyword arguments if
+            # current version is less than from_version without warning
+            elif version.parse(current_version) < version.parse(from_version):
+                return convert_positional_to_keyword(func, args, kwargs)
+
+            # Default case: call the function with the original arguments
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/dipy/testing/tests/test_decorators.py
+++ b/dipy/testing/tests/test_decorators.py
@@ -1,9 +1,12 @@
 """Testing decorators module."""
 
+import warnings
+
 from numpy.testing import assert_equal, assert_raises
 
+import dipy
 from dipy.testing import assert_true
-from dipy.testing.decorators import doctest_skip_parser
+from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
 
 
 def test_skipper():
@@ -51,3 +54,58 @@ def test_skipper():
     del HAVE_AMODULE
     f.__doc__ = docstring
     assert_raises(NameError, doctest_skip_parser, f)
+
+
+def test_warning_for_keywords():
+    original_version = dipy.__version__
+
+    @warning_for_keywords(from_version="1.0.0", until_version="10.0.0")
+    def func_with_kwonly_args(a, b, *, c=3):
+        return a + b + c
+
+    # Case 1: Version is 0.9.0, no warnings expected
+    dipy.__version__ = "0.9.0"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = func_with_kwonly_args(1, 2, 3)
+        assert result == 6, "Expected result to be 6"
+        assert len(w) == 0, "Expected no warnings for version 0.9.0"
+
+    # Case 2: Version is 1.10.0, warnings expected
+    dipy.__version__ = "1.10.0"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = func_with_kwonly_args(1, 2, 3)
+        assert result == 6, "Expected result to be 6"
+        assert len(w) == 1, "Expected warning for version 1.10.0"
+        assert (
+            "Pass ['c'] as keyword args. From version 10.0.0 passing these as "
+            "positional arguments will result in an error" in str(w[-1].message)
+        )
+
+    # Case 3: Version is 1.15.0, warnings expected
+    dipy.__version__ = "1.15.0"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = func_with_kwonly_args(1, 2, 3)
+        assert result == 6, "Expected result to be 6"
+        assert len(w) == 1, "Expected warning for version 1.15.0"
+        assert (
+            "Pass ['c'] as keyword args. From version 10.0.0 passing these as "
+            "positional arguments will result in an error" in str(w[-1].message)
+        )
+
+    # Case 4: Version is 10.1.0, arguments should pass as they are,
+    # expecting TypeError from system
+    dipy.__version__ = "10.1.0"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    try:
+        result = func_with_kwonly_args(1, 2, 3)
+    except TypeError:
+        pass
+
+    # Restore the original version
+    dipy.__version__ = original_version


### PR DESCRIPTION
# Migrating to Keyword Only arguments

## Overview
This PR introduces new feature of decorator function for Keyword-Only arguments as mentioned in issue #3029.

## Changes
- Added Decorator function in decorators.py
- Added Testing function in test_decorators.py
- Added decorator function to functions in stats module

## Related Issues
- #3029 

## Modules Implementation

- [x] stats - #3239 
- [x] align - #3249 
- [x] core - #3251 
- [x] data - #3253 
- [x] denoise - #3252 
- [x] direction - #3254 
- [x] io - #3255 
- [x] nn - #3256 
- [x] reconst - #3257 
- [x] segment - #3258 
- [x] sims - #3259 
- [x] tracking - #3260 
- [x] utils - #3261 
- [x] viz - #3262 
- [x] workflows - #3263 
