### PR TITLE
DOC: Do not use the `scale` option for URL-based images

### DIFF
--- a/doc/examples/denoise_patch2self.py
+++ b/doc/examples/denoise_patch2self.py
@@ -25,8 +25,8 @@ distribution).
 The Patch2Self Framework:
 
 .. _patch2self:
-.. figure:: https://github.com/dipy/dipy_data/blob/master/Patch2Self_Framework.PNG?raw=true
-   :scale: 60 %
+.. image:: https://github.com/dipy/dipy_data/blob/master/Patch2Self_Framework.PNG?raw=true
+   :width: 70 %
    :align: center
 
 The above figure demonstrates the working of Patch2Self. The idea is to build

--- a/doc/interfaces/denoise_flow.rst
+++ b/doc/interfaces/denoise_flow.rst
@@ -101,10 +101,8 @@ This command will denoise the diffusion image and save it to the specified
 output directory.
 
 .. |image3| image:: https://github.com/dipy/dipy_data/blob/master/sherbrooke_3shell_original.png?raw=true
-   :scale: 70%
    :align: middle
 .. |image4| image:: https://github.com/dipy/dipy_data/blob/master/sherbrooke_3shell_denoise_MPPCA.png?raw=true
-   :scale: 70%
    :align: middle
 
 +--------------------+--------------------+
@@ -150,10 +148,8 @@ The command will denoise the input diffusion volume and write the result to the
 specified output directory.
 
 .. |image5| image:: https://github.com/dipy/dipy_data/blob/master/cfin_multib_original.png?raw=true
-   :scale: 20%
    :align: middle
 .. |image6| image:: https://github.com/dipy/dipy_data/blob/master/cfin_multib_denoise_NLMEANS.png?raw=true
-   :scale: 20%
    :align: middle
 
 +--------------------+--------------------+


### PR DESCRIPTION
Do not use the `scale` option for URL-based images as Sphinx cannot determine the image size from a URL:
- Remove the option for the `denoise_flow` images, as they are embedded in a table cell and will use the available cell width by default.
- Use the `image` directive and the `width` option for `denoise_patch2self` (in lieu of the `figure` directive). Make the `width` value be 70% as it provides a reasonably looking result.

Fixes:
```
/dipy/doc/examples_built/preprocessing/denoise_patch2self.rst::
 WARNING: Could not obtain image size. :scale: option is ignored.
```

and
```
/dipy/doc/interfaces/denoise_flow.rst:103:
 WARNING: Could not obtain image size. :scale: option is ignored.
/dipy/doc/interfaces/denoise_flow.rst:106:
 WARNING: Could not obtain image size. :scale: option is ignored.
/dipy/doc/interfaces/denoise_flow.rst:152:
 WARNING: Could not obtain image size. :scale: option is ignored.
/dipy/dipy/doc/interfaces/denoise_flow.rst:155:
 WARNING: Could not obtain image size. :scale: option is ignored.
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/10647886977/job/29516329417#step:5:901 and
https://github.com/dipy/dipy/actions/runs/10647886977/job/29516329417#step:5:909