### PR TITLE
RF: Do not use `np.any` for checking optional array parameters

### DIFF
--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -195,10 +195,10 @@ def _gibbs_removal_2d(image, n_points=3, G0=None, G1=None):
     n_points : int, optional
         Number of neighbours to access local TV (see note). Default is
         set to 3.
-    G0 : 2D ndarray, optional.
+    G0 : 2D ndarray, optional
         Weights for the image corrected along axis 0. If not given, the
         function estimates them using the function :func:`_weights`.
-    G1 : 2D ndarray
+    G1 : 2D ndarray, optional
         Weights for the image corrected along axis 1. If not given, the
         function estimates them using the function :func:`_weights`.
 

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -226,7 +226,7 @@ def _gibbs_removal_2d(image, n_points=3, G0=None, G1=None):
            doi: 10.1002/mrm.26054.
 
     """
-    if np.any(G0) is None or np.any(G1) is None:
+    if G0 is None or G1 is None:
         G0, G1 = _weights(image.shape)
 
     img_c1 = _gibbs_removal_1d(image, axis=1, n_points=n_points)


### PR DESCRIPTION
- DOC: Add missing optional label to optional parameter docstring
- RF: Do not use `np.any` for checking optional array parameters