### PR TITLE
STYLE: Use a leading underscore to name private methods

### DIFF
--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -287,7 +287,7 @@ class QtdmriModel(Cache):
                 ut /= tau_scaling
                 us = np.clip(us, self.eigenvalue_threshold, np.inf)
                 q = np.dot(bvecs, R) * qvals[:, None]
-                M = qtdmri_signal_matrix_(
+                M = _qtdmri_signal_matrix(
                     self.radial_order,
                     self.time_order,
                     us,
@@ -304,7 +304,7 @@ class QtdmriModel(Cache):
                 R = np.eye(3)
                 us = np.tile(us, 3)
                 q = bvecs * qvals[:, None]
-                M = qtdmri_signal_matrix_(
+                M = _qtdmri_signal_matrix(
                     self.radial_order,
                     self.time_order,
                     us,
@@ -321,7 +321,7 @@ class QtdmriModel(Cache):
             R = np.eye(3)
             us = np.tile(us, 3)
             q = bvecs * qvals[:, None]
-            M = qtdmri_isotropic_signal_matrix_(
+            M = _qtdmri_isotropic_signal_matrix(
                 self.radial_order,
                 self.time_order,
                 us[0],
@@ -1042,7 +1042,7 @@ class QtdmriFit:
         if self.model.cartesian:
             if self.model.anisotropic_scaling:
                 q_rot = np.dot(q, self.R)
-                M = qtdmri_signal_matrix_(
+                M = _qtdmri_signal_matrix(
                     self.model.radial_order,
                     self.model.time_order,
                     self.us,
@@ -1052,7 +1052,7 @@ class QtdmriFit:
                     self.model.normalization,
                 )
             else:
-                M = qtdmri_signal_matrix_(
+                M = _qtdmri_signal_matrix(
                     self.model.radial_order,
                     self.model.time_order,
                     self.us,
@@ -1062,7 +1062,7 @@ class QtdmriFit:
                     self.model.normalization,
                 )
         else:
-            M = qtdmri_isotropic_signal_matrix_(
+            M = _qtdmri_isotropic_signal_matrix(
                 self.model.radial_order,
                 self.model.time_order,
                 self.us[0],
@@ -1129,7 +1129,7 @@ class QtdmriFit:
         tau_scaling = self.tau_scaling
         rt_points_ = rt_points * np.r_[1, 1, 1, tau_scaling]
         if self.model.cartesian:
-            K = qtdmri_eap_matrix_(
+            K = _qtdmri_eap_matrix(
                 self.model.radial_order,
                 self.model.time_order,
                 self.us,
@@ -1138,7 +1138,7 @@ class QtdmriFit:
                 self.model.normalization,
             )
         else:
-            K = qtdmri_isotropic_eap_matrix_(
+            K = _qtdmri_isotropic_eap_matrix(
                 self.model.radial_order,
                 self.model.time_order,
                 self.us[0],
@@ -1288,7 +1288,7 @@ def qtdmri_mapmri_isotropic_normalization(j, ell, u0):
     return sqrtC
 
 
-def qtdmri_signal_matrix_(
+def _qtdmri_signal_matrix(
     radial_order, time_order, us, ut, q, tau, normalization=False
 ):
     """Function to generate the qtdmri signal basis."""
@@ -1377,7 +1377,7 @@ def qtdmri_eap_matrix(radial_order, time_order, us, ut, grid):
     return K
 
 
-def qtdmri_isotropic_signal_matrix_(
+def _qtdmri_isotropic_signal_matrix(
     radial_order, time_order, us, ut, q, tau, normalization=False
 ):
     M = qtdmri_isotropic_signal_matrix(radial_order, time_order, us, ut, q, tau)
@@ -1435,7 +1435,7 @@ def qtdmri_isotropic_signal_matrix(radial_order, time_order, us, ut, q, tau):
     return M
 
 
-def qtdmri_eap_matrix_(radial_order, time_order, us, ut, grid, normalization=False):
+def _qtdmri_eap_matrix(radial_order, time_order, us, ut, grid, normalization=False):
     sqrtCut = 1.0
     if normalization:
         sqrtC = qtdmri_mapmri_normalization(us)
@@ -1445,7 +1445,7 @@ def qtdmri_eap_matrix_(radial_order, time_order, us, ut, grid, normalization=Fal
     return K_tau
 
 
-def qtdmri_isotropic_eap_matrix_(
+def _qtdmri_isotropic_eap_matrix(
     radial_order, time_order, us, ut, grid, normalization=False
 ):
     K = qtdmri_isotropic_eap_matrix(radial_order, time_order, us, ut, grid)

--- a/dipy/workflows/multi_io.py
+++ b/dipy/workflows/multi_io.py
@@ -166,7 +166,7 @@ def io_iterator(
 
 
 @warning_for_keywords()
-def io_iterator_(frame, fnc, *, output_strategy="absolute", mix_names=False):
+def _io_iterator(frame, fnc, *, output_strategy="absolute", mix_names=False):
     """Create an IOIterator using introspection.
 
     Parameters

--- a/dipy/workflows/workflow.py
+++ b/dipy/workflows/workflow.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from dipy.testing.decorators import warning_for_keywords
-from dipy.workflows.multi_io import io_iterator_
+from dipy.workflows.multi_io import _io_iterator
 
 
 class Workflow:
@@ -36,7 +36,7 @@ class Workflow:
         else:
             frame = frame.frame
 
-        io_it = io_iterator_(
+        io_it = _io_iterator(
             frame,
             self.run,
             output_strategy=self._output_strategy,


### PR DESCRIPTION
Use a leading underscore to name private methods: using a trailing underscore is translated by Sphinx into the same method name as its underscoreless counterpart.

Fixes:
```
/dipy/dipy/doc/reference/dipy.workflows.rst:651:
 ERROR: Duplicate target name, cannot be used as a unique reference: "io_iterator".
```

and similar errors raised for example in:
https://github.com/dipy/dipy/actions/runs/10472634043/job/29002561651#step:5:1146

Documentation:
https://peps.python.org/pep-0008/#method-names-and-instance-variables