### PR TITLE
DOC: Fix footbibliography-related errors in workflow help doc

### DIFF
--- a/doc/tools/docgen_cmd.py
+++ b/doc/tools/docgen_cmd.py
@@ -163,6 +163,7 @@ if __name__ == '__main__':
                 format_title("output arguments(optional)"))
             help_txt = help_txt.replace("References:",
                                         format_title("References"))
+            help_txt = help_txt.replace(".. footbibliography::", "")
             help_txt = help_txt.rstrip()
             fp.write(help_txt)
 


### PR DESCRIPTION
Fix footbibliography-related errors in workflow help documentation: remove the `sphinxcontrib-bibtex` `.. footbibliography::` directive string from the generated reStructuredText files corresponding to the workflow files help documentation.

The directive is used to introduce automatically the bibliography in the Python code, and is kept when generating the workflow file reStructuredText documentation: it needs to be removed since it has already served its purpose to introduce the references and generates warnings.

Fixes:
```
/dipy/dipy/doc/reference_cmd/dipy_buan_profiles.rst:38:
 WARNING: Explicit markup ends without a blank line; unexpected unindent.
```

and other similar errors raised for example at:
https://github.com/dipy/dipy/actions/runs/10647886977/job/29516329417#step:5:849