### PR TITLE
DOC: Miscellaneous doc formatting fixes (part 3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@
 .. image:: https://github.com/dipy/dipy/actions/workflows/test.yml/badge.svg?branch=master
   :target: https://github.com/dipy/dipy/actions/workflows/test.yml
 
+.. image:: https://github.com/dipy/dipy/actions/workflows/build_docs.yml/badge.svg?branch=master
+  :target: https://github.com/dipy/dipy/actions/workflows/build_docs.yml
+
 .. image:: https://codecov.io/gh/dipy/dipy/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/dipy/dipy
 

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -56,8 +56,8 @@ class StreamlineDistanceMetric(metaclass=abc.ABCMeta):
             Number of threads to be used for OpenMP parallelization. If None
             (default) the value of OMP_NUM_THREADS environment variable is used
             if it is set, otherwise all available threads are used. If < 0 the
-            maximal number of threads minus |num_threads + 1| is used (enter -1
-            to use as many threads as possible). 0 raises an error. Only
+            maximal number of threads minus $|num_threads + 1|$ is used (enter
+            -1 to use as many threads as possible). 0 raises an error. Only
             metrics using OpenMP will use this variable.
 
         """
@@ -383,8 +383,8 @@ class StreamlineLinearRegistration:
             Number of threads to be used for OpenMP parallelization. If None
             (default) the value of OMP_NUM_THREADS environment variable is used
             if it is set, otherwise all available threads are used. If < 0 the
-            maximal number of threads minus |num_threads + 1| is used (enter -1
-            to use as many threads as possible). 0 raises an error. Only
+            maximal number of threads minus $|num_threads + 1|$ is used (enter
+            -1 to use as many threads as possible). 0 raises an error. Only
             metrics using OpenMP will use this variable.
 
         References
@@ -815,7 +815,7 @@ def bundle_min_distance_fast(t, static, moving, block_size, *, num_threads=None)
         Number of threads to be used for OpenMP parallelization. If None
         (default) the value of OMP_NUM_THREADS environment variable is used
         if it is set, otherwise all available threads are used. If < 0 the
-        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        maximal number of threads minus $|num_threads + 1|$ is used (enter -1 to
         use as many threads as possible). 0 raises an error.
 
     Returns
@@ -943,7 +943,7 @@ def progressive_slr(
         Number of threads to be used for OpenMP parallelization. If None
         (default) the value of OMP_NUM_THREADS environment variable is used
         if it is set, otherwise all available threads are used. If < 0 the
-        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        maximal number of threads minus $|num_threads + 1|$ is used (enter -1 to
         use as many threads as possible). 0 raises an error. Only metrics
         using OpenMP will use this variable.
 
@@ -1098,7 +1098,7 @@ def slr_with_qbx(
         Number of threads to be used for OpenMP parallelization. If None
         (default) the value of OMP_NUM_THREADS environment variable is used
         if it is set, otherwise all available threads are used. If < 0 the
-        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        maximal number of threads minus $|num_threads + 1|$ is used (enter -1 to
         use as many threads as possible). 0 raises an error. Only metrics
         using OpenMP will use this variable.
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1039,7 +1039,7 @@ def check_multi_b(gtab, n_bvals, *, non_zero=True, bmag=None):
     Parameters
     ----------
     gtab : GradientTable class instance.
-
+        Gradient table.
     n_bvals : int
         The number of different b-values you are checking for.
     non_zero : bool

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -42,7 +42,7 @@ def nlmeans(
         Number of threads to be used for OpenMP parallelization. If None
         (default) the value of OMP_NUM_THREADS environment variable is used
         if it is set, otherwise all available threads are used. If < 0 the
-        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        maximal number of threads minus $|num_threads + 1|$ is used (enter -1 to
         use as many threads as possible). 0 raises an error.
 
     Returns

--- a/dipy/reconst/base.py
+++ b/dipy/reconst/base.py
@@ -20,6 +20,7 @@ class ReconstModel:
         Parameters
         ----------
         gtab : GradientTable class instance
+            Gradient table.
 
         """
         self.gtab = gtab

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -50,6 +50,7 @@ def auto_response(
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     roi_center : array-like, (3,)
@@ -107,6 +108,7 @@ def response_from_mask(gtab, data, mask):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     mask : ndarray
@@ -210,6 +212,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         Parameters
         ----------
         gtab : GradientTable
+            Gradient table.
         response : tuple or AxSymShResponse object
             A tuple with two elements. The first is the eigen-values as an (3,)
             ndarray and the second is the signal value for the response
@@ -388,6 +391,7 @@ class ConstrainedSDTModel(SphHarmModel):
         Parameters
         ----------
         gtab : GradientTable
+            Gradient table.
         ratio : float
             ratio of the smallest vs the largest eigenvalue of the single
             prolate tensor response function
@@ -474,7 +478,9 @@ def estimate_response(gtab, evals, S0):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     evals : ndarray
+        Eigenvalues.
     S0 : float
         non diffusion weighted
 
@@ -942,6 +948,7 @@ def mask_for_response_ssst(gtab, data, roi_center=None, roi_radii=10, fa_thr=0.7
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data (4D)
     roi_center : array-like, (3,)
@@ -1014,6 +1021,7 @@ def response_from_mask_ssst(gtab, data, mask):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     mask : ndarray
@@ -1074,6 +1082,7 @@ def auto_response_ssst(gtab, data, roi_center=None, roi_radii=10, fa_thr=0.7):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     roi_center : array-like, (3,)
@@ -1144,6 +1153,7 @@ def recursive_response(
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     mask : ndarray, optional

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1687,12 +1687,13 @@ def dki_prediction(dki_params, gtab, S0=1.0):
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
+
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+                second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
     gtab : a GradientTable class instance
         The gradient table for this prediction
     S0 : float or ndarray (optional)

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -319,7 +319,7 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
         Parameters
         ----------
         gtab : GradientTable class instance
-
+            Gradient table.
         fit_method : str or callable
             str can be one of the following:
             'OLS' or 'ULLS' to fit the diffusion tensor and kurtosis tensor

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -313,6 +313,7 @@ def create_qspace(gtab, origin):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     origin : (3,) ndarray
         center of qspace
 
@@ -335,6 +336,7 @@ def create_qtable(gtab, origin):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     origin : (3,) ndarray
         center of qspace
 
@@ -370,6 +372,7 @@ def hanning_filter(gtab, filter_width, origin):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     filter_width : int
     origin : (3,) ndarray
         center of qspace
@@ -439,7 +442,9 @@ def half_to_full_qspace(data, gtab):
     Returns
     -------
     new_data : array, shape (X, Y, Z, 2 * W -1)
+        DWI data across the full Cartesian space.
     new_gtab : GradientTable
+        Gradient table.
 
     Notes
     -----

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -702,7 +702,7 @@ class TensorModel(ReconstModel):
         Parameters
         ----------
         gtab : GradientTable class instance
-
+            Gradient table.
         fit_method : str or callable, optional
             str can be one of the following:
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -95,6 +95,7 @@ class FreeWaterTensorModel(ReconstModel):
         Parameters
         ----------
         gtab : GradientTable class instance
+            Gradient table.
         fit_method : str or callable
             str can be one of the following:
 

--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -33,6 +33,7 @@ def multi_tissue_basis(gtab, sh_order_max, iso_comp):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     sh_order_max : int
         Maximal spherical harmonics order (l).
     iso_comp: int
@@ -107,10 +108,13 @@ class MultiShellResponse:
 def _inflate_response(response, gtab, sh_order_max, delta):
     """Used to inflate the response for the `multiplier_matrix` in the
     `MultiShellDeconvModel`.
+
     Parameters
     ----------
     response : MultiShellResponse object
+        Response function.
     gtab : GradientTable
+        Gradient table.
     sh_order_max : int ``>= 0``
         The maximal order ($l$) of the harmonic.
     delta : Delta generated from `_basic_delta`
@@ -177,6 +181,7 @@ class MultiShellDeconvModel(shm.SphHarmModel):
         Parameters
         ----------
         gtab : GradientTable
+            Gradient table.
         response : ndarray or MultiShellResponse object
             Pre-computed multi-shell fiber response function in the form of a
             MultiShellResponse object, or simple response function as a ndarray.
@@ -568,6 +573,7 @@ def mask_for_response_msmt(
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data (4D)
     roi_center : array-like, (3,)
@@ -691,6 +697,7 @@ def response_from_mask_msmt(gtab, data, mask_wm, mask_gm, mask_csf, tol=20):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     mask_wm : ndarray
@@ -785,6 +792,7 @@ def auto_response_msmt(
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     data : ndarray
         diffusion data
     tol : int, optional

--- a/dipy/reconst/msdki.py
+++ b/dipy/reconst/msdki.py
@@ -279,6 +279,7 @@ class MeanDiffusionKurtosisModel(ReconstModel):
         Parameters
         ----------
         gtab : GradientTable class instance
+            Gradient table.
 
         bmag : int
             The order of magnitude that the bvalues have to differ to be

--- a/dipy/reconst/rumba.py
+++ b/dipy/reconst/rumba.py
@@ -59,6 +59,7 @@ class RumbaSDModel(OdfModel):
         Parameters
         ----------
         gtab : GradientTable
+            Gradient table.
         wm_response : 1d ndarray or 2d ndarray or AxSymShResponse, optional
             Tensor eigenvalues as a (3,) ndarray, multishell eigenvalues as
             a (len(unique_bvals_tolerance(gtab.bvals))-1, 3) ndarray in
@@ -728,6 +729,7 @@ def generate_kernel(gtab, sphere, wm_response, gm_response, csf_response):
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     sphere : Sphere
         Sphere with which to sample discrete fiber orientations in order to
         construct kernel

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -355,6 +355,7 @@ class SparseFascicleModel(ReconstModel, Cache):
         Parameters
         ----------
         gtab : GradientTable class instance
+            Gradient table.
 
         sphere : Sphere class instance, optional
             A sphere on which coefficients will be estimated. Default:

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -372,8 +372,8 @@ class RecoBundles:
             Number of threads to be used for OpenMP parallelization. If None
             (default) the value of OMP_NUM_THREADS environment variable is used
             if it is set, otherwise all available threads are used. If < 0 the
-            maximal number of threads minus |num_threads + 1| is used (enter -1
-            to use as many threads as possible). 0 raises an error.
+            maximal number of threads minus $|num_threads + 1|$ is used (enter
+            -1 to use as many threads as possible). 0 raises an error.
         slr_metric : BundleMinDistanceMetric
         slr_x0 : array or int or str, optional
             Transformation allowed. translation, rigid, similarity or scaling

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -498,6 +498,7 @@ def multi_tensor_dki(
     Parameters
     ----------
     gtab : GradientTable
+        Gradient table.
     mevals : array (K, 3)
         eigenvalues of the diffusion tensor for each individual compartment
     S0 : float (optional)

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -184,8 +184,10 @@ def streamline_signal(streamline, gtab, *, evals=(0.001, 0, 0)):
     Parameters
     ----------
     streamline : a single streamline
+        Streamline data.
 
     gtab : GradientTable class instance
+        Gradient table.
 
     evals : array-like of length 3, optional
         The eigenvalues of the canonical tensor used as an estimate of the

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -168,7 +168,7 @@ class SlrWithQbxFlow(Workflow):
             Number of threads to be used for OpenMP parallelization. If None
             (default) the value of OMP_NUM_THREADS environment variable is
             used if it is set, otherwise all available threads are used. If
-            < 0 the maximal number of threads minus |num_threads + 1| is used
+            < 0 the maximal number of threads minus $|num_threads + 1|$ is used
             (enter -1 to use as many threads as possible). 0 raises an error.
             Only metrics using OpenMP will use this variable.
         greater_than : int, optional

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -16,6 +16,7 @@ DIPY 1.10.0 changes
   switched to the new default solver, Clarabel.
 
 **Workflows**
+
 - The `vol_idx` parameter datatype from ``dipy_median_otsu`` has been changed from `variable int` to `str`.
   this change allows user to provide a range of values for the `vol_idx` parameter. e.g: `--vol_idx 0,1,2` or `--vol_idx 4,5,12-20,22`.
 
@@ -40,6 +41,7 @@ DIPY 1.8.0 changes
 - Change in ``dipy.core.gradients``, function ``reorient_bvecs`` now requires the affine to have a shape of (4, 4, n) or (3, 3, n)
 
 **Direction**
+
 - Change in ``dipy.direction.bootstrap_direction_getter``.
     - The parent class was changes from ``PmfGenDirectionGetter`` to ``DirectionGetter``. The ``BootPmfGen`` functions were merged in ``BootDirectionGetter``.
     - The class constructor parameter `pmfgen` was removed. Parameters `data`, `model` and `sh_order=0` were added.

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -120,7 +120,7 @@ then do you push to upstream on github.
   release artifacts (next section). Only push the release commit to the DIPY_
   repo once you have built the sdists and docs successfully.
   Then continue with building wheels. Only push the release tag to the repo once
-   all wheels have been built successfully on `DIPY Github Actions`_.
+  all wheels have been built successfully on `DIPY Github Actions`_.
 
 * For the wheel build / upload, follow the `wheel builder README`_
   instructions again.  Edit the ``.github/workflows/wheel.yml`` files (if

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -4,10 +4,10 @@ Denoise images using the Marcenko-Pastur PCA algorithm
 ======================================================
 
 The PCA-based denoising algorithm exploits the redundancy across the
-diffusion-weighted images [Manjon2013]_, [Veraart2016a]_. This algorithm has
+diffusion-weighted images [Manjon2013]_, [Veraa2016a]_. This algorithm has
 been shown to provide an optimal compromise between noise suppression and loss
 of anatomical information for different techniques such as DTI [Manjon2013]_,
-spherical deconvolution [Veraart2016a] and DKI [Henri2018]_.
+spherical deconvolution [Veraa2016a] and DKI [Henri2018]_.
 
 The basic idea behind the PCA-based denoising algorithms is to remove the
 components of the data that are classified as noise. The Principal Components

--- a/doc/examples/denoise_patch2self.py
+++ b/doc/examples/denoise_patch2self.py
@@ -94,22 +94,24 @@ denoised_arr = patch2self(
 #
 # .. note::
 #
-# Depending on the acquisition, b0 may exhibit signal attenuation or
-# other artefacts that are not ideal for any denoising algorithm. We therefore
-# provide an option to skip denoising b0 volumes in the data. This can be done
-# by using the option `b0_denoising=False` within Patch2Self.
+#    Depending on the acquisition, b0 may exhibit signal attenuation or
+#    other artefacts that are not ideal for any denoising algorithm. We
+#    therefore provide an option to skip denoising b0 volumes in the data.
+#    This can be done by using the option `b0_denoising=False` within
+#    Patch2Self.
 #
-# Please set ``shift_intensity=True`` and ``clip_negative_vals=False`` by
-# default to avoid negative values in the denoised output.
+#    Please set ``shift_intensity=True`` and ``clip_negative_vals=False`` by
+#    default to avoid negative values in the denoised output.
 #
-# The ``b0_threshold`` is used to separate the b0 volumes from the DWI
-# volumes. Changing the value of the b0 threshold is needed if the b0 volumes
-# in the ``bval`` file have a value greater than the default ``b0_threshold``.
+#    The ``b0_threshold`` is used to separate the b0 volumes from the DWI
+#    volumes. Changing the value of the b0 threshold is needed if the b0 volumes
+#    in the ``bval`` file have a value greater than the default
+#    ``b0_threshold``.
 #
-# The default value of ``b0_threshold`` in DIPY is set to 50. If using data
-# such as HCP 7T, the b0 volumes tend to have a higher b-value (>=50)
-# associated with them in the `bval` file. Please check the b-values for b0s
-# and adjust the ``b0_threshold``` accordingly.
+#    The default value of ``b0_threshold`` in DIPY is set to 50. If using data
+#    such as HCP 7T, the b0 volumes tend to have a higher b-value (>=50)
+#    associated with them in the `bval` file. Please check the b-values for b0s
+#    and adjust the ``b0_threshold``` accordingly.
 #
 # Now let's visualize the output and the residuals obtained from the denoising.
 

--- a/doc/examples/fast_streamline_search.py
+++ b/doc/examples/fast_streamline_search.py
@@ -93,6 +93,7 @@ else:
 # - max_radius : is the maximum distance that can be used with radius search
 #
 # Then, the ``radius_search()`` method needs the following arguments:
+#
 # - radius : for each streamline search find all similar ones in the
 #   "ref_streamlines" that are within the given radius
 #

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -371,8 +371,8 @@ compare_maps(
 #                 Imaging. Magnetic Resonance in Medicine 53: 1432-1440
 # .. [Henriq2021] Henriques RN, Correia MM, Marrale M, Huber E, Kruper J,
 #                 Koudoro S, Yeatman JD, Garyfallidis E, Rokem A (2021).
-#                  Diffusional Kurtosis Imaging in the Diffusion Imaging in
-#                  Python Project. Frontiers in Human Neuroscience 15: 675433.
+#                 Diffusional Kurtosis Imaging in the Diffusion Imaging in
+#                 Python Project. Frontiers in Human Neuroscience 15: 675433.
 # .. [Jensen2010] Jensen JH, Helpern JA (2010). MRI quantification of
 #                 non-Gaussian water diffusion by kurtosis analysis. NMR in
 #                 Biomedicine 23(7): 698-710

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -192,8 +192,8 @@ fig1.savefig("Kurtosis_Microstructural_measures.png")
 #                 2105-2112. doi: 10.3174/ajnr.A3553
 # .. [Henriq2021] Henriques RN, Correia MM, Marrale M, Huber E, Kruper J,
 #                 Koudoro S, Yeatman JD, Garyfallidis E, Rokem A (2021).
-#                  Diffusional Kurtosis Imaging in the Diffusion Imaging in
-#                  Python Project. Frontiers in Human Neuroscience 15: 675433.
+#                 Diffusional Kurtosis Imaging in the Diffusion Imaging in
+#                 Python Project. Frontiers in Human Neuroscience 15: 675433.
 # .. [Hansen2016] Hansen, B, Jespersen, SN (2016). Data for evaluation of fast
 #                 kurtosis strategies, b-value optimization and exploration of
 #                 diffusion MRI contrast. Scientific Data 3: 160072

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -72,11 +72,11 @@ dki_micro_model = dki_micro.KurtosisMicrostructureModel(gtab)
 ###############################################################################
 # Before fitting this microstructural model, it is useful to indicate the
 # regions in which this model provides meaningful information (i.e. voxels of
-# well-aligned fibers). Following Fieremans et al. [Fieremans2011]_, a simple
+# well-aligned fibers). Following Fieremans et al. [Fierem2011]_, a simple
 # way to select this region is to generate a well-aligned fiber mask based on
 # the values of diffusion sphericity, planarity and linearity. Here we will
 # follow these selection criteria for a better comparison of our figures with
-# the original article published by Fieremans et al. [Fieremans2011]_.
+# the original article published by Fieremans et al. [Fierem2011]_.
 # Nevertheless, it is important to note that voxels with well-aligned fibers
 # can be selected based on other approaches such as using predefined regions
 # of interest.

--- a/doc/examples/reconst_mcsd.py
+++ b/doc/examples/reconst_mcsd.py
@@ -18,6 +18,7 @@ extends the SSST-CSD introduced in [Tournier2007]_.
 
 The reconstruction of the fiber orientation distribution function
 (fODF) in MSMT-CSD involves the following steps:
+
     1. Generate a mask using Median Otsu (optional step)
     2. Denoise the data using MP-PCA (optional step)
     3. Generate  Anisotropic Powermap (if T1 unavailable)

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -406,8 +406,8 @@ fig3.savefig("MSDKI_SMT2_invivo.png")
 #                 doi: 10.1002/mrm.27606
 # .. [Henriq2021] Henriques RN, Correia MM, Marrale M, Huber E, Kruper J,
 #                 Koudoro S, Yeatman JD, Garyfallidis E, Rokem A (2021).
-#                  Diffusional Kurtosis Imaging in the Diffusion Imaging in
-#                  Python Project. Frontiers in Human Neuroscience 15: 675433.
+#                 Diffusional Kurtosis Imaging in the Diffusion Imaging in
+#                 Python Project. Frontiers in Human Neuroscience 15: 675433.
 # .. [Kaden2016b] Kaden E, Kelm ND, Carson RP, Does MD, Alexander DC (2016)
 #                 Multi-compartment microscopic diffusion imaging. NeuroImage
 #                 139: 346-359.


### PR DESCRIPTION
- DOC: Add documentation build action status badge to README
- DOC: Enclose absolute value math expression within LaTeX markup
- DOC: Add missing description to parameters across methods
- DOC: Add blank line before list
- DOC: Remove unnecessary indentation in documentation block
- DOC: Remove unnecessary indentations in citation text in examples
- DOC: Indent appropriately documentation block after `note` directive
- DOC: Use accurate citation cross-reference keys