### PR TITLE
FIX: Explicit type origin for long to solve the cython error during compilation

### DIFF
--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -78,7 +78,7 @@ cdef class EnhancementKernel:
         if isinstance(orientations, Sphere):
             # use the sphere defined by the user
             sphere = orientations
-        elif isinstance(orientations, (int, long, float)):
+        elif isinstance(orientations, (int, float)):
             # electrostatic repulsion based on number of orientations
             n_pts = int(orientations)
             if n_pts == 0:


### PR DESCRIPTION
This PR solves the following error:
```  
Error compiling Cython file:
  ------------------------------------------------------------
  ...
          rng = np.random.default_rng()

          if isinstance(orientations, Sphere):
              # use the sphere defined by the user
              sphere = orientations
          elif isinstance(orientations, (int, long, float)):
                                              ^
  ------------------------------------------------------------

  /Users/devel/dipy/dipy/denoise/enhancement_kernel.pyx:81:44: undeclared name not builtin: long
```

This error appear with the latest development version of cython. it should fix the `PRE` matrix