### PR TITLE
doc: Link reconstruction model list to multiple pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -109,7 +109,12 @@ release = version
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
-exclude_patterns = ["_build", "examples", "examples_revamped"]
+exclude_patterns = [
+    "_build",
+    "examples",
+    "examples_revamped",
+    "reconstruction_models_list.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None

--- a/doc/examples/_valid_examples.toml
+++ b/doc/examples/_valid_examples.toml
@@ -77,7 +77,7 @@ Below, an overview of all reconstruction models available on DIPY.
 .. note::
     Some reconstruction models do not have a tutorial yet
 
-.. include:: ../reconstruction_models_list.rst
+.. include:: ../../reconstruction_models_list.rst
 
 
 """


### PR DESCRIPTION
this PR fixes #3347 and address the warnings:

```
/home/runner/work/dipy/dipy/doc/examples_built/reconstruction/index.rst:13: CRITICAL: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'examples_built/reconstruction_models_list.rst'.
```

The approach here is to preprocess the `..include`ndirectives before sphinx/sphinx-gallery which seems to be confused by this inclusion.