### PR TITLE
RF: Allow parallel processing for sphinx extension

### DIFF
--- a/doc/sphinxext/github.py
+++ b/doc/sphinxext/github.py
@@ -159,3 +159,7 @@ def setup(app):
     app.add_role('ghuser', ghuser_role)
     app.add_role('ghcommit', ghcommit_role)
     app.add_config_value('github_project_url', None, 'env')
+    metadata = {"parallel_read_safe": True,
+                "parallel_write_safe": True,
+                }
+    return metadata

--- a/doc/sphinxext/math_dollar.py
+++ b/doc/sphinxext/math_dollar.py
@@ -29,14 +29,15 @@ def dollars_to_math(source):
     # don't change these, since they're probably coming from a nested
     # math environment.  So for each match, we replace it with a temporary
     # string, and later on we substitute the original back.
-    global _data
     _data = {}
+
     def repl(matchobj):
-        global _data
+        nonlocal _data
         s = matchobj.group(0)
         t = f"___XXX_REPL_{len(_data)}___"
         _data[t] = s
         return t
+
     s = re.sub(r"({[^{}$]*\$[^{}$]*\$[^{}]*})", repl, s)
     # matches $...$
     dollars = re.compile(r"(?<!\$)(?<!\\)\$([^\$]+?)\$")
@@ -62,3 +63,7 @@ def mathdollar_docstrings(app, what, name, obj, options, lines):
 def setup(app):
     app.connect("source-read", process_dollars)
     app.connect('autodoc-process-docstring', mathdollar_docstrings)
+    metadata = {"parallel_read_safe": True,
+                "parallel_write_safe": True,
+                }
+    return metadata


### PR DESCRIPTION
Small PR to allow parallel processing during doc generation for our sphinx extension.

It should also fix the following warning during doc generation: 

`{extension_name} extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit`