### PR TITLE
DOC: Consider warnings as errors in documentation CI build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Build documentation
       run: |
         cd doc
-        make -C . html-no-examples
+        make -C . html-no-examples SPHINXOPTS="-W --keep-going"


### PR DESCRIPTION
Consider warnings as errors in documentation CI build.