### PR TITLE
NF: Call `cnp.import_array()` explicitly to use the NumPy C API

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -18,6 +18,8 @@ from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
 
 cdef cnp.dtype f64_dt = np.dtype(np.float64)
 
+cnp.import_array()
+
 
 cdef double min_direct_flip_dist(double *a,double *b,
                                  cnp.npy_intp rows) noexcept nogil:

--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -8,6 +8,9 @@ import numpy as np
 cimport cython
 cimport numpy as cnp
 from dipy.align.fused_types cimport floating
+
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     int dpy_isinf(double)
     double floor(double)

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -17,6 +17,8 @@ from dipy.align.vector_fields cimport(_apply_affine_3d_x0,
 
 from dipy.align.transforms cimport (Transform)
 
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     double cos(double)
     double sin(double)

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -4,6 +4,9 @@ import numpy as np
 cimport cython
 cimport numpy as cnp
 from dipy.align.fused_types cimport floating
+
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     int dpy_isinf(double)
     double sqrt(double)

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -6,6 +6,8 @@
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     double cos(double)
     double sin(double)

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -14,6 +14,7 @@ from dipy.core.interpolation cimport (_interpolate_scalar_2d,
                                       _interpolate_scalar_nn_2d,
                                       _interpolate_scalar_nn_3d)
 
+cnp.import_array()
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double)

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -10,6 +10,8 @@ from libc.math cimport floor
 
 from dipy.align.fused_types cimport floating, number
 
+cnp.import_array()
+
 
 def interp_rbf(data, sphere_origin, sphere_target,
                function='multiquadric', epsilon=None, smooth=0.1,

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -12,6 +12,8 @@ from libc.math cimport sqrt, exp
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 
+cnp.import_array()
+
 
 def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
                block_radius=5, rician=True, num_threads=None):

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -10,6 +10,8 @@ from tempfile import gettempdir
 from libc.math cimport sqrt, exp, fabs, cos, sin, tan, acos, atan2
 from math import ceil
 
+cnp.import_array()
+
 logger = logging.getLogger(__name__)
 
 

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -4,6 +4,8 @@ from libc.math cimport sqrt, exp
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 __all__ = ['firdn', 'upfir', 'nlmeans_block']
 
 cdef inline int _int_max(int a, int b):

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -22,6 +22,8 @@ except ImportError:
     from scipy.linalg import svd
     svd_args = [False]
 
+cnp.import_array()
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,6 +11,8 @@ from dipy.utils.omp import determine_num_threads
 from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
 from dipy.utils.deprecator import deprecated_params
 
+cnp.import_array()
+
 @deprecated_params('sh_order', 'sh_order_max', since='1.9', until='2.0')
 def convolve(odfs_sh, kernel, sh_order_max, test_mode=False, num_threads=None, normalize=True):
     """ Perform the shift-twist convolution with the ODF data and

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -10,6 +10,7 @@ from dipy.direction.peaks import peak_directions
 from dipy.reconst import shm
 from dipy.tracking.direction_getter cimport DirectionGetter
 
+cnp.import_array()
 
 cdef class BootDirectionGetter(DirectionGetter):
 

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -12,6 +12,8 @@ from dipy.reconst import shm
 from dipy.tracking.direction_getter cimport DirectionGetter
 from dipy.utils.fast_numpy cimport copy_point, scalar_muliplication_point
 
+cnp.import_array()
+
 
 cdef int closest_peak(cnp.ndarray[cnp.float_t, ndim=2] peak_dirs,
                       double[::1] direction, double cos_similarity):

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -10,6 +10,8 @@ from dipy.reconst import shm
 from dipy.core.interpolation cimport trilinear_interpolate4d_c
 from libc.stdlib cimport malloc, free
 
+cnp.import_array()
+
 cdef extern from "stdlib.h" nogil:
     void *memset(void *ptr, int value, size_t num)
 

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -16,6 +16,8 @@ from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
 from dipy.utils.fast_numpy cimport (copy_point, cumsum, norm, normalize,
                                      where_to_insert)
 
+cnp.import_array()
+
 
 cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
     """Randomly samples direction of a sphere based on probability mass

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -10,6 +10,8 @@ import numpy as np
 from dipy.tracking.propspeed cimport _propagation_direction
 from dipy.tracking.direction_getter cimport DirectionGetter
 
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     double dpy_rint(double x)
 

--- a/dipy/reconst/quick_squash.pyx
+++ b/dipy/reconst/quick_squash.pyx
@@ -7,6 +7,8 @@ cimport cython
 
 import numpy as np
 
+cnp.import_array()
+
 cdef enum:
     SCALAR, ARRAY
 

--- a/dipy/reconst/vec_val_sum.pyx
+++ b/dipy/reconst/vec_val_sum.pyx
@@ -2,6 +2,8 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 
+cnp.import_array()
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -11,6 +11,8 @@ from libc.math cimport fabs
 from dipy.segment.cythonutils cimport Data2D, Shape,\
     tuple2shape, same_shape, create_memview_2d, free_memview_2d
 
+cnp.import_array()
+
 cdef extern from "math.h" nogil:
     double fabs(double x)
 

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -3,6 +3,8 @@
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 cdef extern from "stdlib.h" nogil:
     ctypedef unsigned long size_t
     void free(void *ptr)

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -6,6 +6,8 @@ cimport numpy as cnp
 from dipy.segment.cythonutils cimport tuple2shape, shape2tuple, shape_from_memview
 from dipy.tracking.streamlinespeed cimport c_set_number_of_points, c_length
 
+cnp.import_array()
+
 
 cdef class Feature:
     """ Extracts features from a sequential datum.

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -8,6 +8,8 @@ from libc.math cimport sqrt, acos
 from dipy.segment.cythonutils cimport tuple2shape, shape2tuple, same_shape
 from dipy.segment.featurespeed cimport IdentityFeature
 
+cnp.import_array()
+
 DEF biggest_double = 1.7976931348623157e+308  #  np.finfo('f8').max
 
 import math

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -5,6 +5,9 @@
 import numpy as np
 
 cimport numpy as cnp
+
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     cdef double NPY_PI
     cdef double NPY_INFINITY

--- a/dipy/stats/tests/test_qc.py
+++ b/dipy/stats/tests/test_qc.py
@@ -66,9 +66,7 @@ def create_test_data(test_r, cube_size, mask_size, num_dwi_vols, num_b0s):
     # The bvecs will be a straight line with a minor perturbance every other
     ref_vec = np.array([1.0, 0.0, 0.0])
     nbr_vec = normalized_vector(ref_vec + 0.00001)
-    bvecs = np.vstack(
-        [ref_vec] * num_b0s + [np.vstack([ref_vec, nbr_vec])] * n_known
-    )
+    bvecs = np.vstack([ref_vec] * num_b0s + [np.vstack([ref_vec, nbr_vec])] * n_known)
 
     cor = np.ones((2, 2)) * test_r
     np.fill_diagonal(cor, 1)

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -11,6 +11,8 @@ from dipy.utils.fast_numpy cimport copy_point
 
 cimport numpy as cnp
 
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     int dpy_signbit(double x)
     double dpy_rint(double x)

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -13,6 +13,8 @@ import numpy as np
 from warnings import warn
 cimport numpy as cnp
 
+cnp.import_array()
+
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double x)

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -11,6 +11,8 @@ from scipy.interpolate import interp1d
 from dipy.utils.omp import determine_num_threads
 from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
 
+cnp.import_array()
+
 cdef class FBCMeasures:
 
     cdef int [:] streamline_length

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -12,6 +12,8 @@ cimport numpy as cnp
 
 from dipy.core.interpolation cimport _trilinear_interpolation_iso, offset
 
+cnp.import_array()
+
 cdef extern from "dpy_math.h" nogil:
     double floor(double x)
     float fabs(float x)

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -8,6 +8,8 @@ cimport numpy as cnp
 
 from dipy.tracking import Streamlines
 
+cnp.import_array()
+
 
 cdef extern from "dpy_math.h" nogil:
     bint dpy_isnan(double x)

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -12,6 +12,8 @@ import numpy as np
 cimport numpy as cnp
 from dipy.tracking._utils import _mapping_to_voxel, _to_voxel_coordinates
 
+cnp.import_array()
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
     'setuptools>=67',
     'packaging>=21',
     'ninja',
-    'Cython>=0.29.35',
+    'Cython>=3.0.4',
     'numpy>=1.22',
     # Developer UI
     'spin>=0.5',
@@ -137,7 +137,7 @@ tracker = "https://github.com/dipy/dipy/issues"
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.13.1",
-    "Cython>=0.29.35",
+    "Cython>=3.0.4",
     "packaging>21.0",
     "wheel",
     "numpy==1.19.5; python_version=='3.8' and platform_python_implementation != 'PyPy'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ requires = [
     "numpy==1.22.4; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
     "numpy==1.22.4; python_version=='3.10' and platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy>=1.26.0b1; python_version>='3.12'",
+    "numpy>=2.0.0; python_version>='3.12'",
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
 


### PR DESCRIPTION
Call `cnp.import_array()` explicitly to use the NumPy C API: Cython modules (or anything using the NumPy C API) must call `cnp.import_array()` to import the NumPy C API.

Fixes:
```
  File "vector_fields.pyx", line 1, in init dipy.align.vector_fields
ImportError: numpy.core.multiarray failed to import
 (auto-generated because you didn't call 'numpy.import_array()' after
 cimporting numpy; use '<void>numpy._import_array' to disable if you
 are certain you don't need it).
```

reported by third-party tool (e.g. MNE) maintaners when testing their tools with NumPy 2.0.

Fixes #3265.