### PR TITLE
DOC: Use references bibliography file for DIPY citation file

### DIFF
--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -80,7 +80,7 @@ class BundleMinDistanceMetric(StreamlineDistanceMetric):
 
     This is the cost function used by the StreamlineLinearRegistration.
 
-    See :footcite:p:`Garyfallidis2014` for further details about the metric.
+    See :footcite:p:`Garyfallidis2014b` for further details about the metric.
 
     Methods
     -------
@@ -1045,7 +1045,7 @@ def slr_with_qbx(
     For efficiency, we apply the registration on cluster centroids and remove
     small clusters.
 
-    See :footcite:p:`Garyfallidis2014`, :footcite:p:`Garyfallidis2015` and
+    See :footcite:p:`Garyfallidis2014b`, :footcite:p:`Garyfallidis2015` and
     :footcite:p:`Garyfallidis2018` for details about the methods involved.
 
     Parameters
@@ -1226,7 +1226,7 @@ def groupwise_slr(
     closer to each other until the procedure converges and there is no more
     improvement.
 
-    See :footcite:p:`Garyfallidis2014`, :footcite:p:`Garyfallidis2015` and
+    See :footcite:p:`Garyfallidis2014b`, :footcite:p:`Garyfallidis2015` and
     :footcite:p:`Garyfallidis2018`.
 
     Parameters

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -154,7 +154,7 @@ class SlrWithQbxFlow(Workflow):
         For efficiency we apply the registration on cluster centroids and
         remove small clusters.
 
-        See :footcite:p:`Garyfallidis2014`, :footcite:p:`Garyfallidis2015`,
+        See :footcite:p:`Garyfallidis2014b`, :footcite:p:`Garyfallidis2015`,
         :footcite:p:`Garyfallidis2018` for further details.
 
         Parameters

--- a/doc/cite.rst
+++ b/doc/cite.rst
@@ -2,52 +2,38 @@
 Publications
 ==============
 
-[1] Garyfallidis E, Brett M, Amirbekian B, Rokem A, van der Walt S, Descoteaux M, Nimmo-Smith I and Dipy Contributors (2014). `DIPY, a library for the analysis of diffusion MRI data. <https://www.frontiersin.org/articles/10.3389/fninf.2014.00008/abstract>`_ Frontiers in Neuroinformatics, vol.8, no.8.
-
-[2] Garyfallidis E, Brett M, Nimmo-Smith I (2010), “Fast Dimensionality Reduction for Brain Tractography Clustering”, 16th Annual Meeting of the Organization for Human Brain Mapping.
-
-[3] Garyfallidis E, Brett M, Tsiaras V, Vogiatzis G, Nimmo-Smith I (2010), “Identification of corresponding tracks in diffusion MRI tractographies” Proc. Intl. Soc. Mag. Reson. Med. 18
-
-[4] Correia M.M, Williams G.B, Yeh F-C, Nimmo-Smith I, Garyfallidis E (2011), “Robustness of diffusion scalar metrics when estimated with Generalized Q-Sampling Imaging acquisition schemes”, Proc. Intl. Soc. Mag. Reson. Med. 19
-
-[5] Chamberlain SR, Hampshire A, Menzies LA, Garyfallidis E, Grant JE, Odlaug BL, Craig K, Fineberg N, Sahakian BJ (2010), “Reduced brain white matter integrity in trichotillomania: a diffusion tensor imaging study.” Arch Gen Psychiatry 67(9):965-71
-
-[6] Garyfallidis E, Brett M, Amirbekian B, Nguyen C, Yeh F-C, Olivetti E, Halchenko Y, Nimmo-Smith I (2011), "Dipy - a novel software library for diffusion MR and tractography", 17th Annual Meeting of the Organization for Human Brain Mapping.
-
-[7] Yeh F-C, Wedeen VJ, Tseng WY (2010), "Generalized Q-Sampling Imaging", IEEE Trans. Med. Imaging.
-
-[8] Garyfallidis E, Brett M, Correia M.M, Williams G.B, Nimmo-Smith I. (2012), "QuickBundles, a method for tractography simplification", Frontiers in
-Neuroscience, 6 (175).
-
-[9] Garyfallidis E, Cote M-A, Rheault F, Sidhu J, Hau J, Petit L, Fortin D, Cunanne S, Descoteaux M,  `Recognition of white matter bundles using local and global streamline-based registration and clustering. <https://www.sciencedirect.com/science/article/abs/pii/S1053811917305839>`_
-
-[10] Garyfallidis E, Ocegueda O, Wassermann D, Descoteaux M. `Robust and efficient linear registration of white-matter fascicles in the space of streamlines. <https://www.sciencedirect.com/science/article/abs/pii/S1053811915003961>`_
-
-[11] Rokem A, Yeatman JD, Pestilli F, Kay KN, Mezer A, et al. (2015), `Evaluating the Accuracy of Diffusion MRI Models in White Matter. <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0123272>`_
-
-[12] Ocegueda O, Dalmau O, Garyfallidis E, Descoteaux M, Rivera M, `On the computation of integrals over fixed-size rectangles of arbitrary dimension. <https://www.sciencedirect.com/science/article/abs/pii/S0167865516300861>`_
-
-[13] Rafael Neto Henriques, Ariel Rokem, Eleftherios Garyfallidis, Samuel St-Jean, Eric Thomas Peterson, Marta Morgado Correia, ReScience volume 3, issue 1, article number 2, 2017
-`[Re] Optimization of a free water elimination two-compartment model for diffusion tensor imaging. <https://www.biorxiv.org/content/early/2017/02/15/108795>`_
-
-[14] Henriques RN, Correia MM, Marrale M, et al. Diffusional Kurtosis Imaging in the Diffusion Imaging in Python Project. Front Hum Neurosci. 2021;15:390. https://www.frontiersin.org/articles/10.3389/fnhum.2021.675433/full
-
+- :cite:t:`Garyfallidis2014a`
+- :cite:t:`Garyfallidis2010b`
+- :cite:t:`Garyfallidis2010a`
+- :cite:t:`Correia2011a`
+- :cite:t:`Chamberlain2010`
+- :cite:t:`Garyfallidis2011`
+- :cite:t:`Yeh2010`
+- :cite:t:`Garyfallidis2012a`
+- :cite:t:`Garyfallidis2018`
+- :cite:t:`Garyfallidis2015`
+- :cite:t:`Rokem2015`
+- :cite:t:`Ocegueda2016`
+- :cite:t:`NetoHenriques2017`
+- :cite:t:`NetoHenriques2021`
 
 A note on citing our work
 --------------------------
 
-* The main reference citation for DIPY is [1].
+* The main reference citation for DIPY is :cite:p:`Garyfallidis2014a`.
 
-* If you are using QuickBundles method please also cite [8].
+* If you are using QuickBundles method please also cite :cite:p:`Garyfallidis2012a`.
 
-* If you are using track correspondence also cite [3].
+* If you are using track correspondence also cite :cite:p:`Garyfallidis2010a`.
 
-* If you are using Generalized Q-sampling please also cite [7].
+* If you are using Generalized Q-sampling please also cite :cite:p:`Yeh2010`.
 
-* If you are using Diffusional Kurtosis Imaging, please also cite [13]
+* If you are using Diffusional Kurtosis Imaging, please also cite :cite:t:`NetoHenriques2017`.
 
 
 Citing other algorithms
 -----------------------
 
 Depending on your research topic, it may also be appropriate to cite related method papers, some of which are listed in the documentation strings of the relevant functions or methods. All references cited in the DIPY codebase and documentation are collected in the :ref:`general_bibliography`.
+
+.. footbibliography::

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -634,6 +634,17 @@
   url       = {https://doi.org/10.1016/j.neuroimage.2015.05.016}
 }
 
+@article{Garyfallidis2014a,
+  author    = {Eleftherios Garyfallidis and Matthew Brett and Bagrat Amirbekian and Ariel Rokem and Stefan Van Der Walt and Maxime Descoteaux and Ian Nimmo-Smith and Dipy Contributors},
+  title     = {{Dipy, a library for the analysis of diffusion MRI data}},
+  journal   = {Frontiers in Neuroinformatics},
+  volume    = {8},
+  year      = {2014},
+  month     = {February},
+  doi       = {10.3389/fninf.2014.00008},
+  url       = {https://doi.org/10.3389/fninf.2014.00008}
+}
+
 @article{Garyfallidis2012a,
   author    = {Eleftherios Garyfallidis and Matthew Brett and Marta M. Correia and Guy B. Williams and Ian Nimmo-Smith},
   title     = {{QuickBundles, a Method for Tractography Simplification}},
@@ -1830,17 +1841,42 @@
   year         = {2016}
 }
 
-@inproceedings{Garyfallidis2014
+@inproceedings{Garyfallidis2014b,
   author       = {Eleftherios Garyfallidis and Demian Wassermann and Maxime Descoteaux},
   title        = {{Direct native-space fiber bundle alignment for group comparisons}},
   booktitle    = {Joint Annual Meeting ISMRM-ESMRMB 2014 SMRT 23rd Annual Meeting},
   organization = {International Society for Magnetic Resonance in Medicine (ISMRM)},
   address      = {Milan, Italy},
   pages        = {},
-  year         = {2014}
+  year         = {2014},
+  month        = {May}
 }
 
-@inproceedings{Garyfallidis2010,
+@inproceedings{Garyfallidis2011,
+  author       = {Eleftherios Garyfallidis and Matthew Brett and Bagrat Amirbekian and Chistopher Nguyen and Fang-Cheng Yeh and Emanuele Olivetti and Yaroslav Halchenko and Ian Nimmo-Smith},
+  title        = {{Dipy - a novel software library for diffusion MR and tractography}},
+  booktitle    = {17th annual meeting of the Organization for Human Brain Mapping},
+  organization = {Organization for Human Brain Mapping (OHBM)},
+  address      = {Quebec City, Canada},
+  volume       = {},
+  pages        = {},
+  year         = {2011},
+  month        = {June}
+}
+
+@inproceedings{Garyfallidis2010b,
+  author       = {Eleftherios Garyfallidis and Matthew Brett and Ian Nimmo-Smith},
+  title        = {{Fast Dimensionality Reduction for Brain Tractography Clustering}},
+  booktitle    = {16th Annual Meeting of the Organization for Human Brain Mapping},
+  organization = {Organization for Human Brain Mapping (OHBM)},
+  address      = {Barcelona, Spain},
+  volume       = {},
+  pages        = {},
+  year         = {2010},
+  month        = {June}
+}
+
+@inproceedings{Garyfallidis2010a,
   author       = {Eleftherios Garyfallidis and Matthew Brett and Vassilis Tsiaras and George Vogiatzis and Ian Nimmo-Smith1},
   title        = {{Identification of corresponding tracks in diffusion MRI tractographies}},
   booktitle    = {Joint Annual Meeting ISMRM-ESMRMB 2010 SMRT 19th Annual Meeting},
@@ -1848,7 +1884,8 @@
   address      = {Stockholm, Sweden},
   volume       = {},
   pages        = {},
-  year         = {2010}
+  year         = {2010},
+  month        = {May}
 }
 
 @inproceedings{Houde2015,

--- a/doc/user_guide/bibliography.rst
+++ b/doc/user_guide/bibliography.rst
@@ -5,4 +5,3 @@ General bibliography
 
 .. bibliography:: ./../references.bib
    :all:
-   :list: enumerated


### PR DESCRIPTION
Use references bibliography file for DIPY citation file.

Add missing citations to `references.bib`.

Add a missing comma after the `Garyfallidis2014` cite key (now renamed to `Garyfallidis2014` since another work from the same author/year is added in this commit).

Remove the `:list: enumerated` flag in `bibliography.rst` to avoid
```
/home/runner/work/dipy/dipy/doc/cite.rst:5:
 WARNING: could not find bibtex key "Garyfallidis2014a"
```

and similar errors.