### PR TITLE
STYLE: Prefer using `isin` over `in1d`

### DIFF
--- a/benchmarks/benchmarks/bench_reconst.py
+++ b/benchmarks/benchmarks/bench_reconst.py
@@ -44,7 +44,7 @@ class BenchVecValSum:
 
 #         labels = labels_img.get_fdata()
 #         shape = labels.shape
-#         mask = np.in1d(labels, [1, 2])
+#         mask = np.isin(labels, [1, 2])
 #         mask.shape = shape
 
 #         center = (50, 40, 40)

--- a/dipy/segment/tests/test_fss.py
+++ b/dipy/segment/tests/test_fss.py
@@ -93,8 +93,8 @@ def test_fss_radius_search():
 
     # Single direction should be a subset of bidirectional
     assert_greater_equal(rs_f1_in_f2.nnz, rs_f1_sd.nnz)
-    assert_true(np.all(np.in1d(rs_f1_sd.row, rs_f2_in_f1.row)))
-    assert_true(np.all(np.in1d(rs_f1_sd.col, rs_f2_in_f1.col)))
+    assert_true(np.all(np.isin(rs_f1_sd.row, rs_f2_in_f1.row)))
+    assert_true(np.all(np.isin(rs_f1_sd.col, rs_f2_in_f1.col)))
 
 
 def test_fss_varying_radius():
@@ -108,12 +108,12 @@ def test_fss_varying_radius():
 
     # smaller radius should be a subset or equal of a bigger radius
     assert_greater_equal(rs_6.nnz, rs_4.nnz)
-    assert_true(np.all(np.in1d(rs_4.row, rs_6.row)))
-    assert_true(np.all(np.in1d(rs_4.col, rs_6.col)))
+    assert_true(np.all(np.isin(rs_4.row, rs_6.row)))
+    assert_true(np.all(np.isin(rs_4.col, rs_6.col)))
 
     assert_greater_equal(rs_4.nnz, rs_2.nnz)
-    assert_true(np.all(np.in1d(rs_2.row, rs_4.row)))
-    assert_true(np.all(np.in1d(rs_2.col, rs_4.col)))
+    assert_true(np.all(np.isin(rs_2.row, rs_4.row)))
+    assert_true(np.all(np.isin(rs_2.col, rs_4.col)))
 
 
 def test_fss_single_point_slines():


### PR DESCRIPTION
Prefer using `isin` over `in1d` in preparation for full NumPy 2.0 compatibility.

Fixes:
```
segment/tests/test_fss.py::test_fss_radius_search
  dipy/venv/lib/python3.12/site-packages/dipy/segment/tests/test_fss.py:96:
 DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    assert_true(np.all(np.in1d(rs_f1_sd.row, rs_f2_in_f1.row)))
```

reported for example in:
https://github.com/dipy/dipy/actions/runs/9605741685/job/26493943578?pr=3266#step:10:10205