### PR TITLE
ENH: Adds Streamline AutoEncoder model

### DIFF
--- a/dipy/nn/finta_model.py
+++ b/dipy/nn/finta_model.py
@@ -1,0 +1,399 @@
+from math import sqrt
+import numpy as np
+import nibabel as nib
+import tensorflow as tf
+import keras
+from keras import layers, Layer, Model, initializers
+from tractoencoder_gsoc.utils import pre_pad
+from tractoencoder_gsoc.utils import dict_kernel_size_flatten_encoder_shape
+
+
+class Encoder(Layer):
+    def __init__(self, latent_space_dims=32, kernel_size=3, **kwargs):
+        """
+        Encoder block of the AutoEncoder.
+        Encodes the input data into a latent
+        space representation.
+
+        Parameters
+        ----------
+        latent_space_dims : int, optional
+            Number of dimensions of the latent
+            space where the data will be encoded.
+            Default: 32
+        kernel_size : int, optional
+            Length of the 1D kernel used in the
+            convolutional layers.
+            Default: 3
+        """
+        super(Encoder, self).__init__(**kwargs)
+
+        # Parameter Initialization
+        self.latent_space_dims = latent_space_dims
+        self.kernel_size = kernel_size
+
+        # Weight and bias initializers for Conv1D layers (matching PyTorch initialization)
+        # Link: https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html (Variables section)
+        # Weights
+        self.k_conv1d_weights_initializer = sqrt(1 / (3 * self.kernel_size))
+        self.conv1d_weights_initializer = initializers.RandomUniform(minval=-self.k_conv1d_weights_initializer,
+                                                                     maxval=self.k_conv1d_weights_initializer,
+                                                                     seed=2208)
+        # Biases
+        self.k_conv1d_biases_initializer = self.k_conv1d_weights_initializer
+        self.conv1d_biases_initializer = self.conv1d_weights_initializer
+
+        self.encod_conv1 = pre_pad(
+            layers.Conv1D(32, self.kernel_size, strides=2, padding='valid',
+                          name="encoder_conv1",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+        self.encod_conv2 = pre_pad(
+            layers.Conv1D(64, self.kernel_size, strides=2, padding='valid',
+                          name="encoder_conv2",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+        self.encod_conv3 = pre_pad(
+            layers.Conv1D(128, self.kernel_size, strides=2, padding='valid',
+                          name="encoder_conv3",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+        self.encod_conv4 = pre_pad(
+            layers.Conv1D(256, self.kernel_size, strides=2, padding='valid',
+                          name="encoder_conv4",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+        self.encod_conv5 = pre_pad(
+            layers.Conv1D(512, self.kernel_size, strides=2, padding='valid',
+                          name="encoder_conv5",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+        self.encod_conv6 = pre_pad(
+            layers.Conv1D(1024, self.kernel_size, strides=1, padding='valid',
+                          name="encoder_conv6",
+                          kernel_initializer=self.conv1d_weights_initializer,
+                          bias_initializer=self.conv1d_biases_initializer)
+        )
+
+        self.flatten = layers.Flatten(name='flatten')
+
+        # For Dense layers
+        # Link: https://pytorch.org/docs/stable/generated/torch.nn.Linear.html (Variables section)
+        # Weights
+        self.k_dense_weights_initializer = sqrt(1 / dict_kernel_size_flatten_encoder_shape[self.kernel_size])
+        self.dense_weights_initializer = initializers.RandomUniform(minval=-self.k_dense_weights_initializer,
+                                                                    maxval=self.k_dense_weights_initializer,
+                                                                    seed=2208)
+        # Biases
+        self.k_dense_biases_initializer = self.k_dense_weights_initializer
+        self.dense_biases_initializer = self.dense_weights_initializer
+
+        self.fc1 = layers.Dense(self.latent_space_dims, name='fc1',
+                                kernel_initializer=self.dense_weights_initializer,
+                                bias_initializer=self.dense_biases_initializer)
+
+    def get_config(self):
+        base_config = super().get_config()
+        config = {
+            "latent_space_dims": keras.saving.serialize_keras_object(self.latent_space_dims),
+            "kernel_size": keras.saving.serialize_keras_object(self.kernel_size)
+        }
+        return {**base_config, **config}
+
+    @classmethod
+    def from_config(cls, config):
+        latent_space_dims = keras.saving.deserialize_keras_object(config.pop('latent_space_dims'))
+        kernel_size = keras.saving.deserialize_keras_object(config.pop('kernel_size'))
+        return cls(latent_space_dims, kernel_size, **config)
+
+    def call(self, input_data):
+        """
+        Run the input data through the Encoder.
+        Encode the input_data into a latent
+        space representation.
+
+        Parameters
+        ----------
+        input_data : tf.Tensor or np.ndarray
+            Data to run through the Encoder.
+            Should be of the shape of a standard
+            streamline with 256 points:
+            (n_samples, 256, 3).
+
+        Returns
+        -------
+        tf.Tensor
+            Encoded input in the latent space,
+            with the shape
+            (n_samples, latent_space_dims).
+        """
+        x = input_data
+
+        h1 = tf.nn.relu(self.encod_conv1(x))
+        h2 = tf.nn.relu(self.encod_conv2(h1))
+        h3 = tf.nn.relu(self.encod_conv3(h2))
+        h4 = tf.nn.relu(self.encod_conv4(h3))
+        h5 = tf.nn.relu(self.encod_conv5(h4))
+        h6 = self.encod_conv6(h5)
+
+        self.encoder_out_size = h6.shape[1:]
+
+        # Flatten
+        # First transpose the tensor to match the PyTorch implementation so the flattening is equal
+        h7 = tf.transpose(h6, perm=[0, 2, 1])
+        h7 = self.flatten(h7)
+        fc1 = self.fc1(h7)
+
+        return fc1
+
+class Decoder(Layer):
+    def __init__(self, encoder_out_size, kernel_size=3, **kwargs):
+        """
+        Decoder block of the AutoEncoder. Decodes
+        the latent space representation to the original
+        data space. The encoder_out_size parameter is
+        used to reshape the output of the fully connected
+        layer to match the size of the convolutional
+        output of the Encoder block.
+
+        Parameters
+        ----------
+        encoder_out_size : tuple
+            Size of the convolutional output of the
+            Encoder block.
+        kernel_size : int, optional
+            Length of the 1D kernel used in the
+            convolutional layers.
+            Default: 3
+        """
+        super(Decoder, self).__init__(**kwargs)
+        self.kernel_size = kernel_size
+        self.encoder_out_size = encoder_out_size
+
+        self.fc2 = layers.Dense(8192, name="fc2")
+        self.decod_conv1 = pre_pad(
+            layers.Conv1D(512, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv1")
+        )
+        self.upsampl1 = layers.UpSampling1D(size=2, name="upsampling1")
+        self.decod_conv2 = pre_pad(
+            layers.Conv1D(256, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv2")
+        )
+        self.upsampl2 = layers.UpSampling1D(size=2, name="upsampling2")
+        self.decod_conv3 = pre_pad(
+            layers.Conv1D(128, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv3")
+        )
+        self.upsampl3 = layers.UpSampling1D(size=2, name="upsampling3")
+        self.decod_conv4 = pre_pad(
+            layers.Conv1D(64, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv4")
+        )
+        self.upsampl4 = layers.UpSampling1D(size=2, name="upsampling4")
+        self.decod_conv5 = pre_pad(
+            layers.Conv1D(32, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv5")
+        )
+        self.upsampl5 = layers.UpSampling1D(size=2, name="upsampling5")
+        self.decod_conv6 = pre_pad(
+            layers.Conv1D(3, self.kernel_size, strides=1, padding='valid',
+                          name="decoder_conv6")
+        )
+
+    def get_config(self):
+        base_config = super().get_config()
+        config = {
+            "encoder_out_size": keras.saving.serialize_keras_object(self.encoder_out_size),
+            "kernel_size": keras.saving.serialize_keras_object(self.kernel_size)
+        }
+        return {**base_config, **config}
+
+    @classmethod
+    def from_config(cls, config):
+        encoder_out_size = keras.saving.deserialize_keras_object(config.pop('encoder_out_size'))
+        kernel_size = keras.saving.deserialize_keras_object(config.pop('kernel_size'))
+        return cls(encoder_out_size, kernel_size, **config)
+
+    def call(self, input_data):
+        """
+        Run the input data through the Decoder.
+        Decode the latent space representation
+        to the original data space.
+
+        Parameters
+        ----------
+        input_data : tf.Tensor or np.ndarray
+            Data to run through the decoder.
+            Should be of the shape of the latent
+            space: (n_samples, latent_space_dims).
+
+        Returns
+        -------
+        tf.Tensor
+            Decoded input in the original
+            data space, with the shape
+            (n_samples, 256, 3).
+        """
+        z = input_data
+        fc = self.fc2(z)
+
+        # Reshape to match encoder output size
+        fc_reshape = tf.reshape(fc, (-1, self.encoder_out_size[0],
+                                     self.encoder_out_size[1]))
+
+        h1 = tf.nn.relu(self.decod_conv1(fc_reshape))
+        h2 = self.upsampl1(h1)
+        h3 = tf.nn.relu(self.decod_conv2(h2))
+        h4 = self.upsampl2(h3)
+        h5 = tf.nn.relu(self.decod_conv3(h4))
+        h6 = self.upsampl3(h5)
+        h7 = tf.nn.relu(self.decod_conv4(h6))
+        h8 = self.upsampl4(h7)
+        h9 = tf.nn.relu(self.decod_conv5(h8))
+        h10 = self.upsampl5(h9)
+        h11 = self.decod_conv6(h10)
+
+        return h11
+
+
+def init_model(latent_space_dims=32, kernel_size=3):
+    r"""
+    Initialize the model with the given latent
+    space dimensions and kernel size.
+    Instantiates the Encoder, the Decoder, and
+    returns the model comprising both blocks.
+
+    Parameters
+    ----------
+    latent_space_dims : int, optional
+        Number of dimensions of the latent
+        space where the data will be encoded
+        Default: 32
+    kernel_size : int, optional
+        Length of the 1D kernel used in the
+        convolutional layers of the Encoder
+        and the Decoder
+        Default: 3
+
+    Returns
+    -------
+    keras.Model
+        AutoEncoder model comprising an
+        Encoder and a Decoder.
+    """
+    input_data = keras.Input(shape=(256, 3), name='input_streamline')
+
+    # encode
+    encoder = Encoder(latent_space_dims=latent_space_dims,
+                      kernel_size=kernel_size)
+    encoded = encoder(input_data)
+
+    # decode
+    decoder = Decoder(encoder.encoder_out_size,
+                      kernel_size=kernel_size)
+    decoded = decoder(encoded)
+    output_data = decoded
+
+    # Instantiate model and name it
+    model = Model(input_data, output_data)
+    model.name = 'IncrFeatStridedConvFCUpsampReflectPadAE'
+    return model
+
+
+class IncrFeatStridedConvFCUpsampReflectPadAE():
+    """
+    Strided convolution-upsampling-based
+    AutoEncoder using reflection-padding and
+    increasing feature maps in decoder.
+    Architecture based on Jon Haitz Legarreta Gorroño's
+    PyTorch implementation, from his FINTA [1] work.
+    [1] https://doi.org/10.1016/j.media.2021.102126
+    """
+
+    def __init__(self, latent_space_dims=32, kernel_size=3):
+
+        # Parameter Initialization
+        self.kernel_size = kernel_size
+        self.latent_space_dims = latent_space_dims
+        self.input = keras.Input(shape=(256, 3), name='input_streamline')
+
+        self.model = init_model(latent_space_dims=self.latent_space_dims,
+                                kernel_size=self.kernel_size)
+
+    def __call__(self, x):
+        r"""
+        Run the input streamlines 'x' through
+        the model (encoder -> decoder)
+
+        Parameters
+        ----------
+        x : tf.Tensor, np.ndarray
+            Tensor of shape (n_samples, 256, 3)
+            containing the input streamlines.
+
+        Returns
+        -------
+        tf.Tensor
+            Reconstruction of input streamlines
+            after passing through the model.
+        """
+        return self.model(x)
+
+    def compile(self, **kwargs):
+        r"""
+        Wrapper of the built in compile method
+        of the model, which configures the model
+        for training. Sets the optimizer weight
+        decay to the same value as in the PyTorch
+        implementation (FINTA [1]).
+        [1] https://doi.org/10.1016/j.media.2021.102126
+        """
+        kwargs['optimizer'].weight_decay = 0.13
+        self.model.compile(**kwargs)
+
+    def summary(self, **kwargs):
+        r"""
+        Get the summary of the model. The summary
+        is textual and includes information about:
+        - The layers and their order in the model.
+        - The output shape of each layer.
+        """
+        return self.model.summary(**kwargs)
+
+    def fit(self, *args, **kwargs,):
+        r"""
+        Wrapper of the built in fit method of the
+        model, which trains the model for a fixed
+        number of epochs. In case of inputing
+        streamlines as input, converts them to
+        numpy arrays.
+        """
+        if isinstance(kwargs['x'], nib.streamlines.ArraySequence):
+            kwargs['x'] = np.array(kwargs['x'])
+        if isinstance(kwargs['y'], nib.streamlines.ArraySequence):
+            kwargs['y'] = np.array(kwargs['y'])
+        return self.model.fit(*args, **kwargs)
+
+    def save_weights(self, *args, **kwargs):
+        """
+        Wrapper of the built in method to save
+        the weights of the model in the specified
+        filepath, which must end
+        in '*.weights.h5'.
+        """
+        self.model.save_weights(*args, **kwargs)
+
+    def save(self, *args, **kwargs):
+        """
+        Wrapper of the built in method to save
+        the model together with its weights in
+        the specified filepath, which must end
+        in '*.keras'.
+        """
+        self.model.save(*args, **kwargs)

--- a/dipy/nn/meson.build
+++ b/dipy/nn/meson.build
@@ -7,6 +7,7 @@ python_sources = [
   'model.py',
   'synb0.py',
   'utils.py',
+  'finta_model.py',
   ]
 
 

--- a/dipy/nn/tests/meson.build
+++ b/dipy/nn/tests/meson.build
@@ -7,6 +7,7 @@ python_sources = [
   'test_synb0.py',
   'test_tf.py',
   'test_utils.py',
+  'test_finta_model.py',
   ]
 
 

--- a/dipy/nn/tests/test_finta_model.py
+++ b/dipy/nn/tests/test_finta_model.py
@@ -1,0 +1,173 @@
+import os
+import pytest
+import tempfile
+
+import numpy as np
+import numpy.testing as npt
+
+import dipy.nn.utils as utils
+from dipy.utils.optpkg import optional_package
+
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+
+if have_tf:
+    from dipy.nn.finta_model import Encoder, Decoder
+    from dipy.nn.finta_model import (
+        IncrFeatStridedConvFCUpsampReflectPadAE as AE)
+
+
+class DummyData():
+    def __init__(self, latent_space_dims: int = 32):
+        """
+        Generate three streamlines, aligned with the x, y, and z axes. Each streamline has 256 points.
+        Generate a latent vector of the given size.
+
+        Parameters
+        ----------
+        latent_space_dims : int, optional
+            Number of dimensions of the latent space vector
+            Default: 32
+        """
+        streamlines = []
+        latent_vectors = []
+        for i in range(3):
+            # Streamlines aligned with the x, y, and z axes
+            streamline = np.zeros((256, 3))
+            streamline[:, i] = np.arange(256)
+            streamline = streamline[np.newaxis, ...]
+            streamlines.append(streamline)
+
+            # Arbitrary latent vectors
+            latent_vector = (i + 1) * np.arange(latent_space_dims)
+            latent_vector = latent_vector[np.newaxis, ...]
+            latent_vectors.append(latent_vector)
+
+        self.streamlines = np.concatenate(streamlines, axis=0)
+
+        self.latent_vectors = np.concatenate(latent_vectors, axis=0)
+
+
+# Test the Encoder on its own as a usable block
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_encoder_parameter_initialization():
+    test_encoder = Encoder(latent_space_dims=10,
+                           kernel_size=3)
+
+    # Check initialization parameters
+    assert test_encoder.latent_space_dims == 10
+    assert test_encoder.kernel_size == 3
+    k_weight_init = np.sqrt(1 / (3 * test_encoder.kernel_size))
+    npt.assert_almost_equal(test_encoder.k_conv1d_weights_initializer,
+                            k_weight_init, decimal=5)
+
+
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_encoder_call():
+    latent_space_dims = 10
+    test_encoder = Encoder(latent_space_dims=latent_space_dims)
+    data = DummyData().streamlines
+    output = test_encoder(data)
+
+    # Check output shape
+    assert output.shape == (data.shape[0], latent_space_dims)
+
+    # Check encoder_out_size
+    assert test_encoder.encoder_out_size == [8, 1024]
+
+    # Check that the encoder is built
+    assert test_encoder.built is True
+
+
+# Test the Decoder on its own as a usable block
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_decoder_parameter_initialization():
+    test_decoder = Decoder(encoder_out_size=[4, 1024])
+
+    # Check initialization parameters
+    assert test_decoder.kernel_size == 3
+    assert test_decoder.encoder_out_size == [4, 1024]
+
+
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_decoder_call():
+    test_decoder = Decoder(encoder_out_size=[8, 1024])
+    data = DummyData(latent_space_dims=10).latent_vectors
+    output = test_decoder(data)
+
+    # Check output shape
+    assert output.shape == (data.shape[0], 256, 3)
+
+    # Check that the decoder is built
+    assert test_decoder.built is True
+
+
+# Test the AutoEncoder fully
+
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_ae_calling_output_shape():
+    latent_space_dims = 32
+    kernel_size = 3
+    test_ae = AE(latent_space_dims=latent_space_dims,
+                 kernel_size=kernel_size)
+
+    data = DummyData().streamlines
+    output = test_ae(data)
+
+    # Check output shape
+    assert output.shape == (data.shape[0], 256, 3)
+
+    # Check that the autoencoder is built
+    assert test_ae.name == "incr_feat_strided_conv_fc_upsamp_reflect_pad_ae"
+
+    # Check that the autoencoder is built
+    assert test_ae.built is True
+
+
+@pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")
+def test_ae_train_weight_saving_and_loading():
+    latent_space_dims = 32
+    kernel_size = 3
+    test_ae = AE(latent_space_dims=latent_space_dims,
+                 kernel_size=kernel_size)
+
+    # Train the model
+    optimizer = tf.keras.optimizers.Adam(learning_rate=1e-5)
+    loss = tf.keras.losses.MeanSquaredError()
+
+    # Compile the model
+    test_ae.compile(optimizer=optimizer, loss=loss)
+
+    # Fit the model
+    input_train_data = DummyData().streamlines
+    input_train_data = tf.convert_to_tensor(input_train_data)
+    test_ae.fit(x=input_train_data,
+                y=input_train_data,
+                batch_size=1,
+                epochs=3)
+
+    # Run the training data through the trained model
+    output_after_train = test_ae(input_train_data)
+
+    # Save the model weights
+    path_weights = tempfile.NamedTemporaryFile().name + ".weights.h5"
+    test_ae.save_weights(path_weights)
+    # Save the model with the weights
+    path_model = tempfile.NamedTemporaryFile().name + ".keras"
+    test_ae.save(path_model)
+
+    # Load the model
+    loaded_ae = tf.keras.models.load_model(path_model, compile=False)
+
+    # Check that the loaded model is the same as the original in parameters
+    # We use inclusion because the loaded one has some extra characters
+    assert "incr_feat_strided_conv_fc_upsamp_reflect_pad_ae" in loaded_ae.name
+    assert loaded_ae.latent_space_dims == test_ae.latent_space_dims
+    assert loaded_ae.kernel_size == test_ae.kernel_size
+
+    # Check that the loaded model outputs the same as the original
+    output_after_load = loaded_ae(input_train_data)
+    npt.assert_allclose(output_after_train, output_after_load)
+
+    # Cleanup the weights and the model
+    os.remove(path_weights)
+    os.remove(path_model)

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -4,6 +4,31 @@ from scipy.ndimage import affine_transform, label
 from dipy.align.reslice import reslice
 from dipy.testing.decorators import warning_for_keywords
 
+from tensorflow import pad as tf_pad
+from keras import Sequential
+from keras.layers import Layer
+
+
+dict_kernel_size_flatten_encoder_shape = {1: 12288,
+                                          2: 10240,
+                                          3: 8192,
+                                          4: 7168,
+                                          5: 5120}
+
+class ReflectionPadding1D(Layer):
+    @warning_for_keywords()
+    def __init__(self, padding: int = 1, **kwargs):
+        super(ReflectionPadding1D, self).__init__(**kwargs)
+        self.padding = padding
+
+    def call(self, inputs):
+        return tf_pad(inputs, [[0, 0], [self.padding, self.padding], [0, 0]],
+                      mode='REFLECT')
+
+
+def pre_pad(layer: Layer):
+    return Sequential([ReflectionPadding1D(padding=1), layer])
+
 
 @warning_for_keywords()
 def normalize(image, *, min_v=None, max_v=None, new_min=-1, new_max=1):


### PR DESCRIPTION
## Summary of PR
Adds the TF2 version of the [FINTA]() AutoEncoder by Jon Haitz, as part of my last GSoC2024 submission.
This PR aims to host other models to come.

### Main contributions
- Adds `IncrFeatStridedConvFCUpsampReflectPadAE` class, the AutoEncoder model class.
- Adds `ReflectionPadding` custom layer class and `pre_pad` function to the `dipy/nn/utils.py` module to support the AutoEncoder model.
- Adds tests to the AutoEncoder model class for: instantiation, training, and weight saving/loading.

