### PR TITLE
DOC: Use placeholder for unused variable in `streamline_tools`

### DIFF
--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -48,7 +48,7 @@ hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames(name="stanford_hard
 label_fname = get_fnames(name="stanford_labels")
 t1_fname = get_fnames(name="stanford_t1")
 
-data, affine, hardi_img = load_nifti(hardi_fname, return_img=True)
+data, _, hardi_img = load_nifti(hardi_fname, return_img=True)
 labels = load_nifti_data(label_fname)
 t1_data = load_nifti_data(t1_fname)
 bvals, bvecs = read_bvals_bvecs(hardi_bval_fname, hardi_bvec_fname)


### PR DESCRIPTION
Use `_` as a placeholder for the unused `affine` variable in `streamline_tools` example when loading the Stanford dataset HARDI data. This reduces confusion as a few lines later the same variable is set to the identity matrix.

Follow-up to commit e6f5ab0.