### PR TITLE
STYLE: Avoid deprecated NumPy types and methods for NumPy 2.0 compat

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1582,7 +1582,7 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
         """
         x = np.asarray(x)
         y = np.asarray(y)
-        X = np.row_stack((x**2, x, np.ones_like(x)))
+        X = np.vstack((x**2, x, np.ones_like(x)))
         XX = X.dot(X.T)
         b = X.dot(y)
         beta = npl.solve(XX, b)

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -408,7 +408,7 @@ def solve_qp(P, Q, G, H):
         opt = np.array(x.value).reshape((Q.shape[0],))
     except cvxpy.error.SolverError:
         opt = np.empty((Q.shape[0],))
-        opt[:] = np.NaN
+        opt[:] = np.nan
 
     return opt
 

--- a/dipy/stats/tests/test_qc.py
+++ b/dipy/stats/tests/test_qc.py
@@ -66,8 +66,8 @@ def create_test_data(test_r, cube_size, mask_size, num_dwi_vols, num_b0s):
     # The bvecs will be a straight line with a minor perturbance every other
     ref_vec = np.array([1.0, 0.0, 0.0])
     nbr_vec = normalized_vector(ref_vec + 0.00001)
-    bvecs = np.row_stack(
-        [ref_vec] * num_b0s + [np.row_stack([ref_vec, nbr_vec])] * n_known
+    bvecs = np.vstack(
+        [ref_vec] * num_b0s + [np.vstack([ref_vec, nbr_vec])] * n_known
     )
 
     cor = np.ones((2, 2)) * test_r

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -1165,7 +1165,7 @@ def test_random_seed_initialization(rng):
     y = np.array([0.0, 1, 2, 21.566539227085478])
     z = np.array([1.0, 1, 1, 51.67881720942744])
 
-    seeds = np.row_stack([np.column_stack([x, y, z]), rng.random((10, 3))])
+    seeds = np.vstack([np.column_stack([x, y, z]), rng.random((10, 3))])
     sc = BinaryStoppingCriterion(np.ones((4, 4, 4)))
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
 

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -162,7 +162,7 @@ fig.savefig("beta_histogram.png")
 # We use $\beta$ to filter out these redundant streamlines, and generate an
 # optimized group of streamlines:
 
-optimized_sl = [np.row_stack(candidate_sl)[np.where(fiber_fit.beta > 0)[0]]]
+optimized_sl = [np.vstack(candidate_sl)[np.where(fiber_fit.beta > 0)[0]]]
 scene = window.Scene()
 scene.add(actor.streamtube(optimized_sl, cmap.line_colors(optimized_sl)))
 scene.add(cc_ROI_actor)


### PR DESCRIPTION
Avoid deprecated NumPy types and methods in preparation for full NumPy 2.0 compatibility.

Fixes:
```
dipy/align/imwarp.py:1585:13: NPY201 [*]
 `np.row_stack` will be removed in NumPy 2.0.
 Use `numpy.vstack` instead.
dipy/reconst/mcsd.py:411:18: NPY201 [*]
 `np.NaN` will be removed in NumPy 2.0.
 Use `numpy.nan` instead.
dipy/stats/tests/test_qc.py:69:13: NPY201 [*]
 `np.row_stack` will be removed in NumPy 2.0.
 Use `numpy.vstack` instead.
dipy/stats/tests/test_qc.py:70:32: NPY201 [*]
 `np.row_stack` will be removed in NumPy 2.0.
 Use `numpy.vstack` instead.
dipy/tracking/tests/test_tracking.py:1168:13:
 NPY201 [*] `np.row_stack` will be removed in NumPy 2.0.
 Use `numpy.vstack` instead.
doc/examples/linear_fascicle_evaluation.py:165:17:
 NPY201 [*] `np.row_stack` will be removed in NumPy 2.0.
 Use `numpy.vstack` instead.
```

reported when running:
ruff check . --select NPY201

All these features were already available in recent versions of NumPy 1.x, including the minimum required one for DIPY.

Documentation:
https://numpy.org/devdocs/numpy_2_0_migration_guide.html