### PR TITLE
FIX: remove keyword only warning on examples (part2)

### DIFF
--- a/dipy/reconst/mcsd.py
+++ b/dipy/reconst/mcsd.py
@@ -855,16 +855,16 @@ def auto_response_msmt(
     mask_wm, mask_gm, mask_csf = mask_for_response_msmt(
         gtab,
         data,
-        roi_center,
-        roi_radii,
-        wm_fa_thr,
-        gm_fa_thr,
-        csf_fa_thr,
-        gm_md_thr,
-        csf_md_thr,
+        roi_center=roi_center,
+        roi_radii=roi_radii,
+        wm_fa_thr=wm_fa_thr,
+        gm_fa_thr=gm_fa_thr,
+        csf_fa_thr=csf_fa_thr,
+        gm_md_thr=gm_md_thr,
+        csf_md_thr=csf_md_thr,
     )
     response_wm, response_gm, response_csf = response_from_mask_msmt(
-        gtab, data, mask_wm, mask_gm, mask_csf, tol
+        gtab, data, mask_wm, mask_gm, mask_csf, tol=tol
     )
 
     return response_wm, response_gm, response_csf

--- a/doc/examples/reconst_qtdmri.py
+++ b/doc/examples/reconst_qtdmri.py
@@ -101,7 +101,7 @@ for i, (data_, mask_, gtab_) in enumerate(zip(data, cc_masks, gtabs)):
 
     # estimate fractional anisotropy (FA) for this slice
     tenmod = dti.TensorModel(gtab_)
-    tenfit = tenmod.fit(data_middle_slice, data_middle_slice[..., 0] > 0)
+    tenfit = tenmod.fit(data_middle_slice, mask=data_middle_slice[..., 0] > 0)
     fa = tenfit.fa
 
     # set mask color to green with 0.5 opacity as overlay

--- a/doc/examples/reconst_qtiplus.py
+++ b/doc/examples/reconst_qtiplus.py
@@ -178,7 +178,7 @@ mask[:, :, :13] = 0
 mask[:, :, 14:] = 0
 
 qtimodel_217 = qti.QtiModel(gtab_217)
-qtifit_217 = qtimodel_217.fit(data_217, mask)
+qtifit_217 = qtimodel_217.fit(data_217, mask=mask)
 
 ###############################################################################
 # Now we can fit the QTI model using the default unconstrained fitting method

--- a/doc/examples/reconst_sh.py
+++ b/doc/examples/reconst_sh.py
@@ -89,7 +89,7 @@ sh_coeffs = sf_to_sh(odf, sphere, sh_order_max=sh_order_max, basis_type=sh_basis
 # reconstruct our original signal. We will now reproject our signal on a high
 # resolution sphere using ``sh_to_sf``.
 
-high_res_sph = get_sphere(name="symmetric724").subdivide(2)
+high_res_sph = get_sphere(name="symmetric724").subdivide(n=2)
 reconst = sh_to_sf(
     sh_coeffs, high_res_sph, sh_order_max=sh_order_max, basis_type=sh_basis
 )


### PR DESCRIPTION
This short PR fix some warnings on our tutorials (PART2 and last part - follow up of #3355)

All warnings were coming from keyword-only arguments feature recently added