### PR TITLE
ci: Bump scientific-python/upload-nightly-action from 0.6.0 to 0.6.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -190,14 +190,14 @@ jobs:
           path: ./dist
           merge-multiple: true
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@ccf29c805b5d0c1dc31fa97fcdb962be074cade3 # 0.6.0
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_NIGHTLY_TOKEN}}
           anaconda_nightly_upload_organization: dipy
           anaconda_nightly_upload_labels: dev
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@ccf29c805b5d0c1dc31fa97fcdb962be074cade3 # 0.6.0
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.ANACONDA_SCIENTIFIC_PYTHON_NIGHTLY_TOKEN}}


### PR DESCRIPTION
* scientific-python/upload-nightly-action v0.6.1 fixes a breaking bug in v0.6.0.
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.6.1

c.f. https://github.com/scientific-python/upload-nightly-action/issues/106