### PR TITLE
DOC: Add Exporting and importing Mapping field information in recipes and registration tutorial

### DIFF
--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -12,6 +12,7 @@ We will register two 3D volumes from the same modality using SyN with the Cross
 
 import numpy as np
 
+from dipy.align import read_mapping, write_mapping
 from dipy.align.imaffine import AffineMap
 from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
 from dipy.align.metrics import CCMetric
@@ -176,6 +177,19 @@ regtools.overlay_slices(
 # resolution.
 #
 #
+# If you wish, you can also save the transformation to a file, so that it can
+# be applied to other images in the future. This can be done with the
+# `write_mapping` function. The data in the file will be organized with shape
+# (X, Y, Z, 3, 2), such that the forward mapping in each voxel is in
+# data[i, j, k, :, 0] and the backward mapping in each voxel is in
+# data[i, j, k, :, 1]
+
+write_mapping(mapping, "mapping.nii.gz")
+# To read the mapping back, use the `read_mapping` function
+saved_mapping = read_mapping("mapping.nii.gz", hardi_fname, b0_fname)
+
+
+###############################################################################
 # References
 # ----------
 #

--- a/doc/recipes.rst
+++ b/doc/recipes.rst
@@ -54,5 +54,35 @@ answer it yourself and contribute to the documentation!
         save_nifti(otensor, data, affine, image.header)
 
 
+.. dropdown:: How do I save/read the output fields from the Symmetric Diffeomorphic Registration?
+   :animate: fade-in-slide-down
+
+   The mapping fields is saved in a Nifti file. The data in the file is organized with
+   shape (X, Y, Z, 3, 2), such that the forward mapping in each voxel is in
+   `data[i, j, k, :, 0]` and the backward mapping in each voxel is in
+   `data[i, j, k, :, 1]`.
+
+   The output fields from the Symmetric Diffeomorphic Registration can be saved and
+   read using the functions `write_mapping` and `read_mapping` respectively.
+
+   .. code-block:: Python
+
+        from dipy.align import read_mapping, write_mapping
+        from dipy.align.imwarp import DiffeomorphicMap, SymmetricDiffeomorphicRegistration
+
+        # Load your static and moving images and setup the registration parameters.
+        # Then apply the registration
+
+        sdr = SymmetricDiffeomorphicRegistration(metric, level_iters)
+        mapping = sdr.optimize(static, moving)
+
+        # Save the mapping
+        write_mapping(mapping,'outputField.nii.gz')
+
+        # If you need to read the mapping back
+        mapping = read_mapping('outputField.nii.gz', static_filename, moving_filename)
+
+
+
 
 .. include:: links_names.inc


### PR DESCRIPTION
Exporting and importing Mapping field in Syn registration is a recurrent request. 

This PR adds this information:
- In the recipe as an How to
- in a tutorial which will help the user to understand the different steps.

This PR fixes #3361 and address https://github.com/dipy/dipy/discussions/3272 discussion

