### PR TITLE
STYLE: Remove empty quoted paragraph in developer guide index

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -1,4 +1,4 @@
- .. _development:
+.. _development:
 
 DIPY Developer Guide
 ====================


### PR DESCRIPTION
Remove empty quoted paragraph in developer guide index: remove the whitespace before the document label.