### PR TITLE
CI: pin cvxpy  to 1.4.4 until 1.5.x issues are solved

### DIFF
--- a/.github/workflows/test_optional.yml
+++ b/.github/workflows/test_optional.yml
@@ -15,12 +15,12 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py==3.11.0 nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.24.2 matplotlib h5py==3.11.0 nibabel cvxpy<=1.4.4 tqdm
       extra-depends: scikit_learn pandas statsmodels tables scipy==1.10.1
   conda:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["macos-latest", "windows-latest"]'
       install-type: '["conda"]'
-      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py==3.11.0 nibabel cvxpy tqdm
+      depends: cython!=0.29.29 numpy==1.25.0 matplotlib h5py==3.11.0 nibabel cvxpy<=1.4.4 tqdm
       extra-depends: scikit-learn pandas statsmodels pytables scipy==1.10.1

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -34,7 +34,7 @@ on:
         description: ""
         type: string
         required: false
-        default: cython!=0.29.29 numpy matplotlib h5py nibabel cvxpy tqdm
+        default: cython!=0.29.29 numpy matplotlib h5py nibabel cvxpy<=1.4.4 tqdm
       extra-depends:
         description: ""
         type: string

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.22.4
 scipy>=1.8.1
 nibabel>=4.0.0
 h5py
-cvxpy
+cvxpy<=1.4.4
 pandas
 tables
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ dev = [
 ]
 
 extra = ["dipy[viz, ml]",
-         "cvxpy",
+         "cvxpy<=1.4.4",
          "scikit-image",
          "boto3"
         ]


### PR DESCRIPTION
We are getting these errors below with the 1.5.x serie of CVXPY

```python
=========================== short test summary info ===========================
FAILED reconst/tests/test_qti.py::test_cvxpy_1x6_to_3x3 - TypeError: reshape() takes from 1 to 2 positional arguments but 3 were given
FAILED reconst/tests/test_qti.py::test_cvxpy_1x21_to_6x6 - TypeError: reshape() takes from 1 to 2 positional arguments but 3 were given
FAILED reconst/tests/test_qti.py::test_ls_sdp_fits - AssertionError: 
Arrays are not almost equal to 2 decimals

Mismatched elements: 24 / 56 (42.9%)
Max absolute difference among violations: 0.3333333333333333
Max relative difference among violations: 1.0
 ACTUAL: array([[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
         0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
         0.,  0.],...
 DESIRED: array([[ 0.  ,  0.33,  0.33,  0.33,  0.  ,  0.  ,  0.  ,  0.09,  0.09,
         0.09, -0.06, -0.06, -0.06,  0.  ,  0.  ,  0.  ,  0.  ,  0.  ,
         0.  ,  0.  ,  0.  ,  0.  ,  0.13,  0.13,  0.13,  0.  ,  0.  ,...
FAILED reconst/tests/test_qti.py::test_qti_fit - AssertionError: 
Arrays are not almost equal to 2 decimals

Mismatched elements: 120 / 121 (99.2%)
Max absolute difference among violations: 508.32854165982826
Max relative difference among violations: 0.8999324591485982
 ACTUAL: array([[ 1073.18,  1073.18,  1073.18,  1073.18,  1073.18,  1073.18,
         1073.18,  1073.18,  1073.18,  1073.18,  1073.18,  1073.18,
         1073.18,  1073.18,  1073.18,  1073.18,  1073.18,  1073.18,...
 DESIRED: array([[ 1000.  ,   643.11,   653.6 ,   615.35,   625.13,   574.86,
          606.  ,   645.64,   624.61,   587.64,   632.26,   622.18,
          624.55,   579.73,   572.63,   647.8 ,   657.02,   568.41,...
===== 4 failed, 1017 passed, 65 skipped, 4 warnings in 1795.
```

I am not sure we can do something about this error. I created an issue in CVXPY here: https://github.com/cvxpy/cvxpy/issues/2548

until, we have a solution, I think the best choice is to pin cvxpy for our CIs