### PR TITLE
DOC: Reference footnote in `streamline_tools`

### DIFF
--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -75,10 +75,11 @@ csapeaks = peaks.peaks_from_model(
 )
 
 ###############################################################################
-# Now we can use EuDX to track all of the white matter. To keep things
-# reasonably fast we use ``density=1`` which will result in 1 seeds per voxel.
-# The stopping criterion, determining when the tracking stops, is set to stop
-# when the tracking exits the white matter.
+# Now we can use EuDX to track all of the white matter. We define an identity
+# matrix for the affine transformation [#]_ of the seeding locations. To keep
+# things reasonably fast we use ``density=1`` which will result in 1 seeds per
+# voxel. The stopping criterion, determining when the tracking stops, is set to
+# stop when the tracking exits the white matter.
 
 affine = np.eye(4)
 seeds = utils.seeds_from_mask(white_matter, affine, density=1)


### PR DESCRIPTION
Reference footnote in `streamline_tools`.

Fixes:
```
/dipy/doc/examples_built/streamline_analysis/streamline_tools.rst:336:
 WARNING: Footnote [#] is not referenced. [ref.footnote]
```

raised for example at:
https://github.com/dipy/dipy/actions/runs/11284383070/job/31385471672?pr=3373#step:5:686