### PR TITLE
DOC: Miscellaneous documentation improvements (part 2)

### DIFF
--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1057,7 +1057,9 @@ def slr_with_qbx(
     Parameters
     ----------
     static : Streamlines
-    moving : Streamlines
+        Fixed or reference set of streamlines.
+    moving : streamlines
+        Moving streamlines.
 
     x0 : str, optional.
         rigid, similarity or affine transformation model (default affine)

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1078,20 +1078,19 @@ def slr_with_qbx(
         If True, logs information about optimization. Default: False
 
     greater_than : int, optional
-            Keep streamlines that have length greater than
-            this value (default 50)
+        Keep streamlines that have length greater than this value.
 
     less_than : int, optional
-            Keep streamlines have length less than this value (default 250)
+        Keep streamlines have length less than this value.
 
     qbx_thr : variable int
-            Thresholds for QuickBundlesX (default [40, 30, 20, 15])
+        Thresholds for QuickBundlesX.
 
     nb_pts : int, optional
-            Number of points for discretizing each streamline (default 20)
+        Number of points for discretizing each streamline.
 
     progressive : boolean, optional
-            (default True)
+       True to enable progressive registration.
 
     rng : np.random.Generator
         If None creates random generator in function.

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -582,7 +582,7 @@ class StreamlineRegistrationMap:
 
         Parameters
         ----------
-        matrix : array,
+        matopt : array,
             4x4 affine matrix which transforms the moving to the static
             streamlines
 
@@ -592,7 +592,7 @@ class StreamlineRegistrationMap:
         fopt : float,
             final value of the metric
 
-        matrix_history : array
+        matopt_history : array
             All transformation matrices created during the optimization
 
         funcs : int,

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -2261,7 +2261,7 @@ def read_bundles_2_subjects(
     bundles : array-like
         E.g., ['af.left', 'cst.right', 'cc_1']. See all the available bundles
         in the ``exp_bundles_maps/bundles_2_subjects`` directory of your
-        ``$HOME/.dipy`` folder.
+        ``DIPY_HOME`` of ``$HOME/.dipy`` folder.
 
     Returns
     -------
@@ -2618,7 +2618,8 @@ def fetch_hcp(
     profile_name : string, optional
         The name of the AWS profile used for access. Default: "hcp"
     path : string, optional
-        Path to save files into. Default: '~/.dipy'
+        Path to save files into. Defaults to the value of the ``DIPY_HOME``
+        environment variable is set; otherwise, defaults to ``$HOME/.dipy``.
     study : string, optional
         Which HCP study to grab. Default: 'HCP_1200'
     aws_access_key_id : string, optional
@@ -2838,7 +2839,8 @@ def fetch_hbn(subjects, *, path=None, include_afq=False):
         For example: ["NDARAA948VFH", "NDAREK918EC2"].
 
     path : string, optional
-        Path to save files into. Default: '~/.dipy'
+        Path to save files into. Defaults to the value of the ``DIPY_HOME``
+        environment variable is set; otherwise, defaults to ``$HOME/.dipy``.
 
     include_afq : bool, optional
         Whether to include pyAFQ derivatives. Default: False

--- a/dipy/denoise/gibbs.py
+++ b/dipy/denoise/gibbs.py
@@ -2,7 +2,6 @@ from functools import partial
 import multiprocessing as mp
 
 import numpy as np
-import scipy
 import scipy.fft
 
 from dipy.testing.decorators import warning_for_keywords

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -33,7 +33,7 @@ def convolve(odfs_sh, kernel, sh_order_max, *, test_mode=False, num_threads=None
         Number of threads to be used for OpenMP parallelization. If None
         (default) the value of OMP_NUM_THREADS environment variable is used
         if it is set, otherwise all available threads are used. If < 0 the
-        maximal number of threads minus |num_threads + 1| is used (enter -1 to
+        maximal number of threads minus $|num_threads + 1|$ is used (enter -1 to
         use as many threads as possible). 0 raises an error.
     normalize : boolean
         Apply max-normalization to the output such that its value range matches

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -679,7 +679,7 @@ def csdeconv(dwsignal, X, B_reg, tau=0.1, convergence=50, P=None):
 
                 solve $Qf_n = z$ using Cholesky decomposition
 
-    We'd like to thanks Donald Tournier for his help with describing and
+    We would like to thank Donald Tournier for his help with describing and
     implementing this algorithm.
 
     References

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -102,8 +102,8 @@ def auto_response(
     until="1.4",
 )
 def response_from_mask(gtab, data, mask):
-    """Computation of single-shell single-tissue (ssst) response
-        function from a given mask.
+    """Computation of single-shell single-tissue (ssst) response function from a
+    given mask.
 
     Parameters
     ----------
@@ -753,19 +753,19 @@ def odf_deconv(odf_sh, R, B_reg, lambda_=1.0, tau=0.1, r2_term=False):
     Parameters
     ----------
     odf_sh : ndarray (``(sh_order_max + 1)*(sh_order_max + 2)/2``,)
-         ndarray of SH coefficients for the ODF spherical function to be
-         deconvolved
+        ndarray of SH coefficients for the ODF spherical function to be
+        deconvolved
     R : ndarray (``(sh_order_max + 1)(sh_order_max + 2)/2``,
-         ``(sh_order_max + 1)(sh_order_max + 2)/2``)
-         SDT matrix in SH basis
+        ``(sh_order_max + 1)(sh_order_max + 2)/2``)
+        SDT matrix in SH basis
     B_reg : ndarray (``(sh_order_max + 1)(sh_order_max + 2)/2``,
-         ``(sh_order_max + 1)(sh_order_max + 2)/2``)
-         SH basis matrix used for deconvolution
+        ``(sh_order_max + 1)(sh_order_max + 2)/2``)
+        SH basis matrix used for deconvolution
     lambda_ : float
-         lambda parameter in minimization equation (default 1.0)
+        lambda parameter in minimization equation (default 1.0)
     tau : float
-         threshold (``tau *max(fODF)``) controlling the amplitude below
-         which the corresponding fODF is assumed to be zero.
+        threshold (``tau *max(fODF)``) controlling the amplitude below
+        which the corresponding fODF is assumed to be zero.
     r2_term : bool
          True if ODF is computed from model that uses the $r^2$ term in the
          integral.  Recall that Tuch's ODF (used in Q-ball Imaging [1]_) and

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -141,14 +141,14 @@ def cti_prediction(cti_params, gtab1, gtab2, S0=1):
     Parameters
     ----------
     cti_params: numpy.ndarray (..., 48)
-    All parameters estimated from the correlation tensor model.
-    Parameters are ordered as follows:
+        All parameters estimated from the correlation tensor model.
+        Parameters are ordered as follows:
 
-        1. Three diffusion tensor's eigenvalues
-        2. Three lines of the eigenvector matrix each containing the
-           first, second and third coordinates of the eigenvector
-        3. Fifteen elements of the kurtosis tensor
-        4. Twenty-One elements of the covariance tensor
+            1. Three diffusion tensor's eigenvalues
+            2. Three lines of the eigenvector matrix each containing the
+               first, second and third coordinates of the eigenvector
+            3. Fifteen elements of the kurtosis tensor
+            4. Twenty-One elements of the covariance tensor
 
     gtab1: dipy.core.gradients.GradientTable
         A GradientTable class instance for first DDE diffusion epoch
@@ -279,14 +279,14 @@ class CorrelationTensorModel(ReconstModel):
         Parameters
         ----------
         cti_params: numpy.ndarray (..., 48)
-        All parameters estimated from the correlation tensor model.
-        Parameters are ordered as follows:
+            All parameters estimated from the correlation tensor model.
+            Parameters are ordered as follows:
 
-            1. Three diffusion tensor's eigenvalues
-            2. Three lines of the eigenvector matrix each containing the
-               first, second and third coordinates of the eigenvector
-            3. Fifteen elements of the kurtosis tensor
-            4. Twenty-One elements of the covariance tensor
+                1. Three diffusion tensor's eigenvalues
+                2. Three lines of the eigenvector matrix each containing the
+                   first, second and third coordinates of the eigenvector
+                3. Fifteen elements of the kurtosis tensor
+                4. Twenty-One elements of the covariance tensor
 
         gtab1: dipy.core.gradients.GradientTable
             A GradientTable class instance for first DDE diffusion epoch
@@ -569,14 +569,14 @@ def ls_fit_cti(
     Returns
     -------
     cti_params : array (48)
-    All parameters estimated from the diffusion kurtosis model for all N
-    voxels. Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model for all N
+        voxels. Parameters are ordered as follows:
 
-        1) Three diffusion tensor eigenvalues.
-        2) Three blocks of three elements, containing the first second and
-            third coordinates of the diffusion tensor eigenvectors.
-        3) Fifteen elements of the kurtosis tensor.
-        4) Twenty One elements of the covariance tensor.
+            1) Three diffusion tensor eigenvalues.
+            2) Three blocks of three elements, containing the first second and
+                third coordinates of the diffusion tensor eigenvectors.
+            3) Fifteen elements of the kurtosis tensor.
+            4) Twenty One elements of the covariance tensor.
 
     """
     A = design_matrix

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -342,16 +342,6 @@ class CorrelationTensorFit(DiffusionKurtosisFit):
 
         Parameters
         ----------
-        params: numpy.ndarray (...,43)
-                All parameters estimated from the correlation tensor model.
-                Parameters are ordered as follows:
-
-                1. Three diffusion tensor's eigenvalues
-                2. Three lines of the eigenvector matrix each containing the
-                   first, second and third coordinates of the eigenvector
-                3. Fifteen elements of the kurtosis tensor
-                4. Twenty-One elements of the covariance tensor
-
         gtab1: dipy.core.gradients.GradientTable
             A GradientTable class instance for first DDE diffusion epoch
         gtab2: dipy.core.gradients.GradientTable

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -105,7 +105,7 @@ def split_cti_params(cti_params):
 
     Parameters
     ----------
-        params: numpy.ndarray (..., 48)
+    cti_params: numpy.ndarray (..., 48)
         All parameters estimated from the correlation tensor model.
         Parameters are ordered as follows:
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -600,10 +600,10 @@ def apparent_kurtosis_coef(
         All parameters estimated from the diffusion kurtosis model.
         Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvectors respectively
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvectors respectively
+            3) Fifteen elements of the kurtosis tensor
     sphere : a Sphere class instance
         The AKC will be calculated for each of the vertices in the sphere
     min_diffusivity : float (optional)
@@ -707,10 +707,10 @@ def mean_kurtosis(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=3, analytical=
         All parameters estimated from the diffusion kurtosis model.
         Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-           second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, mean
         kurtosis values that are smaller than `min_kurtosis` are replaced with
@@ -988,13 +988,13 @@ def radial_kurtosis(
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-           second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
 
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, radial
@@ -1130,13 +1130,13 @@ def axial_kurtosis(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=10, analytica
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-           second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
 
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, axial
@@ -1346,13 +1346,13 @@ def kurtosis_maximum(dki_params, sphere="repulsion100", gtol=1e-2, mask=None):
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eingenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-           second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eingenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
 
     sphere : Sphere class instance, optional
         The sphere providing sample directions for the initial search of the
@@ -1421,13 +1421,13 @@ def mean_kurtosis_tensor(dki_params, min_kurtosis=-3.0 / 7, max_kurtosis=10):
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
 
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-           second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+               second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
 
     min_kurtosis : float (optional)
         To keep kurtosis values within a plausible biophysical range, mean
@@ -1586,12 +1586,13 @@ def kurtosis_fractional_anisotropy(dki_params):
     Parameters
     ----------
     dki_params : ndarray (x, y, z, 27) or (n, 27)
-    All parameters estimated from the diffusion kurtosis model.
-    Parameters are ordered as follows:
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the first,
-            second and third coordinates of the eigenvector
-        3) Fifteen elements of the kurtosis tensor
+        All parameters estimated from the diffusion kurtosis model.
+        Parameters are ordered as follows:
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the first,
+                second and third coordinates of the eigenvector
+            3) Fifteen elements of the kurtosis tensor
+
     Returns
     -------
     kfa : array
@@ -1681,7 +1682,7 @@ def dki_prediction(dki_params, gtab, S0=1.0):
 
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the first,
-                second and third coordinates of the eigenvector
+               second and third coordinates of the eigenvector
             3) Fifteen elements of the kurtosis tensor
     gtab : a GradientTable class instance
         The gradient table for this prediction
@@ -1952,14 +1953,13 @@ class DiffusionKurtosisModel(ReconstModel):
         Parameters
         ----------
         dki_params : ndarray (x, y, z, 27) or (n, 27)
-        All parameters estimated from the diffusion kurtosis model.
-        Parameters are ordered as follows::
+            All parameters estimated from the diffusion kurtosis model.
+            Parameters are ordered as follows:
 
-        1. Three diffusion tensor's eigenvalues
-        2. Three lines of the eigenvector matrix each containing the
-        first, second and third coordinates of the eigenvector
-        3. Fifteen elements of the kurtosis tensor
-
+                1. Three diffusion tensor's eigenvalues
+                2. Three lines of the eigenvector matrix each containing the
+                first, second and third coordinates of the eigenvector
+                3. Fifteen elements of the kurtosis tensor
 
         S0 : float or ndarray (optional)
             The non diffusion-weighted signal in every voxel, or across all
@@ -1998,10 +1998,10 @@ class DiffusionKurtosisFit(TensorFit):
             not including S0.
             Parameters are ordered as follows:
 
-            1) Three diffusion tensor's eigenvalues
-            2) Three lines of the eigenvector matrix each containing the
-               first, second and third coordinates of the eigenvector
-            3) Fifteen elements of the kurtosis tensor
+                1) Three diffusion tensor's eigenvalues
+                2) Three lines of the eigenvector matrix each containing the
+                   first, second and third coordinates of the eigenvector
+                3) Fifteen elements of the kurtosis tensor
         model_S0 : ndarray (x, y, z, 1) or (n, 1), optional
             S0 estimated from the diffusion kurtosis model.
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -33,7 +33,7 @@ from dipy.reconst.vec_val_sum import vec_val_vect
 
 
 def _positive_evals(L1, L2, L3, er=2e-7):
-    """Helper function that identifies which voxels in a array have all
+    """Helper function that identifies which voxels in an array have all
     eigenvalues significantly larger than zero
 
     Parameters
@@ -2797,7 +2797,7 @@ ind_ele = {
 
 
 def Wrotate_element(kt, indi, indj, indk, indl, B):
-    r"""Compute the the specified index element of a kurtosis tensor rotated
+    r"""Compute the specified index element of a kurtosis tensor rotated
     to the coordinate system basis B
 
     Parameters
@@ -2822,7 +2822,7 @@ def Wrotate_element(kt, indi, indj, indk, indl, B):
 
     Notes
     -----
-    It is assumed that initial kurtosis tensor elementes are defined on the
+    It is assumed that initial kurtosis tensor elements are defined on the
     Cartesian coordinate system.
 
     References

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -2023,6 +2023,8 @@ class DiffusionKurtosisFit(TensorFit):
         Parameters
         ----------
         sphere : Sphere class instance
+            Sphere providing sample directions to compute the apparent kurtosis
+            coefficient.
 
         Returns
         -------

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1203,6 +1203,8 @@ class TensorFit:
         Parameters
         ----------
         sphere : Sphere class instance
+            Sphere providing sample directions to compute the apparent diffusion
+            coefficient.
 
         Returns
         -------

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -613,7 +613,7 @@ def nls_iter(
         The minimum signal value. Needs to be a strictly positive
         number.
     cholesky : bool, optional
-        If true it uses Cholesky decomposition to insure that diffusion tensor
+        If true it uses Cholesky decomposition to ensure that diffusion tensor
         is positive define.
         Default: False
     f_transform : bool, optional
@@ -762,7 +762,7 @@ def nls_fit_tensor(
         0 and 1.
         Default: True
     cholesky : bool, optional
-        If true it uses Cholesky decomposition to insure that diffusion tensor
+        If true it uses Cholesky decomposition to ensure that diffusion tensor
         is positive define.
         Default: False
     jac : bool

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -28,6 +28,8 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
             'standard' or 'gqi2'
         sampling_length : float,
             diffusion sampling length (lambda in eq. 2.14 and 2.16)
+        normalize_peaks : bool, optional
+            True to normalize peaks.
 
         References
         ----------

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -571,7 +571,7 @@ class IvimModelVP(ReconstModel):
         the volume fractions are determined. Then the last step is non linear
         least square fitting on all the parameters. The results of the first
         and second step are utilized as the initial values for the last step
-        of the algorithm. (see [1]_ and [2]_ for a comparison and a through
+        of the algorithm. (see [1]_ and [2]_ for a comparison and a thorough
         discussion).
 
         References
@@ -752,7 +752,7 @@ class IvimModelVP(ReconstModel):
         Cost function for the least square problem. The cost function is used
         in the Least Squares function of SciPy in :func: `fit`. It guarantees
         that stopping point of the algorithm is at least a stationary point
-        with reduction in the the number of iterations required by the
+        with reduction in the number of iterations required by the
         differential evolution optimizer.
 
         Parameters

--- a/dipy/reconst/msdki.py
+++ b/dipy/reconst/msdki.py
@@ -418,13 +418,13 @@ class MeanDiffusionKurtosisFit:
     @auto_attr
     def msd(self):
         r"""
-        Mean signal diffusitivity (MSD) calculated from the mean signal
+        Mean signal diffusivity (MSD) calculated from the mean signal
         Diffusion Kurtosis Model.
 
         Returns
         -------
         msd : ndarray
-            Calculated signal mean diffusitivity.
+            Calculated signal mean diffusivity.
 
         References
         ----------

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -102,6 +102,7 @@ class QtdmriModel(Cache):
         cvxpy solver name. Optionally optimize the positivity constraint
         with a particular cvxpy solver. See https://www.cvxpy.org/ for
         details.
+        Default: None (cvxpy chooses its own solver)
 
     References
     ----------

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -551,7 +551,7 @@ class QtdmriFit:
     def qtdmri_to_mapmri_coef(self, tau):
         """This function converts the qtdmri coefficients to mapmri
         coefficients for a given tau [1]_. The conversion is performed by a
-        matrix multiplication that evaluates the time-depenent part of the
+        matrix multiplication that evaluates the time-dependent part of the
         basis and multiplies it with the coefficients, after which coefficients
         with the same spatial orders are summed up, resulting in mapmri
         coefficients.

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1196,7 +1196,7 @@ class ResidualBootstrapWrapper:
     """Returns a residual bootstrap sample of the signal_object when indexed
 
     Wraps a signal_object, this signal object can be an interpolator. When
-    indexed, the the wrapper indexes the signal_object to get the signal.
+    indexed, the wrapper indexes the signal_object to get the signal.
     There wrapper than samples the residual bootstrap distribution of signal and
     returns that sample.
     """

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -184,7 +184,7 @@ def bundle_shape_similarity(
 
     Returns
     -------
-    ba_value : Float
+    ba_value : float
         Bundle similarity score between two tracts
 
     References

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -631,7 +631,7 @@ def kurtosis_element(D_comps, frac, ind_i, ind_j, ind_k, ind_l, *, DT=None, MD=N
     Returns
     -------
     wijkl : float
-            kurtosis tensor element of index i, j, k, l
+        kurtosis tensor element of index i, j, k, l
 
     Notes
     -----

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -21,11 +21,14 @@ def unlist_streamlines(streamlines):
     Parameters
     ----------
     streamlines: sequence
+        Streamlines.
 
     Returns
     -------
     points : array
+        Streamlines' points.
     offsets : array
+        Streamlines' offsets.
 
     """
 
@@ -49,11 +52,14 @@ def relist_streamlines(points, offsets):
     Parameters
     ----------
     points : array
+        Streamlines' points.
     offsets : array
+        Streamlines' offsets.
 
     Returns
     -------
     streamlines: sequence
+        Streamlines.
     """
 
     streamlines = [points[0 : offsets[0]]]

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -818,7 +818,7 @@ def horizon(
         File path to replay recorded events
     return_showm : bool
         Return ShowManager object. Used only at Python level. Can be used
-        for extending Horizon's cababilities externally and for testing
+        for extending Horizon's capabilities externally and for testing
         purposes.
 
     References

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -759,8 +759,8 @@ def horizon(
     Parameters
     ----------
     tractograms : sequence of StatefulTractograms
-            StatefulTractograms are used for making sure that the coordinate
-            systems are correct
+        StatefulTractograms are used for making sure that the coordinate
+        systems are correct
     images : sequence of tuples
         Each tuple contains data and affine
     pams : sequence of PeakAndMetrics

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -157,7 +157,10 @@ class SlrWithQbxFlow(Workflow):
         Parameters
         ----------
         static_files : string
+            List of reference/fixed bundle tractograms.
         moving_files : string
+            List of target bundle tractograms that will be moved/registered to
+            match the static bundles.
         x0 : string, optional
             rigid, similarity or affine transformation model.
         rm_small_clusters : int, optional
@@ -179,6 +182,7 @@ class SlrWithQbxFlow(Workflow):
         nb_pts : int, optional
             Number of points for discretizing each streamline.
         progressive : boolean, optional
+            True to enable progressive registration.
         out_dir : string, optional
             Output directory. (default current directory)
         out_moved : string, optional

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1009,7 +1009,7 @@ class BundleWarpFlow(Workflow):
         out_dist : string, optional
             Filename of MDF distance matrix.
         out_matched_pairs : string, optional
-            Filename of matched pairs; treamline correspondences between two
+            Filename of matched pairs; streamline correspondences between two
             bundles.
 
         References

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -316,7 +316,7 @@ fig2.savefig("MSDKI_invivo.png")
 #
 # This figure shows that the contrast of in-vivo MSD and MSK maps (upper
 # panels) are similar to the contrast of MD and MSK maps (lower panels);
-# however, in the upper part we insure that direct contributions of fiber
+# however, in the upper part we ensure that direct contributions of fiber
 # dispersion were removed. The upper panels also reveal that MSDKI measures
 # are let sensitive to noise artefacts than standard DKI measures (as pointed
 # by [NetoHe2018]_), particularly one can observe that MSK maps always present


### PR DESCRIPTION
- DOC: Use the appropriate Python data type to document parameter
- DOC: Enclose absolute value math expression within LaTeX markup
- DOC: Increase consistency in default cvxpy solver docstrings
- DOC: Fix typos and grammar
- STYLE: Remove unused import
- DOC: Improve explanation on DIPY's default download data folder
- DOC: Add missing doctrings to method input parameters
- DOC: Use the appropriate indentation in docstrings
- DOC: Match docstring parameter names with names in function signature
- DOC: Remove non-existing parameter docstring