### PR TITLE
BugFix: New Atlas OMM not working with Horizon

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -545,7 +545,7 @@ class Horizon:
                         data,
                         affine=affine,
                         world_coords=self.world_coords,
-                        rgb=self.rgb
+                        rgb=self.rgb,
                     )
                     self.__tabs.append(
                         SlicesTab(

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -545,8 +545,7 @@ class Horizon:
                         data,
                         affine=affine,
                         world_coords=self.world_coords,
-                        rgb=self.rgb,
-                        is_binary=binary_image,
+                        rgb=self.rgb
                     )
                     self.__tabs.append(
                         SlicesTab(

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -23,7 +23,6 @@ from dipy.viz.horizon.util import (
     check_img_dtype,
     check_img_shapes,
     check_peak_size,
-    is_binary_image,
     unpack_image,
     unpack_surface,
 )
@@ -529,8 +528,7 @@ class Horizon:
                 title = f"Image {img_count + 1}"
                 data, affine, fname = unpack_image(img)
                 self.vox2ras = affine
-                binary_image = is_binary_image(data)
-                if binary_image and self.__roi_images:
+                if self.__roi_images:
                     if "rois" in self.random_colors:
                         roi_color = next(self.color_gen)
                     roi_actor = actor.contour_from_roi(

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -335,8 +335,7 @@ class SlicesTab(HorizonTab):
                 # Updating visibilities
                 slices = [self._slice_x, self._slice_y, self._slice_z]
                 for i, s in enumerate(slices):
-                    self._update_slice_visibility(None, s, i,
-                                                  visibility=s.visibility)
+                    self._update_slice_visibility(None, s, i, visibility=s.visibility)
 
                 self._volume.selected_value = value
                 self._force_render(self)

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -335,7 +335,8 @@ class SlicesTab(HorizonTab):
                 # Updating visibilities
                 slices = [self._slice_x, self._slice_y, self._slice_z]
                 for i, s in enumerate(slices):
-                    self._update_slice_visibility(None, s, i, s.visibility)
+                    self._update_slice_visibility(None, s, i,
+                                                  visibility=s.visibility)
 
                 self._volume.selected_value = value
                 self._force_render(self)

--- a/dipy/viz/horizon/util.py
+++ b/dipy/viz/horizon/util.py
@@ -152,33 +152,6 @@ def _unpack_data(data, return_size=3):
     return result
 
 
-def is_binary_image(data):
-    """Check if an image is binary image.
-
-    Parameters
-    ----------
-    data : ndarray
-
-    Returns
-    -------
-    boolean
-        Whether the image is binary or not
-    """
-
-    sample_cube_size = int(max(data.shape) / 10.0)
-    sample_cube = [sample_cube_size] * data.ndim
-
-    for idx, dim in enumerate(data.shape):
-        if dim < sample_cube[idx]:
-            data = np.take(data, np.arange(stop=dim), axis=idx)
-        else:
-            start = int(dim / 2) - int(sample_cube[idx] / 2)
-            stop = int(dim / 2) + int(sample_cube[idx] / 2)
-            data = np.take(data, np.arange(start=start, stop=stop), axis=idx)
-
-    return np.unique(data).shape[0] <= 2
-
-
 @warning_for_keywords()
 def check_peak_size(pams, *, ref_img_shape=None, sync_imgs=False):
     """Check shape of peaks.

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -23,9 +23,8 @@ class SlicesVisualizer:
         *,
         affine=None,
         world_coords=False,
-        percentiles=(2, 98),
+        percentiles=(0, 100),
         rgb=False,
-        is_binary=False,
     ):
         self._interactor = interactor
         self._scene = scene
@@ -41,8 +40,6 @@ class SlicesVisualizer:
         self._data_shape = data.shape
         self._rgb = False
         self._percentiles = percentiles
-        if is_binary:
-            self._percentiles = [0, 100]
 
         vol_data = self._data
 

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -10,7 +10,6 @@ from dipy.viz.horizon.util import (
     check_img_dtype,
     check_img_shapes,
     check_peak_size,
-    is_binary_image,
     show_ellipsis,
     unpack_surface,
 )
@@ -125,16 +124,6 @@ def test_show_ellipsis():
 
     available_size = 12
     npt.assert_equal(show_ellipsis(text, text_size, available_size), text)
-
-
-@set_random_number_generator()
-def test_is_binary_image(rng):
-    data = 255 * rng.random((197, 233, 189))
-    npt.assert_equal(False, is_binary_image(data))
-
-    data = rng.integers(0, 1, size=(10, 20, 100, 200))
-
-    npt.assert_equal(True, is_binary_image(data))
 
 
 @set_random_number_generator()


### PR DESCRIPTION
This PR aims to support the new Atlas (Images with intensities from 0 to 0.9).

**Underlying issue:**
The slice visualizer in Horizon supported the intensity percentile from (2, 98), due to underlying errors from earlier versions of FURY when trying to move the slider to min or max values.

**Solution:**
The current minimum required version of the FURY does not have that issue. So, updating the percentile range will open the image properly.

**Additional Changes**
Fixed a method call where the `visibility` argument was not passed as a keyword argument. Resulting in user warnings.