### PR TITLE
DOC: Host MNI template note references in references file

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -1991,16 +1991,8 @@ mni_notes = """
 
     The following publications should be referenced when using these templates:
 
-    .. [1] VS Fonov, AC Evans, K Botteron, CR Almli, RC McKinstry, DL Collins
-           and BDCG, Unbiased average age-appropriate atlases for pediatric
-           studies, NeuroImage, 54:1053-8119,
-           DOI: 10.1016/j.neuroimage.2010.07.033
-
-    .. [2] VS Fonov, AC Evans, RC McKinstry, CR Almli and DL Collins,
-            Unbiased nonlinear average age-appropriate brain templates from
-            birth to adulthood, NeuroImage, 47:S102
-            Organization for Human Brain Mapping 2009 Annual Meeting,
-            DOI: https://doi.org/10.1016/S1053-8119(09)70884-5
+    - :footcite:t:`Fonov2013`
+    - :footcite:t:`Fonov2009`
 
     **License for the MNI templates:**
 
@@ -2014,6 +2006,10 @@ mni_notes = """
     authors are not responsible for any data loss, equipment damage, property
     loss, or injury to subjects or patients resulting from the use or misuse
     of this software package.
+
+    References
+    ----------
+    .. footbibliography::
 """
 
 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -633,6 +633,30 @@
   url       = {https://doi.org/10.1016/j.neuroimage.2011.06.006}
 }
 
+@article{Fonov2013,
+  author    = {Vladimir Fonov and Alan C. Evans and Kelly Botteron and C. Robert Almli and Robert C. McKinstry and D. Louis Collins},
+  title     = {{Unbiased average age-appropriate atlases for pediatric studies}},
+  journal   = {NeuroImage},
+  volume    = {54},
+  number    = {1},
+  pages     = {313-327},
+  year      = {2011},
+  doi       = {10.1016/j.neuroimage.2010.07.033},
+  url       = {https://doi.org/10.1016/j.neuroimage.2010.07.033}
+}
+
+@article{Fonov2009,
+  author    = {Vladimir S. Fonov and Alan C. Evans and Robert C. McKinstry and C. Robert Almli and D. Louis Collins},
+  title     = {{Unbiased nonlinear average age-appropriate brain templates from birth to adulthood}},
+  journal   = {NeuroImage},
+  volume    = {47},
+  pages     = {S102},
+  year      = {2009},
+  doi       = {10.1016/S1053-8119(09)70884-5},
+  url       = {https://doi.org/10.1016/S1053-8119(09)70884-5},
+  note      = {Organization for Human Brain Mapping 2009 Annual Meeting}
+}
+
 @article{Garyfallidis2021,
   author    = {Eleftherios Garyfallidis and Serge Koudoro and Javier Guaje and Marc-Alexandre C\^{o}t\'{e} and Soham Biswas and David Reagan and Nasim Anousheh and Filipi Silva and Geoffrey Fox and Fury Contributors},
   title     = {{FURY: advanced scientific visualization}},


### PR DESCRIPTION
Host MNI template note references in references file.

Fixes:
```
/home/runner/work/dipy/dipy/doc/reference/dipy.data.rst:11:
 WARNING: Citation [Rdd61b42961d4-1] is not referenced.
/home/runner/work/dipy/dipy/doc/reference/dipy.data.rst:16:
 WARNING: Citation [Rdd61b42961d4-2] is not referenced.
/home/runner/work/dipy/dipy/doc/reference/dipy.data.rst:36:
 WARNING: Citation [R85b62a945869-1] is not referenced.
/home/runner/work/dipy/dipy/doc/reference/dipy.data.rst:41:
 WARNING: Citation [R85b62a945869-2] is not referenced.
```

raised for example in:
https://github.com/dipy/dipy/actions/runs/10603092244/job/29386606308#step:5:1016