### PR TITLE
FIX: nighlty wheels for macOS arm64

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
             compiler_env: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LIBRARY_PATH=/usr/local/opt/llvm/lib:$LIBRARY_PATH
           - os: macos-14
             cibw_arch: arm64
-            compiler_env: CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ LIBRARY_PATH=/opt/homebrew/opt/llvm/lib:$LIBRARY_PATH
+            compiler_env: CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ LIBRARY_PATH=/opt/homebrew/opt/llvm/lib:$LIBRARY_PATH MACOSX_DEPLOYMENT_TARGET=14.0
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
small PR to fix our nightly wheels for macOS arm64.

We were encountering the following error:

```
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 11.0:
  /private/var/folders/h9/l1shxhdd69nct08ylzq0n6q00000gn/T/tmpws13eaj7/wheel/dipy/.dylibs/libomp.dylib has a minimum target of 14.0
``` 

So, the `MACOSX_DEPLOYMENT_TARGET` environment variable should fix this issue.