### PR TITLE
BF: Fixing single-slice data error in Patch2Self

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -525,6 +525,10 @@ def _patch2self_version1(
     else:
         calc_dtype = np.float32
 
+    if 1 in data.shape and data.shape[-1] != 1:
+        position = data.shape.index(1)
+        data = np.concatenate((data, data, data), position)
+
     # Segregates volumes by b0 threshold
     b0_idx = np.argwhere(bvals <= b0_threshold)
     dwi_idx = np.argwhere(bvals > b0_threshold)


### PR DESCRIPTION
Bug Fix for Issue #2469. Fixing the error that arises when a single slice data was used for denoising in version 1 of Patch2Self.