### PR TITLE
RF: Update pyproject.toml for numpy 2.0

### DIFF
--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -863,16 +863,23 @@ def test_positivity_constraint(radial_order=6, rng=None):
 
     # Set the cvxpy solver to CLARABEL as the one picked otherwise for this
     # problem (OSQP) triggers a `Solution may be inaccurate` UserWarning
-    mapmod_constraint = MapmriModel(
-        gtab,
-        radial_order=radial_order,
-        laplacian_regularization=False,
-        positivity_constraint=True,
-        pos_grid=gridsize,
-        pos_radius="adaptive",
-        cvxpy_solver=mapmri.cvxpy.CLARABEL,
-    )
-    mapfit_constraint = mapmod_constraint.fit(S_noise)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*Solution may be inaccurate.*",
+            category=UserWarning,
+        )
+        mapmod_constraint = MapmriModel(
+            gtab,
+            radial_order=radial_order,
+            laplacian_regularization=False,
+            positivity_constraint=True,
+            pos_grid=gridsize,
+            pos_radius="adaptive",
+            cvxpy_solver=mapmri.cvxpy.CLARABEL,
+        )
+        mapfit_constraint = mapmod_constraint.fit(S_noise)
+
     pdf = mapfit_constraint.pdf(r_grad)
     pdf_negative_constraint = pdf[pdf < 0].sum()
 

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -73,9 +73,10 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     --------
     >>> import warnings
     >>> import numpy as np
-    >>> with clear_and_catch_warnings(modules=[np.core.fromnumeric]):
+    >>> with clear_and_catch_warnings(modules=[np.lib.scimath]):
     ...     warnings.simplefilter('always')
-    ...     # do something that raises a warning in np.core.fromnumeric
+    ...     # do something that raises a warning in np.lib.scimath
+    ...     _ = np.arccos(90)
 
     Notes
     -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,8 +140,14 @@ requires = [
     "Cython>=3.0.4",
     "packaging>21.0",
     "wheel",
-    'numpy>=2.0.0rc1',
-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+    # numpy requirement for wheel builds for distribution on PyPI - building
+    # against 2.x yields wheels that are also compatible with numpy 1.x at
+    # runtime.
+    # Note that building against numpy 1.x works fine too - users and
+    # redistributors can do this by installing the numpy version they like and
+    # disabling build isolation.
+    "numpy>=2.0.0rc1; python_version>='3.9' and platform_python_implementation!='PyPy'",
+    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
 ]
 
 [tool.spin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,15 +137,10 @@ tracker = "https://github.com/dipy/dipy/issues"
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.13.1",
-    "Cython>=0.29.35",
+    "Cython>=3.0.4",
     "packaging>21.0",
     "wheel",
-    "numpy==1.19.5; python_version=='3.8' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.4; python_version=='3.9' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.4; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.22.4; python_version=='3.10' and platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy>=1.26.0b1; python_version>='3.12'",
+    'numpy>=2.0.0rc1',
     "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
 ]
 


### PR DESCRIPTION
> A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

make sure that we always build DIPY with `numpy>=2.0.0rc1`