### PR TITLE
[NF] DAM implementation for tissue classification using DMRI signal properties.

### DIFF
--- a/dipy/segment/tests/meson.build
+++ b/dipy/segment/tests/meson.build
@@ -10,6 +10,7 @@ python_sources = [
   'test_mrf.py',
   'test_qbx.py',
   'test_quickbundles.py',
+  'test_tissue.py',
   'test_utils.py',
   ]
 

--- a/dipy/segment/tests/test_tissue.py
+++ b/dipy/segment/tests/test_tissue.py
@@ -1,38 +1,27 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_
-from dipy.segment.tissue import dam_classifier, compute_directional_average
+from numpy.testing import assert_, assert_equal, assert_raises
+import pytest
+
+from dipy.segment.tissue import compute_directional_average, dam_classifier
+from dipy.utils.optpkg import optional_package
+
+sklearn, has_sklearn, _ = optional_package("sklearn")
+needs_sklearn = pytest.mark.skipif(not has_sklearn, reason="Requires sklearn")
 
 
+@needs_sklearn
 def test_compute_directional_average_valid():
-
     data = np.array([100, 80, 60, 50, 40, 20, 10])
     bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
     P, V = compute_directional_average(data, bvals)
 
-    assert_(isinstance(P, float), 'P should be a float')
-    assert_(isinstance(V, float), 'V should be a float')
+    assert_(isinstance(P, float), "P should be a float")
+    assert_(isinstance(V, float), "V should be a float")
     assert_(P != 0, "P should not be zero")
     assert_(V != 0, "V should not be zero")
 
 
-def test_compute_directional_average_insufficient_bvals():
-
-    data = np.array([100, 80, 60, 50])
-    bvals = np.array([0, 0, 100, 100])
-    wm_threshold = 0.5
-
-    assert_equal(data.shape[0], bvals.shape[0],
-                 "The length of bvals must match the last dimension of data")
-
-    try:
-        compute_directional_average(data, bvals)
-    except ValueError as e:
-        assert_equal(str(e), "Insufficient unique b-values for fitting.")
-    else:
-        raise AssertionError(
-            "ValueError not raised for insufficient unique b-values")
-
-
+@needs_sklearn
 def test_compute_directional_average_low_signal():
     data = np.array([20, 10, 5, 3, 2, 1, 1])  # Very low signal
     bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
@@ -43,6 +32,7 @@ def test_compute_directional_average_low_signal():
     assert_equal(V, 0, "V should be 0 when low signal")
 
 
+@needs_sklearn
 def test_compute_directional_average_div_by_zero():
     data = np.array([100, 100, 100, 100, 100, 100, 100])
     bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
@@ -52,16 +42,23 @@ def test_compute_directional_average_div_by_zero():
     assert_(np.allclose(P, 0))
 
 
+@needs_sklearn
 def test_dam_classifier_valid():
     data = np.random.rand(3, 3, 3, 7) * 100  # Simulated random data
     bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
 
-    assert_equal(data.shape[-1], bvals.shape[0],
-                 "The number of bvals must match the last dimension of data")
+    assert_equal(
+        data.shape[-1],
+        bvals.shape[0],
+        "The number of bvals must match the last dimension of data",
+    )
 
     wm_mask, gm_mask = dam_classifier(data, bvals, wm_threshold=0.5)
 
-    assert_equal(wm_mask.shape, (3, 3, 3),
-                 "Shape of wm_mask should be (3, 3, 3)")
-    assert_equal(gm_mask.shape, (3, 3, 3),
-                 "Shape of gm_mask should be (3, 3, 3)")
+    assert_equal(wm_mask.shape, (3, 3, 3), "Shape of wm_mask should be (3, 3, 3)")
+    assert_equal(gm_mask.shape, (3, 3, 3), "Shape of gm_mask should be (3, 3, 3)")
+
+    data = np.array([100, 80, 60, 50])
+    bvals = np.array([0, 0, 100, 100])
+
+    assert_raises(ValueError, dam_classifier, data, bvals, wm_threshold=0.5)

--- a/dipy/segment/tests/test_tissue.py
+++ b/dipy/segment/tests/test_tissue.py
@@ -1,0 +1,67 @@
+import numpy as np
+from numpy.testing import assert_equal, assert_
+from dipy.segment.tissue import dam_classifier, compute_directional_average
+
+
+def test_compute_directional_average_valid():
+
+    data = np.array([100, 80, 60, 50, 40, 20, 10])
+    bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
+    P, V = compute_directional_average(data, bvals)
+
+    assert_(isinstance(P, float), 'P should be a float')
+    assert_(isinstance(V, float), 'V should be a float')
+    assert_(P != 0, "P should not be zero")
+    assert_(V != 0, "V should not be zero")
+
+
+def test_compute_directional_average_insufficient_bvals():
+
+    data = np.array([100, 80, 60, 50])
+    bvals = np.array([0, 0, 100, 100])
+    wm_threshold = 0.5
+
+    assert_equal(data.shape[0], bvals.shape[0],
+                 "The length of bvals must match the last dimension of data")
+
+    try:
+        compute_directional_average(data, bvals)
+    except ValueError as e:
+        assert_equal(str(e), "Insufficient unique b-values for fitting.")
+    else:
+        raise AssertionError(
+            "ValueError not raised for insufficient unique b-values")
+
+
+def test_compute_directional_average_low_signal():
+    data = np.array([20, 10, 5, 3, 2, 1, 1])  # Very low signal
+    bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
+
+    P, V = compute_directional_average(data, bvals, low_signal_threshold=50)
+
+    assert_equal(P, 0, "P should be 0 when low signal")
+    assert_equal(V, 0, "V should be 0 when low signal")
+
+
+def test_compute_directional_average_div_by_zero():
+    data = np.array([100, 100, 100, 100, 100, 100, 100])
+    bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
+
+    P, V = compute_directional_average(data, bvals)
+
+    assert_(np.allclose(P, 0))
+
+
+def test_dam_classifier_valid():
+    data = np.random.rand(3, 3, 3, 7) * 100  # Simulated random data
+    bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
+
+    assert_equal(data.shape[-1], bvals.shape[0],
+                 "The number of bvals must match the last dimension of data")
+
+    wm_mask, gm_mask = dam_classifier(data, bvals, wm_threshold=0.5)
+
+    assert_equal(wm_mask.shape, (3, 3, 3),
+                 "Shape of wm_mask should be (3, 3, 3)")
+    assert_equal(gm_mask.shape, (3, 3, 3),
+                 "Shape of gm_mask should be (3, 3, 3)")

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -3,8 +3,9 @@ import numpy as np
 from dipy.segment.mrf import ConstantObservationModel, IteratedConditionalModes
 from dipy.sims.voxel import add_noise
 from dipy.testing.decorators import warning_for_keywords
-from sklearn.linear_model import LinearRegression
-
+from dipy.utils.optpkg import optional_package
+sklearn, has_sklearn, _ = optional_package("sklearn")
+linear_model, _, _ = optional_package("sklearn.linear_model")
 class TissueClassifierHMRF:
     """
     This class contains the methods for tissue classification using the
@@ -127,23 +128,28 @@ class TissueClassifierHMRF:
         return initial_segmentation, final_segmentation, PVE
 
 
-def compute_directional_average(data, bvals, b0_thresh=10):
+def compute_directional_average(data, bvals, *,
+                                b0_thresh=50, low_signal_threshold=50):
     """
     Compute the mean signal for each unique b-value shell and fit a linear model.
 
     Parameters
     ----------
-        data : ndarray
-            The diffusion MRI data.
-        bvals : ndarray
-            The b-values corresponding to the diffusion data.
+    data : ndarray
+        The diffusion MRI data.
+    bvals : ndarray
+        The b-values corresponding to the diffusion data.
+    b0_thresh : float, optional
+        The threshold below for a b=0 image.
+    low_signal_threshold : float, optional
+        The threshold below which a voxel is considered to have low signal.
 
     Returns
     -------
-        P : float
-            The slope of the linear model.
-        V : float
-            The intercept of the linear model.
+    P : float
+        The slope of the linear model.
+    V : float
+        The intercept of the linear model.
     """
     unique_bvals = np.unique(bvals)
     # Mean signal for b=0 (non-diffusion weighted)
@@ -153,16 +159,19 @@ def compute_directional_average(data, bvals, b0_thresh=10):
         raise ValueError("Insufficient unique b-values for fitting.")
 
     # If the mean signal for b=0 is too low, return 0, 0
-    if data[bvals < b0_thresh].mean() < 50:
+    if s0 < low_signal_threshold:
         return 0, 0
 
-    S_bvals = [data[bvals == bval].mean() / (s0 + 0.01)
-               for bval in unique_bvals[1:]]
-    S_bvals = np.array(S_bvals)
+    masks = bvals[:, np.newaxis] == unique_bvals[np.newaxis, 1:]
 
-    # Avoid log(0)
-    if 0 in S_bvals:
-        S_bvals = S_bvals + 0.001
+    # Calculate the mean for each mask
+    means = np.sum(data[:, np.newaxis] * masks, axis=0) / np.sum(masks, axis=0)
+
+    # Normalize by s0. Avoid division by zero by adding 0.01 for stable division
+    S_bvals = means / (s0 + 0.01)
+
+    # Avoid log(0) by adding 0.001 for stable linear regression fit
+    S_bvals[S_bvals == 0] = 0.001
 
     S_log = np.log(S_bvals)
 
@@ -173,7 +182,7 @@ def compute_directional_average(data, bvals, b0_thresh=10):
     y = S_log
 
     # Fit linear model
-    model = LinearRegression()
+    model = linear_model.LinearRegression()
     model.fit(X, y)
     P = model.coef_[0]
     V = model.intercept_
@@ -181,29 +190,30 @@ def compute_directional_average(data, bvals, b0_thresh=10):
     return P, V
 
 
-def compute_P_map(data, bvals, wm_threshold=0.5, b0_thresh=10):
+def dam_classifier(data, bvals, wm_threshold, *,
+                   b0_thresh=50, low_signal_threshold=50):
     """
     Compute the P (slope) map for the entire dataset.
 
     Parameters
     ----------
-        data : ndarray
-            The diffusion MRI data.
-        bvals : ndarray
-            The b-values corresponding to the diffusion data.
-        wm_threshold : float, optional
-            The threshold below which a voxel is considered white matter.
-            Default is 0.5.
-        b0_thresh : float, optional
-            The threshold below for a b=0 image.
-            Default is 10.
+    data : ndarray
+        The diffusion MRI data.
+    bvals : ndarray
+        The b-values corresponding to the diffusion data.
+    wm_threshold : float, optional
+        The threshold below which a voxel is considered white matter.
+    b0_thresh : float, optional
+        The intensity threshold for a b=0 image.
+    low_signal_threshold : float, optional
+        The threshold below which a voxel is considered to have low signal.
 
     Returns
     -------
-        wm_mask : ndarray
-            A binary mask for white matter.
-        gm_mask : ndarray
-            A binary mask for grey matter.
+    wm_mask : ndarray
+        A binary mask for white matter.
+    gm_mask : ndarray
+        A binary mask for grey matter.
     """
     P_map = np.zeros(data.shape[:-1])
     for i in range(data.shape[0]):
@@ -211,9 +221,13 @@ def compute_P_map(data, bvals, wm_threshold=0.5, b0_thresh=10):
             for k in range(data.shape[2]):
                 voxel_data = data[i, j, k, :]
                 if np.any(bvals != 0):
-                    P, _ = compute_directional_average(voxel_data, bvals, b0_thresh)
+                    P, _ = compute_directional_average(
+                        voxel_data, bvals, b0_thresh=b0_thresh,
+                        low_signal_threshold=low_signal_threshold
+                    )
                     P_map[i, j, k] = P
 
+    # Adding a small slope threshold for P_map to avoid 0 sloped background voxels
     wm_mask = (P_map <= wm_threshold) & (P_map > 0.01)
 
     # Grey matter has a higher P value than white matter

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -154,10 +154,10 @@ def compute_directional_average(
         Precomputed mean signal map for b=0 images.
     masks : ndarray, optional
         Precomputed masks for each unique b-value shell.
-    b0_threshold : float, optional
-        The intensity threshold for a b=0 image.
     b0_mask : ndarray, optional
         Precomputed mask for b=0 images.
+    b0_threshold : float, optional
+        The intensity threshold for a b=0 image.
     low_signal_threshold : float, optional
         The threshold below which a voxel is considered to have low signal.
 
@@ -206,7 +206,9 @@ def compute_directional_average(
 def dam_classifier(
     data, bvals, wm_threshold, *, b0_threshold=50, low_signal_threshold=50
 ):
-    """Compute the P (slope) map for the entire dataset.
+    """Computes the P-map (fitting slope) on data to extract white and grey matter.
+
+    See :footcite:p:`Cheng2020` for further details about the method.
 
     Parameters
     ----------
@@ -214,7 +216,7 @@ def dam_classifier(
         The diffusion MRI data.
     bvals : ndarray
         The b-values corresponding to the diffusion data.
-    wm_threshold : float, optional
+    wm_threshold : float
         The threshold below which a voxel is considered white matter.
     b0_threshold : float, optional
         The intensity threshold for a b=0 image.
@@ -227,6 +229,11 @@ def dam_classifier(
         A binary mask for white matter.
     gm_mask : ndarray
         A binary mask for grey matter.
+
+    References
+    ----------
+    .. footbibliography::
+
     """
     # Precompute unique b-values, masks, and b=0 mask
     unique_bvals = np.unique(bvals)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -4,8 +4,11 @@ from dipy.segment.mrf import ConstantObservationModel, IteratedConditionalModes
 from dipy.sims.voxel import add_noise
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.optpkg import optional_package
+
 sklearn, has_sklearn, _ = optional_package("sklearn")
 linear_model, _, _ = optional_package("sklearn.linear_model")
+
+
 class TissueClassifierHMRF:
     """
     This class contains the methods for tissue classification using the
@@ -128,8 +131,16 @@ class TissueClassifierHMRF:
         return initial_segmentation, final_segmentation, PVE
 
 
-def compute_directional_average(data, bvals, *,
-                                b0_thresh=50, low_signal_threshold=50):
+def compute_directional_average(
+    data,
+    bvals,
+    *,
+    s0_map=None,
+    masks=None,
+    b0_mask=None,
+    b0_threshold=50,
+    low_signal_threshold=50,
+):
     """
     Compute the mean signal for each unique b-value shell and fit a linear model.
 
@@ -139,8 +150,14 @@ def compute_directional_average(data, bvals, *,
         The diffusion MRI data.
     bvals : ndarray
         The b-values corresponding to the diffusion data.
-    b0_thresh : float, optional
-        The threshold below for a b=0 image.
+    s0_map : ndarray, optional
+        Precomputed mean signal map for b=0 images.
+    masks : ndarray, optional
+        Precomputed masks for each unique b-value shell.
+    b0_threshold : float, optional
+        The intensity threshold for a b=0 image.
+    b0_mask : ndarray, optional
+        Precomputed mask for b=0 images.
     low_signal_threshold : float, optional
         The threshold below which a voxel is considered to have low signal.
 
@@ -151,35 +168,31 @@ def compute_directional_average(data, bvals, *,
     V : float
         The intercept of the linear model.
     """
-    unique_bvals = np.unique(bvals)
-    # Mean signal for b=0 (non-diffusion weighted)
-    s0 = data[bvals < b0_thresh].mean()
+    if b0_mask is None:
+        b0_mask = bvals < b0_threshold
+    if masks is None:
+        unique_bvals = np.unique(bvals)
+        masks = bvals[:, np.newaxis] == unique_bvals[np.newaxis, 1:]
+    if s0_map is None:
+        s0_map = data[..., b0_mask].mean(axis=-1)
 
-    if len(unique_bvals) <= 2:
-        raise ValueError("Insufficient unique b-values for fitting.")
-
-    # If the mean signal for b=0 is too low, return 0, 0
-    if s0 < low_signal_threshold:
+    if s0_map < low_signal_threshold:
         return 0, 0
-
-    masks = bvals[:, np.newaxis] == unique_bvals[np.newaxis, 1:]
 
     # Calculate the mean for each mask
     means = np.sum(data[:, np.newaxis] * masks, axis=0) / np.sum(masks, axis=0)
 
-    # Normalize by s0. Avoid division by zero by adding 0.01 for stable division
-    S_bvals = means / (s0 + 0.01)
+    # Normalize by s0, avoiding division by zero by adding 0.01 for stable division
+    s_bvals = means / (s0_map[..., np.newaxis] + 0.01)
 
     # Avoid log(0) by adding 0.001 for stable linear regression fit
-    S_bvals[S_bvals == 0] = 0.001
+    s_bvals[s_bvals == 0] = 0.001
+    s_log = y = np.log(s_bvals)
 
-    S_log = np.log(S_bvals)
-
-    xb = -np.log(np.arange(1, len(unique_bvals)))
+    xb = -np.log(np.arange(1, s_log.shape[-1] + 1))
 
     # Reshape xb for linear regression
-    X = xb[:len(S_log)].reshape(-1, 1)
-    y = S_log
+    X = xb.reshape(-1, 1)
 
     # Fit linear model
     model = linear_model.LinearRegression()
@@ -190,10 +203,10 @@ def compute_directional_average(data, bvals, *,
     return P, V
 
 
-def dam_classifier(data, bvals, wm_threshold, *,
-                   b0_thresh=50, low_signal_threshold=50):
-    """
-    Compute the P (slope) map for the entire dataset.
+def dam_classifier(
+    data, bvals, wm_threshold, *, b0_threshold=50, low_signal_threshold=50
+):
+    """Compute the P (slope) map for the entire dataset.
 
     Parameters
     ----------
@@ -203,7 +216,7 @@ def dam_classifier(data, bvals, wm_threshold, *,
         The b-values corresponding to the diffusion data.
     wm_threshold : float, optional
         The threshold below which a voxel is considered white matter.
-    b0_thresh : float, optional
+    b0_threshold : float, optional
         The intensity threshold for a b=0 image.
     low_signal_threshold : float, optional
         The threshold below which a voxel is considered to have low signal.
@@ -215,22 +228,37 @@ def dam_classifier(data, bvals, wm_threshold, *,
     gm_mask : ndarray
         A binary mask for grey matter.
     """
+    # Precompute unique b-values, masks, and b=0 mask
+    unique_bvals = np.unique(bvals)
+    if len(unique_bvals) <= 2:
+        raise ValueError("Insufficient unique b-values for fitting.")
+
+    b0_mask = bvals < b0_threshold
+    masks = bvals[:, np.newaxis] == unique_bvals[np.newaxis, 1:]
+
+    # Precompute s0 (mean signal for b=0)
+    s0_map = data[..., b0_mask].mean(axis=-1)
+
+    # If the mean signal for b=0 is too low, set those voxels to 0 for both P and V
+    valid_voxels = s0_map >= low_signal_threshold
+
     P_map = np.zeros(data.shape[:-1])
-    for i in range(data.shape[0]):
-        for j in range(data.shape[1]):
-            for k in range(data.shape[2]):
-                voxel_data = data[i, j, k, :]
-                if np.any(bvals != 0):
-                    P, _ = compute_directional_average(
-                        voxel_data, bvals, b0_thresh=b0_thresh,
-                        low_signal_threshold=low_signal_threshold
-                    )
-                    P_map[i, j, k] = P
+    for idx in range(data.shape[0] * data.shape[1] * data.shape[2]):
+        i, j, k = np.unravel_index(idx, P_map.shape)
+        if valid_voxels[i, j, k]:
+            P, _ = compute_directional_average(
+                data[i, j, k, :],
+                bvals,
+                masks=masks,
+                b0_mask=b0_mask,
+                s0_map=s0_map[i, j, k],
+                low_signal_threshold=low_signal_threshold,
+            )
+            P_map[i, j, k] = P
 
     # Adding a small slope threshold for P_map to avoid 0 sloped background voxels
     wm_mask = (P_map <= wm_threshold) & (P_map > 0.01)
-
     # Grey matter has a higher P value than white matter
-    gm_mask = (P_map > wm_threshold)
+    gm_mask = P_map > wm_threshold
 
     return wm_mask, gm_mask

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -312,6 +312,31 @@
   url       = {https://doi.org/10.1038/s41598-020-74054-4}
 }
 
+@article{Chang2005,
+  author    = {Lin-Ching Chang and Derek K. Jones and Carlo Pierpaoli},
+  title     = {{RESTORE: Robust estimation of tensors by outlier rejection}},
+  journal   = {Magnetic Resonance in Medicine},
+  volume    = {53},
+  number    = {5},
+  pages     = {1088-1095},
+  year      = {2005},
+  doi       = {10.1002/mrm.20426},
+  url       = {https://doi.org/10.1002/mrm.20426}
+}
+
+@article{Cheng2020,
+  author    = {Hu Cheng and Sharlene Newman and Maryam Afzali and Shreyas Fadnavis and Eleftherios Garyfallidis},
+  title     = {{Segmentation of the brain using direction-averaged signal of DWI images}},
+  journal   = {Magnetic Resonance Imaging},
+  publisher = {Elsevier},
+  volume    = {69},
+  pages     = {1-7},
+  year      = {2020},
+  month     = {June},
+  doi       = {10.1016/j.mri.2020.02.010},
+  url       = {https://doi.org/10.1016/j.mri.2020.02.010}
+}
+
 @article{Cheng2022,
   author    = {Hu Cheng and Sophia Vinci-Booher and Jian Wang and Bradley Caron and Qiuting Wen and Sharlene Newman and Franco Pestilli},
   title     = {{Denoising diffusion weighted imaging data using convolutional neural networks}},
@@ -324,18 +349,6 @@
   month     = {September},
   doi       = {10.1371/journal.pone.0274396},
   url       = {https://doi.org/10.1371/journal.pone.0274396}
-}
-
-@article{Chang2005,
-  author    = {Lin-Ching Chang and Derek K. Jones and Carlo Pierpaoli},
-  title     = {{RESTORE: Robust estimation of tensors by outlier rejection}},
-  journal   = {Magnetic Resonance in Medicine},
-  volume    = {53},
-  number    = {5},
-  pages     = {1088-1095},
-  year      = {2005},
-  doi       = {10.1002/mrm.20426},
-  url       = {https://doi.org/10.1002/mrm.20426}
 }
 
 @article{Chung2006,

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -324,19 +324,6 @@
   url       = {https://doi.org/10.1002/mrm.20426}
 }
 
-@article{Cheng2020,
-  author    = {Hu Cheng and Sharlene Newman and Maryam Afzali and Shreyas Fadnavis and Eleftherios Garyfallidis},
-  title     = {{Segmentation of the brain using direction-averaged signal of DWI images}},
-  journal   = {Magnetic Resonance Imaging},
-  publisher = {Elsevier},
-  volume    = {69},
-  pages     = {1-7},
-  year      = {2020},
-  month     = {June},
-  doi       = {10.1016/j.mri.2020.02.010},
-  url       = {https://doi.org/10.1016/j.mri.2020.02.010}
-}
-
 @article{Cheng2022,
   author    = {Hu Cheng and Sophia Vinci-Booher and Jian Wang and Bradley Caron and Qiuting Wen and Sharlene Newman and Franco Pestilli},
   title     = {{Denoising diffusion weighted imaging data using convolutional neural networks}},
@@ -349,6 +336,19 @@
   month     = {September},
   doi       = {10.1371/journal.pone.0274396},
   url       = {https://doi.org/10.1371/journal.pone.0274396}
+}
+
+@article{Cheng2020,
+  author    = {Hu Cheng and Sharlene Newman and Maryam Afzali and Shreyas Fadnavis and Eleftherios Garyfallidis},
+  title     = {{Segmentation of the brain using direction-averaged signal of DWI images}},
+  journal   = {Magnetic Resonance Imaging},
+  publisher = {Elsevier},
+  volume    = {69},
+  pages     = {1-7},
+  year      = {2020},
+  month     = {June},
+  doi       = {10.1016/j.mri.2020.02.010},
+  url       = {https://doi.org/10.1016/j.mri.2020.02.010}
 }
 
 @article{Chung2006,


### PR DESCRIPTION
This PR is for addition of tissue classifier method based on Directional Average maps based on the paper

Cheng, H., Newman, S., Afzali, M., Fadnavis, S. S., & Garyfallidis, E. (2020). Segmentation of the brain using direction-averaged signal of DWI images. Magnetic Resonance Imaging, 69, 1–7. https://doi.org/10.1016/j.mri.2020.02.010 .

Usage Example:

```
from dipy.io.gradients import read_bvals_bvecs
from dipy.io.image import load_nifti
from dipy.core.gradients import gradient_table
from dipy.segment.mask import median_otsu
import matplotlib.pyplot as plt
from dipy.segment.tissue import dam_classifier

data, affine = load_nifti("100307/T1w/Diffusion/data.nii.gz")

bvals, bvecs = read_bvals_bvecs("100307/T1w/Diffusion/bvals", "100307/T1w/Diffusion/bvecs")
gtab = gradient_table(bvals, bvecs)

maskdata, mask = median_otsu(data, vol_idx=[0,1], median_radius=2, numpass=5,
                             autocrop=False, dilate=1)

wm_mask, gm_mask = dam_classifier(data, bvals, wm_threshold=0.5, b0_thresh=50, low_signal_threshold=50)

plt.figure(figsize=(10, 5))
plt.subplot(1, 2, 1)
plt.imshow(wm_mask[:, :, data.shape[2]//2], cmap='gray')
plt.title('White Matter Mask')
plt.axis('off')

plt.subplot(1, 2, 2)
plt.imshow(gm_mask[:, :, data.shape[2]//2], cmap='gray')
plt.title('Grey Matter Mask')
plt.axis('off')

plt.show()
```
The results for a HCP data sample

![image](https://github.com/user-attachments/assets/3faf55da-5c04-4148-bd75-0f52e76ef99b)






