### PR TITLE
DOC: Miscellaneous doc formatting fixes (part 4)

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -265,7 +265,8 @@ def write_mapping(mapping, fname):
 
     Parameters
     ----------
-    mapping : a DiffeomorphicMap object derived from :func:`syn_registration`
+    mapping : DiffeomorphicMap
+        Registration mapping derived from :func:`syn_registration`
     fname : str
         Full path to the nifti file storing the mapping
 

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -1218,7 +1218,6 @@ class AffineRegistration:
                 array, shape (dim+1, dim+1).
             If None:
                 Start from identity.
-            The default is None.
         ret_metric : boolean, optional
             if True, it returns the parameters for measuring the
             similarity between the images (default 'False').

--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -1070,11 +1070,7 @@ def v_cycle_3d(
     filtering (GS-iterate) the current level, then solves for the residual
     at a coarser resolution and finally refines the solution at the current
     resolution. This scheme corresponds to the V-cycle proposed by Bruhn and
-    Weickert[1].
-    [1] Andres Bruhn and Joachim Weickert, "Towards ultimate motion estimation:
-        combining highest accuracy with real-time performance",
-        10th IEEE International Conference on Computer Vision, 2005.
-        ICCV 2005.
+    Weickert [1]_.
 
     Parameters
     ----------
@@ -1105,6 +1101,13 @@ def v_cycle_3d(
     -------
     energy : the energy of the EM (or SSD if sigmafield[...]==1) metric at this
         iteration
+
+    References
+    ----------
+    ..  [1] Andres Bruhn and Joachim Weickert, "Towards ultimate motion
+            estimation: combining highest accuracy with real-time performance",
+            10th IEEE International Conference on Computer Vision, 2005.
+            ICCV 2005.
     """
     # pre-smoothing
     for _ in range(k):

--- a/dipy/align/streamwarp.py
+++ b/dipy/align/streamwarp.py
@@ -214,6 +214,14 @@ def bundlewarp_vector_filed(moving_aligned, deformed_bundle):
     directions : List
         Unitary vector directions
     colors : List
+        Colors for bundle warping field vectors. Colors follow the convention
+        used in DTI-derived maps (e.g. color FA) [Pajevic1999]_.
+
+    References
+    ----------
+    .. [Pajevic1999] Pajevic S, Pierpaoli (1999). Color schemes to represent the
+       orientation of anisotropic tissues from diffusion tensor data: application
+       to white matter fiber tract mapping in the human brain.
     """
     points_aligned, _ = unlist_streamlines(moving_aligned)
     points_deformed, _ = unlist_streamlines(deformed_bundle)

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -970,18 +970,19 @@ def perpendicular_directions(v, *, num=30, half=False):
     Perpendicular directions are estimated using the following two step
     procedure:
 
-        1) the perpendicular directions are first sampled in a unit
-        circumference parallel to the plane normal to the x-axis.
+    1) the perpendicular directions are first sampled in a unit
+       circumference parallel to the plane normal to the x-axis.
 
-        2) Samples are then rotated and aligned to the plane normal to vector
-        v. The rotational matrix for this rotation is constructed as reference
-        frame basis which axis are the following:
-            - The first axis is vector v
-            - The second axis is defined as the normalized vector given by the
-            cross product between vector v and the unit vector aligned to the
-            x-axis
-            - The third axis is defined as the cross product between the
-            previous computed vector and vector v.
+    2) Samples are then rotated and aligned to the plane normal to vector
+       v. The rotational matrix for this rotation is constructed as reference
+       frame basis which axis are the following:
+
+       - The first axis is vector v
+       - The second axis is defined as the normalized vector given by the
+         cross product between vector v and the unit vector aligned to the
+         x-axis
+       - The third axis is defined as the cross product between the
+         previous computed vector and vector v.
 
     Following this two steps, coordinates of the final perpendicular directions
     are given as:

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -247,31 +247,48 @@ def vector_norm(vec, *, axis=-1, keepdims=False):
 
 
 def rodrigues_axis_rotation(r, theta):
-    """Rodrigues formula
+    r"""Rodrigues formula
 
-    Rotation matrix for rotation around axis r for angle theta.
+    Rotation matrix for rotation around axis `r` for angle `theta`.
 
     The rotation matrix is given by the Rodrigues formula:
 
-    R = Id + sin(theta)*Sn + (1-cos(theta))*Sn^2
+    .. math::
+        :nowrap:
 
-    with::
+        \mathbf{R} = \mathbf{I} + \sin(\theta)*\mathbf{S}_n +
+        (1-\cos(\theta))*\mathbf{S}_n^2
 
-             0  -nz  ny
-      Sn =   nz   0 -nx
-            -ny  nx   0
+    with:
 
-    where n = r / ||r||
+    .. math::
 
-    In case the angle ||r|| is very small, the above formula may lead
+        Sn =
+        \begin{pmatrix}
+            0 & -n{z} & n{y} \\
+            n{z} & 0 & -n{x} \\
+            -n{y} & n{x} & 0
+        \end{pmatrix}
+
+    where :math:`n = r / ||r||`
+
+    In case the angle :math:`||r||` is very small, the above formula may lead
     to numerical instabilities. We instead use a Taylor expansion
-    around theta=0:
+    around :math:`theta=0`:
 
-    R = I + sin(theta)/tetha Sr + (1-cos(theta))/teta2 Sr^2
+    .. math::
+        :nowrap:
+
+        R = I + \sin(\theta)/\theta \mathbf{S}_r +
+        (1-\cos(\theta))/\theta^2 \mathbf{S}_r^2
 
     leading to:
 
-    R = I + (1-theta2/6)*Sr + (1/2-theta2/24)*Sr^2
+    .. math::
+        :nowrap:
+
+        R = \mathbf{I} + (1-\theta^2/6)*\mathbf{S}_r +
+        (\frac{1}{2}-\theta^2/24)*\mathbf{S}_r^2
 
     Parameters
     ----------

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -275,12 +275,15 @@ def rodrigues_axis_rotation(r, theta):
 
     Parameters
     ----------
-    r :  array_like shape (3,), axis
-    theta : float, angle in degrees
+    r :  array_like shape (3,)
+        Axis.
+    theta : float
+        Angle in degrees.
 
     Returns
     -------
-    R : array, shape (3,3), rotation matrix
+    R : array, shape (3,3)
+        Rotation matrix.
 
     Examples
     --------

--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -92,6 +92,7 @@ class Optimizer:
         constraints : dict or sequence of dict, optional
             Constraints definition (only for COBYLA and SLSQP).
             Each constraint is defined in a dictionary with fields:
+
                 type : str
                     Constraint type: 'eq' for equality, 'ineq' for inequality.
                 fun : callable
@@ -100,6 +101,7 @@ class Optimizer:
                     The Jacobian of `fun` (only for SLSQP).
                 args : sequence, optional
                     Extra arguments to be passed to the function and Jacobian.
+
             Equality constraint means that the constraint function result is to
             be zero whereas inequality means that it is to be non-negative.
             Note that COBYLA only supports inequality constraints.
@@ -115,10 +117,12 @@ class Optimizer:
         options : dict, optional
             A dictionary of solver options. All methods accept the following
             generic options:
+
                 maxiter : int
                     Maximum number of iterations to perform.
                 disp : bool
                     Set to True to print convergence messages.
+
             For method-specific options, see
             `show_options('minimize', method)`.
 

--- a/dipy/denoise/adaptive_soft_matching.py
+++ b/dipy/denoise/adaptive_soft_matching.py
@@ -13,7 +13,8 @@ def adaptive_soft_matching(ima, fimau, fimao, sigma):
 
     Parameters
     ----------
-    ima : the original (not filtered) image
+    ima : ndarray
+        Original (unfiltered) image
     fimau : 3D double array,
         filtered image with optimized non-local means using a small block
         (suggested:3x3), which corresponds to a "high resolution" filter.

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -280,7 +280,6 @@ def gibbs_removal(vol, *, slice_axis=2, n_points=3, inplace=True, num_processes=
 
     References
     ----------
-    Please cite the following articles
     .. [1] Neto Henriques, R., 2018. Advanced Methods for Diffusion MRI Data
            Analysis and their Application to the Healthy Ageing Brain
            (Doctoral thesis). https://doi.org/10.17863/CAM.29356

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -16,6 +16,7 @@ def non_local_means(
     arr : 3D or 4D ndarray
         The array to be denoised
     mask : 3D ndarray
+        Mask on data where the non-local means will be applied.
     sigma : float
         standard deviation of the noise estimated from the data
     patch_radius : int

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -25,11 +25,13 @@ class Dpy:
 
         Parameters
         ----------
-        fname : str, full filename
-        mode : 'r' read
-         'w' write
-         'r+' read and write only if file already exists
-        compression : 0 no compression to 9 maximum compression
+        fname : str
+            Full filename
+        mode : str, optional
+            Use 'r' to read, 'w' to write, and 'r+' to read and write (only if
+            file already exists).
+        compression : int, optional
+            0 no compression to 9 maximum compression.
 
         Examples
         --------

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -30,7 +30,7 @@ def nifti1_symmat(image_data, *args, **kwargs):
         last dimension
     *args
         Passed to Nifti1Image
-    *kwargs
+    **kwargs
         Passed to Nifti1Image
 
     Returns

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -13,6 +13,7 @@ def normalize(image, *, min_v=None, max_v=None, new_min=-1, new_max=1):
     Parameters
     ----------
     image : np.ndarray
+        Image to be normalized.
     min_v : int or float, optional
         minimum value range for normalization
         intensities below min_v will be clipped

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -1056,8 +1056,8 @@ def response_from_mask_ssst(gtab, data, mask):
     References
     ----------
     .. [1] Tournier, J.D., et al. NeuroImage 2004. Direct estimation of the
-    fiber orientation density function from diffusion-weighted MRI
-    data using spherical deconvolution
+       fiber orientation density function from diffusion-weighted MRI
+       data using spherical deconvolution
     """
 
     ten = TensorModel(gtab)

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -68,7 +68,8 @@ def multi_gaussian_k_from_c(ccti, MD):
     ----------
     ccti: array(..., 21)
         Covariance Tensor Elements with no hidden factors.
-    MD: Mean Diffusivity (MD) of a diffusion tensor.
+    MD : ndarray
+        Mean Diffusivity (MD) of a diffusion tensor.
 
     Returns
     -------
@@ -205,6 +206,7 @@ class CorrelationTensorModel(ReconstModel):
         gtab2: dipy.core.gradients.GradientTable
             A GradientTable class instance for second DDE diffusion epoch
         fit_method : str or callable, optional
+            Fitting method.
         args, kwargs :
             arguments and key-word arguments passed to the fit_method.
 

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -210,9 +210,9 @@ class CorrelationTensorModel(ReconstModel):
         fit_method : str or callable, optional
             Fitting method.
         *args
-            Variable length argument list passed to the fit method.
+            Variable length argument list passed to the :func:`fit` method.
         **kwargs
-            Arbitrary keyword arguments passed to the fit method.
+            Arbitrary keyword arguments passed to the :func:`fit` method.
 
         """
         self.gtab1 = gtab1

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -197,7 +197,7 @@ class CorrelationTensorModel(ReconstModel):
     """Class for the Correlation Tensor Model"""
 
     def __init__(self, gtab1, gtab2, fit_method="WLS", *args, **kwargs):
-        """Correlation Tensor Imaging Model [1]
+        """Correlation Tensor Imaging Model [1]_
 
         Parameters
         ----------

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -367,21 +367,21 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
 
     @property
     def K_aniso(self):
-        r"""Returns the anisotropic Source of Kurtosis (K_aniso)
+        r"""Returns the anisotropic Source of Kurtosis ($K_{aniso}$)
 
-            Notes
-            -----
-            The K_aniso is defined as[1]_:
+        Notes
+        -----
+        The $K_{aniso}$ is defined as [1]_:
 
-            :math::
+        .. math::
 
             \[K_{aniso} = \frac{6}{5} \cdot \frac{\langle V_{\lambda}(D_c)
-                                                  \rangle}{\overline{D}^2}\]
+                                              \rangle}{\overline{D}^2}\]
 
-        where: $K_{aniso}$ is the anisotropic kurtosis,
-            $\langle V_{\lambda}(D_c) \rangle$ represents the mean of the
-            variance of eigenvalues of the diffusion tensor,
-            $\overline{D}$ is the mean of the diffusion tensor.
+        where $K_{aniso}$ is the anisotropic kurtosis,
+        $\langle V_{\lambda}(D_c) \rangle$ represents the mean of the variance
+        of eigenvalues of the diffusion tensor, $\overline{D}$ is the mean of
+        the diffusion tensor.
 
         References
         ----------
@@ -429,19 +429,19 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
 
     @property
     def K_iso(self):
-        r"""Returns the isotropic Source of Kurtosis (K_iso)
+        r"""Returns the isotropic Source of Kurtosis ($K_{iso}$)
 
         Notes
         -----
-        The K_iso is defined as :
+        The $K_{iso}$ is defined as :
 
-        :math::
-            $$ K_{\text{iso}} = 3 \cdot \frac{V(\overline{D}^c)}{\overline{D}^2} $$
+        .. math::
 
-        where: $ K_{\text{iso}} $ is the isotropic kurtosis,
-            \(V({\overline{D}^c})\) represents the variance of the diffusion
-            tensor raised to the power c,
-            \(\overline{D}\) is the mean of the diffusion tensor.
+            K_{\text{iso}} = 3 \cdot \frac{V(\overline{D}^c)}{\overline{D}^2}
+
+        where: $K_{\text{iso}}$ is the isotropic kurtosis, $V({\overline{D}^c})$
+        represents the variance of the diffusion tensor raised to the power $c$,
+        $\overline{D}$ is the mean of the diffusion tensor.
 
         """
         C = self.ct
@@ -470,9 +470,9 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
 
             Notes
             -----
-            $K_total$ is defined as :
+            $K_{total}$ is defined as:
 
-            :math::
+            .. math::
                 \[\Psi = \frac{2}{5} \cdot \frac{D_{11}^2 + D_{22}^2 + D_{33}^2
                                                  + 2D_{12}^2 + 2D_{13}^2 +
                                                  2D_{23}^2{\overline{D}^2} -
@@ -482,12 +482,11 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
                                                       + 2W_{1133} + 2W_{2233})\
                   ]
 
-            where \(\Psi\) is a variable representing a part of the total
-            excess kurtosis,
-            \(D_{ij}\) are elements of the diffusion tensor,
-            \(\overline{D}\) is the mean of the diffusion tensor.
-            \{\overline{W}} is the mean kurtosis,
-            \(W_{ijkl}\) are elements of the kurtosis tensor.
+            where $\Psi$ is a variable representing a part of the total
+            excess kurtosis, $D_{ij}$ are elements of the diffusion tensor,
+            $\overline{D}$ is the mean of the diffusion tensor. $\overline{W}$
+            is the mean kurtosis, $W_{ijkl}$ are elements of the kurtosis
+            tensor.
         """
 
         mean_K = self.mkt()

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -209,8 +209,10 @@ class CorrelationTensorModel(ReconstModel):
             A GradientTable class instance for second DDE diffusion epoch
         fit_method : str or callable, optional
             Fitting method.
-        args, kwargs :
-            arguments and key-word arguments passed to the fit_method.
+        *args
+            Variable length argument list passed to the fit method.
+        **kwargs
+            Arbitrary keyword arguments passed to the fit method.
 
         """
         self.gtab1 = gtab1

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -294,7 +294,7 @@ class CorrelationTensorModel(ReconstModel):
             A GradientTable class instance for second DDE diffusion epoch
         S0 : float or ndarray (optional)
             The non diffusion-weighted signal in every voxel, or across all
-            voxels. Default: 1
+            voxels.
 
         Returns
         -------

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -143,11 +143,13 @@ def cti_prediction(cti_params, gtab1, gtab2, S0=1):
     cti_params: numpy.ndarray (..., 48)
     All parameters estimated from the correlation tensor model.
     Parameters are ordered as follows:
+
         1. Three diffusion tensor's eigenvalues
         2. Three lines of the eigenvector matrix each containing the
-        first, second and third coordinates of the eigenvector
+           first, second and third coordinates of the eigenvector
         3. Fifteen elements of the kurtosis tensor
         4. Twenty-One elements of the covariance tensor
+
     gtab1: dipy.core.gradients.GradientTable
         A GradientTable class instance for first DDE diffusion epoch
 
@@ -280,9 +282,10 @@ class CorrelationTensorModel(ReconstModel):
 
             1. Three diffusion tensor's eigenvalues
             2. Three lines of the eigenvector matrix each containing the
-            first, second and third coordinates of the eigenvector
+               first, second and third coordinates of the eigenvector
             3. Fifteen elements of the kurtosis tensor
             4. Twenty-One elements of the covariance tensor
+
         gtab1: dipy.core.gradients.GradientTable
             A GradientTable class instance for first DDE diffusion epoch
         gtab2: dipy.core.gradients.GradientTable
@@ -313,6 +316,7 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
         model_params : ndarray (x, y, z, 48) or (n, 48)
             All parameters estimated from the diffusion kurtosis model.
             Parameters are ordered as follows:
+
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector
@@ -342,9 +346,10 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
 
                 1. Three diffusion tensor's eigenvalues
                 2. Three lines of the eigenvector matrix each containing the
-                first, second and third coordinates of the eigenvector
+                   first, second and third coordinates of the eigenvector
                 3. Fifteen elements of the kurtosis tensor
                 4. Twenty-One elements of the covariance tensor
+
         gtab1: dipy.core.gradients.GradientTable
             A GradientTable class instance for first DDE diffusion epoch
         gtab2: dipy.core.gradients.GradientTable
@@ -565,6 +570,7 @@ def ls_fit_cti(
     cti_params : array (48)
     All parameters estimated from the diffusion kurtosis model for all N
     voxels. Parameters are ordered as follows:
+
         1) Three diffusion tensor eigenvalues.
         2) Three blocks of three elements, containing the first second and
             third coordinates of the diffusion tensor eigenvectors.

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -2742,16 +2742,16 @@ def Wrotate(kt, Basis):
 
     Notes
     -----
-    KT elements are assumed to be ordered as follows:
+    The kurtosis tensor elements are assumed to be ordered as follows:
 
     .. math::
 
-    \begin{matrix} ( & W_{xxxx} & W_{yyyy} & W_{zzzz} & W_{xxxy} & W_{xxxz}
-                     & ... \\
-                     & W_{xyyy} & W_{yyyz} & W_{xzzz} & W_{yzzz} & W_{xxyy}
-                     & ... \\
-                     & W_{xxzz} & W_{yyzz} & W_{xxyz} & W_{xyyz} & W_{xyzz}
-                     & & )\end{matrix}
+    KT =
+    \begin{pmatrix}
+        W_{xxxx} & W_{yyyy} & W_{zzzz} & W_{xxxy} & W_{xxxz} \\
+        W_{xyyy} & W_{yyyz} & W_{xzzz} & W_{yzzz} & W_{xxyy} \\
+        W_{xxzz} & W_{yyzz} & W_{xxyz} & W_{xyyz} & W_{xyzz}
+    \end{pmatrix}
 
     References
     ----------
@@ -2882,12 +2882,12 @@ def Wcons(k_elements):
 
     .. math::
 
-    \begin{matrix} ( & W_{xxxx} & W_{yyyy} & W_{zzzz} & W_{xxxy} & W_{xxxz}
-                     & ... \\
-                     & W_{xyyy} & W_{yyyz} & W_{xzzz} & W_{yzzz} & W_{xxyy}
-                     & ... \\
-                     & W_{xxzz} & W_{yyzz} & W_{xxyz} & W_{xyyz} & W_{xyzz}
-                     & & )\end{matrix}
+    KT =
+    \begin{pmatrix}
+        W_{xxxx} & W_{yyyy} & W_{zzzz} & W_{xxxy} & W_{xxxz} \\
+        W_{xyyy} & W_{yyyz} & W_{xzzz} & W_{yzzz} & W_{xxyy} \\
+        W_{xxzz} & W_{yyzz} & W_{xxyz} & W_{xyyz} & W_{xyzz}
+    \end{pmatrix}
 
     Returns
     -------

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1787,7 +1787,7 @@ class DiffusionKurtosisModel(ReconstModel):
 
             callable has to have the signature:
                 fit_method(design_matrix, data, *args, **kwargs).
-            Default: "WLS"
+                Default: "WLS"
         return_S0_hat : bool
             Boolean to return (True) or not (False) the S0 values for the fit.
         *args

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1790,8 +1790,10 @@ class DiffusionKurtosisModel(ReconstModel):
             Default: "WLS"
         return_S0_hat : bool
             Boolean to return (True) or not (False) the S0 values for the fit.
-        args, kwargs :
-            arguments and key-word arguments passed to the fit_method.
+        *args
+            Variable length argument list passed to the fit method.
+        **kwargs
+            Arbitrary keyword arguments passed to the fit method.
 
         References
         ----------

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -633,7 +633,7 @@ def apparent_kurtosis_coef(
         Because negative eigenvalues are not physical and small eigenvalues
         cause quite a lot of noise in diffusion-based metrics, diffusivity
         values smaller than `min_diffusivity` are replaced with
-        `min_diffusivity`. Default = 0
+        `min_diffusivity`.
     min_kurtosis : float (optional)
         Because high-amplitude negative values of kurtosis are not physically
         and biologicaly pluasible, and these cause artefacts in
@@ -742,10 +742,10 @@ def mean_kurtosis(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=3, analytical=
     max_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, mean
         kurtosis values that are larger than `max_kurtosis` are replaced with
-        `max_kurtosis`. Default = 10
+        `max_kurtosis`.
     analytical : bool (optional)
         If True, MK is calculated using its analytical solution, otherwise an
-        exact numerical estimator is used (see Notes). Default is set to True
+        exact numerical estimator is used (see Notes).
 
     Returns
     -------
@@ -1787,7 +1787,7 @@ class DiffusionKurtosisModel(ReconstModel):
 
             callable has to have the signature:
                 ``fit_method(design_matrix, data, *args, **kwargs)``
-                Default: "WLS"
+
         return_S0_hat : bool
             Boolean to return (True) or not (False) the S0 values for the fit.
         *args
@@ -2184,12 +2184,12 @@ class DiffusionKurtosisFit(TensorFit):
         max_kurtosis : float (optional)
             To keep kurtosis values within a plausible biophysical range, axial
             kurtosis values that are larger than `max_kurtosis` are replaced
-            with `max_kurtosis`. Default = 10
+            with `max_kurtosis`.
         analytical : bool (optional)
             If True, AK is calculated from rotated diffusion kurtosis tensor,
             otherwise it will be computed from the apparent diffusion kurtosis
             values along the principal axis of the diffusion tensor
-            (see notes). Default is set to True.
+            (see notes).
 
         Returns
         -------

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1786,7 +1786,7 @@ class DiffusionKurtosisModel(ReconstModel):
                    See func:`dki.cls_fit_dki`.
 
             callable has to have the signature:
-                fit_method(design_matrix, data, *args, **kwargs).
+                ``fit_method(design_matrix, data, *args, **kwargs)``
                 Default: "WLS"
         return_S0_hat : bool
             Boolean to return (True) or not (False) the S0 values for the fit.

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -620,8 +620,9 @@ def apparent_kurtosis_coef(
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
+
         1) Three diffusion tensor's eigenvalues
         2) Three lines of the eigenvector matrix each containing the first,
             second and third coordinates of the eigenvectors respectively
@@ -726,11 +727,12 @@ def mean_kurtosis(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=3, analytical=
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
+
         1) Three diffusion tensor's eigenvalues
         2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
+           second and third coordinates of the eigenvector
         3) Fifteen elements of the kurtosis tensor
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, mean
@@ -1011,10 +1013,12 @@ def radial_kurtosis(
     dki_params : ndarray (x, y, z, 27) or (n, 27)
     All parameters estimated from the diffusion kurtosis model.
     Parameters are ordered as follows:
+
         1) Three diffusion tensor's eigenvalues
         2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
+           second and third coordinates of the eigenvector
         3) Fifteen elements of the kurtosis tensor
+
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, radial
         kurtosis values that are smaller than `min_kurtosis` are replaced with
@@ -1151,10 +1155,12 @@ def axial_kurtosis(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=10, analytica
     dki_params : ndarray (x, y, z, 27) or (n, 27)
     All parameters estimated from the diffusion kurtosis model.
     Parameters are ordered as follows:
+
         1) Three diffusion tensor's eigenvalues
         2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
+           second and third coordinates of the eigenvector
         3) Fifteen elements of the kurtosis tensor
+
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, axial
         kurtosis values that are smaller than `min_kurtosis` are replaced with
@@ -1365,10 +1371,12 @@ def kurtosis_maximum(dki_params, sphere="repulsion100", gtol=1e-2, mask=None):
     dki_params : ndarray (x, y, z, 27) or (n, 27)
     All parameters estimated from the diffusion kurtosis model.
     Parameters are ordered as follows:
+
         1) Three diffusion tensor's eingenvalues
         2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
+           second and third coordinates of the eigenvector
         3) Fifteen elements of the kurtosis tensor
+
     sphere : Sphere class instance, optional
         The sphere providing sample directions for the initial search of the
         maximal value of kurtosis.
@@ -1438,10 +1446,12 @@ def mean_kurtosis_tensor(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=10):
     dki_params : ndarray (x, y, z, 27) or (n, 27)
     All parameters estimated from the diffusion kurtosis model.
     Parameters are ordered as follows:
+
         1) Three diffusion tensor's eigenvalues
         2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
+           second and third coordinates of the eigenvector
         3) Fifteen elements of the kurtosis tensor
+
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, mean
         kurtosis values that are smaller than `min_kurtosis` are replaced with
@@ -1515,10 +1525,12 @@ def radial_tensor_kurtosis(dki_params, *, min_kurtosis=-3.0 / 7, max_kurtosis=10
     dki_params : ndarray (x, y, z, 27) or (n, 27)
         All parameters estimated from the diffusion kurtosis model.
         Parameters are ordered as follows:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the first,
                second and third coordinates of the eigenvector
             3) Fifteen elements of the kurtosis tensor
+
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, radial
         kurtosis values that are smaller than `min_kurtosis` are replaced with
@@ -1765,12 +1777,14 @@ class DiffusionKurtosisModel(ReconstModel):
             The gradient table for the data set.
         fit_method : str or callable, optional
             str be one of the following:
-                'OLS' or 'ULLS' for ordinary least squares.
-                'WLS', 'WLLS' or 'UWLLS' for weighted ordinary least squares.
-                    See dki.ls_fit_dki.
-                'CLS' for LMI constrained ordinary least squares [3].
-                'CWLS' for LMI constrained weighted least squares [3].
-                    See dki.cls_fit_dki.
+
+                - 'OLS' or 'ULLS' for ordinary least squares.
+                - 'WLS', 'WLLS' or 'UWLLS' for weighted ordinary least squares.
+                   See func:`dki.ls_fit_dki`.
+                - 'CLS' for LMI constrained ordinary least squares [3]_.
+                - 'CWLS' for LMI constrained weighted least squares [3]_.
+                   See func:`dki.cls_fit_dki`.
+
             callable has to have the signature:
                 fit_method(design_matrix, data, *args, **kwargs).
             Default: "WLS"
@@ -2004,9 +2018,10 @@ class DiffusionKurtosisFit(TensorFit):
             All parameters estimated from the diffusion kurtosis model,
             not including S0.
             Parameters are ordered as follows:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the
-                first, second and third coordinates of the eigenvector
+               first, second and third coordinates of the eigenvector
             3) Fifteen elements of the kurtosis tensor
         model_S0 : ndarray (x, y, z, 1) or (n, 1), optional
             S0 estimated from the diffusion kurtosis model.
@@ -2522,12 +2537,13 @@ def params_to_dki_params(result, min_diffusivity=0):
     Returns
     -------
     dki_params : array (27)
-    All parameters estimated from the diffusion kurtosis model for all N
-    voxels. Parameters are ordered as follows:
-        1) Three diffusion tensor eigenvalues.
-        2) Three blocks of three elements, containing the first second and
-            third coordinates of the diffusion tensor eigenvectors.
-        3) Fifteen elements of the kurtosis tensor.
+        All parameters estimated from the diffusion kurtosis model for all N
+        voxels. Parameters are ordered as follows:
+
+            1) Three diffusion tensor eigenvalues.
+            2) Three blocks of three elements, containing the first second and
+               third coordinates of the diffusion tensor eigenvectors.
+            3) Fifteen elements of the kurtosis tensor.
 
     """
 
@@ -2583,12 +2599,13 @@ def ls_fit_dki(
     Returns
     -------
     dki_params : array (27)
-    All parameters estimated from the diffusion kurtosis model for all N
-    voxels. Parameters are ordered as follows:
-        1) Three diffusion tensor eigenvalues.
-        2) Three blocks of three elements, containing the first second and
-            third coordinates of the diffusion tensor eigenvectors.
-        3) Fifteen elements of the kurtosis tensor.
+        All parameters estimated from the diffusion kurtosis model for all N
+        voxels. Parameters are ordered as follows:
+
+            1) Three diffusion tensor eigenvalues.
+            2) Three blocks of three elements, containing the first second and
+               third coordinates of the diffusion tensor eigenvectors.
+            3) Fifteen elements of the kurtosis tensor.
 
     References
     ----------
@@ -2664,12 +2681,13 @@ def cls_fit_dki(
     Returns
     -------
     dki_params : array (27)
-    All parameters estimated from the diffusion kurtosis model for all N
-    voxels. Parameters are ordered as follows:
-        1) Three diffusion tensor eigenvalues.
-        2) Three blocks of three elements, containing the first second and
-            third coordinates of the diffusion tensor eigenvectors.
-        3) Fifteen elements of the kurtosis tensor.
+        All parameters estimated from the diffusion kurtosis model for all N
+        voxels. Parameters are ordered as follows:
+
+            1) Three diffusion tensor eigenvalues.
+            2) Three blocks of three elements, containing the first second and
+               third coordinates of the diffusion tensor eigenvectors.
+            3) Fifteen elements of the kurtosis tensor.
 
     References
     ----------
@@ -2898,12 +2916,13 @@ def split_dki_param(dki_params):
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
+
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
 
     Returns
     -------

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1791,9 +1791,9 @@ class DiffusionKurtosisModel(ReconstModel):
         return_S0_hat : bool
             Boolean to return (True) or not (False) the S0 values for the fit.
         *args
-            Variable length argument list passed to the fit method.
+            Variable length argument list passed to the :func:`fit` method.
         **kwargs
-            Arbitrary keyword arguments passed to the fit method.
+            Arbitrary keyword arguments passed to the :func:`fit` method.
 
         References
         ----------

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -340,7 +340,8 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
                 fit_method(design_matrix, data, *args, **kwargs)
 
         args, kwargs : arguments and key-word arguments passed to the
-           fit_method. See dki.ols_fit_dki, dki.wls_fit_dki for details
+           fit_method. See :func:`dki.ols_fit_dki`, :func:`dki.wls_fit_dki` for
+           details
 
         References
         ----------

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -37,6 +37,7 @@ def axonal_water_fraction(dki_params, sphere="repulsion100", gtol=1e-2, mask=Non
     dki_params : ndarray (x, y, z, 27) or (n, 27)
         All parameters estimated from the diffusion kurtosis model.
         Parameters are ordered as follows:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the first,
                second and third coordinates of the eigenvector
@@ -81,6 +82,7 @@ def diffusion_components(dki_params, sphere="repulsion100", awf=None, mask=None)
     dki_params : ndarray (x, y, z, 27) or (n, 27)
         All parameters estimated from the diffusion kurtosis model.
         Parameters are ordered as follows:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the first,
                second and third coordinates of the eigenvector
@@ -189,8 +191,10 @@ def dkimicro_prediction(params, gtab, S0=1):
     Parameters
     ----------
     params : ndarray (x, y, z, 40) or (n, 40)
-    All parameters estimated from the diffusion kurtosis microstructure model.
+        All parameters estimated from the diffusion kurtosis microstructure
+        model.
         Parameters are ordered as follows:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the
                first, second and third coordinates of the eigenvector
@@ -321,12 +325,13 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
             Gradient table.
         fit_method : str or callable
             str can be one of the following:
-            'OLS' or 'ULLS' to fit the diffusion tensor and kurtosis tensor
-            using the ordinary linear least squares solution
-                dki.ols_fit_dki
-            'WLS' or 'UWLLS' to fit the diffusion tensor and kurtosis tensor
-            using the ordinary linear least squares solution
-                dki.wls_fit_dki
+
+            - 'OLS' or 'ULLS' to fit the diffusion tensor and kurtosis tensor
+              using the ordinary linear least squares solution
+              `:func:dki.ols_fit_dki`
+            - 'WLS' or 'UWLLS' to fit the diffusion tensor and kurtosis tensor
+              using the ordinary linear least squares solution
+              :func:`dki.wls_fit_dki`
 
             callable has to have the signature:
                 fit_method(design_matrix, data, *args, **kwargs)
@@ -420,6 +425,7 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
             All parameters estimated from the diffusion kurtosis
             microstructural model.
             Parameters are ordered as follows:
+
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector
@@ -427,6 +433,7 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
                 4) Six elements of the hindered diffusion tensor
                 5) Six elements of the restricted diffusion tensor
                 6) Axonal water fraction
+
         S0 : float or ndarray (optional)
             The non diffusion-weighted signal in every voxel, or across all
             voxels. Default: 1
@@ -460,6 +467,7 @@ class KurtosisMicrostructuralFit(DiffusionKurtosisFit):
             All parameters estimated from the diffusion kurtosis
             microstructural model.
             Parameters are ordered as follows:
+
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -93,7 +93,7 @@ def diffusion_components(dki_params, sphere="repulsion100", awf=None, mask=None)
     awf : ndarray (optional)
         Array containing values of the axonal water fraction that has the shape
         dki_params.shape[:-1]. If not given this will be automatically computed
-        using :func:`axonal_water_fraction`" with function's default precision.
+        using :func:`axonal_water_fraction` with function's default precision.
     mask : ndarray (optional)
         A boolean array used to mark the coordinates in the data that should be
         analyzed that has the shape dki_params.shape[:-1]

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -87,8 +87,7 @@ def diffusion_components(dki_params, sphere="repulsion100", awf=None, mask=None)
             3) Fifteen elements of the kurtosis tensor
     sphere : Sphere class instance, optional
         The sphere providing sample directions to sample the restricted and
-        hindered cellular diffusion tensors. For more details see Fieremans
-        et al., 2011.
+        hindered cellular diffusion tensors. For more details see [1]_.
     awf : ndarray (optional)
         Array containing values of the axonal water fraction that has the shape
         dki_params.shape[:-1]. If not given this will be automatically computed

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -337,7 +337,7 @@ class KurtosisMicrostructureModel(DiffusionKurtosisModel):
               :func:`dki.wls_fit_dki`
 
             callable has to have the signature:
-                fit_method(design_matrix, data, *args, **kwargs)
+                ``fit_method(design_matrix, data, *args, **kwargs)``
 
         args, kwargs : arguments and key-word arguments passed to the
            fit_method. See :func:`dki.ols_fit_dki`, :func:`dki.wls_fit_dki` for

--- a/dipy/reconst/dki_micro.py
+++ b/dipy/reconst/dki_micro.py
@@ -216,16 +216,19 @@ def dkimicro_prediction(params, gtab, S0=1):
     Notes
     -----
     1) The predicted signal is given by:
-    $S(\theta, b) = S_0 * [f * e^{-b ADC_{r}} + (1-f) * e^{-b ADC_{h}]$, where
-    $ ADC_{r} and ADC_{h} are the apparent diffusion coefficients of the
-    diffusion hindered and restricted compartment for a given direction
-    $\theta$, $b$ is the b value provided in the GradientTable input for that
-    direction, $f$ is the volume fraction of the restricted diffusion
-    compartment (also known as the axonal water fraction).
+       .. math::
+
+           S(\theta, b) = S_0 * [f * e^{-b ADC_{r}} + (1-f) * e^{-b ADC_{h}]
+
+       where $ADC_{r}$ and $ADC_{h}$ are the apparent diffusion coefficients of
+       the diffusion hindered and restricted compartment for a given direction
+       $\theta$, $b$ is the b value provided in the GradientTable input for that
+       direction, $f$ is the volume fraction of the restricted diffusion
+       compartment (also known as the axonal water fraction).
 
     2) In the original article of DKI microstructural model [1]_, the hindered
-    and restricted tensors were defined as the intra-cellular and
-    extra-cellular diffusion compartments respectively.
+       and restricted tensors were defined as the intra-cellular and
+       extra-cellular diffusion compartments respectively.
     """
 
     # Initialize pred_sig

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -374,6 +374,7 @@ def hanning_filter(gtab, filter_width, origin):
     gtab : GradientTable
         Gradient table.
     filter_width : int
+        Strength of the Hanning filter.
     origin : (3,) ndarray
         center of qspace
 

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -397,11 +397,11 @@ def pdf_interp_coords(sphere, rradius, origin):
     Parameters
     ----------
     sphere : object,
-            Sphere
+        Sphere
     rradius : array, shape (N,)
-            line interpolation points
+        line interpolation points
     origin : array, shape (3,)
-            center of the grid
+        center of the grid
 
     """
     interp_coords = rradius * sphere.vertices[np.newaxis].T

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -2282,6 +2282,7 @@ def quantize_evecs(evecs, odf_vertices=None):
     Parameters
     ----------
     evecs : ndarray
+        Eigenvectors.
     odf_vertices : ndarray, optional
         If None, then set vertices from symmetric362 sphere.  Otherwise use
         passed ndarray as vertices

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -718,7 +718,7 @@ class TensorModel(ReconstModel):
                 :func:`dti.restore_fit_tensor`
 
             callable has to have the signature:
-              fit_method(design_matrix, data, *args, **kwargs)
+              ``fit_method(design_matrix, data, *args, **kwargs)``
 
         return_S0_hat : bool, optional
             Boolean to return (True) or not (False) the S0 values for the fit.
@@ -1321,7 +1321,7 @@ def iter_fit_tensor(step=1e4):
         fit_tensor : callable
             A tensor fitting callable (most likely a function). The callable
             has to have the signature:
-              fit_method(design_matrix, data, *args, **kwargs)
+              ``fit_method(design_matrix, data, *args, **kwargs)``
         """
 
         @functools.wraps(fit_tensor)

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -447,7 +447,8 @@ def norm(q_form):
     -----
     The Frobenius norm is defined as:
 
-    :math:
+    .. math::
+
         ||A||_F = [\sum_{i,j} abs(a_{i,j})^2]^{1/2}
 
     See Also

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -724,7 +724,8 @@ class TensorModel(ReconstModel):
             Boolean to return (True) or not (False) the S0 values for the fit.
 
         args, kwargs : arguments and key-word arguments passed to the
-           fit_method. See dti.wls_fit_tensor, dti.ols_fit_tensor for details
+           fit_method. See :func:`dti.wls_fit_tensor`,
+           :func:`dti.ols_fit_tensor` for details
 
         min_signal : float, optional
             The minimum signal value. Needs to be a strictly positive

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -195,6 +195,7 @@ class FreeWaterTensorFit(TensorFit):
         model_params : ndarray (x, y, z, 13) or (n, 13)
             All parameters estimated from the free water tensor model.
             Parameters are ordered as follows:
+
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -210,13 +210,11 @@ class IvimModelTRR(ReconstModel):
             used while estimating the value of D. The assumption is that at
             higher b values the effects of perfusion is less and hence the
             signal can be approximated as a mono-exponential decay.
-            default : 400.
 
         split_b_S0 : float, optional
             The b-value to split the data on for two-stage fit for estimation
             of S0 and initial guess for D_star. The assumption here is that
             at low bvalues the effects of perfusion are more.
-            default : 200.
 
         bounds : tuple of arrays with 4 elements, optional
             Bounds to constrain the fitted model parameters. This is only
@@ -231,32 +229,26 @@ class IvimModelTRR(ReconstModel):
             parameters after the linear fitting by splitting the data based on
             bvalues. This gives more accurate parameters but takes more time.
             The linear fit can be used to get a quick estimation of the
-            parameters. default : False
+            parameters.
 
         tol : float, optional
             Tolerance for convergence of minimization.
-            default : 1e-15
 
         x_scale : array-like, optional
             Scaling for the parameters. This is passed to `least_squares` which
             is only available for Scipy version > 0.17.
-            default: [1000, 0.01, 0.001, 0.0001]
 
         gtol : float, optional
             Tolerance for termination by the norm of the gradient.
-            default : 1e-15
 
         ftol : float, optional
             Tolerance for termination by the change of the cost function.
-            default : 1e-15
 
         eps : float, optional
             Step size used for numerical approximation of the jacobian.
-            default : 1e-15
 
         maxiter : int, optional
             Maximum number of iterations to perform.
-            default : 1000
 
         References
         ----------
@@ -539,11 +531,9 @@ class IvimModelVP(ReconstModel):
         maxiter: int, optional
             Maximum number of iterations for the Differential Evolution in
             SciPy.
-            default : 10
 
         xtol : float, optional
             Tolerance for convergence of minimization.
-            default : 1e-8
 
         References
         ----------

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -194,14 +194,11 @@ class IvimModelTRR(ReconstModel):
         extracellular water, with a diffusion coefficient D. In this model
         the echo attenuation of a signal in a single voxel can be written as
 
-            .. math::
+        .. math::
 
             S(b) = S_0[f*e^{(-b*D\*)} + (1-f)e^{(-b*D)}]
 
-            Where:
-            .. math::
-
-            S_0, f, D\* and D are the IVIM parameters.
+        where $S_0$, $f$, $D\*$ and $D$ are the IVIM parameters.
 
         Parameters
         ----------
@@ -533,15 +530,11 @@ class IvimModelVP(ReconstModel):
         extracellular water, with a diffusion coefficient D. In this model
         the echo attenuation of a signal in a single voxel can be written as
 
-            .. math::
+        .. math::
 
             S(b) = S_0*[f*e^{(-b*D\*)} + (1-f)e^{(-b*D)}]
 
-            Where:
-            .. math::
-
-            S_0, f, D\* and D are the IVIM parameters.
-
+        where $S_0$, $f$, $D\*$ and $D$ are the IVIM parameters.
 
         maxiter: int, optional
             Maximum number of iterations for the Differential Evolution in

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1021,8 +1021,8 @@ class MapmriFit(ReconstFit):
         return E
 
     def predict(self, qvals_or_gtab, S0=100.0):
-        r"""Recovers the reconstructed signal for any qvalue array or
-        gradient table.
+        """Recovers the reconstructed signal for any qvalue array or gradient
+        table.
         """
         if isinstance(qvals_or_gtab, np.ndarray):
             q = qvals_or_gtab

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1010,9 +1010,9 @@ class MapmriFit(ReconstFit):
         return norm_of_laplacian
 
     def fitted_signal(self, gtab=None):
-        """
-        Recovers the fitted signal for the given gradient table. If no gradient
-        table is given it recovers the signal for the gtab of the model object.
+        """Recovers the fitted signal for the given gradient table. If no
+        gradient table is given it recovers the signal for the gtab of the model
+        object.
         """
         if gtab is None:
             E = self.predict(self.model.gtab, S0=1.0)

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1988,8 +1988,8 @@ def map_laplace_u(n, m):
     References
     ----------
     .. [1] Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
-    using Laplacian-regularized MAP-MRI and its application to HCP data."
-    NeuroImage (2016).
+       using Laplacian-regularized MAP-MRI and its application to HCP data."
+       NeuroImage (2016).
 
     """
     return (-1) ** n * delta(n, m) / (2 * np.sqrt(np.pi))
@@ -2011,8 +2011,8 @@ def map_laplace_t(n, m):
     References
     ----------
     .. [1] Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
-    using Laplacian-regularized MAP-MRI and its application to HCP data."
-    NeuroImage (2016).
+       using Laplacian-regularized MAP-MRI and its application to HCP data."
+       NeuroImage (2016).
 
     """
     a = np.sqrt((m - 1) * m) * delta(m - 2, n)
@@ -2037,8 +2037,8 @@ def map_laplace_s(n, m):
     References
     ----------
     .. [1] Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
-    using Laplacian-regularized MAP-MRI and its application to HCP data."
-    NeuroImage (2016).
+       using Laplacian-regularized MAP-MRI and its application to HCP data."
+       NeuroImage (2016).
 
     """
 

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1079,8 +1079,8 @@ class QtdmriFit:
         fitted signal contains spurious oscillations. A high laplacian norm may
         indicate that these are present, and any q-space indices that
         use integrals of the signal may be corrupted (e.g. RTOP, RTAP, RTPP,
-        QIV). In contrast to [1], the Laplacian now describes oscillations in
-        the 4-dimensional qt-signal [2].
+        QIV). In contrast to [1]_, the Laplacian now describes oscillations in
+        the 4-dimensional qt-signal [2]_.
 
         References
         ----------

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1025,8 +1025,8 @@ class QtdmriFit:
         return E
 
     def predict(self, qvals_or_gtab, S0=1.0):
-        r"""Recovers the reconstructed signal for any qvalue array or
-        gradient table.
+        """Recovers the reconstructed signal for any qvalue array or gradient
+        table.
         """
         tau_scaling = self.tau_scaling
         if isinstance(qvals_or_gtab, np.ndarray):

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1014,9 +1014,9 @@ class QtdmriFit:
         return qiv
 
     def fitted_signal(self, gtab=None):
-        """
-        Recovers the fitted signal for the given gradient table. If no gradient
-        table is given it recovers the signal for the gtab of the model object.
+        """Recovers the fitted signal for the given gradient table. If no
+        gradient table is given it recovers the signal for the gtab of the model
+        object.
         """
         if gtab is None:
             E = self.predict(self.model.gtab)

--- a/dipy/reconst/rumba.py
+++ b/dipy/reconst/rumba.py
@@ -901,24 +901,30 @@ def rumba_deconv_global(
     -----
     TV modifies our cost function as follows:
 
-    $J(\textbf{f}) = -\log{P(\textbf{S}|\textbf{H}, \textbf{f}, \sigma^2, n)})+
-    \alpha_{TV}TV(\textbf{f})$
+    .. math::
+
+    J(\textbf{f}) = -\log{P(\textbf{S}|\textbf{H}, \textbf{f}, \sigma^2, n)})+
+    \alpha_{TV}TV(\textbf{f})
 
     where the first term is the negative log likelihood described in the notes
     of `rumba_deconv`, and the second term is the TV energy, or the sum of
     gradient absolute values for the fODF across the entire brain. This results
     in a new multiplicative factor in the iterative scheme, now becoming:
 
-    $\textbf{f}^{k+1} = \textbf{f}^k \circ \frac{\textbf{H}^T\left[\textbf{S}
+    .. math::
+
+    \textbf{f}^{k+1} = \textbf{f}^k \circ \frac{\textbf{H}^T\left[\textbf{S}
     \circ\frac{I_n(\textbf{S}\circ\textbf{Hf}^k/\sigma^2)} {I_{n-1}(\textbf{S}
     \circ\textbf{Hf}^k/\sigma^2)} \right ]} {\textbf{H}^T\textbf{Hf}^k}\circ
-    \textbf{R}^k$
+    \textbf{R}^k
 
     where $\textbf{R}^k$ is computed voxelwise by:
 
-    $(\textbf{R}^k)_j = \frac{1}{1 - \alpha_{TV}div\left(\frac{\triangledown[
+    .. math::
+
+    (\textbf{R}^k)_j = \frac{1}{1 - \alpha_{TV}div\left(\frac{\triangledown[
     \textbf{f}^k_{3D}]_j}{\lvert\triangledown[\textbf{f}^k_{3D}]_j \rvert}
-    \right)\biggr\rvert_{x, y, z}}$
+    \right)\biggr\rvert_{x, y, z}}
 
     Here, $\triangledown$ is the symbol for the 3D gradient at any voxel.
 

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -130,6 +130,7 @@ class IsotropicFit(ReconstFit):
         Parameters
         ----------
         model : IsotropicModel class instance
+            Isotropic model.
         params : ndarray
             The mean isotropic model parameters (the mean diffusion-weighted
             signal in each voxel).

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -365,7 +365,6 @@ class SparseFascicleModel(ReconstModel, Cache):
         response : (3,) array-like, optional
             The eigenvalues of a canonical tensor to be used as the response
             function of single-fascicle signals.
-            Default:[0.0015, 0.0005, 0.0005]
 
         solver : string, or initialized linear model object.
             This will determine the algorithm used to solve the set of linear
@@ -376,15 +375,14 @@ class SparseFascicleModel(ReconstModel, Cache):
             `sklearn.linear_model.ElasticNet`, `sklearn.linear_model.Lasso` or
             `sklearn.linear_model.Ridge` and other objects that inherit from
             `sklearn.base.RegressorMixin`.
-            Default: 'ElasticNet'.
 
         l1_ratio : float, optional
             Sets the balance between L1 and L2 regularization in ElasticNet
-            [Zou2005]_. Default: 0.5
+            [Zou2005]_.
 
         alpha : float, optional
             Sets the balance between least-squares error and L1/L2
-            regularization in ElasticNet [Zou2005]_. Default: 0.001
+            regularization in ElasticNet [Zou2005]_.
 
         isotropic : IsotropicModel class instance
             This is a class that implements the function that calculates the
@@ -522,7 +520,6 @@ class SparseFascicleModel(ReconstModel, Cache):
               explicitly releases the GIL (for instance a Cython loop wrapped
               in a "with nogil" block or an expensive call to a library such
               as NumPy).
-            Default: 'multiprocessing'.
 
         Returns
         -------

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -509,6 +509,7 @@ class SparseFascicleModel(ReconstModel, Cache):
         parallel_backend: str, ParallelBackendBase instance or None
             Specify the parallelization backend implementation.
             Supported backends are:
+
             - "loky" used by default, can induce some
               communication and memory overhead when exchanging input and
               output data with the worker Python processes.

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -531,7 +531,7 @@ def shore_matrix(radial_order, zeta, gtab, tau=1 / (4 * np.pi**2)):
         scale factor
     gtab : GradientTable,
         gradient directions and bvalues container class
-    tau : float,
+    tau : float, optional
         diffusion time. By default the value that makes q=sqrt(b).
 
     References

--- a/dipy/reconst/utils.py
+++ b/dipy/reconst/utils.py
@@ -13,11 +13,14 @@ def dki_design_matrix(gtab):
     -------
     B : array (N, 22)
         Design matrix or B matrix for the DKI model
-        B[j, :] = (Bxx, Bxy, Byy, Bxz, Byz, Bzz,
-                   Bxxxx, Byyyy, Bzzzz, Bxxxy, Bxxxz,
-                   Bxyyy, Byyyz, Bxzzz, Byzzz, Bxxyy,
-                   Bxxzz, Byyzz, Bxxyz, Bxyyz, Bxyzz,
-                   BlogS0)
+
+        .. math::
+
+           B[j, :] = (Bxx, Bxy, Byy, Bxz, Byz, Bzz,
+                      Bxxxx, Byyyy, Bzzzz, Bxxxy, Bxxxz,
+                      Bxyyy, Byyyz, Bxzzz, Byzzz, Bxxyy,
+                      Bxxzz, Byyzz, Bxxyz, Bxyyz, Bxyzz,
+                      BlogS0)
 
     """
     b = gtab.bvals

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -173,6 +173,7 @@ def bundle_shape_similarity(
     bundle2 : Streamlines
         White matter tract from another subject (eg: AF_L)
     rng : np.random.Generator
+        Random number generator.
     clust_thr : array-like, optional
         list of clustering thresholds used in quickbundlesX
     threshold : float, optional
@@ -523,6 +524,7 @@ class RecoBundles:
             Use Streamline-based Linear Registration (SLR) locally
             (default True)
         slr_metric : BundleMinDistanceMetric
+            Bundle distance metric.
         slr_x0 : array or int or str
             Transformation allowed. translation, rigid, similarity or scaling
             Initial parametrization for the optimization.
@@ -557,7 +559,7 @@ class RecoBundles:
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])
             (default None)
         slr_bounds : array
-            (default None)
+            SLR bounds.
         slr_select : tuple
             Select the number of streamlines from model to neirborhood of
             model to perform the local SLR.
@@ -648,7 +650,9 @@ class RecoBundles:
         Parameters
         ----------
         model_bundle : Streamlines
+            Model bundle streamlines.
         pruned_streamlines : Streamlines
+            Pruned bundle streamlines.
         slr_select : tuple
             Select the number of streamlines from model to neighborhood of
             model to perform the local SLR.

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -555,7 +555,7 @@ class RecoBundles:
                 b) "similarity"
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1.])``
                 c) "affine"
-                    ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])
+                    ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])``
         slr_bounds : array
             SLR bounds.
         slr_select : tuple

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -521,8 +521,7 @@ class RecoBundles:
         reduction_distance : string
             Reduction distance type can be mdf or mam (default mdf)
         slr : bool
-            Use Streamline-based Linear Registration (SLR) locally
-            (default True)
+            Use Streamline-based Linear Registration (SLR) locally.
         slr_metric : BundleMinDistanceMetric
             Bundle distance metric.
         slr_x0 : array or int or str
@@ -557,7 +556,6 @@ class RecoBundles:
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1.])``
                 c) "affine"
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])
-            (default None)
         slr_bounds : array
             SLR bounds.
         slr_select : tuple
@@ -565,11 +563,10 @@ class RecoBundles:
             model to perform the local SLR.
         slr_method : string
             Optimization method 'L_BFGS_B' or 'Powell' optimizers can be used.
-            (default 'L-BFGS-B')
         pruning_thr : float
-            Pruning after reducing the search space (default 6).
+            Pruning after reducing the search space.
         pruning_distance : string
-            Pruning distance type can be mdf or mam (default mdf)
+            Pruning distance type can be mdf or mam.
 
         Returns
         -------

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -585,10 +585,10 @@ class RecoBundles:
             clustering, Neuroimage, 2017.
 
         .. [Chandio2020] Chandio, B.Q., Risacher, S.L., Pestilli, F.,
-        Bullock, D., Yeh, FC., Koudoro, S., Rokem, A., Harezlak, J., and
-        Garyfallidis, E. Bundle analytics, a computational framework for
-        investigating the shapes and profiles of brain pathways across
-        populations. Sci Rep 10, 17149 (2020)
+           Bullock, D., Yeh, FC., Koudoro, S., Rokem, A., Harezlak, J., and
+           Garyfallidis, E. Bundle analytics, a computational framework for
+           investigating the shapes and profiles of brain pathways across
+           populations. Sci Rep 10, 17149 (2020)
         """
         if self.verbose:
             t = time()

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -559,7 +559,7 @@ class RecoBundles:
         slr_bounds : array
             SLR bounds.
         slr_select : tuple
-            Select the number of streamlines from model to neirborhood of
+            Select the number of streamlines from model to neighborhood of
             model to perform the local SLR.
         slr_method : string
             Optimization method 'L_BFGS_B' or 'Powell' optimizers can be used.

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -722,6 +722,7 @@ def qbx_and_merge(
     Parameters
     ----------
     streamlines : Streamlines
+        Streamlines.
     thresholds : sequence
         List of distance thresholds for QuickBundlesX.
     nb_pts : int

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -235,7 +235,7 @@ class ClusterMap:
         Returns
         -------
         `Cluster` object(s)
-            When `idx` is a int, returns a single `Cluster` object.
+            When `idx` is an int, returns a single `Cluster` object.
 
             When `idx`is either a slice, list or boolean array, returns
             a list of `Cluster` objects.

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Decorators for dipy tests
 """

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """Test scripts
 
 Run scripts and check outputs

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -846,6 +846,7 @@ def transform_tracking_output(tracking_output, affine, *, save_seeds=False):
         The voxel_to_rasmm matrix, typically from a NIFTI file.
     save_seeds : bool, optional
         If set, seeds associated to streamlines will be also moved and returned
+
     Returns
     -------
     streamlines : generator

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -186,6 +186,7 @@ def check_peak_size(pams, *, ref_img_shape=None, sync_imgs=False):
     Parameters
     ----------
     pams : PeaksAndMetrics
+        Peaks and metrics.
     ref_img_shape : tuple, optional
         3D shape of the image, by default None.
     sync_imgs : bool, optional

--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -56,8 +56,8 @@ class PeakActor(Actor):
     affine : array, optional
         4x4 transformation array from native coordinates to world coordinates.
     colors : None or string ('rgb_standard') or tuple (3D or 4D) or
-             array/ndarray (N, 3 or 4) or array/ndarray (K, 3 or 4) or
-             array/ndarray(N, ) or array/ndarray (K, )
+        array/ndarray (N, 3 or 4) or array/ndarray (K, 3 or 4) or
+        array/ndarray(N, ) or array/ndarray (K, )
         If None a standard orientation colormap is used for every line.
         If one tuple of color is used. Then all streamlines will have the same
         color.

--- a/dipy/viz/panel.py
+++ b/dipy/viz/panel.py
@@ -75,9 +75,13 @@ def slicer_panel(
     Parameters
     ----------
     scene : Scene
+        Scene.
     iren : Interactor
+        Interactor.
     data : 3d ndarray
+        Data to be sliced.
     affine : 4x4 ndarray
+        Affine matrix.
     world_coords : bool
         If True then the affine is applied.
 

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -85,7 +85,8 @@ def overlay_images(
     fname : string (optional)
         the file name to write the resulting figure. If None (default), the
         image is not saved.
-    fig_kwargs: extra parameters for saving figure, e.g. `dpi=300`.
+    fig_kwargs : dict
+        Extra parameters for saving figure, e.g. `dpi=300`.
     """
     # Normalize the input images to [0,255]
     img0 = 255 * ((img0 - img0.min()) / (img0.max() - img0.min()))
@@ -215,7 +216,8 @@ def plot_2d_diffeomorphic_map(
     show_figure : bool, optional
         if True (default), the deformed grids will be plotted using matplotlib,
         else the grids are just returned
-    fig_kwargs: extra parameters for saving figure, e.g. `dpi=300`.
+    fig_kwargs : dict
+        Extra parameters for saving figure, e.g. `dpi=300`.
 
     Returns
     -------
@@ -339,7 +341,8 @@ def plot_slices(V, *, slice_indices=None, fname=None, **fig_kwargs):
     fname : string (optional)
         the name of the file to save the figure to. If None (default), the
         figure is not saved to disk.
-    fig_kwargs: extra parameters for saving figure, e.g. `dpi=300`.
+    fig_kwargs : dict
+        Extra parameters for saving figure, e.g. `dpi=300`.
     """
     if slice_indices is None:
         slice_indices = np.array(V.shape) // 2

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -339,17 +339,17 @@ class ImageRegistrationFlow(Workflow):
             Number of bins to discretize the joint and marginal PDF.
 
         sampling_prop : int, optional
-            Number ([0-100]) of voxels for calculating the PDF.
-             'None' implies all voxels.
+            Number ([0-100]) of voxels for calculating the PDF. None implies all
+            voxels.
 
         metric : string, optional
             Similarity metric for gathering mutual information).
 
         level_iters : variable int, optional
             The number of iterations at each scale of the scale space.
-             `level_iters[0]` corresponds to the coarsest scale,
-             `level_iters[-1]` the finest, where n is the length of the
-              sequence.
+            `level_iters[0]` corresponds to the coarsest scale,
+            `level_iters[-1]` the finest, where n is the length of the
+            sequence.
 
         sigmas : variable floats, optional
             Custom smoothing parameter to build the scale space (one parameter
@@ -389,8 +389,7 @@ class ImageRegistrationFlow(Workflow):
             Name for the saved affine matrix.
 
         out_quality : string, optional
-            Name of the file containing the saved quality
-             metric.
+            Name of the file containing the saved quality metric.
         """
 
         io_it = self.get_io_iterator()

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -330,10 +330,10 @@ class ImageRegistrationFlow(Workflow):
             Path to the moving image file.
 
         transform : string, optional
-            com: center of mass, trans: translation, rigid: rigid body,
-            rigid_isoscaling: rigid body + isotropic scaling, rigid_scaling:
-            rigid body + scaling, affine: full affine including translation,
-            rotation, shearing and scaling.
+            ``'com'``: center of mass; ``'trans'``: translation; ``'rigid'``:
+            rigid body; ``'rigid_isoscaling'``: rigid body + isotropic scaling,
+            ``'rigid_scaling'``: rigid body + scaling; ``'affine'``: full affine
+            including translation, rotation, shearing and scaling.
 
         nbins : int, optional
             Number of bins to discretize the joint and marginal PDF.

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -343,7 +343,7 @@ class ImageRegistrationFlow(Workflow):
             voxels.
 
         metric : string, optional
-            Similarity metric for gathering mutual information).
+            Similarity metric for gathering mutual information.
 
         level_iters : variable int, optional
             The number of iterations at each scale of the scale space.

--- a/dipy/workflows/docstring_parser.py
+++ b/dipy/workflows/docstring_parser.py
@@ -40,6 +40,7 @@ class Reader:
 
     def __init__(self, data):
         """
+
         Parameters
         ----------
         data : str

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -297,6 +297,7 @@ class SplitFlow(Workflow):
         input_files : variable string
             Any number of Nifti1 files
         vol_idx : int, optional
+            Index of the 3D volume to extract.
         out_dir : string, optional
             Output directory. (default current directory)
         out_split : string, optional

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -437,6 +437,7 @@ class LinearMixedModelsFlow(Workflow):
         title : string
             Title for the plot.
         bundle_name : string
+            Bundle name.
         x : list
             list containing segment/disk number for x-axis.
         y : list

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -62,6 +62,7 @@ class HorizonFlow(Workflow):
         Parameters
         ----------
         input_files : variable string
+            Filenames.
         cluster : bool, optional
             Enable QuickBundlesX clustering.
         rgb : bool, optional

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -18,6 +18,7 @@ obtain the underlying fiber distribution.
 
 In this way, the reconstruction of the fiber orientation distribution function
 (fODF) in CSD involves two steps:
+
     1. Estimation of the fiber response function
     2. Use the response function to reconstruct the fODF
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -127,13 +127,17 @@ See some of our :ref:`Past Announcements <old_news>`
    theory/index
    reference/index
    reference_cmd/index
+   recipes
    api_changes
    stateoftheart
    old_highlights
    old_news
    glossary
+   developers
+   gimbal_lock
    faq
    cite
+   subscribe
 
 .. Main content will be displayed using the jinja template
 

--- a/doc/release_notes/release1.4.1.rst
+++ b/doc/release_notes/release1.4.1.rst
@@ -43,7 +43,7 @@ Pull Requests (28):
 * :ghpull:`2373`: [FIX] warning if not the same number of points
 * :ghpull:`2372`: Expand patch radius if input is int
 * :ghpull:`2348`: RF: Use new name for this function.
-* :ghpull:`2363`: [ENH] Adding cython file(*.pyx) in documentation
+* :ghpull:`2363`: [ENH] Adding cython file(``*.pyx``) in documentation
 * :ghpull:`2365`: [DOC]: Change defaults in Patch2Self example
 * :ghpull:`2349`: [ENH] Allow for other statistics, like median, in afq_profile
 * :ghpull:`2350`: [FIX] Use npy_intp variables instead of int and size_t to iterate over numpy arrays
@@ -78,8 +78,8 @@ Issues (61):
 * :ghissue:`2341`: Allow use of all threads in the gibbs ringing workflow
 * :ghissue:`2348`: RF: Use new name for this function.
 * :ghissue:`2353`: How to create tractogram from a multi-shell data for RecoBundles
-* :ghissue:`1311`: Adding cython file(*.pyx) in documentation
-* :ghissue:`2363`: [ENH] Adding cython file(*.pyx) in documentation
+* :ghissue:`1311`: Adding cython file(``*.pyx``) in documentation
+* :ghissue:`2363`: [ENH] Adding cython file(``*.pyx``) in documentation
 * :ghissue:`1302`: [DOC] cython (pyx) files are not parsed
 * :ghissue:`366`: Some doc missing
 * :ghissue:`2365`: [DOC]: Change defaults in Patch2Self example

--- a/doc/sphinxext/docscrape.py
+++ b/doc/sphinxext/docscrape.py
@@ -22,6 +22,7 @@ class Reader:
     """
     def __init__(self, data):
         """
+
         Parameters
         ----------
         data : str

--- a/doc/theory/index.rst
+++ b/doc/theory/index.rst
@@ -5,5 +5,8 @@
 .. toctree::
    :maxdepth: 2
 
+   bmatrix
+   b_and_q
    spherical
    sh_basis
+   gqi


### PR DESCRIPTION
- DOC: Add documentation files to toctree
- DOC: Enclose star-containing file extension text with double backticks
- DOC: Document method parameters
- STYLE: Remove emacs and vi editor mode lines
- DOC: Fix unexpected indentation errors related to references
- DOC: Indent properly references
- DOC: Use the appropriate syntax to link references
- DOC: Fix formatting of lists in method docstrings
- DOC: Use appropriate syntax for math equations
- DOC: Document appropriately the variable length and kw argument list
- DOC: Use the `func` directive to cross-reference methods
- DOC: Fix docstring indentation
- DOC: Enclose star-containing docstring text with double backticks
- DOC: Remove parameter default values from docstrings
- DOC: Document an optional parameter as such
- DOC: Fix miscellaneous typos
- DOC: Use double backticks for registration transform options in flow
- DOC: Add missing ending double backtick markup
- DOC: Do not leave empty line in method description docstring start
- DOC: Remove raw docstring marker where not necessary
- DOC: Add blank line before parameter block in method docstring
- DOC: Fix docstring indentation by removing unnecessary default value
- DOC: Add a blank line between method docstring parameter, return 