### PR TITLE
RF: fix step argument in DTI NLLS model

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -756,6 +756,14 @@ class TensorModel(ReconstModel):
 
         if not callable(fit_method):
             try:
+                if fit_method.upper() in ["NLS", "NLLS"] and "step" in kwargs:
+                    _ = kwargs.pop("step")
+                    warnings.warn(
+                        "The 'step' parameter can not be used in the "
+                        f"{fit_method.upper()} method. It will be ignored.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 fit_method = common_fit_methods[fit_method.upper()]
             except KeyError as e:
                 e_s = '"' + str(fit_method) + '" is not a known fit '

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -192,6 +192,10 @@ def test_tensor_model():
 
     # Test error-handling:
     npt.assert_raises(ValueError, dti.TensorModel, gtab, fit_method="crazy_method")
+    npt.assert_warns(UserWarning, dti.TensorModel, gtab, fit_method="NLLS", step=1e4)
+    with npt.assert_warns(UserWarning):
+        model = dti.TensorModel(gtab, fit_method="NLS", step=1e4)
+        npt.assert_equal(model.kwargs.get("step", None), None)
 
     # Test custom fit tensor method
     try:


### PR DESCRIPTION
this PR fixes #3030

It warns user that `step` can not be used for NLLS.

This is a problem found by @captainnova. Can you have a quick look into it. Thanks!
