### PR TITLE
DOC: Fix param order

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -334,14 +334,14 @@ def resample(
         Containing the data for the moving object, or full path to a nifti file
         with the moving data.
 
+    static : array, nifti image or str
+        Containing the data for the static object, or full path to a nifti file
+        with the moving data.
+
     moving_affine : 4x4 array, optional
         An affine transformation associated with the moving object. Required if
         data is provided as an array. If provided together with nifti/path,
         will over-ride the affine that is in the nifti.
-
-    static : array, nifti image or str
-        Containing the data for the static object, or full path to a nifti file
-        with the moving data.
 
     static_affine : 4x4 array, optional
         An affine transformation associated with the static object. Required if


### PR DESCRIPTION
Just fixes an issue where params were listed in the wrong order.

FYI if you haven't considered it, you could use [numpydoc's checks](https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks) in your doc build to catch this particular error with something like:
```
numpydoc_validate = True
numpydoc_validation_checks = {"PR03"}
```
But it looks like you use some custom vendored version (?) so you'd need to switch back to the official one.

As a numpydoc maintainer I'm also curious why you vendor your own parser. :thinking: 