### PR TITLE
DOC: Fix miscellaneous documentation build warnings (part 3)

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -444,6 +444,7 @@ def real_sh_tournier(sh_order_max, theta, phi, *, full_basis=False, legacy=True)
     The SH are computed as initially defined in :footcite:p:`Tournier2007` then
     updated in MRtrix3 :footcite:p:`Tournier2019`, where the real harmonic
     $Y_l^m$ is defined to be:
+
     .. math::
        :nowrap:
 
@@ -502,6 +503,7 @@ def real_sh_descoteaux(sh_order_max, theta, phi, *, full_basis=False, legacy=Tru
 
     The definition adopted here follows :footcite:p:`Descoteaux2007`, where the
     real harmonic $Y_l^m$ is defined to be:
+
     .. math::
        :nowrap:
 

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -491,7 +491,7 @@ def build_slider(
         slider.handles[0].color = (1.0, 0.5, 0.0)
         slider.handles[1].color = (1.0, 0.5, 0.0)
 
-    return (slider_label, HorizonUIElement(True, initial_value, slider))
+    return slider_label, HorizonUIElement(True, initial_value, slider)
 
 
 @warning_for_keywords()

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -434,6 +434,8 @@ def build_slider(
         Size of label text to display with slider
     label_style_bold : bool, optional
         Is label should have bold style.
+    is_double_slider : bool, optional
+        True if the slider allows to adjust two values.
 
     Returns
     -------

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -437,7 +437,10 @@ def build_slider(
 
     Returns
     -------
-    (label: HorizonUIElement, element(slider): HorizonUIElement)
+    label : HorizonUIElement
+        Slider label.
+    HorizonUIElement
+        Slider.
     """
 
     if is_double_slider and "ratio" in text_template:

--- a/dipy/viz/horizon/tab/base.py
+++ b/dipy/viz/horizon/tab/base.py
@@ -435,8 +435,8 @@ def build_slider(
     label_style_bold : bool, optional
         Is label should have bold style.
 
-    Return
-    ------
+    Returns
+    -------
     (label: HorizonUIElement, element(slider): HorizonUIElement)
     """
 


### PR DESCRIPTION
- DOC: Add blank line before displayed math `.. math::` directive
- DOC: Fix typo in method docstring return section name
- DOC: Document properly `viz.horizon.tab.base.build_slider` return params
- DOC: Document missing input arg in `viz.horizon.tab.base.build_slider`
- STYLE: Remove redundant parentheses in method return statement