### PR TITLE
STYLE: Import explicitly `direction.peaks` symbols

### DIFF
--- a/dipy/direction/__init__.py
+++ b/dipy/direction/__init__.py
@@ -1,6 +1,13 @@
 from .bootstrap_direction_getter import BootDirectionGetter
 from .closest_peak_direction_getter import ClosestPeakDirectionGetter
-from .peaks import *
+from .peaks import (
+    PeaksAndMetrics,
+    peak_directions,
+    peak_directions_nl,
+    peaks_from_model,
+    peaks_from_positions,
+    reshape_peaks_for_visualization,
+)
 from .probabilistic_direction_getter import (
     DeterministicMaximumDirectionGetter,
     ProbabilisticDirectionGetter,

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,7 +30,7 @@ ignore = [
 
 [lint.extend-per-file-ignores]
 "dipy/align/__init__.py" = ["E402"]
-"dipy/direction/__init__.py" = ["F401", "F403"]
+"dipy/direction/__init__.py" = ["F401"]
 "dipy/reconst/*.py" = ["B026"]
 "dipy/testing/tests/test_testing.py" = ["B028"]
 "dipy/viz/__init__.py" = ["F401"]


### PR DESCRIPTION
Import explicitly `direction.peaks` symbols.

Fixes:
```
dipy/direction/__init__.py:3:1: F403
 `from .peaks import *` used; unable to detect undefined names
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/9045357134/job/24855013530#step:4:281

Remove the corresponding rule from the `ruff` per-file ignore list.