### PR TITLE
BF: Updated non_local_means

### DIFF
--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -1,5 +1,6 @@
-import numpy as np
 from numbers import Number
+
+import numpy as np
 
 from dipy.denoise.nlmeans_block import nlmeans_block
 from dipy.testing.decorators import warning_for_keywords
@@ -54,7 +55,7 @@ def non_local_means(
             raise ValueError(
                 "sigma should have the same length as the last "
                 "dimension of arr for 4D data",
-                sigma
+                sigma,
             )
     else:
         if not isinstance(sigma, Number):

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -55,7 +55,7 @@ def non_local_means(
                 "sigma should have the same length as the last "
                 "dimension of arr for 4D data",
                 sigma
-                )
+            )
     else:
         if not isinstance(sigma, Number):
             raise ValueError("sigma should be a float", sigma)

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -44,7 +44,7 @@ def test_scalar_sigma(rng):
     S0[:10, :10, :10] = 300 + noise[:10, :10, :10]
 
     assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=False)
-    
+
     noise = "a"
     assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=False)
 
@@ -94,11 +94,12 @@ def test_nlmeans_dtype():
 
 def test_nlmeans_2D_sigma():
     S0 = np.ones((20, 20, 20, 3))
-    noise = np.ones((3,2))
+    noise = np.ones((3, 2))
     assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=True)
-    
+
     S0 = np.ones((20, 20, 20))
     assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=True)
+
 
 def test_nlmeans_sigma_arr():
     S0 = np.ones((20, 20, 20, 3))

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -44,6 +44,9 @@ def test_scalar_sigma(rng):
     S0[:10, :10, :10] = 300 + noise[:10, :10, :10]
 
     assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=False)
+    
+    noise = "a"
+    assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=False)
 
 
 @set_random_number_generator()
@@ -87,3 +90,17 @@ def test_nlmeans_dtype():
     mask[10:14, 10:14, 10:14] = 1
     S0n = non_local_means(S0, sigma=1, mask=mask, rician=True)
     assert_equal(S0.dtype, S0n.dtype)
+
+
+def test_nlmeans_2D_sigma():
+    S0 = np.ones((20, 20, 20, 3))
+    noise = np.ones((3,2))
+    assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=True)
+    
+    S0 = np.ones((20, 20, 20))
+    assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=True)
+
+def test_nlmeans_sigma_arr():
+    S0 = np.ones((20, 20, 20, 3))
+    noise = np.ones(4)
+    assert_raises(ValueError, non_local_means, S0, sigma=noise, rician=True)

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -15,6 +15,16 @@ def test_nlmeans_static():
     S0nb = non_local_means(S0, sigma=1.0, rician=False)
     assert_array_almost_equal(S0, S0nb)
 
+    S0 = 100 * np.ones((20, 20, 20, 3), dtype="f8")
+    S0nb = non_local_means(S0, sigma=1.0, rician=False)
+    assert_array_almost_equal(S0, S0nb)
+
+    S0nb = non_local_means(S0, sigma=np.array(1.0), rician=False)
+    assert_array_almost_equal(S0, S0nb)
+
+    S0nb = non_local_means(S0, sigma=np.array([1.0]), rician=False)
+    assert_array_almost_equal(S0, S0nb)
+
 
 @set_random_number_generator()
 def test_nlmeans_random_noise(rng):


### PR DESCRIPTION
Fixes #3285 
- Added the option for sigma to also be an ndarray so that it works nicely with the output of
estimate_sigma on a 4D dataset. Made the decision that if the input is scalar and arr is 4D, repeat input arr.shape[-1] times. That way the old behaviour when the input is a scalar on 4D arr is preserved while also allowing sigma to have multiple values in the final for loop. New code works with old tests.
 - Added tests for the new checks.
 - Updated non_local_means docs.