### PR TITLE
DOC: Remove `tracking_introduction_eudx` from quick start

### DIFF
--- a/doc/examples/_valid_examples.toml
+++ b/doc/examples/_valid_examples.toml
@@ -40,7 +40,6 @@ position = 1
 enable = true
 files = [
     "quick_start.py",
-    "tracking_introduction_eudx.py",
 ]
 
 


### PR DESCRIPTION
Remove `tracking_introduction_eudx` from the quick start guide:
- The file is already included in the tracking group.
- Directly adding it to the start guide with no other context may be counterproductive, as it skips many of the other steps needed before streamline tracking.
- Although tracking is a very unique capability of DIPY, DIPY has many more capabilities that are not highlighted (and may go unnoticed) if we only add the tracking to the quick start guide: the quick start guide would be more useful if it contained some documentation about the workflow for streamline tracking or how each module is related to each other for the purposes of dMRI analysis.
- It eases the documentation configuration as we do not need additional tinkering to avoid the label duplication warning.

Fixes:
```
/dipy/doc/examples_built/quick_start/tracking_introduction_eudx.rst:25:
 WARNING: duplicate label intro_basic_tracking, other instance in
/dipy/doc/examples_built/fiber_tracking/tracking_introduction_eudx_1.rst
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/11284383070/job/31385471672?pr=3373#step:5:6836