### PR TITLE
FIX: missing keyword only arguments on example

### DIFF
--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -167,7 +167,7 @@ fig1.savefig("Gibbs_suppression_structural.png")
 
 bvals = [200, 400, 1000, 2000]
 
-img, gtab = read_cenir_multib(bvals)
+img, gtab = read_cenir_multib(bvals=bvals)
 
 data = np.asarray(img.dataobj)
 

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -84,7 +84,7 @@ print("Sigma estimation time", time() - t)
 
 t = time()
 
-denoised_arr = localpca(data, sigma, tau_factor=2.3, patch_radius=2)
+denoised_arr = localpca(data, sigma=sigma, tau_factor=2.3, patch_radius=2)
 
 print("Time taken for local PCA (slow)", -t + time())
 

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -154,8 +154,8 @@ FA_orig = dki_orig.fa
 FA_den = dki_den.fa
 MD_orig = dki_orig.md
 MD_den = dki_den.md
-MK_orig = dki_orig.mk(0, 3)
-MK_den = dki_den.mk(0, 3)
+MK_orig = dki_orig.mk(min_kurtosis=0, max_kurtosis=3)
+MK_den = dki_den.mk(min_kurtosis=0, max_kurtosis=3)
 
 
 fig2, ax = plt.subplots(2, 3, figsize=(10, 6), subplot_kw={"xticks": [], "yticks": []})

--- a/doc/examples/motion_correction.py
+++ b/doc/examples/motion_correction.py
@@ -50,7 +50,7 @@ gtab = gradient_table(bvals_small, bvecs=bvecs_small)
 # Start motion correction of our reduced DWI dataset(between-volumes motion
 # correction).
 
-data_corrected, reg_affines = motion_correction(data_small, gtab, affine)
+data_corrected, reg_affines = motion_correction(data_small, gtab, affine=affine)
 
 ###############################################################################
 # Save our DWI dataset corrected to a new Nifti file.

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -126,7 +126,7 @@ TORT = dki_micro_fit.tortuosity
 ###############################################################################
 # These parameters are plotted below on top of the mean kurtosis maps:
 
-MK = dkifit.mk(0, 3)
+MK = dkifit.mk(min_kurtosis=0, max_kurtosis=3)
 
 axial_slice = 9
 

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -41,7 +41,7 @@ signal, _ = multi_tensor(
     gtab, evals, S0=100, angles=directions, fractions=fractions, snr=None
 )
 
-sphere = get_sphere(name="repulsion724").subdivide(1)
+sphere = get_sphere(name="repulsion724").subdivide(n=1)
 
 odf_gt = multi_tensor_odf(
     sphere.vertices, evals, angles=directions, fractions=fractions

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -83,7 +83,7 @@ fm = ForecastModel(gtab, sh_order_max=6, dec_alg="CSD")
 ###############################################################################
 # Fit the FORECAST to the data
 
-f_fit = fm.fit(data_small, mask_small)
+f_fit = fm.fit(data_small, mask=mask_small)
 
 ###############################################################################
 # Calculate the crossing invariant tensor indices :footcite:p:`Kaden2016a`: the

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -162,7 +162,7 @@ dki_model = dki.DiffusionKurtosisModel(gtab)
 dki_fit = dki_model.fit(dwi)
 
 MD = dki_fit.md
-MK = dki_fit.mk(0, 3)
+MK = dki_fit.mk(min_kurtosis=0, max_kurtosis=3)
 
 ###############################################################################
 # Now we plot the results as a function of the ground truth intersection
@@ -270,7 +270,7 @@ dki_model = dki.DiffusionKurtosisModel(gtab)
 dki_fit = dki_model.fit(data, mask=mask)
 
 MD = dki_fit.md
-MK = dki_fit.mk(0, 3)
+MK = dki_fit.mk(min_kurtosis=0, max_kurtosis=3)
 
 ###############################################################################
 # Let's now visualize the data using matplotlib for a selected axial slice.

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -107,7 +107,7 @@ plt.savefig("simulated_signal.png", bbox_inches="tight")
 # cached spheres, which we can read in the following way.
 
 sphere = get_sphere(name="repulsion724")
-sphere = sphere.subdivide(2)
+sphere = sphere.subdivide(n=2)
 
 odf = multi_tensor_odf(sphere.vertices, mevals, angles, fractions)
 

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -91,13 +91,13 @@ regtools.plot_2d_diffeomorphic_map(mapping, delta=10, fname="diffeomorphic_map.p
 # Now let's warp the moving image and see if it gets similar to the static
 # image
 
-warped_moving = mapping.transform(moving, "linear")
+warped_moving = mapping.transform(moving, interpolation="linear")
 regtools.overlay_images(
     static,
     warped_moving,
     title0="Static",
     title_mid="Overlay",
-    title_1="Warped moving",
+    title1="Warped moving",
     fname="direct_warp_result.png",
 )
 

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -69,7 +69,11 @@ pre_align = np.array(
 # moving image towards the static image
 
 affine_map = AffineMap(
-    pre_align, static.shape, static_affine, moving.shape, moving_affine
+    pre_align,
+    domain_grid_shape=static.shape,
+    domain_grid2world=static_affine,
+    codomain_grid_shape=moving.shape,
+    codomain_grid2world=moving_affine,
 )
 
 resampled = affine_map.transform(moving)


### PR DESCRIPTION
This short PR fix some warnings on our tutorials.

All warnings were coming from keyword-only arguments feature recently added