### PR TITLE
FIX: explicit keyword argument for Horizon

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -454,7 +454,7 @@ class Horizon:
 
         title = f"Horizon {horizon_version}"
         self.show_m = window.ShowManager(
-            scene,
+            scene=scene,
             title=title,
             size=(1920, 1080),
             reset_camera=False,
@@ -722,7 +722,7 @@ class Horizon:
 
         else:
             window.record(
-                scene, out_path=self.out_png, size=(1200, 900), reset_camera=False
+                scene=scene, out_path=self.out_png, size=(1200, 900), reset_camera=False
             )
 
 

--- a/dipy/viz/horizon/visualizer/cluster.py
+++ b/dipy/viz/horizon/visualizer/cluster.py
@@ -105,7 +105,7 @@ class ClustersVisualizer:
         print("Building cluster actors\n")
         for idx, cent in enumerate(centroids):
             centroid_actor = actor.streamtube(
-                [cent], colors, linewidth=linewidths[idx], lod=False
+                [cent], colors=colors, linewidth=linewidths[idx], lod=False
             )
             self.__scene.add(centroid_actor)
 

--- a/dipy/viz/horizon/visualizer/surface.py
+++ b/dipy/viz/horizon/visualizer/surface.py
@@ -13,7 +13,9 @@ class SurfaceVisualizer:
         self._vertices, self._faces = surface
 
         self._surface_actor = surface_actor(
-            self._vertices, self._faces, np.full((self._vertices.shape[0], 3), color)
+            self._vertices,
+            faces=self._faces,
+            colors=np.full((self._vertices.shape[0], 3), color),
         )
 
         scene.add(self._surface_actor)

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -142,7 +142,7 @@ def slicer_panel(
 
     if pam is not None:
         peaks_actor_z = actor.peak_slicer(
-            pam.peak_dirs, None, mask=mask, affine=affine, colors=None
+            pam.peak_dirs, peaks_values=None, mask=mask, affine=affine, colors=None
         )
 
     slicer_opacity = 1.0

--- a/dipy/viz/streamline.py
+++ b/dipy/viz/streamline.py
@@ -83,7 +83,7 @@ def show_bundles(
         window.show(scene)
 
     if save_as is not None:
-        window.record(scene, n_frames=1, out_path=save_as, size=(900, 900))
+        window.record(scene=scene, n_frames=1, out_path=save_as, size=(900, 900))
 
 
 @warning_for_keywords()
@@ -132,7 +132,7 @@ def viz_two_bundles(b1, b2, fname, *, c1=(1, 0, 0), c2=(0, 1, 0), interactive=Fa
     if interactive:
         window.show(ren)
 
-    window.record(ren, n_frames=1, out_path=fname, size=(1200, 1200))
+    window.record(scene=ren, n_frames=1, out_path=fname, size=(1200, 1200))
     if interactive:
         im = plt.imread(fname)
         plt.figure(figsize=(10, 10))
@@ -186,7 +186,7 @@ def viz_vector_field(
     if interactive:
         window.show(scene)
 
-    window.record(scene, n_frames=1, out_path=fname, size=(1200, 1200))
+    window.record(scene=scene, n_frames=1, out_path=fname, size=(1200, 1200))
     if interactive:
         im = plt.imread(fname)
         plt.figure(figsize=(10, 10))
@@ -220,20 +220,22 @@ def viz_displacement_mag(bundle, offsets, fname, *, interactive=False):
         saturation_range=saturation,
     )
 
-    stream_actor = actor.line(bundle, offsets, linewidth=7, lookup_colormap=lut_cmap)
+    stream_actor = actor.line(
+        bundle, colors=offsets, linewidth=7, lookup_colormap=lut_cmap
+    )
 
     stream_actor.RotateX(-70)
     stream_actor.RotateZ(90)
 
     scene.add(stream_actor)
-    bar = actor.scalar_bar(lut_cmap)
+    bar = actor.scalar_bar(lookup_table=lut_cmap)
 
     scene.add(bar)
 
     if interactive:
         window.show(scene)
 
-    window.record(scene, n_frames=1, out_path=fname, size=(2000, 1500))
+    window.record(scene=scene, n_frames=1, out_path=fname, size=(2000, 1500))
     if interactive:
         im = plt.imread(fname)
         plt.figure(figsize=(10, 10))

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -105,6 +105,7 @@ def test_horizon(rng):
     streamlines.append(s1)
     streamlines.append(s2)
     streamlines.append(s3)
+    streamlines.shrink_data()
 
     affine = np.array(
         [

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -33,8 +33,8 @@ def test_slicer(rng):
     affine = np.diag([1, 3, 2, 1])
     data2, affine2 = reslice(data, affine, zooms=(1, 3, 2), new_zooms=(1, 1, 1))
 
-    slicer = actor.slicer(data2, affine2, interpolation="linear")
-    slicer.display(None, None, 25)
+    slicer = actor.slicer(data2, affine=affine2, interpolation="linear")
+    slicer.display(x=None, y=None, z=25)
 
     scene.add(slicer)
     scene.reset_camera()
@@ -86,18 +86,22 @@ def test_contour_from_roi():
     streamlines = list(streamlines)
 
     # Prepare the display objects.
-    streamlines_actor = actor.line(streamlines, colormap.line_colors(streamlines))
-    seedroi_actor = actor.contour_from_roi(seed_mask, affine, [0, 1, 1], 0.5)
+    streamlines_actor = actor.line(
+        streamlines, colors=colormap.line_colors(streamlines)
+    )
+    seedroi_actor = actor.contour_from_roi(
+        seed_mask, affine=affine, color=[0, 1, 1], opacity=0.5
+    )
 
     # Create the 3d display.
     sc = window.Scene()
     sc2 = window.Scene()
     sc.add(streamlines_actor)
-    arr3 = window.snapshot(sc, "test_surface3.png", offscreen=True)
+    arr3 = window.snapshot(sc, fname="test_surface3.png", offscreen=True)
     report3 = window.analyze_snapshot(arr3, find_objects=True)
     sc2.add(streamlines_actor)
     sc2.add(seedroi_actor)
-    arr4 = window.snapshot(sc2, "test_surface4.png", offscreen=True)
+    arr4 = window.snapshot(sc2, fname="test_surface4.png", offscreen=True)
     report4 = window.analyze_snapshot(arr4, find_objects=True)
 
     # assert that the seed ROI rendering is not far
@@ -132,9 +136,9 @@ def test_bundle_maps(rng):
         value_range=(1.0, 1),
     )
 
-    line = actor.line(bundle, metric, linewidth=0.1, lookup_colormap=lut)
+    line = actor.line(bundle, colors=metric, linewidth=0.1, lookup_colormap=lut)
     scene.add(line)
-    scene.add(actor.scalar_bar(lut, " "))
+    scene.add(actor.scalar_bar(lookup_table=lut))
 
     report = window.analyze_scene(scene)
 
@@ -147,7 +151,7 @@ def test_bundle_maps(rng):
     values = 100 * rng.random((nb_points))
     # values[:nb_points/2] = 0
 
-    line = actor.streamtube(bundle, values, linewidth=0.1, lookup_colormap=lut)
+    line = actor.streamtube(bundle, colors=values, linewidth=0.1, lookup_colormap=lut)
     scene.add(line)
     # window.show(scene)
 
@@ -159,7 +163,7 @@ def test_bundle_maps(rng):
     colors = rng.random((nb_points, 3))
     # values[:nb_points/2] = 0
 
-    line = actor.line(bundle, colors, linewidth=2)
+    line = actor.line(bundle, colors=colors, linewidth=2)
     scene.add(line)
     # window.show(scene)
 
@@ -173,8 +177,8 @@ def test_bundle_maps(rng):
 
     # try other input options for colors
     scene.clear()
-    actor.line(bundle, (1.0, 0.5, 0))
-    actor.line(bundle, np.arange(len(bundle)))
+    actor.line(bundle, colors=(1.0, 0.5, 0))
+    actor.line(bundle, colors=np.arange(len(bundle)))
     actor.line(bundle)
     colors = [rng.random(b.shape) for b in bundle]
     actor.line(bundle, colors=colors)
@@ -248,13 +252,13 @@ def test_odf_slicer(interactive=False):
     # Test that odf_slicer.display works properly
     scene.clear()
     scene.add(odf_actor)
-    scene.add(actor.axes((11, 11, 11)))
+    scene.add(actor.axes(scale=(11, 11, 11)))
     for i in range(11):
-        odf_actor.display(i, None, None)
+        odf_actor.display(x=i, y=None, z=None)
         if interactive:
             window.show(scene)
     for j in range(11):
-        odf_actor.display(None, j, None)
+        odf_actor.display(x=None, y=j, z=None)
         if interactive:
             window.show(scene)
 

--- a/doc/examples/bundle_assignment_maps.py
+++ b/doc/examples/bundle_assignment_maps.py
@@ -44,7 +44,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="af_l_before_assignment_maps.png", size=(600, 600))
+window.record(scene=scene, out_path="af_l_before_assignment_maps.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -82,7 +82,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="af_l_after_assignment_maps.png", size=(600, 600))
+window.record(scene=scene, out_path="af_l_after_assignment_maps.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/bundle_extraction.py
+++ b/doc/examples/bundle_extraction.py
@@ -51,7 +51,7 @@ scene = window.Scene()
 scene.SetBackground(1, 1, 1)
 scene.add(actor.line(atlas, colors=(1, 0, 1)))
 scene.add(actor.line(target, colors=(1, 1, 0)))
-window.record(scene, out_path="tractograms_initial.png", size=(600, 600))
+window.record(scene=scene, out_path="tractograms_initial.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -89,7 +89,9 @@ scene = window.Scene()
 scene.SetBackground(1, 1, 1)
 scene.add(actor.line(atlas, colors=(1, 0, 1)))
 scene.add(actor.line(moved, colors=(1, 1, 0)))
-window.record(scene, out_path="tractograms_after_registration.png", size=(600, 600))
+window.record(
+    scene=scene, out_path="tractograms_after_registration.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 
@@ -155,7 +157,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="AF_L_model_bundle.png", size=(600, 600))
+window.record(scene=scene, out_path="AF_L_model_bundle.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -189,7 +191,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="AF_L_recognized_bundle.png", size=(600, 600))
+window.record(scene=scene, out_path="AF_L_recognized_bundle.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -239,7 +241,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="AF_L_recognized_bundle2.png", size=(600, 600))
+window.record(scene=scene, out_path="AF_L_recognized_bundle2.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -288,7 +290,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="AF_L_recognized_bundle3.png", size=(600, 600))
+window.record(scene=scene, out_path="AF_L_recognized_bundle3.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -343,7 +345,9 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="AF_L_refine_recognized_bundle.png", size=(600, 600))
+window.record(
+    scene=scene, out_path="AF_L_refine_recognized_bundle.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 
@@ -383,7 +387,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="CST_L_model_bundle.png", size=(600, 600))
+window.record(scene=scene, out_path="CST_L_model_bundle.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -415,7 +419,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="CST_L_recognized_bundle.png", size=(600, 600))
+window.record(scene=scene, out_path="CST_L_recognized_bundle.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -465,7 +469,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="CST_L_recognized_bundle2.png", size=(600, 600))
+window.record(scene=scene, out_path="CST_L_recognized_bundle2.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -514,7 +518,7 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="CST_L_recognized_bundle3.png", size=(600, 600))
+window.record(scene=scene, out_path="CST_L_recognized_bundle3.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -570,7 +574,9 @@ scene.set_camera(
     position=(-360.11, -30.46, -40.44),
     view_up=(-0.03, 0.028, 0.89),
 )
-window.record(scene, out_path="CST_L_refine_recognized_bundle.png", size=(600, 600))
+window.record(
+    scene=scene, out_path="CST_L_refine_recognized_bundle.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 

--- a/doc/examples/bundle_registration.py
+++ b/doc/examples/bundle_registration.py
@@ -54,7 +54,7 @@ def show_both_bundles(bundles, colors=None, show=True, fname=None):
     scene.SetBackground(1.0, 1, 1)
     for i, bundle in enumerate(bundles):
         color = colors[i]
-        lines_actor = actor.streamtube(bundle, color, linewidth=0.3)
+        lines_actor = actor.streamtube(bundle, colors=color, linewidth=0.3)
         lines_actor.RotateX(-90)
         lines_actor.RotateZ(90)
         scene.add(lines_actor)
@@ -62,7 +62,7 @@ def show_both_bundles(bundles, colors=None, show=True, fname=None):
         window.show(scene)
     if fname is not None:
         sleep(1)
-        window.record(scene, n_frames=1, out_path=fname, size=(900, 900))
+        window.record(scene=scene, n_frames=1, out_path=fname, size=(900, 900))
 
 
 show_both_bundles(

--- a/doc/examples/bundle_shape_similarity.py
+++ b/doc/examples/bundle_shape_similarity.py
@@ -49,14 +49,14 @@ def show_both_bundles(bundles, colors=None, show=True, fname=None):
     scene.SetBackground(1.0, 1, 1)
     for i, bundle in enumerate(bundles):
         color = colors[i]
-        streamtube_actor = actor.streamtube(bundle, color, linewidth=0.3)
+        streamtube_actor = actor.streamtube(bundle, colors=color, linewidth=0.3)
         streamtube_actor.RotateX(-90)
         streamtube_actor.RotateZ(90)
         scene.add(streamtube_actor)
     if show:
         window.show(scene)
     if fname is not None:
-        window.record(scene, n_frames=1, out_path=fname, size=(900, 900))
+        window.record(scene=scene, n_frames=1, out_path=fname, size=(900, 900))
 
 
 show_both_bundles(

--- a/doc/examples/cluster_confidence.py
+++ b/doc/examples/cluster_confidence.py
@@ -87,11 +87,11 @@ lut_cmap = actor.colormap_lookup_table(
     scale_range=(cci.min(), cci.max() / 4), hue_range=hue, saturation_range=saturation
 )
 
-bar3 = actor.scalar_bar(lut_cmap)
+bar3 = actor.scalar_bar(lookup_table=lut_cmap)
 scene.add(bar3)
 
 stream_actor = actor.line(
-    long_streamlines, cci, linewidth=0.1, lookup_colormap=lut_cmap
+    long_streamlines, colors=cci, linewidth=0.1, lookup_colormap=lut_cmap
 )
 scene.add(stream_actor)
 
@@ -102,7 +102,7 @@ scene.add(stream_actor)
 interactive = False
 if interactive:
     window.show(scene)
-window.record(scene, out_path="cci_streamlines.png", size=(800, 800))
+window.record(scene=scene, out_path="cci_streamlines.png", size=(800, 800))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -153,7 +153,7 @@ scene.add(keep_streamlines_actor)
 interactive = False
 if interactive:
     window.show(scene)
-window.record(scene, out_path="filtered_cci_streamlines.png", size=(800, 800))
+window.record(scene=scene, out_path="filtered_cci_streamlines.png", size=(800, 800))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -175,7 +175,7 @@ model_kernel = actor.odf_slicer(
 model_kernel.display(x=3)
 scene.add(model_kernel)
 scene.set_camera(position=(30, 0, 0), focal_point=(0, 0, 0), view_up=(0, 0, 1))
-window.record(scene, out_path="kernel.png", size=(900, 900))
+window.record(scene=scene, out_path="kernel.png", size=(900, 900))
 if interactive:
     window.show(scene)
 
@@ -248,7 +248,7 @@ fodf_spheres_enh_sharp = actor.odf_slicer(
 fodf_spheres_enh_sharp.SetPosition(25, 25, 0)
 scene.add(fodf_spheres_enh_sharp)
 
-window.record(scene, out_path="enhancements.png", size=(900, 900))
+window.record(scene=scene, out_path="enhancements.png", size=(900, 900))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/fast_streamline_search.py
+++ b/doc/examples/fast_streamline_search.py
@@ -41,7 +41,7 @@ scene.add(actor.line(streamlines))
 if interactive:
     window.show(scene)
 else:
-    window.record(scene, out_path="tractograms_initial.png", size=(600, 600))
+    window.record(scene=scene, out_path="tractograms_initial.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -69,7 +69,7 @@ scene.set_camera(
 if interactive:
     window.show(scene)
 else:
-    window.record(scene, out_path="AF_L_model_bundle.png", size=(600, 600))
+    window.record(scene=scene, out_path="AF_L_model_bundle.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -126,7 +126,7 @@ scene.set_camera(
 if interactive:
     window.show(scene)
 else:
-    window.record(scene, out_path="AF_L_recognized_bundle.png", size=(600, 600))
+    window.record(scene=scene, out_path="AF_L_recognized_bundle.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -144,7 +144,7 @@ scene = window.Scene()
 scene.SetBackground(1, 1, 1)
 cmap = actor.colormap_lookup_table(scale_range=(nn_dist.min(), nn_dist.max()))
 scene.add(actor.line(recognized_af_l, colors=nn_dist, lookup_colormap=cmap))
-scene.add(actor.scalar_bar(cmap, title="distance to atlas (mm)"))
+scene.add(actor.scalar_bar(lookup_table=cmap, title="distance to atlas (mm)"))
 scene.set_camera(
     focal_point=(-18.17281532, -19.55606842, 6.92485857),
     position=(-360.11, -30.46, -40.44),
@@ -153,7 +153,9 @@ scene.set_camera(
 if interactive:
     window.show(scene)
 else:
-    window.record(scene, out_path="AF_L_recognized_bundle_dist.png", size=(600, 600))
+    window.record(
+        scene=scene, out_path="AF_L_recognized_bundle_dist.png", size=(600, 600)
+    )
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -173,7 +175,7 @@ ref_color[ids_ref] = (0.0, 1.0, 0.0)
 
 scene = window.Scene()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.line(model_af_l, ref_color))
+scene.add(actor.line(model_af_l, colors=ref_color))
 scene.set_camera(
     focal_point=(-18.17281532, -19.55606842, 6.92485857),
     position=(-360.11, -30.46, -40.44),
@@ -183,7 +185,9 @@ scene.set_camera(
 if interactive:
     window.show(scene)
 else:
-    window.record(scene, out_path="AF_L_model_bundle_reached.png", size=(600, 600))
+    window.record(
+        scene=scene, out_path="AF_L_model_bundle_reached.png", size=(600, 600)
+    )
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -216,7 +216,7 @@ fbc_sl_thres, clrs_thres, rfbc_thres = fbc.get_points_rfbc_thresholded(
 scene = window.Scene()
 
 # Original lines colored by LFBC
-lineactor = actor.line(fbc_sl_orig, np.vstack(clrs_orig), linewidth=0.2)
+lineactor = actor.line(fbc_sl_orig, colors=np.vstack(clrs_orig), linewidth=0.2)
 scene.add(lineactor)
 
 # Horizontal (axial) slice of T1 data
@@ -231,14 +231,14 @@ scene.add(vol_actor2)
 
 # Show original fibers
 scene.set_camera(position=(-264, 285, 155), focal_point=(0, -14, 9), view_up=(0, 0, 1))
-window.record(scene, n_frames=1, out_path="OR_before.png", size=(900, 900))
+window.record(scene=scene, n_frames=1, out_path="OR_before.png", size=(900, 900))
 if interactive:
     window.show(scene)
 
 # Show thresholded fibers
 scene.rm(lineactor)
-scene.add(actor.line(fbc_sl_thres, np.vstack(clrs_thres), linewidth=0.2))
-window.record(scene, n_frames=1, out_path="OR_after.png", size=(900, 900))
+scene.add(actor.line(fbc_sl_thres, colors=np.vstack(clrs_thres), linewidth=0.2))
+window.record(scene=scene, n_frames=1, out_path="OR_after.png", size=(900, 900))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -59,7 +59,7 @@ scene.SetBackground(1, 1, 1)
 scene.add(actor.point(hsph_initial.vertices, window.colors.red, point_radius=0.05))
 scene.add(actor.point(hsph_updated.vertices, window.colors.green, point_radius=0.05))
 
-window.record(scene, out_path="initial_vs_updated.png", size=(300, 300))
+window.record(scene=scene, out_path="initial_vs_updated.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -78,7 +78,7 @@ sph = Sphere(xyz=np.vstack((hsph_updated.vertices, -hsph_updated.vertices)))
 scene.clear()
 scene.add(actor.point(sph.vertices, window.colors.green, point_radius=0.05))
 
-window.record(scene, out_path="full_sphere.png", size=(300, 300))
+window.record(scene=scene, out_path="full_sphere.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -132,7 +132,7 @@ colors = np.ascontiguousarray(colors)
 
 scene.add(actor.point(gtab.gradients, colors, point_radius=100))
 
-window.record(scene, out_path="gradients.png", size=(300, 300))
+window.record(scene=scene, out_path="gradients.png", size=(300, 300))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/histology_resdnn.py
+++ b/doc/examples/histology_resdnn.py
@@ -119,7 +119,9 @@ scene.zoom(camera["zoom_factor"])
 if interactive:
     window.show(scene, reset_camera=False)
 
-window.record(scene, out_path="pred_fODF.png", size=(1000, 1000), reset_camera=False)
+window.record(
+    scene=scene, out_path="pred_fODF.png", size=(1000, 1000), reset_camera=False
+)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -72,7 +72,7 @@ candidate_sl = candidate_sl_sft.streamlines
 interactive = False
 
 candidate_streamlines_actor = actor.streamtube(
-    candidate_sl, cmap.line_colors(candidate_sl)
+    candidate_sl, colors=cmap.line_colors(candidate_sl)
 )
 cc_ROI_actor = actor.contour_from_roi(cc_slice, color=(1.0, 1.0, 0.0), opacity=0.5)
 
@@ -88,7 +88,7 @@ scene.add(candidate_streamlines_actor)
 scene.add(cc_ROI_actor)
 scene.add(vol_actor)
 scene.add(vol_actor2)
-window.record(scene, n_frames=1, out_path="life_candidates.png", size=(800, 800))
+window.record(scene=scene, n_frames=1, out_path="life_candidates.png", size=(800, 800))
 if interactive:
     window.show(scene)
 
@@ -164,10 +164,10 @@ fig.savefig("beta_histogram.png")
 
 optimized_sl = [np.vstack(candidate_sl)[np.where(fiber_fit.beta > 0)[0]]]
 scene = window.Scene()
-scene.add(actor.streamtube(optimized_sl, cmap.line_colors(optimized_sl)))
+scene.add(actor.streamtube(optimized_sl, colors=cmap.line_colors(optimized_sl)))
 scene.add(cc_ROI_actor)
 scene.add(vol_actor)
-window.record(scene, n_frames=1, out_path="life_optimized.png", size=(800, 800))
+window.record(scene=scene, n_frames=1, out_path="life_optimized.png", size=(800, 800))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/path_length_map.py
+++ b/doc/examples/path_length_map.py
@@ -83,11 +83,11 @@ streamlines = Streamlines(streamlines)
 # Visualize the streamlines and the Path Length Map base ROI
 # (in this case also the seed ROI)
 
-streamlines_actor = actor.line(streamlines, cmap.line_colors(streamlines))
+streamlines_actor = actor.line(streamlines, colors=cmap.line_colors(streamlines))
 surface_opacity = 0.5
 surface_color = [0, 1, 1]
 seedroi_actor = actor.contour_from_roi(
-    seed_mask, affine, surface_color, surface_opacity
+    seed_mask, affine=affine, color=surface_color, opacity=surface_opacity
 )
 
 scene = window.Scene()
@@ -102,7 +102,7 @@ interactive = False
 if interactive:
     window.show(scene)
 
-window.record(scene, n_frames=1, out_path="plm_roi_sls.png", size=(800, 800))
+window.record(scene=scene, n_frames=1, out_path="plm_roi_sls.png", size=(800, 800))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -105,7 +105,7 @@ csa_odfs_actor.display(z=0)
 
 scene.add(csa_odfs_actor)
 print("Saving illustration as csa_odfs.png")
-window.record(scene, n_frames=1, out_path="csa_odfs.png", size=(600, 600))
+window.record(scene=scene, n_frames=1, out_path="csa_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -127,7 +127,7 @@ response_actor = actor.odf_slicer(
 )
 scene.add(response_actor)
 print("Saving illustration as csd_response.png")
-window.record(scene, out_path="csd_response.png", size=(200, 200))
+window.record(scene=scene, out_path="csd_response.png", size=(200, 200))
 if interactive:
     window.show(scene)
 
@@ -195,7 +195,7 @@ scene = window.Scene()
 
 scene.add(response_actor)
 print("Saving illustration as csd_recursive_response.png")
-window.record(scene, out_path="csd_recursive_response.png", size=(200, 200))
+window.record(scene=scene, out_path="csd_recursive_response.png", size=(200, 200))
 if interactive:
     window.show(scene)
 
@@ -237,7 +237,7 @@ fodf_spheres = actor.odf_slicer(
 scene.add(fodf_spheres)
 
 print("Saving illustration as csd_odfs.png")
-window.record(scene, out_path="csd_odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="csd_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -261,11 +261,11 @@ csd_peaks = peaks_from_model(
 )
 
 scene.clear()
-fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values)
+fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, peaks_values=csd_peaks.peak_values)
 scene.add(fodf_peaks)
 
 print("Saving illustration as csd_peaks.png")
-window.record(scene, out_path="csd_peaks.png", size=(600, 600))
+window.record(scene=scene, out_path="csd_peaks.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -282,7 +282,7 @@ fodf_spheres.GetProperty().SetOpacity(0.4)
 scene.add(fodf_spheres)
 
 print("Saving illustration as csd_both.png")
-window.record(scene, out_path="csd_both.png", size=(600, 600))
+window.record(scene=scene, out_path="csd_both.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -76,7 +76,7 @@ odf_actor = actor.odf_slicer(odfs, sphere=sphere, scale=0.5, colormap="plasma")
 odf_actor.display(y=0)
 odf_actor.RotateX(90)
 scene.add(odf_actor)
-window.record(scene, out_path="dsid.png", size=(300, 300))
+window.record(scene=scene, out_path="dsid.png", size=(300, 300))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -250,7 +250,9 @@ scene.add(
 )
 
 print("Saving illustration as tensor_ellipsoids.png")
-window.record(scene, n_frames=1, out_path="tensor_ellipsoids.png", size=(600, 600))
+window.record(
+    scene=scene, n_frames=1, out_path="tensor_ellipsoids.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 
@@ -272,7 +274,7 @@ tensor_odfs = tenmodel.fit(data[20:50, 55:85, 38:39]).odf(sphere)
 odf_actor = actor.odf_slicer(tensor_odfs, sphere=sphere, scale=0.5, colormap=None)
 scene.add(odf_actor)
 print("Saving illustration as tensor_odfs.png")
-window.record(scene, n_frames=1, out_path="tensor_odfs.png", size=(600, 600))
+window.record(scene=scene, n_frames=1, out_path="tensor_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -148,7 +148,7 @@ odf_actor = actor.odf_slicer(
 )
 scene = window.Scene()
 scene.add(odf_actor)
-window.record(scene, out_path="fODFs.png", size=(600, 600), magnification=4)
+window.record(scene=scene, out_path="fODFs.png", size=(600, 600), magnification=4)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -373,7 +373,7 @@ sfu = actor.odf_slicer(odf, sphere=sphere, colormap="plasma", scale=0.5)
 sfu.display(y=0)
 sfu.RotateX(-90)
 scene.add(sfu)
-window.record(scene, out_path="odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_mcsd.py
+++ b/doc/examples/reconst_mcsd.py
@@ -320,7 +320,7 @@ scene.add(fodf_spheres)
 scene.reset_camera_tight()
 
 print("Saving illustration as msdodf.png")
-window.record(scene, out_path="msdodf.png", size=(600, 600))
+window.record(scene=scene, out_path="msdodf.png", size=(600, 600))
 
 if interactive:
     window.show(scene)

--- a/doc/examples/reconst_rumba.py
+++ b/doc/examples/reconst_rumba.py
@@ -96,7 +96,7 @@ response_actor = actor.odf_slicer(response_odf, sphere=sphere, colormap="plasma"
 
 scene.add(response_actor)
 print("Saving illustration as default_response.png")
-window.record(scene, out_path="default_response.png", size=(200, 200))
+window.record(scene=scene, out_path="default_response.png", size=(200, 200))
 
 if interactive:
     window.show(scene)
@@ -134,7 +134,7 @@ response_odf = response_odf[None, None, None, :]
 response_actor = actor.odf_slicer(response_odf, sphere=sphere, colormap="plasma")
 scene.add(response_actor)
 print("Saving illustration as estimated_response.png")
-window.record(scene, out_path="estimated_response.png", size=(200, 200))
+window.record(scene=scene, out_path="estimated_response.png", size=(200, 200))
 if interactive:
     window.show(scene)
 
@@ -181,7 +181,7 @@ response_actor = actor.odf_slicer(rec_response_signal, sphere=sphere, colormap="
 
 scene.add(response_actor)
 print("Saving illustration as recursive_response.png")
-window.record(scene, out_path="recursive_response.png", size=(200, 200))
+window.record(scene=scene, out_path="recursive_response.png", size=(200, 200))
 if interactive:
     window.show(scene)
 
@@ -296,7 +296,7 @@ fodf_spheres = actor.odf_slicer(
 )
 scene.add(fodf_spheres)
 print("Saving illustration as rumba_odfs.png")
-window.record(scene, out_path="rumba_odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="rumba_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -328,10 +328,10 @@ rumba_peaks = peaks_from_model(
 peak_values = np.clip(rumba_peaks.peak_values * 15, 0, 1)
 peak_dirs = rumba_peaks.peak_dirs
 
-fodf_peaks = actor.peak_slicer(peak_dirs, peak_values)
+fodf_peaks = actor.peak_slicer(peak_dirs, peaks_values=peak_values)
 scene.add(fodf_peaks)
 
-window.record(scene, out_path="rumba_peaks.png", size=(600, 600))
+window.record(scene=scene, out_path="rumba_peaks.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -386,7 +386,7 @@ fodf_spheres = actor.odf_slicer(
 
 scene.add(fodf_spheres)
 print("Saving illustration as rumba_global_odfs.png")
-window.record(scene, out_path="rumba_global_odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="rumba_global_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -426,11 +426,13 @@ for idx in np.ndindex(shape):  # iterate through each voxel
 # Scale up for visualization
 peak_values = np.clip(peak_values * 15, 0, 1)
 
-fodf_peaks = actor.peak_slicer(peak_dirs[:, :, 0:1, :], peak_values[:, :, 0:1, :])
+fodf_peaks = actor.peak_slicer(
+    peak_dirs[:, :, 0:1, :], peaks_values=peak_values[:, :, 0:1, :]
+)
 scene.add(fodf_peaks)
 
 print("Saving illustration as rumba_global_peaks.png")
-window.record(scene, out_path="rumba_global_peaks.png", size=(600, 600))
+window.record(scene=scene, out_path="rumba_global_peaks.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_sfm.py
+++ b/doc/examples/reconst_sfm.py
@@ -120,7 +120,7 @@ fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=0.8, colormap="plas
 scene = window.Scene()
 scene.add(fodf_spheres)
 
-window.record(scene, out_path="sf_odfs.png", size=(1000, 1000))
+window.record(scene=scene, out_path="sf_odfs.png", size=(1000, 1000))
 if interactive:
     window.show(scene)
 
@@ -138,10 +138,10 @@ sf_peaks = dpp.peaks_from_model(
 
 
 scene.clear()
-fodf_peaks = actor.peak_slicer(sf_peaks.peak_dirs, sf_peaks.peak_values)
+fodf_peaks = actor.peak_slicer(sf_peaks.peak_dirs, peaks_values=sf_peaks.peak_values)
 scene.add(fodf_peaks)
 
-window.record(scene, out_path="sf_peaks.png", size=(1000, 1000))
+window.record(scene=scene, out_path="sf_peaks.png", size=(1000, 1000))
 if interactive:
     window.show(scene)
 
@@ -151,7 +151,7 @@ if interactive:
 fodf_spheres.GetProperty().SetOpacity(0.4)
 scene.add(fodf_spheres)
 
-window.record(scene, out_path="sf_both.png", size=(1000, 1000))
+window.record(scene=scene, out_path="sf_both.png", size=(1000, 1000))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -59,7 +59,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving illustration as symm_signal.png")
-window.record(scene, out_path="symm_signal.png", size=(300, 300))
+window.record(scene=scene, out_path="symm_signal.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -98,7 +98,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving output as symm_reconst.png")
-window.record(scene, out_path="symm_reconst.png", size=(300, 300))
+window.record(scene=scene, out_path="symm_reconst.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -126,7 +126,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving output as asym_signal.png")
-window.record(scene, out_path="asym_signal.png", size=(300, 300))
+window.record(scene=scene, out_path="asym_signal.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -148,7 +148,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving output as asym_reconst.png")
-window.record(scene, out_path="asym_reconst.png", size=(300, 300))
+window.record(scene=scene, out_path="asym_reconst.png", size=(300, 300))
 if interactive:
     window.show(scene)
 
@@ -173,7 +173,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving output as asym_reconst_full.png")
-window.record(scene, out_path="asym_reconst_full.png", size=(300, 300))
+window.record(scene=scene, out_path="asym_reconst_full.png", size=(300, 300))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -92,7 +92,7 @@ sfu = actor.odf_slicer(odf[:, None, :], sphere=sphere, colormap="plasma", scale=
 sfu.RotateX(-90)
 sfu.display(y=0)
 scene.add(sfu)
-window.record(scene, out_path="odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -102,7 +102,7 @@ scene = window.Scene()
 scene.add(
     actor.tensor_slicer(evals1, evecs1, scalar_colors=cfa1, sphere=sphere, scale=0.3)
 )
-window.record(scene, out_path="tensor_ellipsoids_wls.png", size=(600, 600))
+window.record(scene=scene, out_path="tensor_ellipsoids_wls.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -134,7 +134,7 @@ scene = window.Scene()
 scene.add(
     actor.tensor_slicer(evals2, evecs2, scalar_colors=cfa2, sphere=sphere, scale=0.3)
 )
-window.record(scene, out_path="tensor_ellipsoids_wls_noisy.png", size=(600, 600))
+window.record(scene=scene, out_path="tensor_ellipsoids_wls_noisy.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -170,7 +170,9 @@ scene.add(
     actor.tensor_slicer(evals3, evecs3, scalar_colors=cfa3, sphere=sphere, scale=0.3)
 )
 print("Saving illustration as tensor_ellipsoids_restore_noisy.png")
-window.record(scene, out_path="tensor_ellipsoids_restore_noisy.png", size=(600, 600))
+window.record(
+    scene=scene, out_path="tensor_ellipsoids_restore_noisy.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 

--- a/doc/examples/segment_clustering_features.py
+++ b/doc/examples/segment_clustering_features.py
@@ -166,9 +166,11 @@ for cluster, color in zip(clusters, colormap):
 scene = window.Scene()
 scene.clear()
 scene.SetBackground(0, 0, 0)
-scene.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
+scene.add(actor.streamtube(streamlines, colors=window.colors.white, opacity=0.05))
 scene.add(actor.point(centers[:, 0, :], colormap_full, point_radius=0.2))
-window.record(scene, n_frames=1, out_path="center_of_mass_feature.png", size=(600, 600))
+window.record(
+    scene=scene, n_frames=1, out_path="center_of_mass_feature.png", size=(600, 600)
+)
 if interactive:
     window.show(scene)
 
@@ -214,8 +216,8 @@ scene = window.Scene()
 scene.clear()
 scene.SetBackground(0, 0, 0)
 scene.add(actor.point(midpoints[:, 0, :], colormap_full, point_radius=0.2))
-scene.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
-window.record(scene, n_frames=1, out_path="midpoint_feature.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=window.colors.white, opacity=0.05))
+window.record(scene=scene, n_frames=1, out_path="midpoint_feature.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -255,8 +257,8 @@ for cluster, color in zip(clusters, colormap):
 scene = window.Scene()
 scene.clear()
 scene.SetBackground(0, 0, 0)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="arclength_feature.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="arclength_feature.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -300,8 +302,8 @@ for cluster, color in zip(clusters, colormap):
 scene = window.Scene()
 scene.clear()
 scene.SetBackground(0, 0, 0)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="vector_of_endpoints_feature.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="vector_of_endpoints_feature.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -143,8 +143,8 @@ for cluster, color in zip(clusters, colormap):
 scene = window.Scene()
 scene.clear()
 scene.SetBackground(0, 0, 0)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="cosine_metric.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="cosine_metric.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/segment_extending_clustering_framework.py
+++ b/doc/examples/segment_extending_clustering_framework.py
@@ -130,8 +130,8 @@ for cluster, color in zip(clusters, cmap):
 
 scene = window.Scene()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="fornix_clusters_arclength.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="fornix_clusters_arclength.png", size=(600, 600))
 
 # Enables/disables interactive visualization
 interactive = False
@@ -224,8 +224,8 @@ for cluster, color in zip(clusters, cmap):
 
 scene = window.Scene()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="fornix_clusters_cosine.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="fornix_clusters_cosine.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/segment_quickbundles.py
+++ b/doc/examples/segment_quickbundles.py
@@ -62,8 +62,8 @@ interactive = False
 
 scene = window.Scene()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.streamtube(streamlines, window.colors.white))
-window.record(scene, out_path="fornix_initial.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=window.colors.white))
+window.record(scene=scene, out_path="fornix_initial.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -79,9 +79,9 @@ colormap = colormap.create_colormap(np.arange(len(clusters)))
 
 scene.clear()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
-scene.add(actor.streamtube(clusters.centroids, colormap, linewidth=0.4))
-window.record(scene, out_path="fornix_centroids.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=window.colors.white, opacity=0.05))
+scene.add(actor.streamtube(clusters.centroids, colors=colormap, linewidth=0.4))
+window.record(scene=scene, out_path="fornix_centroids.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -99,8 +99,8 @@ for cluster, color in zip(clusters, colormap):
 
 scene.clear()
 scene.SetBackground(1, 1, 1)
-scene.add(actor.streamtube(streamlines, colormap_full))
-window.record(scene, out_path="fornix_clusters.png", size=(600, 600))
+scene.add(actor.streamtube(streamlines, colors=colormap_full))
+window.record(scene=scene, out_path="fornix_clusters.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -122,7 +122,7 @@ odf_actor.RotateX(90)
 scene.add(odf_actor)
 
 print("Saving illustration as multi_tensor_simulation")
-window.record(scene, out_path="multi_tensor_simulation.png", size=(300, 300))
+window.record(scene=scene, out_path="multi_tensor_simulation.png", size=(300, 300))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -114,21 +114,25 @@ interactive = False
 
 scene = window.Scene()
 scene.SetBackground(*window.colors.white)
-bundle_actor = actor.streamtube(bundle, window.colors.red, linewidth=0.3)
+bundle_actor = actor.streamtube(bundle, colors=window.colors.red, linewidth=0.3)
 
 scene.add(bundle_actor)
 
-bundle_actor2 = actor.streamtube(bundle_downsampled, window.colors.red, linewidth=0.3)
+bundle_actor2 = actor.streamtube(
+    bundle_downsampled, colors=window.colors.red, linewidth=0.3
+)
 bundle_actor2.SetPosition(0, 40, 0)
 
-bundle_actor3 = actor.streamtube(bundle_downsampled2, window.colors.red, linewidth=0.3)
+bundle_actor3 = actor.streamtube(
+    bundle_downsampled2, colors=window.colors.red, linewidth=0.3
+)
 bundle_actor3.SetPosition(0, 80, 0)
 
 scene.add(bundle_actor2)
 scene.add(bundle_actor3)
 
 scene.set_camera(position=(0, 0, 0), focal_point=(30, 0, 0))
-window.record(scene, out_path="simulated_cosine_bundle.png", size=(900, 900))
+window.record(scene=scene, out_path="simulated_cosine_bundle.png", size=(900, 900))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -120,7 +120,9 @@ interactive = False
 
 # Make display objects
 color = cmap.line_colors(cc_streamlines)
-cc_streamlines_actor = actor.line(cc_streamlines, cmap.line_colors(cc_streamlines))
+cc_streamlines_actor = actor.line(
+    cc_streamlines, colors=cmap.line_colors(cc_streamlines)
+)
 cc_ROI_actor = actor.contour_from_roi(cc_slice, color=(1.0, 1.0, 0.0), opacity=0.5)
 
 vol_actor = actor.slicer(t1_data)
@@ -137,12 +139,14 @@ scene.add(cc_streamlines_actor)
 scene.add(cc_ROI_actor)
 
 # Save figures
-window.record(scene, n_frames=1, out_path="corpuscallosum_axial.png", size=(800, 800))
+window.record(
+    scene=scene, n_frames=1, out_path="corpuscallosum_axial.png", size=(800, 800)
+)
 if interactive:
     window.show(scene)
 scene.set_camera(position=[-1, 0, 0], focal_point=[0, 0, 0], view_up=[0, 0, 1])
 window.record(
-    scene, n_frames=1, out_path="corpuscallosum_sagittal.png", size=(800, 800)
+    scene=scene, n_frames=1, out_path="corpuscallosum_sagittal.png", size=(800, 800)
 )
 if interactive:
     window.show(scene)

--- a/doc/examples/surface_seed.py
+++ b/doc/examples/surface_seed.py
@@ -49,7 +49,7 @@ scene.set_camera(position=(-500, 0, 0), view_up=(0.0, 0.0, 1))
 
 # Uncomment the line below to show to display the window
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="surface_seed1.png", size=(600, 600))
+window.record(scene=scene, out_path="surface_seed1.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -111,7 +111,7 @@ scene.set_camera(position=(-500, 0, 0), view_up=(0.0, 0.0, 1))
 
 # Uncomment the line below to show to display the window
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="surface_seed2.png", size=(600, 600))
+window.record(scene=scene, out_path="surface_seed2.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -80,8 +80,8 @@ save_trk(sft, "tractogram_bootstrap_dg.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_bootstrap_dg.png", size=(800, 800))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
+    window.record(scene=scene, out_path="tractogram_bootstrap_dg.png", size=(800, 800))
     if interactive:
         window.show(scene)
 
@@ -112,7 +112,9 @@ save_trk(sft, "closest_peak_dg_CSD.trk")
 if has_fury:
     scene = window.Scene()
     scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_closest_peak_dg.png", size=(800, 800))
+    window.record(
+        scene=scene, out_path="tractogram_closest_peak_dg.png", size=(800, 800)
+    )
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_deterministic.py
+++ b/doc/examples/tracking_deterministic.py
@@ -87,7 +87,9 @@ save_trk(sft, "tractogram_deterministic_dg.trk")
 if has_fury:
     scene = window.Scene()
     scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_deterministic_dg.png", size=(800, 800))
+    window.record(
+        scene=scene, out_path="tractogram_deterministic_dg.png", size=(800, 800)
+    )
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_introduction_eudx.py
+++ b/doc/examples/tracking_introduction_eudx.py
@@ -96,10 +96,12 @@ csa_peaks = peaks_from_model(
 if has_fury:
     scene = window.Scene()
     scene.add(
-        actor.peak_slicer(csa_peaks.peak_dirs, csa_peaks.peak_values, colors=None)
+        actor.peak_slicer(
+            csa_peaks.peak_dirs, peaks_values=csa_peaks.peak_values, colors=None
+        )
     )
 
-    window.record(scene, out_path="csa_direction_field.png", size=(900, 900))
+    window.record(scene=scene, out_path="csa_direction_field.png", size=(900, 900))
 
     if interactive:
         window.show(scene, size=(800, 800))
@@ -176,14 +178,16 @@ if has_fury:
     # Prepare the display objects.
     color = colormap.line_colors(streamlines)
 
-    streamlines_actor = actor.line(streamlines, colormap.line_colors(streamlines))
+    streamlines_actor = actor.line(
+        streamlines, colors=colormap.line_colors(streamlines)
+    )
 
     # Create the 3D display.
     scene = window.Scene()
     scene.add(streamlines_actor)
 
     # Save still images for this static example. Or for interactivity use
-    window.record(scene, out_path="tractogram_EuDX.png", size=(800, 800))
+    window.record(scene=scene, out_path="tractogram_EuDX.png", size=(800, 800))
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_pft.py
+++ b/doc/examples/tracking_pft.py
@@ -132,8 +132,8 @@ save_trk(sft, "tractogram_pft.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_pft.png", size=(800, 800))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
+    window.record(scene=scene, out_path="tractogram_pft.png", size=(800, 800))
     if interactive:
         window.show(scene)
 
@@ -159,8 +159,10 @@ save_trk(sft, "tractogram_probabilistic_cmc.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_probabilistic_cmc.png", size=(800, 800))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
+    window.record(
+        scene=scene, out_path="tractogram_probabilistic_cmc.png", size=(800, 800)
+    )
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_probabilistic.py
+++ b/doc/examples/tracking_probabilistic.py
@@ -86,9 +86,9 @@ save_trk(sft, "tractogram_probabilistic_dg_pmf.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_probabilistic_dg_pmf.png", size=(800, 800)
+        scene=scene, out_path="tractogram_probabilistic_dg_pmf.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)
@@ -123,8 +123,10 @@ save_trk(sft, "tractogram_probabilistic_dg_sh.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_probabilistic_dg_sh.png", size=(800, 800))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
+    window.record(
+        scene=scene, out_path="tractogram_probabilistic_dg_sh.png", size=(800, 800)
+    )
     if interactive:
         window.show(scene)
 
@@ -165,9 +167,9 @@ save_trk(sft, "tractogram_probabilistic_dg_sh_pfm.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_probabilistic_dg_sh_pfm.png", size=(800, 800)
+        scene=scene, out_path="tractogram_probabilistic_dg_sh_pfm.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)

--- a/doc/examples/tracking_ptt.py
+++ b/doc/examples/tracking_ptt.py
@@ -71,8 +71,8 @@ save_trk(sft, "tractogram_ptt_dg_pmf.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
-    window.record(scene, out_path="tractogram_ptt_dg_pmf.png", size=(800, 800))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
+    window.record(scene=scene, out_path="tractogram_ptt_dg_pmf.png", size=(800, 800))
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_rumba.py
+++ b/doc/examples/tracking_rumba.py
@@ -118,7 +118,7 @@ streamlines = Streamlines(streamline_generator)
 
 color = colormap.line_colors(streamlines)
 streamlines_actor = actor.streamtube(
-    list(transform_streamlines(streamlines, inv(t1_aff))), color, linewidth=0.1
+    list(transform_streamlines(streamlines, inv(t1_aff))), colors=color, linewidth=0.1
 )
 
 vol_actor = actor.slicer(t1_data)
@@ -133,7 +133,9 @@ scene.add(streamlines_actor)
 if interactive:
     window.show(scene)
 
-window.record(scene, out_path="tractogram_probabilistic_rumba.png", size=(800, 800))
+window.record(
+    scene=scene, out_path="tractogram_probabilistic_rumba.png", size=(800, 800)
+)
 
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
 save_trk(sft, "tractogram_probabilistic_rumba.trk")

--- a/doc/examples/tracking_sfm.py
+++ b/doc/examples/tracking_sfm.py
@@ -135,22 +135,22 @@ plot_streamlines = select_random_set_of_streamlines(streamlines, 900)
 if has_fury:
     streamlines_actor = actor.streamtube(
         list(transform_streamlines(plot_streamlines, inv(t1_aff))),
-        colormap.line_colors(streamlines),
+        colors=colormap.line_colors(streamlines),
         linewidth=0.1,
     )
 
     vol_actor = actor.slicer(t1_data)
 
-    vol_actor.display(40, None, None)
+    vol_actor.display(x=40)
     vol_actor2 = vol_actor.copy()
-    vol_actor2.display(None, None, 35)
+    vol_actor2.display(z=35)
 
     scene = window.Scene()
     scene.add(streamlines_actor)
     scene.add(vol_actor)
     scene.add(vol_actor2)
 
-    window.record(scene, out_path="tractogram_sfm.png", size=(800, 800))
+    window.record(scene=scene, out_path="tractogram_sfm.png", size=(800, 800))
     if interactive:
         window.show(scene)
 

--- a/doc/examples/tracking_stopping_criterion.py
+++ b/doc/examples/tracking_stopping_criterion.py
@@ -133,9 +133,9 @@ save_trk(sft, "tractogram_probabilistic_thresh_all.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_deterministic_thresh_all.png", size=(800, 800)
+        scene=scene, out_path="tractogram_deterministic_thresh_all.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)
@@ -200,9 +200,9 @@ save_trk(sft, "tractogram_deterministic_binary_all.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_deterministic_binary_all.png", size=(800, 800)
+        scene=scene, out_path="tractogram_deterministic_binary_all.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)
@@ -297,9 +297,9 @@ save_trk(sft, "tractogram_deterministic_act_all.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_deterministic_act_all.png", size=(800, 800)
+        scene=scene, out_path="tractogram_deterministic_act_all.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)
@@ -319,9 +319,9 @@ save_trk(sft, "tractogram_deterministic_act_valid.trk")
 
 if has_fury:
     scene = window.Scene()
-    scene.add(actor.line(streamlines, colormap.line_colors(streamlines)))
+    scene.add(actor.line(streamlines, colors=colormap.line_colors(streamlines)))
     window.record(
-        scene, out_path="tractogram_deterministic_act_valid.png", size=(800, 800)
+        scene=scene, out_path="tractogram_deterministic_act_valid.png", size=(800, 800)
     )
     if interactive:
         window.show(scene)

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -86,7 +86,7 @@ stream_actor = actor.line(streamlines)
 if not world_coords:
     image_actor_z = actor.slicer(data, affine=np.eye(4))
 else:
-    image_actor_z = actor.slicer(data, affine)
+    image_actor_z = actor.slicer(data, affine=affine)
 
 ###############################################################################
 # We can also change also the opacity of the slicer.
@@ -268,7 +268,10 @@ if interactive:
 
 else:
     window.record(
-        scene, out_path="bundles_and_3_slices.png", size=(1200, 900), reset_camera=False
+        scene=scene,
+        out_path="bundles_and_3_slices.png",
+        size=(1200, 900),
+        reset_camera=False,
     )
 
 ###############################################################################

--- a/doc/examples/viz_bundles.py
+++ b/doc/examples/viz_bundles.py
@@ -60,7 +60,7 @@ scene.add(stream_actor)
 
 # Uncomment the line below to show to display the window
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle1.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle1.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -82,7 +82,7 @@ scene.camera_info()
 # Here we will need to input the ``fa`` map in ``streamtube`` or ``line``.
 
 scene.clear()
-stream_actor2 = actor.line(bundle_native, fa, linewidth=0.1)
+stream_actor2 = actor.line(bundle_native, colors=fa, linewidth=0.1)
 
 ###############################################################################
 # We can also show the scalar bar.
@@ -93,7 +93,7 @@ scene.add(stream_actor2)
 scene.add(bar)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle2.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle2.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -113,14 +113,16 @@ saturation = (0.0, 1.0)  # white to red
 
 lut_cmap = actor.colormap_lookup_table(hue_range=hue, saturation_range=saturation)
 
-stream_actor3 = actor.line(bundle_native, fa, linewidth=0.1, lookup_colormap=lut_cmap)
-bar2 = actor.scalar_bar(lut_cmap)
+stream_actor3 = actor.line(
+    bundle_native, colors=fa, linewidth=0.1, lookup_colormap=lut_cmap
+)
+bar2 = actor.scalar_bar(lookup_table=lut_cmap)
 
 scene.add(stream_actor3)
 scene.add(bar2)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle3.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle3.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -135,12 +137,12 @@ window.record(scene, out_path="bundle3.png", size=(600, 600))
 # orange.
 
 scene.clear()
-stream_actor4 = actor.line(bundle_native, (1.0, 0.5, 0), linewidth=0.1)
+stream_actor4 = actor.line(bundle_native, colors=(1.0, 0.5, 0), linewidth=0.1)
 
 scene.add(stream_actor4)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle4.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle4.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -168,16 +170,16 @@ lut_cmap = actor.colormap_lookup_table(
 )
 
 stream_actor5 = actor.line(
-    bundle_native, lengths, linewidth=0.1, lookup_colormap=lut_cmap
+    bundle_native, colors=lengths, linewidth=0.1, lookup_colormap=lut_cmap
 )
 
 scene.add(stream_actor5)
-bar3 = actor.scalar_bar(lut_cmap)
+bar3 = actor.scalar_bar(lookup_table=lut_cmap)
 
 scene.add(bar3)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle5.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle5.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -199,13 +201,13 @@ rng = np.random.default_rng()
 colors = [rng.random(streamline.shape) for streamline in bundle_native]
 
 stream_actor6 = actor.line(
-    bundle_native, np.asarray(colors, dtype=object), linewidth=0.2
+    bundle_native, colors=np.asarray(colors, dtype=object), linewidth=0.2
 )
 
 scene.add(stream_actor6)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
-window.record(scene, out_path="bundle6.png", size=(600, 600))
+window.record(scene=scene, out_path="bundle6.png", size=(600, 600))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/viz_roi_contour.py
+++ b/doc/examples/viz_roi_contour.py
@@ -61,7 +61,7 @@ streamlines = Streamlines(streamlines)
 ###############################################################################
 # We will create a streamline actor from the streamlines.
 
-streamlines_actor = actor.line(streamlines, cmap.line_colors(streamlines))
+streamlines_actor = actor.line(streamlines, colors=cmap.line_colors(streamlines))
 
 ###############################################################################
 # Next, we create a surface actor from the corpus callosum seed ROI. We
@@ -73,7 +73,7 @@ surface_opacity = 0.5
 surface_color = [0, 1, 1]
 
 seedroi_actor = actor.contour_from_roi(
-    seed_mask, affine, surface_color, surface_opacity
+    seed_mask, affine=affine, color=surface_color, opacity=surface_opacity
 )
 
 ###############################################################################
@@ -92,7 +92,7 @@ interactive = False
 if interactive:
     window.show(scene)
 
-window.record(scene, out_path="contour_from_roi_tutorial.png", size=(1200, 900))
+window.record(scene=scene, out_path="contour_from_roi_tutorial.png", size=(1200, 900))
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -51,7 +51,7 @@ value_range = (mean - 0.5 * std, mean + 1.5 * std)
 # transformation matrix. The default behavior of this function is to show the
 # middle slice of the last dimension of the resampled data.
 
-slice_actor = actor.slicer(data, affine, value_range)
+slice_actor = actor.slicer(data, affine=affine, value_range=value_range)
 
 ###############################################################################
 # The ``slice_actor`` contains an axial slice.
@@ -69,7 +69,7 @@ slice_actor2 = slice_actor.copy()
 # Now we have a new ``slice_actor`` which displays the middle slice of the
 # sagittal plane.
 
-slice_actor2.display(slice_actor2.shape[0] // 2, None, None)
+slice_actor2.display(x=slice_actor2.shape[0] // 2, y=None, z=None)
 
 scene.add(slice_actor2)
 
@@ -84,7 +84,7 @@ scene.zoom(1.4)
 ###############################################################################
 # Otherwise, you can save a screenshot using the following command.
 
-window.record(scene, out_path="slices.png", size=(600, 600), reset_camera=False)
+window.record(scene=scene, out_path="slices.png", size=(600, 600), reset_camera=False)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -121,7 +121,7 @@ lut = actor.colormap_lookup_table(
 # This is because the lookup table is applied in the slice after interpolating
 # to (0, 255).
 
-fa_actor = actor.slicer(fa, affine, lookup_colormap=lut)
+fa_actor = actor.slicer(fa, affine=affine, lookup_colormap=lut)
 
 scene.clear()
 scene.add(fa_actor)
@@ -131,7 +131,9 @@ scene.zoom(1.4)
 
 # window.show(scene, size=(600, 600), reset_camera=False)
 
-window.record(scene, out_path="slices_lut.png", size=(600, 600), reset_camera=False)
+window.record(
+    scene=scene, out_path="slices_lut.png", size=(600, 600), reset_camera=False
+)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
@@ -239,7 +241,7 @@ border = 10
 for j in range(rows):
     for i in range(cols):
         slice_mosaic = slice_actor.copy()
-        slice_mosaic.display(None, None, cnt)
+        slice_mosaic.display(z=cnt)
         slice_mosaic.SetPosition(
             (X + border) * i, 0.5 * cols * (Y + border) - (Y + border) * j, 0
         )
@@ -265,7 +267,7 @@ scene.zoom(1.0)
 # the mosaic up/down and left/right using the middle mouse button drag,
 # zoom in/out using the scroll wheel, and pick voxels with left click.
 
-window.record(scene, out_path="mosaic.png", size=(900, 600), reset_camera=False)
+window.record(scene=scene, out_path="mosaic.png", size=(900, 600), reset_camera=False)
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold


### PR DESCRIPTION
The last release of FURY enforces keyword-only arguments. 

This new feature generates a ton of warning in our codebase so this PR just fix this issue and make everything more explicit.

viz CI's should be back to normal after this PR