### PR TITLE
STYLE: Prefer using `np.asarray` to avoid copy while creating an array

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -1126,7 +1126,7 @@ class TriLinearInterpolator(Interpolator):
                              "of a 3d voxel")
 
     def __getitem__(self, index):
-        index = np.array(index, copy=False, dtype="float")
+        index = np.asarray(index, dtype="float")
         try:
             return trilinear_interp(self.data, index, self.voxel_size)
         except IndexError:

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -184,8 +184,12 @@ class Sphere:
             self.faces = np.asarray(faces)
 
         if theta is not None:
-            self.theta = np.array(theta, copy=False, ndmin=1)
-            self.phi = np.array(phi, copy=False, ndmin=1)
+            self.theta = np.asarray(theta)
+            if self.theta.ndim < 1:
+                self.theta = np.reshape(self.theta, (1,))
+            self.phi = np.asarray(phi)
+            if self.phi.ndim < 1:
+                self.phi = np.reshape(self.phi, (1,))
             return
 
         if xyz is not None:

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1893,7 +1893,7 @@ class DiffusionKurtosisModel(ReconstModel):
             # Check for valid shape of the mask
             if mask.shape != data.shape[:-1]:
                 raise ValueError("Mask is not the same shape as data.")
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
 
         data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
         data_in_mask = np.maximum(data_in_mask, self.min_signal)

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -129,7 +129,7 @@ def diffusion_components(dki_params, sphere="repulsion100", awf=None, mask=None)
         if mask.shape != shape:
             raise ValueError("Mask is not the same shape as dki_params.")
         else:
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
 
     # check or compute awf values
     if awf is None:
@@ -374,7 +374,7 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
             # Check for valid shape of the mask
             if mask.shape != data.shape[:-1]:
                 raise ValueError("Mask is not the same shape as data.")
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
         data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
         if self.min_signal is None:

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -793,7 +793,7 @@ class TensorModel(ReconstModel):
             # Check for valid shape of the mask
             if mask.shape != img_shape:
                 raise ValueError("Mask is not the same shape as data.")
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
         data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
         if adjacency > 0:

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -41,8 +41,9 @@ cdef class EuDXDirectionGetter(DirectionGetter):
             raise ValueError(msg)
         self._qa = np.ascontiguousarray(self.peak_values, dtype=np.double)
         self._ind = np.ascontiguousarray(self.peak_indices, dtype=np.double)
-        self._odf_vertices = np.array(self.sphere.vertices, copy=False,
-                                      dtype=np.double, order='C')
+        self._odf_vertices = np.asarray(
+            self.sphere.vertices, dtype=np.double, order='C'
+        )
 
         self.initialized = True
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -401,7 +401,7 @@ def wls_fit_tensor(
     else:
         if mask.shape != data.shape[:-1]:
             raise ValueError("Mask is not the same shape as data.")
-        mask = np.array(mask, dtype=bool, copy=False)
+        mask = np.asarray(mask, dtype=bool)
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)
@@ -794,7 +794,7 @@ def nls_fit_tensor(
     else:
         if mask.shape != data.shape[:-1]:
             raise ValueError("Mask is not the same shape as data.")
-        mask = np.array(mask, dtype=bool, copy=False)
+        mask = np.asarray(mask, dtype=bool)
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)

--- a/dipy/reconst/msdki.py
+++ b/dipy/reconst/msdki.py
@@ -192,7 +192,7 @@ def awf_from_msk(msk, mask=None):
     else:
         if mask.shape != msk.shape:
             raise ValueError("Mask is not the same shape as data.")
-        mask = np.array(mask, dtype=bool, copy=False)
+        mask = np.asarray(mask, dtype=bool)
 
     # looping voxels
     index = ndindex(mask.shape)
@@ -629,7 +629,7 @@ def wls_fit_msdki(
     else:
         if mask.shape != msignal.shape[:-1]:
             raise ValueError("Mask is not the same shape as data.")
-        mask = np.array(mask, dtype=bool, copy=False)
+        mask = np.asarray(mask, dtype=bool)
 
     index = ndindex(mask.shape)
     for v in index:

--- a/dipy/reconst/qti.py
+++ b/dipy/reconst/qti.py
@@ -788,7 +788,7 @@ class QtiModel(ReconstModel):
         else:
             if mask.shape != data.shape[:-1]:
                 raise ValueError("Mask is not the same shape as data.")
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
         if self.fit_method_name == "SDPdc":
             params = self.fit_method(data, mask, self.X, self.cvxpy_solver)
         else:

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -533,7 +533,7 @@ class SparseFascicleModel(ReconstModel, Cache):
             # Check for valid shape of the mask
             if mask.shape != data.shape[:-1]:
                 raise ValueError("Mask is not the same shape as data.")
-            mask = np.array(mask, dtype=bool, copy=False)
+            mask = np.asarray(mask, dtype=bool)
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
         # Fitting is done on the relative signal (S/S0):

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -379,7 +379,9 @@ def seeds_from_mask(mask, affine, density=(1, 1, 1)):
     array([[ 0.,  0.,  0.]])
 
     """
-    mask = np.array(mask, dtype=bool, copy=False, ndmin=3)
+    mask = np.asarray(mask, dtype=bool)
+    if mask.ndim < 1:
+        mask = np.reshape(mask, (3,))
     if mask.ndim != 3:
         raise ValueError("mask cannot be more than 3d")
 
@@ -477,7 +479,9 @@ def random_seeds_from_mask(
            [-0.41435083, -0.26318949,  0.30127447]])
 
     """
-    mask = np.array(mask, dtype=bool, copy=False, ndmin=3)
+    mask = np.asarray(mask, dtype=bool)
+    if mask.ndim < 1:
+        mask = np.reshape(mask, (3,))
     if mask.ndim != 3:
         raise ValueError("mask cannot be more than 3d")
 


### PR DESCRIPTION
Prefer using `np.asarray` to avoid copy while creating an array in preparation for full NumPy 2.0 compatibility.

Fixes:
```
FAILED core/tests/test_interpolation.py::test_TriLinearInterpolator -
 ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)`
 to allow a copy when needed (no behavior change in NumPy 1.x).
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/9605741685/job/26493943578?pr=3266#step:10:7997