### PR TITLE
BF: Allow passing kwargs in `fit` method, by moving parallelization kwargs elsewhere

### DIFF
--- a/dipy/reconst/base.py
+++ b/dipy/reconst/base.py
@@ -14,7 +14,7 @@ particular set of data (different voxels, for example).
 class ReconstModel:
     """Abstract class for signal reconstruction models"""
 
-    def __init__(self, gtab, **parallel_kwargs):
+    def __init__(self, gtab):
         """Initialization of the abstract class for signal reconstruction models
 
         Parameters
@@ -24,9 +24,8 @@ class ReconstModel:
 
         """
         self.gtab = gtab
-        self.parallel_kwargs = parallel_kwargs
 
-    def fit(self, data, mask=None):
+    def fit(self, data, mask=None, **kwargs):
         return ReconstFit(self, data)
 
 

--- a/dipy/reconst/base.py
+++ b/dipy/reconst/base.py
@@ -14,7 +14,7 @@ particular set of data (different voxels, for example).
 class ReconstModel:
     """Abstract class for signal reconstruction models"""
 
-    def __init__(self, gtab):
+    def __init__(self, gtab, **parallel_kwargs):
         """Initialization of the abstract class for signal reconstruction models
 
         Parameters
@@ -24,8 +24,9 @@ class ReconstModel:
 
         """
         self.gtab = gtab
+        self.parallel_kwargs = parallel_kwargs
 
-    def fit(self, data, mask=None, **kwargs):
+    def fit(self, data, mask=None):
         return ReconstFit(self, data)
 
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1936,7 +1936,7 @@ class DiffusionKurtosisModel(ReconstModel):
         return DiffusionKurtosisFit(self, dki_params, model_S0=S0_params)
 
     @multi_voxel_fit
-    def multi_fit(self, data_thres, mask=None):
+    def multi_fit(self, data, mask=None):
         extra_args = (
             {}
             if not self.convexity_constraint
@@ -1947,7 +1947,7 @@ class DiffusionKurtosisModel(ReconstModel):
         )
         params, extra = self.fit_method(
             self.design_matrix,
-            data_thres,
+            data,
             self.inverse_design_matrix,
             return_S0_hat=self.return_S0_hat,
             weights=self.weights,

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -44,7 +44,8 @@ def multi_voxel_fit(single_voxel_fit):
         # The following are "standard" arguments:
         args.pop(args.index("self"))
         args.pop(args.index("data"))
-        args.pop(args.index("mask"))
+        if "mask" in args:
+            args.pop(args.index("mask"))
         # What remains are arguments that are defined separate from **kwargs
         # (kwargs are specifically reserved only for parallelization
         # arguments):

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -36,20 +36,24 @@ def multi_voxel_fit(single_voxel_fit):
 
     def new_fit(self, data, mask=None, **kwargs):
         """Fit method for every voxel in data"""
-        # Analyze if the single voxel fit has any additiona key-word arguments:
+        # Analyze if the single voxel fit has any "non standard"
+        # key-word arguments:
         arg_spec = getargspec(single_voxel_fit)
         # List of the arguments to the function:
         args = arg_spec.args
+        # The following are "standard" arguments:
         args.pop(args.index("self"))
         args.pop(args.index("data"))
         args.pop(args.index("mask"))
-        # What remains are arguments that are not in **kwargs:
+        # What remains are arguments that are defined separate from **kwargs
+        # (which we reserve for parallelization arguments):
         func_kwargs = {}
         for kwarg in args:
             func_kwargs.update({kwarg: kwargs[kwarg]})
             kwargs.pop(kwarg)
 
-        # If only one voxel just return a normal fit
+        # If only one voxel just return a standard fit, passing through
+        # the functions key-word arguments:
         if data.ndim == 1:
             return single_voxel_fit(self, data, **func_kwargs)
 

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,7 +1,7 @@
 """Tools to easily make multi voxel models"""
 
 from functools import partial
-from inspect import getargspec
+from inspect import getfullargspec as getargspec
 import multiprocessing
 
 import numpy as np

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -40,19 +40,20 @@ def multi_voxel_fit(single_voxel_fit):
         # key-word arguments:
         arg_spec = getargspec(single_voxel_fit)
         # List of the arguments to the function:
-        args = arg_spec.args
+        this_args = arg_spec.args
         # The following are "standard" arguments:
-        args.pop(args.index("self"))
-        args.pop(args.index("data"))
-        if "mask" in args:
-            args.pop(args.index("mask"))
+        this_args.pop(this_args.index("self"))
+        this_args.pop(this_args.index("data"))
+        if "mask" in this_args:
+            this_args.pop(this_args.index("mask"))
         # What remains are arguments that are defined separate from **kwargs
         # (kwargs are specifically reserved only for parallelization
         # arguments):
         func_kwargs = {}
-        for kwarg in args:
-            func_kwargs.update({kwarg: kwargs[kwarg]})
-            kwargs.pop(kwarg)
+        for kwarg in this_args:
+            if kwarg in kwargs:
+                func_kwargs.update({kwarg: kwargs[kwarg]})
+                kwargs.pop(kwarg)
 
         # If only one voxel just return a standard fit, passing through
         # the functions key-word arguments (no mask needed).

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -53,7 +53,7 @@ def multi_voxel_fit(single_voxel_fit):
             kwargs.pop(kwarg)
 
         # If only one voxel just return a standard fit, passing through
-        # the functions key-word arguments:
+        # the functions key-word arguments (no mask needed).
         if data.ndim == 1:
             return single_voxel_fit(self, data, **func_kwargs)
 

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -46,7 +46,8 @@ def multi_voxel_fit(single_voxel_fit):
         args.pop(args.index("data"))
         args.pop(args.index("mask"))
         # What remains are arguments that are defined separate from **kwargs
-        # (which we reserve for parallelization arguments):
+        # (kwargs are specifically reserved only for parallelization
+        # arguments):
         func_kwargs = {}
         for kwarg in args:
             func_kwargs.update({kwarg: kwargs[kwarg]})

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -57,7 +57,7 @@ def multi_voxel_fit(single_voxel_fit):
             bar.set_description("Fitting reconstruction model using serial execution")
             for ijk in ndindex(data.shape[:-1]):
                 if mask[ijk]:
-                    fit_array[ijk] = single_voxel_fit(self, data[ijk])
+                    fit_array[ijk] = single_voxel_fit(self, data[ijk], **kwargs)
                 bar.update()
             bar.close()
         else:

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,6 +1,7 @@
 """Tools to easily make multi voxel models"""
 
 from functools import partial
+from inspect import getargspec
 import multiprocessing
 
 import numpy as np
@@ -35,10 +36,26 @@ def multi_voxel_fit(single_voxel_fit):
 
     def new_fit(self, data, mask=None, **kwargs):
         """Fit method for every voxel in data"""
+        # Analyze if the single voxel fit has any "non standard"
+        # key-word arguments:
+        arg_spec = getargspec(single_voxel_fit)
+        # List of the arguments to the function:
+        args = arg_spec.args
+        # The following are "standard" arguments:
+        args.pop(args.index("self"))
+        args.pop(args.index("data"))
+        args.pop(args.index("mask"))
+        # What remains are arguments that are defined separate from **kwargs
+        # (which we reserve for parallelization arguments):
+        func_kwargs = {}
+        for kwarg in args:
+            func_kwargs.update({kwarg: kwargs[kwarg]})
+            kwargs.pop(kwarg)
+
         # If only one voxel just return a standard fit, passing through
         # the functions key-word arguments:
         if data.ndim == 1:
-            return single_voxel_fit(self, data, **kwargs)
+            return single_voxel_fit(self, data, **func_kwargs)
 
         # Make a mask if mask is None
         if mask is None:
@@ -50,14 +67,15 @@ def multi_voxel_fit(single_voxel_fit):
         # Fit data where mask is True
         fit_array = np.empty(data.shape[:-1], dtype=object)
         # Default to serial execution:
-        engine = self.parallel_kwargs.get("engine", "serial")
-        verbose = self.parallel_kwargs.get("verbose", True)
+        engine = kwargs.get("engine", "serial")
         if engine == "serial":
-            bar = tqdm(total=np.sum(mask), position=0, disable=verbose)
+            bar = tqdm(
+                total=np.sum(mask), position=0, disable=kwargs.get("verbose", True)
+            )
             bar.set_description("Fitting reconstruction model using serial execution")
             for ijk in ndindex(data.shape[:-1]):
                 if mask[ijk]:
-                    fit_array[ijk] = single_voxel_fit(self, data[ijk], **kwargs)
+                    fit_array[ijk] = single_voxel_fit(self, data[ijk], **func_kwargs)
                 bar.update()
             bar.close()
         else:
@@ -77,8 +95,8 @@ def multi_voxel_fit(single_voxel_fit):
                         _parallel_fit_worker,
                         chunks,
                         func_args=[single_voxel_with_self],
-                        func_kwargs=kwargs,
-                        **self.parallel_kwargs,
+                        func_kwargs=func_kwargs,
+                        **kwargs,
                     )
                 )
             )

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -144,10 +144,15 @@ def test_CallableArray():
 def test_multi_voxel_fit(rng):
     class SillyModel:
         @multi_voxel_fit
-        def fit(self, data, mask=None, another_kwarg=None, **kwargs):
+        def fit(
+            self, data, mask=None, another_kwarg=None, kwarg_untouched=True, **kwargs
+        ):
             # We want to make sure that all kwargs are passed through to the
             # the fitting procedure
             assert another_kwarg is not None
+            # Make sure that an argument that is not passed is still
+            # usable in the fitting procedure:
+            assert kwarg_untouched
             return SillyFit(model, data)
 
         def predict(self, S0):

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -179,15 +179,16 @@ def test_multi_voxel_fit(rng):
 
     # Test without a mask
     many_voxels = np.zeros((2, 3, 4, 64))
-    fit = model.fit(many_voxels, another_kwarg="foo")
-    expected = np.empty((2, 3, 4))
-    expected[:] = 2.0
-    npt.assert_array_equal(fit.model_attr, expected)
-    expected = np.ones((2, 3, 4, 12))
-    npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
-    npt.assert_equal(fit.directions.shape, (2, 3, 4))
-    S0 = 100.0
-    npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+    for verbose in [True, False]:
+        fit = model.fit(many_voxels, verbose=verbose, another_kwarg="foo")
+        expected = np.empty((2, 3, 4))
+        expected[:] = 2.0
+        npt.assert_array_equal(fit.model_attr, expected)
+        expected = np.ones((2, 3, 4, 12))
+        npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
+        npt.assert_equal(fit.directions.shape, (2, 3, 4))
+        S0 = 100.0
+        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with parallelization (using the "serial" dummy engine)
     fit = model.fit(many_voxels, another_kwarg="foo", engine="serial")

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -192,22 +192,28 @@ def test_multi_voxel_fit(rng):
     # Test with parallelization (using the "serial" dummy engine)
     fit = model.fit(many_voxels, another_kwarg="foo", engine="serial")
 
-    # If parallelization engines are installed use them to test:
-    if has_joblib:
-        fit = model.fit(
-            many_voxels,
-            another_kwarg="foo",
-            engine="joblib",
-        )
-        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+    for verbose in [True, False]:
+        # If parallelization engines are installed use them to test:
+        if has_joblib:
+            fit = model.fit(
+                many_voxels,
+                verbose=verbose,
+                another_kwarg="foo",
+                engine="joblib",
+            )
+            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
-    if has_dask:
-        fit = model.fit(many_voxels, another_kwarg="foo", engine="dask")
-        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+        if has_dask:
+            fit = model.fit(
+                many_voxels, verbose=verbose, another_kwarg="foo", engine="dask"
+            )
+            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
-    if has_ray:
-        fit = model.fit(many_voxels, another_kwarg="foo", engine="ray")
-        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+        if has_ray:
+            fit = model.fit(
+                many_voxels, verbose=verbose, another_kwarg="foo", engine="ray"
+            )
+            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask
     mask = np.zeros((3, 3, 3)).astype("bool")

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -194,27 +194,35 @@ def test_multi_voxel_fit(rng):
     fit = model.fit(many_voxels, another_kwarg="foo", engine="serial")
 
     for verbose in [True, False]:
-        # If parallelization engines are installed use them to test:
-        if has_joblib:
-            fit = model.fit(
-                many_voxels,
-                verbose=verbose,
-                another_kwarg="foo",
-                engine="joblib",
-            )
-            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+        # Test with single value kwarg, or sequence of kwarg values
+        for another_kwarg in ["foo", len(many_voxels) * ["foo"]]:
+            # If parallelization engines are installed use them to test:
+            if has_joblib:
+                fit = model.fit(
+                    many_voxels,
+                    verbose=verbose,
+                    another_kwarg=another_kwarg,
+                    engine="joblib",
+                )
+                npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
-        if has_dask:
-            fit = model.fit(
-                many_voxels, verbose=verbose, another_kwarg="foo", engine="dask"
-            )
-            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+            if has_dask:
+                fit = model.fit(
+                    many_voxels,
+                    verbose=verbose,
+                    another_kwarg=another_kwarg,
+                    engine="dask",
+                )
+                npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
-        if has_ray:
-            fit = model.fit(
-                many_voxels, verbose=verbose, another_kwarg="foo", engine="ray"
-            )
-            npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+            if has_ray:
+                fit = model.fit(
+                    many_voxels,
+                    verbose=verbose,
+                    another_kwarg=another_kwarg,
+                    engine="ray",
+                )
+                npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask
     mask = np.zeros((3, 3, 3)).astype("bool")

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -3,10 +3,7 @@ from functools import reduce
 import numpy as np
 import numpy.testing as npt
 
-from dipy.core.gradients import gradient_table
 from dipy.core.sphere import unit_icosahedron
-from dipy.data import get_fnames
-from dipy.reconst.base import ReconstFit, ReconstModel
 from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
@@ -145,21 +142,18 @@ def test_CallableArray():
 
 @set_random_number_generator()
 def test_multi_voxel_fit(rng):
-    class SillyModel(ReconstModel):
-        def __init__(self, gtab, **parallel_kwargs):
-            ReconstModel.__init__(self, gtab, parallel_kwargs=parallel_kwargs)
-
+    class SillyModel:
         @multi_voxel_fit
-        def fit(self, data, mask=None, fit_kwarg=None):
-            # We want to make sure that we can define a custom kwarg for the
-            # fit method:
-            assert fit_kwarg is not None
+        def fit(self, data, mask=None, another_kwarg=None, **kwargs):
+            # We want to make sure that all kwargs are passed through to the
+            # the fitting procedure
+            assert another_kwarg is not None
             return SillyFit(model, data)
 
         def predict(self, S0):
             return np.ones(10) * S0
 
-    class SillyFit(ReconstFit):
+    class SillyFit:
         def __init__(self, model, data):
             self.model = model
             self.data = data
@@ -178,56 +172,48 @@ def test_multi_voxel_fit(rng):
             return np.ones(self.data.shape) * S0
 
     # Test the single voxel case
-    fdata, fbval, fbvec = get_fnames("small_25")
-    gtab = gradient_table(fbval, fbvec)
-    model = SillyModel(gtab)
+    model = SillyModel()
     single_voxel = np.zeros(64)
-    fit = model.fit(single_voxel, fit_kwarg="foo")
+    fit = model.fit(single_voxel, another_kwarg="foo")
     npt.assert_equal(type(fit), SillyFit)
 
     # Test without a mask
     many_voxels = np.zeros((2, 3, 4, 64))
-    fit = model.fit(many_voxels, fit_kwarg="foo")
-    expected = np.empty((2, 3, 4))
-    expected[:] = 2.0
-    npt.assert_array_equal(fit.model_attr, expected)
-    expected = np.ones((2, 3, 4, 12))
-    npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
-    npt.assert_equal(fit.directions.shape, (2, 3, 4))
-    S0 = 100.0
-    npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+    for verbose in [True, False]:
+        fit = model.fit(many_voxels, verbose=verbose, another_kwarg="foo")
+        expected = np.empty((2, 3, 4))
+        expected[:] = 2.0
+        npt.assert_array_equal(fit.model_attr, expected)
+        expected = np.ones((2, 3, 4, 12))
+        npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
+        npt.assert_equal(fit.directions.shape, (2, 3, 4))
+        S0 = 100.0
+        npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with parallelization (using the "serial" dummy engine)
-    model = SillyModel(gtab, parallel_kwargs={"engine": "serial", "verbose": False})
-    fit = model.fit(many_voxels, fit_kwarg="foo")
+    fit = model.fit(many_voxels, another_kwarg="foo", engine="serial")
 
     for verbose in [True, False]:
         # If parallelization engines are installed use them to test:
         if has_joblib:
-            model = SillyModel(
-                gtab, parallel_kwargs={"engine": "joblib", "verbose": verbose}
-            )
-
             fit = model.fit(
                 many_voxels,
-                fit_kwarg="foo",
+                verbose=verbose,
+                another_kwarg="foo",
+                engine="joblib",
             )
             npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
         if has_dask:
-            model = SillyModel(
-                gtab, parallel_kwargs={"engine": "dask", "verbose": verbose}
+            fit = model.fit(
+                many_voxels, verbose=verbose, another_kwarg="foo", engine="dask"
             )
-
-            fit = model.fit(many_voxels, fit_kwarg="foo")
             npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
         if has_ray:
-            model = SillyModel(
-                gtab, parallel_kwargs={"engine": "ray", "verbose": verbose}
+            fit = model.fit(
+                many_voxels, verbose=verbose, another_kwarg="foo", engine="ray"
             )
-
-            fit = model.fit(many_voxels, fit_kwarg="foo")
             npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask
@@ -236,7 +222,7 @@ def test_multi_voxel_fit(rng):
     mask[1, 1] = 1
     mask[2, 2] = 1
     data = np.zeros((3, 3, 3, 64))
-    fit = model.fit(data, mask, fit_kwarg="foo")
+    fit = model.fit(data, mask, another_kwarg="foo")
     expected = np.zeros((3, 3, 3))
     expected[0, 0] = 2
     expected[1, 1] = 2

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -144,14 +144,14 @@ def test_CallableArray():
 def test_multi_voxel_fit(rng):
     class SillyModel:
         @multi_voxel_fit
-        def fit(self, data, mask=None, **kwargs):
-            return SillyFit(model, data)
+        def fit(self, data, mask=None, another_kwarg=None, **kwargs):
+            return SillyFit(model, data, another_kwarg=another_kwarg)
 
         def predict(self, S0):
             return np.ones(10) * S0
 
     class SillyFit:
-        def __init__(self, model, data):
+        def __init__(self, model, data, another_kwarg):
             self.model = model
             self.data = data
 
@@ -171,12 +171,12 @@ def test_multi_voxel_fit(rng):
     # Test the single voxel case
     model = SillyModel()
     single_voxel = np.zeros(64)
-    fit = model.fit(single_voxel)
+    fit = model.fit(single_voxel, another_kwarg="foo")
     npt.assert_equal(type(fit), SillyFit)
 
     # Test without a mask
     many_voxels = np.zeros((2, 3, 4, 64))
-    fit = model.fit(many_voxels)
+    fit = model.fit(many_voxels, another_kwarg="foo")
     expected = np.empty((2, 3, 4))
     expected[:] = 2.0
     npt.assert_array_equal(fit.model_attr, expected)
@@ -187,19 +187,19 @@ def test_multi_voxel_fit(rng):
     npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with parallelization (using the "serial" dummy engine)
-    fit = model.fit(many_voxels, engine="serial")
+    fit = model.fit(many_voxels, engine="serial", another_kwarg="foo")
 
     # If parallelization engines are installed use them to test:
     if has_joblib:
-        fit = model.fit(many_voxels, engine="joblib")
+        fit = model.fit(many_voxels, engine="joblib", another_kwarg="foo")
         npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     if has_dask:
-        fit = model.fit(many_voxels, engine="dask")
+        fit = model.fit(many_voxels, engine="dask", another_kwarg="foo")
         npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     if has_ray:
-        fit = model.fit(many_voxels, engine="ray")
+        fit = model.fit(many_voxels, engine="ray", another_kwarg="foo")
         npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask


### PR DESCRIPTION
Trying to address issues raised in https://github.com/dipy/dipy/pull/3170/files#r1666792968

Assuming this is the issue, it still needs some testing to make sure that it works as expected.