### PR TITLE
RF: Decorator fix

### DIFF
--- a/dipy/core/onetime.py
+++ b/dipy/core/onetime.py
@@ -54,7 +54,6 @@ Hettinger. http://users.rcn.com/python/download/Descriptor.htm
 [2] Python data model, https://docs.python.org/reference/datamodel.html
 """
 
-from dipy.testing.decorators import warning_for_keywords
 
 # ----------------------------------------------------------------------------
 # Classes and Functions
@@ -163,8 +162,7 @@ class OneTimeProperty:
         self.getter = func
         self.name = func.__name__
 
-    @warning_for_keywords()
-    def __get__(self, obj, *, type=None):
+    def __get__(self, obj, type=None):
         """This will be called on attribute access on the class or instance."""
 
         if obj is None:

--- a/dipy/nn/deepn4.py
+++ b/dipy/nn/deepn4.py
@@ -252,7 +252,7 @@ class DeepN4:
             subj, 128
         )
         in_max = np.percentile(input_data[np.nonzero(input_data)], 99.99)
-        input_data = normalize(input_data, 0, in_max, 0, 1)
+        input_data = normalize(input_data, min_v=0, max_v=in_max, new_min=0, new_max=1)
         input_data = np.squeeze(input_data)
         input_vols = np.zeros((1, 128, 128, 128, 1))
         input_vols[0, :, :, :, 0] = input_data

--- a/dipy/nn/evac.py
+++ b/dipy/nn/evac.py
@@ -473,7 +473,9 @@ class EVACPlus:
         n_T1 = np.zeros(T1.shape)
         for i, T1_img in enumerate(T1):
             n_T1[i] = normalize(T1_img, new_min=0, new_max=1)
-            t_img, t_affine, ori_shape = transform_img(n_T1[i], affine[i], voxsize[i])
+            t_img, t_affine, ori_shape = transform_img(
+                n_T1[i], affine[i], voxsize=voxsize[i]
+            )
             input_data[..., i] = t_img
             rev_affine[i] = t_affine
             ori_shapes[i] = ori_shape

--- a/dipy/nn/synb0.py
+++ b/dipy/nn/synb0.py
@@ -283,8 +283,8 @@ class Synb0:
         # Normalize the data.
         p99 = np.percentile(b0, 99, axis=(1, 2, 3))
         for i in range(shape[0]):
-            T1[i] = normalize(T1[i], 0, 150, -1, 1)
-            b0[i] = normalize(b0[i], 0, p99[i], -1, 1)
+            T1[i] = normalize(T1[i], min_v=0, max_v=150, new_min=-1, new_max=1)
+            b0[i] = normalize(b0[i], min_v=0, max_v=p99[i], new_min=-1, new_max=1)
 
         if dim == 3:
             if batch_size is not None:

--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -33,7 +33,7 @@ def test_default_weights_batch():
     fake_affine = np.array([np.eye(4), np.eye(4)])
     fake_voxsize = np.ones((2, 3))
     results_arr = evac_model.predict(
-        input_arr, fake_affine, fake_voxsize, batch_size=2, return_prob=True
+        input_arr, fake_affine, voxsize=fake_voxsize, batch_size=2, return_prob=True
     )
     npt.assert_almost_equal(results_arr, output_arr, decimal=4)
 

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -1782,7 +1782,9 @@ class DiffusionKurtosisModel(ReconstModel):
                     msg = "Maximum convexity_level supported is 4."
                     warnings.warn(msg, stacklevel=2)
                     self.convexity_level = 4
-                self.sdp_constraints = load_sdp_constraints("dki", self.convexity_level)
+                self.sdp_constraints = load_sdp_constraints(
+                    "dki", order=self.convexity_level
+                )
             self.sdp = PositiveDefiniteLeastSquares(22, A=self.sdp_constraints)
 
         self.weights = fit_method in {"WLS", "WLLS", "UWLLS", "CWLS"}

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -243,14 +243,16 @@ class MapmriModel(ReconstModel, Cache):
                         " anistropic_scaling=True."
                     )
                 if radial_order > 10:
-                    self.sdp_constraints = load_sdp_constraints("hermite", 10)
+                    self.sdp_constraints = load_sdp_constraints("hermite", order=10)
                     warn(
                         "Global constraints are currently supported for"
                         " radial_order <= 10.",
                         stacklevel=2,
                     )
                 else:
-                    self.sdp_constraints = load_sdp_constraints("hermite", radial_order)
+                    self.sdp_constraints = load_sdp_constraints(
+                        "hermite", order=radial_order
+                    )
                 m = (2 + radial_order) * (4 + radial_order) * (3 + 2 * radial_order)
                 m = m // 24
                 self.sdp = PositiveDefiniteLeastSquares(m, A=self.sdp_constraints)

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -133,6 +133,9 @@ def warning_for_keywords(from_version="1.10.0", until_version="2.0.0"):
         def wrapper(*args, **kwargs):
             current_version = dipy.__version__
 
+            parsed_version = version.parse(current_version)
+            current_version = parsed_version.base_version
+
             def convert_positional_to_keyword(func, args, kwargs):
                 """
                 Converts excess positional arguments to keyword arguments.

--- a/dipy/testing/tests/test_decorators.py
+++ b/dipy/testing/tests/test_decorators.py
@@ -107,5 +107,31 @@ def test_warning_for_keywords():
     except TypeError:
         pass
 
+    # Case 5: Version is a pre-release like '2.0.0rc1', warnings expected
+    dipy.__version__ = "2.0.0rc1"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = func_with_kwonly_args(1, 2, 3)
+        assert result == 6, "Expected result to be 6"
+        assert len(w) == 1, "Expected warning for version 2.0.0rc1"
+        assert (
+            "Pass ['c'] as keyword args. From version 10.0.0 passing these as "
+            "positional arguments will result in an error" in str(w[-1].message)
+        )
+
+    # Case 6: Version is a dev release like '1.10.0.dev1', warnings expected
+    dipy.__version__ = "1.10.0.dev1"
+    assert func_with_kwonly_args(1, 2, c=3) == 6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = func_with_kwonly_args(1, 2, 3)
+        assert result == 6, "Expected result to be 6"
+        assert len(w) == 1, "Expected warning for version 1.10.0.dev1"
+        assert (
+            "Pass ['c'] as keyword args. From version 10.0.0 passing these as "
+            "positional arguments will result in an error" in str(w[-1].message)
+        )
+
     # Restore the original version
     dipy.__version__ = original_version

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -329,8 +329,8 @@ class Horizon:
             active_streamlines, self.tractograms[0], Space.RASMM
         )
         hz2 = Horizon(
-            [active_sft],
-            self.images,
+            tractograms=[active_sft],
+            images=self.images,
             cluster=True,
             cluster_thr=self.cluster_thr / 2.0,
             random_colors=self.random_colors,
@@ -501,7 +501,7 @@ class Horizon:
                 # Information panel
                 # It will be changed once all the elements wrapped in horizon
                 # elements.
-                text_block = build_label(HELP_MESSAGE, 18)
+                text_block = build_label(HELP_MESSAGE, font_size=18)
 
                 self.help_panel = ui.Panel2D(
                     size=(300, 200),
@@ -549,7 +549,12 @@ class Horizon:
                         is_binary=binary_image,
                     )
                     self.__tabs.append(
-                        SlicesTab(slices_viz, title, fname, self._show_force_render)
+                        SlicesTab(
+                            slices_viz,
+                            title,
+                            fname,
+                            force_render=self._show_force_render,
+                        )
                     )
                     img_count += 1
 

--- a/dipy/viz/horizon/tab/peak.py
+++ b/dipy/viz/horizon/tab/peak.py
@@ -120,8 +120,8 @@ class PeaksTab(HorizonTab):
 
         self._view_modes = ["Cross section", "Range"]
         self._view_mode_toggler = build_radio_button(
-            self._view_modes,
-            [self._view_modes[0]],
+            labels=self._view_modes,
+            checked_labels=[self._view_modes[0]],
             padding=1.5,
             on_change=self._toggle_view_mode,
         )

--- a/dipy/viz/horizon/tab/tests/test_base.py
+++ b/dipy/viz/horizon/tab/tests/test_base.py
@@ -110,7 +110,7 @@ def test_build_slider():
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 def test_build_checkbox():
-    checkbox = build_checkbox(["Hello", "Hi"], ["Hello"])
+    checkbox = build_checkbox(labels=["Hello", "Hi"], checked_labels=["Hello"])
 
     npt.assert_equal(len(checkbox.obj.checked_labels), 1)
     npt.assert_equal(len(checkbox.obj.labels), 2)
@@ -133,7 +133,7 @@ def test_build_checkbox():
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 def test_build_radio():
-    radio = build_radio_button(["Hello", "Hi"], ["Hello"])
+    radio = build_radio_button(labels=["Hello", "Hi"], checked_labels=["Hello"])
 
     npt.assert_equal(len(radio.obj.checked_labels), 1)
     npt.assert_equal(len(radio.obj.labels), 2)
@@ -161,13 +161,17 @@ def test_build_switcher():
         npt.assert_equal(none_switcher, None)
         check_for_warnings(l_warns, "No items passed in switcher")
 
-    switcher_label, switcher = build_switcher([{"label": "Hello", "value": "hello"}])
+    switcher_label, switcher = build_switcher(
+        items=[{"label": "Hello", "value": "hello"}]
+    )
     npt.assert_equal(switcher.selected_value[0], 0)
     npt.assert_equal(switcher.selected_value[1], "hello")
     npt.assert_equal(switcher_label.selected_value, "")
 
     switcher_label, switcher = build_switcher(
-        [{"label": "Hello", "value": "hello"}], "Greeting", 1
+        items=[{"label": "Hello", "value": "hello"}],
+        label="Greeting",
+        initial_selection=1,
     )
     npt.assert_equal(switcher.selected_value[0], 0)
     npt.assert_equal(switcher.selected_value[1], "hello")

--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -235,8 +235,7 @@ class PeakActor(Actor):
         )
 
     @calldata_type(VTK_OBJECT)
-    @warning_for_keywords()
-    def __display_peaks_vtk_callback(self, caller, event, *, calldata=None):
+    def __display_peaks_vtk_callback(self, caller, event, calldata=None):
         if calldata is not None:
             calldata.SetUniformi("isRange", self.__is_range)
             calldata.SetUniform3f("highRanges", self.__high_ranges)

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -128,7 +128,7 @@ def test_horizon(rng):
     tractograms = [sft]
     images = None
     horizon(
-        tractograms,
+        tractograms=tractograms,
         images=images,
         cluster=True,
         cluster_thr=5,
@@ -145,7 +145,7 @@ def test_horizon(rng):
     # tractograms in native coords (not supported for now)
     with npt.assert_raises(ValueError) as ve:
         horizon(
-            tractograms,
+            tractograms=tractograms,
             images=images,
             cluster=True,
             cluster_thr=5,
@@ -164,7 +164,7 @@ def test_horizon(rng):
     # only images
     tractograms = None
     horizon(
-        tractograms,
+        tractograms=tractograms,
         images=images,
         cluster=True,
         cluster_thr=5,
@@ -179,7 +179,7 @@ def test_horizon(rng):
 
     # no clustering tractograms and images
     horizon(
-        tractograms,
+        tractograms=tractograms,
         images=images,
         cluster=False,
         cluster_thr=5,

--- a/dipy/viz/tests/test_streamline.py
+++ b/dipy/viz/tests/test_streamline.py
@@ -51,18 +51,18 @@ def test_output_created():
 
             view = "sagital"  # codespell:ignore sagital
             fname = os.path.join(temp_dir, f"test_{view}.png")
-            show_bundles(bundles, False, view=view, save_as=fname)
+            show_bundles(bundles, interactive=False, view=view, save_as=fname)
             assert_equal(os.path.exists(fname), True)
 
         views = ["axial", "sagittal", "coronal"]
 
         for view in views:
             fname = os.path.join(temp_dir, f"test_{view}.png")
-            show_bundles(bundles, False, view=view, save_as=fname)
+            show_bundles(bundles, interactive=False, view=view, save_as=fname)
             assert_equal(os.path.exists(fname), True)
 
         fname = os.path.join(temp_dir, "test_colors.png")
-        show_bundles(bundles, False, colors=colors, save_as=fname)
+        show_bundles(bundles, interactive=False, colors=colors, save_as=fname)
         assert_equal(os.path.exists(fname), True)
 
         # Check rendered image is not empty
@@ -78,7 +78,9 @@ def test_output_created():
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
 def test_incorrect_view():
-    assert_raises(ValueError, show_bundles, bundles, False, "wrong_view")
+    assert_raises(
+        ValueError, show_bundles, bundles, interactive=False, view="wrong_view"
+    )
 
 
 @pytest.mark.skipif(
@@ -89,10 +91,10 @@ def test_bundlewarp_viz():
         cingulum_bundles = two_cingulum_bundles()
 
         cb1 = cingulum_bundles[0]
-        cb1 = Streamlines(set_number_of_points(cb1, 20))
+        cb1 = Streamlines(set_number_of_points(cb1, nb_points=20))
 
         cb2 = cingulum_bundles[1]
-        cb2 = Streamlines(set_number_of_points(cb2, 20))
+        cb2 = Streamlines(set_number_of_points(cb2, nb_points=20))
 
         deformed_bundle, affine_bundle, _, _, _ = bundlewarp(cb1, cb2)
 

--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -52,7 +52,7 @@ class EVACPlusFlow(Workflow):
                 fpath, return_img=True, return_voxsize=True
             )
             evac = EVACPlus()
-            mask_volume = evac.predict(data, affine, voxsize)
+            mask_volume = evac.predict(data, affine, voxsize=voxsize)
             masked_volume = mask_volume * data
 
             save_nifti(mask_out_path, mask_volume.astype(np.float64), affine)

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -381,7 +381,14 @@ class BundleAnalysisTractometryFlow(Workflow):
                 c = os.path.join(pre, "org_bundles")
                 d = os.path.join(pre, "anatomical_measures")
                 buan_bundle_profiles(
-                    model_bundle_folder, b, c, d, group_id, sub, no_disks, out_dir
+                    model_bundle_folder,
+                    b,
+                    c,
+                    d,
+                    group_id,
+                    sub,
+                    no_disks=no_disks,
+                    out_dir=out_dir,
                 )
 
 
@@ -632,7 +639,7 @@ class BundleShapeAnalysis(Workflow):
                     ).streamlines
 
                     ba_value = bundle_shape_similarity(
-                        bundle1, bundle2, rng, clust_thr, threshold
+                        bundle1, bundle2, rng, clust_thr=clust_thr, threshold=threshold
                     )
 
                     ba_matrix[i][j] = ba_value

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -62,7 +62,7 @@ def test_horizon_flow(rng):
     images = None
 
     horizon(
-        tractograms,
+        tractograms=tractograms,
         images=images,
         cluster=True,
         cluster_thr=5,
@@ -78,7 +78,7 @@ def test_horizon_flow(rng):
     buan_colors = np.ones(streamlines.get_data().shape)
 
     horizon(
-        tractograms,
+        tractograms=tractograms,
         buan=True,
         buan_colors=buan_colors,
         world_coords=True,
@@ -90,7 +90,7 @@ def test_horizon_flow(rng):
     images = [(data, affine, "test/test.nii.gz")]
 
     horizon(
-        tractograms,
+        tractograms=tractograms,
         images=images,
         cluster=True,
         cluster_thr=5,


### PR DESCRIPTION
### Description:
This PR refactors the version handling logic in the warning_for_keywords decorator by using the packaging module for parsing and comparing versions.

- Added packaging.version.parse for accurate version parsing.
- Improved version comparisons by using the base_version attribute, which removes any pre-release or development suffixes.

This change improves the reliability of version-based warnings and argument handling in the decorator.