### PR TITLE
DOC: Miscellaneous improvements to `PeakActor` docstring

### DIFF
--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -73,11 +73,10 @@ class PeakActor(Actor):
         Add a default lookup table to the colormap. Look at
         :func:`fury.actor.colormap_lookup_table` for more information.
     linewidth : float, optional
-        Line thickness. Default is 1.
+        Line thickness.
     symmetric: bool, optional
         If True, peaks are drawn for both peaks_dirs and -peaks_dirs. Else,
-        peaks are only drawn for directions given by peaks_dirs. Default is
-        True.
+        peaks are only drawn for directions given by peaks_dirs.
 
     """
 

--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -55,9 +55,7 @@ class PeakActor(Actor):
         Peak values. The shape of the array should be (X, Y, Z, D).
     affine : array, optional
         4x4 transformation array from native coordinates to world coordinates.
-    colors : None or string ('rgb_standard') or tuple (3D or 4D) or
-        array/ndarray (N, 3 or 4) or array/ndarray (K, 3 or 4) or
-        array/ndarray(N, ) or array/ndarray (K, )
+    colors : None or string ('rgb_standard') or tuple (3D or 4D) or array/ndarray (N, 3 or 4) or (K, 3 or 4) or (N, ) or (K, )
         If None a standard orientation colormap is used for every line.
         If one tuple of color is used. Then all streamlines will have the same
         color.
@@ -78,7 +76,7 @@ class PeakActor(Actor):
         If True, peaks are drawn for both peaks_dirs and -peaks_dirs. Else,
         peaks are only drawn for directions given by peaks_dirs.
 
-    """
+    """  # noqa: E501
 
     @warning_for_keywords()
     def __init__(


### PR DESCRIPTION
- DOC: Remove default values from `PeakActor` parameters docstrings
- DOC: Avoid splitting parameter type documentation over multiple lines 