### PR TITLE
DOC: Remove unnecessary leading whitespace in rst doc paragraph

### DIFF
--- a/doc/interfaces/bundlewarp_registration_flow.rst
+++ b/doc/interfaces/bundlewarp_registration_flow.rst
@@ -49,7 +49,7 @@ the key characteristics of the original bundle.
 
 
 The following BundleWarp workflow requires two positional input arguments;
- ``static`` and ``moving`` .trk files. In our case, the ``static`` input bundle
+``static`` and ``moving`` .trk files. In our case, the ``static`` input bundle
 is the ``s_UF_L.trk``, and the ``moving`` is ``m_UF_L.trk``.
 
 Run the following workflow::


### PR DESCRIPTION
Remove unnecessary leading whitespace in reStructuredText doc paragraph.

Fixes:
```
/dipy/doc/interfaces/bundlewarp_registration_flow.rst:53:
 WARNING: Definition list ends without a blank line; unexpected unindent.
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/10812941556/job/29995758096#step:5:564

Appeared after PR https://github.com/dipy/dipy/pull/3221 was merged.