### PR TITLE
NF: Add `__len__` to `GradientTable`

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -341,6 +341,19 @@ class GradientTable:
         msg += f"          max {self.bvecs.max():f}\n"
         return msg
 
+    def __len__(self):
+        """Get the number of gradients. Includes the b0s.
+
+        Examples
+        --------
+        >>> bvals = np.array([1000, 1000, 1000, 1000, 2000, 2000, 2000, 2000, 0])
+        >>> bvecs = generate_bvecs(bvals.shape[-1])
+        >>> gtab = gradient_table(bvals, bvecs)
+        >>> len(gtab)
+        9
+        """
+        return len(self.bvals)
+
 
 def gradient_table_from_bvals_bvecs(
     bvals, bvecs, b0_threshold=50, atol=1e-2, btens=None, **kwargs

--- a/doc/examples/quick_start.py
+++ b/doc/examples/quick_start.py
@@ -127,6 +127,12 @@ print(gtab.bvals)
 print(gtab.bvecs[:10, :])
 
 ###############################################################################
+# You can get the number of gradients (including the number of b0 values)
+# calling ``len`` on the ``GradientTable`` instance:
+
+print(len(gtab))
+
+###############################################################################
 # ``gtab``  can be used to tell what part of the data is the S0 volumes
 # (volumes which correspond to b-values of 0).
 


### PR DESCRIPTION
Add the `__len__` method to `GradientTable`: adds the ability to query the number of gradients using `len()`.

Add the corresponding tests.

Add a doctest example.

Demonstrate it in the `Getting started with DIPY` `Quick Start` documentation section.

Resolves #3282.