### PR TITLE
DOC: Update the CI tool to GHA in `CONTRIBUTING` file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ of the documentation for the procedures we use in developing the code.
 ### Tests and test coverage
 
 We use [pytest](https://docs.pytest.org) to write tests of the code,
-and [Azure Pipelines](https://dev.azure.com/dipy/dipy) and [Travis-CI](https://travis-ci.com/dipy/dipy)
+and [GitHub Actions](https://github.com/dipy/dipy/actions)
 for continuous integration.
 
 If you are adding code into a module that already has a 'test' file (e.g., if


### PR DESCRIPTION
Update the CI tool in `CONTRIBUTNG` file: the switch from Azure Pipelines and Travis CI took place across several commits in pull requests
https://github.com/dipy/dipy/pull/2315
https://github.com/dipy/dipy/pull/2518

and released as of version 1.5.0 (Mar 11, 2022).