### PR TITLE
DOC: Miscellaneous documentation improvements (part 3)

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -212,10 +212,13 @@ def register_dwi_to_template(
 
     Returns
     -------
-    warped_b0, mapping: The fist is an array with the b0 volume warped to the
-    template. If reg_method is "syn", the second is a DiffeomorphicMap class
-    instance that can be used to transform between the two spaces. Otherwise,
-    if reg_method is "aff", this is a 4x4 matrix encoding the affine transform.
+    warped_b0 : ndarray
+        b0 volume warped to the template.
+    mapping : DiffeomorphicMap or ndarray
+        If reg_method is "syn", a DiffeomorphicMap class instance that can be
+        used to transform between the two spaces. Otherwise, if reg_method is
+        "aff", a 4x4 matrix encoding the affine transform.
+
 
     Notes
     -----

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -110,7 +110,7 @@ class AffineMap:
         sampling information needs to be specified each time the `transform`
         or `transform_inverse` is called to transform images. Note that such
         sampling information is not necessary to transform points defined in
-        physical space, such as stream lines.
+        physical space, such as streamlines.
 
         Parameters
         ----------

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -429,9 +429,9 @@ class AffineMap:
 
         Returns
         -------
-        transformed : array, shape `sampling_grid_shape` or
-                      `self.codomain_shape`
-            the transformed image, sampled at the requested grid
+        transformed : array
+            the transformed image, sampled at the requested grid, with shape
+            `sampling_grid_shape` or `self.codomain_shape`.
 
         """
         transformed = self._apply_transform(
@@ -490,9 +490,9 @@ class AffineMap:
 
         Returns
         -------
-        transformed : array, shape `sampling_grid_shape` or
-                      `self.codomain_shape`
-            the transformed image, sampled at the requested grid
+        transformed : array
+            the transformed image, sampled at the requested grid, with shape
+            `sampling_grid_shape` or `self.codomain_shape`.
 
         """
         transformed = self._apply_transform(

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -329,10 +329,10 @@ class StreamlineLinearRegistration:
 
             If 1D array with:
                 a) 6 elements then only rigid registration is performed with
-                the 3 first elements for translation and 3 for rotation.
+                   the 3 first elements for translation and 3 for rotation.
                 b) 7 elements also isotropic scaling is performed (similarity).
                 c) 12 elements then translation, rotation (in degrees),
-                scaling and shearing is performed (affine).
+                   scaling and shearing is performed (affine).
 
                 Here is an example of x0 with 12 elements:
                 ``x0=np.array([0, 10, 0, 40, 0, 0, 2., 1.5, 1, 0.1, -0.5, 0])``

--- a/dipy/reconst/cti.py
+++ b/dipy/reconst/cti.py
@@ -111,7 +111,7 @@ def split_cti_params(cti_params):
 
             1. Three diffusion tensor's eigenvalues
             2. Three lines of the eigenvector matrix each containing the
-            first, second and third coordinates of the eigenvector
+               first, second and third coordinates of the eigenvector
             3. Fifteen elements of the kurtosis tensor
             4. Twenty-One elements of the covariance tensor
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1756,12 +1756,12 @@ class DiffusionKurtosisModel(ReconstModel):
         fit_method : str or callable, optional
             str be one of the following:
 
-                - 'OLS' or 'ULLS' for ordinary least squares.
-                - 'WLS', 'WLLS' or 'UWLLS' for weighted ordinary least squares.
-                   See func:`dki.ls_fit_dki`.
-                - 'CLS' for LMI constrained ordinary least squares [3]_.
-                - 'CWLS' for LMI constrained weighted least squares [3]_.
-                   See func:`dki.cls_fit_dki`.
+            - 'OLS' or 'ULLS' for ordinary least squares.
+            - 'WLS', 'WLLS' or 'UWLLS' for weighted ordinary least squares.
+              See func:`dki.ls_fit_dki`.
+            - 'CLS' for LMI constrained ordinary least squares [3]_.
+            - 'CWLS' for LMI constrained weighted least squares
+              [3]_. See func:`dki.cls_fit_dki`.
 
             callable has to have the signature:
                 ``fit_method(design_matrix, data, *args, **kwargs)``

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1958,7 +1958,7 @@ class DiffusionKurtosisModel(ReconstModel):
 
                 1. Three diffusion tensor's eigenvalues
                 2. Three lines of the eigenvector matrix each containing the
-                first, second and third coordinates of the eigenvector
+                   first, second and third coordinates of the eigenvector
                 3. Fifteen elements of the kurtosis tensor
 
         S0 : float or ndarray (optional)

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -314,7 +314,7 @@ def wls_iter(
             FS, SI = np.meshgrid(fs, sig)
             SA = SI - FS * S0 * SFW.T
             # SA < 0 means that the signal components from the free water
-            # component is larger than the total fiber. This cases are present
+            # component is larger than the total fiber. These cases are present
             # for inappropriate large volume fractions (given the current S0
             # value estimated). To overcome this issue negative SA are replaced
             # by data's min positive signal.

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -385,6 +385,7 @@ def wls_fit_tensor(
     fw_params : ndarray (x, y, z, 13)
         Matrix containing in the last dimension the free water model parameters
         in the following order:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the
                first, second and third coordinates of the eigenvector
@@ -785,6 +786,7 @@ def nls_fit_tensor(
     fw_params : ndarray (x, y, z, 13)
         Matrix containing in the dimension the free water model parameters in
         the following order:
+
             1) Three diffusion tensor's eigenvalues
             2) Three lines of the eigenvector matrix each containing the
                first, second and third coordinates of the eigenvector

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -255,7 +255,7 @@ def wls_iter(
         Value of the free water isotropic diffusion. Default is set to 3e-3
         $mm^{2}.s^{-1}$. Please adjust this value if you are assuming different
         units of diffusion.
-     mdreg : float, optimal
+    mdreg : float, optimal
         DTI's mean diffusivity regularization threshold. If standard DTI
         diffusion tensor's mean diffusivity is almost near the free water
         diffusion value, the diffusion signal is assumed to be only free water

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -271,12 +271,15 @@ def wls_iter(
 
     Returns
     -------
-    All parameters estimated from the free water tensor model.
-    Parameters are ordered as follows:
-        1) Three diffusion tensor's eigenvalues
-        2) Three lines of the eigenvector matrix each containing the
-           first, second and third coordinates of the eigenvector
-        3) The volume fraction of the free water compartment
+    fw_params : ndarray
+        All parameters estimated from the free water tensor model. Parameters
+        are ordered as follows:
+
+            1) Three diffusion tensor's eigenvalues
+            2) Three lines of the eigenvector matrix each containing the
+               first, second and third coordinates of the eigenvector
+            3) The volume fraction of the free water compartment
+
     """
     W = design_matrix
 

--- a/dipy/reconst/qti.py
+++ b/dipy/reconst/qti.py
@@ -722,13 +722,12 @@ class QtiModel(ReconstModel):
             Gradient table with b-tensors.
         fit_method : str, optional
             Must be one of the following:
-                'OLS' for ordinary least squares
-                    :func:`qti._ols_fit`
-                'WLS' for weighted least squares
-                    :func:`qti._wls_fit`
-                'SDPDc' for semidefinite programming with positivity
-                        constraints applied [2]_
-                    :func:`qti._sdpdc_fit`
+
+            - 'OLS' for ordinary least squares :func:`qti._ols_fit`
+            - 'WLS' for weighted least squares :func:`qti._wls_fit`
+            - 'SDPDc' for semidefinite programming with positivity constraints
+              applied [2]_ :func:`qti._sdpdc_fit`
+
         cvxpy_solver: str, optionals
             solver for the SDP formulation. default: 'SCS'
 

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -412,7 +412,7 @@ class RecoBundles:
         slr_bounds : array, optional
             (default None)
         slr_select : tuple, optional
-            Select the number of streamlines from model to neirborhood of
+            Select the number of streamlines from model to neighborhood of
             model to perform the local SLR.
         slr_method : string, optional
             Optimization method 'L_BFGS_B' or 'Powell' optimizers can be used.

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -407,8 +407,8 @@ class RecoBundles:
                 b) "similarity"
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1.])``
                 c) "affine"
-                    ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])
-            (default None)
+                    ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])``
+
         slr_bounds : array, optional
             (default None)
         slr_select : tuple, optional

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -410,7 +410,7 @@ class RecoBundles:
                     ``x0 = np.array([0, 0, 0, 0, 0, 0, 1., 1., 1, 0, 0, 0])``
 
         slr_bounds : array, optional
-            (default None)
+            SLR bounds.
         slr_select : tuple, optional
             Select the number of streamlines from model to neighborhood of
             model to perform the local SLR.

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -530,10 +530,10 @@ class RecoBundles:
 
             If 1D array with:
                 a) 6 elements then only rigid registration is performed with
-                the 3 first elements for translation and 3 for rotation.
+                   the 3 first elements for translation and 3 for rotation.
                 b) 7 elements also isotropic scaling is performed (similarity).
                 c) 12 elements then translation, rotation (in degrees),
-                scaling and shearing are performed (affine).
+                   scaling and shearing are performed (affine).
 
                 Here is an example of x0 with 12 elements:
                 ``x0=np.array([0, 10, 0, 40, 0, 0, 2., 1.5, 1, 0.1, -0.5, 0])``


### PR DESCRIPTION
- DOC: Fix typos and grammar
- DOC: Format properly returned parameter docstrings
- DOC: Make the parameter type dwell on a single line
- DOC: Indent appropriately a parameter docstring
- DOC: Enclose inline literal in double bacticks
- DOC: Add description to parameter docstring
- DOC: Use the appropriate indentation in docstrings
- DOC: Add parameter name/type line to return docstring
- DOC: Add an empty line before list items
- DOC: Indent appropriately enumerated lists