### PR TITLE
DOC: Use `misc` for other types of BibTeX entries

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1578,36 +1578,6 @@
   url       = {https://doi.org/10.1111/j.1467-9868.2005.00503.x}
 }
 
-%% dataset
-@dataset{Wassermann2017,
-  author    = {Demian Wassermann and Mathieu Santin and Anne-Charlotte Philippe and Rutger Fick and Rachid Deriche and Stephane Lehericy and and Alexandra Petiet},
-  title     = {{Test-Retest qt-dMRI datasets for Non-Parametric GraphNet-Regularized Representation of dMRI in Space and Time}},
-  publisher = {Zenodo},
-  year      = {2017},
-  month     = {September},
-  doi       = {10.5281/zenodo.996889},
-  url       = {https://zenodo.org/records/996889}
-}
-
-%% electronic
-@electronic{Chandio2023,
-  author       = {Bramsh Qamar Chandio and Emanuele Olivetti and David Romero-Bascones and Jaroslaw Harezlak and Eleftherios Garyfallidis},
-  title        = {{BundleWarp, streamline-based nonlinear registration of white matter tracts}},
-  howpublished = {bioRxiv},
-  publisher    = {Cold Spring Harbor Laboratory},
-  year         = {2023},
-  doi          = {https://doi.org/10.1101/2023.01.04.522802}
-}
-
-@electronic{NetoHenriques2017,
-  author       = {Rafael {Neto Henriques} and Ariel Rokem and Eleftherios Garyfallidis and Samuel St-Jean and Eric Thomas Peterson and Marta Morgado Correia},
-  title        = {{[Re] Optimization of a free water elimination two-compartment model for diffusion tensor imaging}},
-  howpublished = {bioRxiv},
-  publisher    = {Cold Spring Harbor Laboratory},
-  year         = {2017},
-  doi          = {https://doi.org/10.1101/108795}
-}
-
 %% incollection
 @incollection{Topgaard2016,
   author    = {Daniel Topgaard},
@@ -1943,6 +1913,36 @@
   publisher = {Springer International Publishing},
   address   = {Cham},
   pages     = {51--63}
+}
+
+%% misc
+@misc{Chandio2023,
+  author       = {Bramsh Qamar Chandio and Emanuele Olivetti and David Romero-Bascones and Jaroslaw Harezlak and Eleftherios Garyfallidis},
+  title        = {{BundleWarp, streamline-based nonlinear registration of white matter tracts}},
+  howpublished = {bioRxiv},
+  publisher    = {Cold Spring Harbor Laboratory},
+  year         = {2023},
+  doi          = {https://doi.org/10.1101/2023.01.04.522802}
+}
+
+@misc{NetoHenriques2017,
+  author       = {Rafael {Neto Henriques} and Ariel Rokem and Eleftherios Garyfallidis and Samuel St-Jean and Eric Thomas Peterson and Marta Morgado Correia},
+  title        = {{[Re] Optimization of a free water elimination two-compartment model for diffusion tensor imaging}},
+  howpublished = {bioRxiv},
+  publisher    = {Cold Spring Harbor Laboratory},
+  year         = {2017},
+  doi          = {https://doi.org/10.1101/108795}
+}
+
+@misc{Wassermann2017,
+  author       = {Demian Wassermann and Mathieu Santin and Anne-Charlotte Philippe and Rutger Fick and Rachid Deriche and Stephane Lehericy and and Alexandra Petiet},
+  title        = {{Test-Retest qt-dMRI datasets for Non-Parametric GraphNet-Regularized Representation of dMRI in Space and Time}},
+  howpublished = {Zenodo},
+  year         = {2017},
+  month        = {September},
+  doi          = {10.5281/zenodo.996889},
+  url          = {https://zenodo.org/records/996889},
+  note         = {Dataset}
 }
 
 %% phdthesis


### PR DESCRIPTION
Use `misc` for other types of BibTeX entries: `dataset` and `electronic` entries are supported by `biblatex` but not by BibTeX, so use `misc` for such types.