### PR TITLE
BF: fix s390x compatibility

### DIFF
--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import os
 from os.path import join as pjoin
+import sys
 from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
@@ -18,6 +19,7 @@ from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
 fury, have_fury, setup_module = optional_package("fury", min_version="0.10.0")
+is_big_endian = "big" in sys.byteorder.lower()
 
 
 FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
@@ -41,6 +43,7 @@ def teardown_module():
     FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
 
 
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_direct_trx_loading():
     trx = tmm.load(FILEPATH_DIX["gs.trx"])
     tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
@@ -74,6 +77,7 @@ def test_tck_equal_in_vox_space():
     assert_allclose(tmp_points_vox, sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_trx_equal_in_vox_space():
     sft = load_tractogram(
         FILEPATH_DIX["gs.trx"], FILEPATH_DIX["gs.nii"], to_space=Space.VOX
@@ -117,6 +121,7 @@ def test_tck_equal_in_rasmm_space():
     assert_allclose(tmp_points_rasmm, sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_trx_equal_in_rasmm_space():
     sft = load_tractogram(
         FILEPATH_DIX["gs.trx"], FILEPATH_DIX["gs.nii"], to_space=Space.RASMM
@@ -160,6 +165,7 @@ def test_tck_equal_in_voxmm_space():
     assert_allclose(tmp_points_voxmm, sft.streamlines.get_data(), atol=1e-3, rtol=1e-6)
 
 
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_trx_equal_in_voxmm_space():
     sft = load_tractogram(
         FILEPATH_DIX["gs.trx"], FILEPATH_DIX["gs.nii"], to_space=Space.VOXMM
@@ -366,6 +372,7 @@ def test_tck_iterative_saving_loading():
             save_tractogram(sft_iter, pjoin(tmp_dir, "gs_iter.tck"))
 
 
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_trx_iterative_saving_loading():
     sft = load_tractogram(
         FILEPATH_DIX["gs.trx"], FILEPATH_DIX["gs.nii"], to_space=Space.RASMM

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,9 +1,7 @@
-import sys
 import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
-import pytest
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
@@ -12,8 +10,6 @@ from dipy.segment.clustering import qbx_and_merge
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.distances import bundles_distances_mam
 from dipy.tracking.streamline import Streamlines
-
-is_big_endian = "big" in sys.byteorder.lower()
 
 
 def setup_module():
@@ -35,7 +31,6 @@ def setup_module():
     f.extend(f3)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_check_defaults():
     rb = RecoBundles(f, greater_than=0, clust_thr=10)
 
@@ -69,7 +64,6 @@ def test_rb_check_defaults():
         assert_equal(row.min(), 0)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_disable_slr():
     rb = RecoBundles(f, greater_than=0, clust_thr=10)
 
@@ -103,7 +97,6 @@ def test_rb_disable_slr():
         assert_equal(row.min(), 0)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 @set_random_number_generator(42)
 def test_rb_slr_threads(rng):
     rb_multi = RecoBundles(f, greater_than=0, clust_thr=10, rng=rng)
@@ -133,7 +126,6 @@ def test_rb_slr_threads(rng):
         assert_almost_equal(row.min(), 0, decimal=4)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_no_verbose_and_mam():
     rb = RecoBundles(f, greater_than=0, clust_thr=10, verbose=False)
 
@@ -171,7 +163,6 @@ def test_rb_no_verbose_and_mam():
         assert_equal(row.min(), 0)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_clustermap():
     cluster_map = qbx_and_merge(f, thresholds=[40, 25, 20, 10])
 
@@ -208,7 +199,6 @@ def test_rb_clustermap():
         assert_equal(row.min(), 0)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_no_neighb():
     # what if no neighbors are found? No recognition
 
@@ -245,7 +235,6 @@ def test_rb_no_neighb():
         assert_equal(len(rec_trans), 0)
 
 
-@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_rb_reduction_mam():
     rb = RecoBundles(f, greater_than=0, clust_thr=10, verbose=True)
 

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -7,7 +7,7 @@ from libc.stdlib cimport malloc, free
 cimport numpy as cnp
 
 from dipy.tracking import Streamlines
-
+from dipy.utils.arrfuncs import as_native_array
 
 cdef extern from "dpy_math.h" nogil:
     bint dpy_isnan(double x)
@@ -99,15 +99,15 @@ def length(streamlines):
 
         arclengths = np.zeros(len(streamlines), dtype=np.float64)
 
-        if streamlines._data.dtype == np.float32:
+        if as_native_array(streamlines._data).dtype == np.float32:
             c_arclengths_from_arraysequence[float2d](
-                                    streamlines._data,
+                                    as_native_array(streamlines._data),
                                     streamlines._offsets.astype(np.intp),
                                     streamlines._lengths.astype(np.intp),
                                     arclengths)
         else:
             c_arclengths_from_arraysequence[double2d](
-                                      streamlines._data,
+                                      as_native_array(streamlines._data),
                                       streamlines._offsets.astype(np.intp),
                                       streamlines._lengths.astype(np.intp),
                                       arclengths)
@@ -319,7 +319,7 @@ def set_number_of_points(streamlines, nb_points=3):
             return Streamlines()
 
         nb_streamlines = len(streamlines)
-        dtype = streamlines._data.dtype
+        dtype = as_native_array(streamlines._data).dtype
         new_streamlines = Streamlines()
         new_streamlines._data = np.zeros((nb_streamlines * nb_points, 3),
                                          dtype=dtype)
@@ -330,12 +330,12 @@ def set_number_of_points(streamlines, nb_points=3):
 
         if dtype == np.float32:
             c_set_number_of_points_from_arraysequence[float2d](
-                streamlines._data, streamlines._offsets.astype(np.intp),
+                as_native_array(streamlines._data), streamlines._offsets.astype(np.intp),
                 streamlines._lengths.astype(np.intp), nb_points,
                 new_streamlines._data)
         else:
             c_set_number_of_points_from_arraysequence[double2d](
-                streamlines._data, streamlines._offsets.astype(np.intp),
+                as_native_array(streamlines._data), streamlines._offsets.astype(np.intp),
                 streamlines._lengths.astype(np.intp), nb_points,
                 new_streamlines._data)
 

--- a/dipy/utils/tests/test_tractogram.py
+++ b/dipy/utils/tests/test_tractogram.py
@@ -1,10 +1,16 @@
+import sys
+
+import pytest
 import trx.trx_file_memmap as tmm
 
 from dipy.data import get_fnames
 from dipy.io.streamline import load_tractogram
 from dipy.utils.tractogram import concatenate_tractogram
 
+is_big_endian = "big" in sys.byteorder.lower()
 
+
+@pytest.mark.skipif(is_big_endian, reason="Little Endian architecture required")
 def test_concatenate():
     filepath_dix, _, _ = get_fnames(name="gold_standard_tracks")
     sft = load_tractogram(filepath_dix["gs.trk"], filepath_dix["gs.nii"])


### PR DESCRIPTION
This PR fixes big-endian system (like s390x) compatibility. It fixes this particular error:

`E   ValueError: Little-endian buffer not supported on big-endian compiler`

Some tests had to be skipped due to TRX file format which seems to not be compatible with big endian system. We need to warn @arokem and @frheault  concerning `[trx-python](https://github.com/tee-ar-ex/trx-python)` package.

this fixes #2886

<img width="863" alt="image" src="https://github.com/user-attachments/assets/99c0f880-b86d-4e06-bd49-8621e36ec4e9">


Thanks to [sharkcz](https://github.com/sharkcz) for giving me access to a s390x machine and Thanks to @penguinpee and @nteodosio for pushing this issue here.

if you have time, feel free to try this PR.