### PR TITLE
ensure all calls to a python executable are to `python3`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # the setup.py file, this Makefile is just meant as a command
 # convenience/reminder while doing development.
 
-PYTHON ?= python
+PYTHON ?= python3
 PKGDIR=dipy
 DOCSRC_DIR=doc
 DOCDIR=${PKGDIR}/${DOCSRC_DIR}
@@ -89,4 +89,4 @@ build-stamp-source:
 
 # Checks to see if local files pass formatting rules
 format:
-	python -m pycodestyle dipy
+	$(PYTHON) -m pycodestyle dipy

--- a/dipy/core/profile.py
+++ b/dipy/core/profile.py
@@ -66,7 +66,7 @@ class Profiler:
             if ext in (".py", ".pyx"):  # python/cython file
                 print("profiling python/cython file ...")
                 subprocess.call(
-                    ["python", "-m", "cProfile", "-o", "profile.prof", call]
+                    ["python3", "-m", "cProfile", "-o", "profile.prof", call]
                 )
                 s = pstats.Stats("profile.prof")
                 stats = s.strip_dirs().sort_stats("time")

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,7 +47,7 @@ examples-clean:
 	-cd examples_built && find . -not -name "README" -not -name ".gitignore" -exec rm -rfd {} \; || true
 
 gitwash-update:
-	python ../tools/gitwash_dumper.py devel dipy --repo-name=dipy --github-user=dipy \
+	python3 ../tools/gitwash_dumper.py devel dipy --repo-name=dipy --github-user=dipy \
             --project-url=https://dipy.org \
             --project-ml-url=https://mail.python.org/mailman/listinfo/neuroimaging
 

--- a/doc/devel/installation_from_source.rst
+++ b/doc/devel/installation_from_source.rst
@@ -88,8 +88,8 @@ Ubuntu/Debian
 
 ::
 
-    sudo apt-get install python-dev python-setuptools
-    sudo apt-get install python-numpy python-scipy
+    sudo apt-get install python3-dev python3-setuptools
+    sudo apt-get install python3-numpy python3-scipy
     sudo apt-get install cython
 
 then::
@@ -101,7 +101,7 @@ then::
 
 You might want the optional packages too (highly recommended)::
 
-    sudo apt-get install ipython python-h5py python-vtk python-matplotlib
+    sudo apt-get install ipython python3-h5py python3-vtk python3-matplotlib
 
 
 Now follow :ref:`install-source-nix`.
@@ -123,7 +123,7 @@ used with your specific version of python.
 
 For getting this information, type this command in shell like ``cmd`` or Powershell_::
 
-    python -c "import platform;print(platform.python_compiler())"
+    python3 -c "import platform;print(platform.python_compiler())"
 
 This command should print information of this form::
 
@@ -274,7 +274,7 @@ version in the system: the ``Sphinx`` package used should correspond to that of
 the virtual environment where ``DIPY`` lives. This can be solved by specifying
 the path to the ``Sphinx`` package in the virtual environment::
 
-    make html SPHINXBUILD='python <path_to_sphinx>/sphinx-build'
+    make html SPHINXBUILD='python3 <path_to_sphinx>/sphinx-build'
 
 
 .. include:: ../links_names.inc

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -22,7 +22,7 @@ Release checklist
 * Generate, Review and update the release notes. Run the following command from
   the root directory of DIPY::
 
-    python tools/github_stats.py 1.7.0 > doc/release_notes/release1.8.rst
+    python3 tools/github_stats.py 1.7.0 > doc/release_notes/release1.8.rst
 
   where ``1.7.0`` was the last release tag name.
 
@@ -66,7 +66,7 @@ Release checklist
 
     make distclean
     git clean -fxd
-    python -m build  or  pip install --no-build-isolation  -e .
+    python3 -m build  or  pip install --no-build-isolation  -e .
 
 * Make sure all tests pass on your local machine (from the ``<dipy root>`` directory)::
 

--- a/tools/osxbuild.py
+++ b/tools/osxbuild.py
@@ -4,7 +4,7 @@ Stolen with thankfulness from the numpy distribution
 
 This is a simple script, most of the heavy lifting is done in bdist_mpkg.
 
-To run this script:  'python build.py'
+To run this script:  'python3 build.py'
 
 Installer is built using sudo so file permissions are correct when installed on
 user system.  Script will prompt for sudo pwd.

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -37,7 +37,7 @@ def get_dipydir():
 # import compileall and then get dir os.path.split
 def compile_tree():
     """Compile all Python files below current directory."""
-    stat = os.system('python -m compileall .')
+    stat = os.system('python3 -m compileall .')
     if stat:
         msg = '*** ERROR: Some Python files in tree do NOT compile! ***\n'
         msg += 'See messages above for the actual file that produced it.\n'


### PR DESCRIPTION
This patch is from the Debian package for `dipy`.