### PR TITLE
CI: define output path for coverage

### DIFF
--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -426,7 +426,7 @@ class ReconstDtiFlow(Workflow):
             Name of the peaks values volume to be saved.
         out_peaks_indices : string, optional
             Name of the peaks indices volume to be saved.
-        out_sphere: string, optional
+        out_sphere : string, optional
             Sphere vertices name to be saved.
         out_qa : string, optional
             Name of the Quantitative Anisotropy to be saved.
@@ -882,11 +882,11 @@ class ReconstCSDFlow(Workflow):
             Name of the peaks indices volume to be saved.
         out_gfa : string, optional
             Name of the generalized FA volume to be saved.
-        out_sphere: string, optional
+        out_sphere : string, optional
             Sphere vertices name to be saved.
-        out_b: string, optional
+        out_b : string, optional
             Name of the B Matrix to be saved.
-        out_qa: string, optional
+        out_qa : string, optional
             Name of the Quantitative Anisotropy to be saved.
 
 
@@ -1716,7 +1716,7 @@ class ReconstRUMBAFlow(Workflow):
         roi_center : variable int, optional
             Center of ROI in data. If center is None, it is assumed that it is
             the center of the volume with shape `data.shape[:3]`.
-        roi_radii : int or array-like, optional
+        roi_radii : variable int, optional
             radii of cuboid ROI in voxels.
         fa_thr : float, optional
             FA threshold to compute the WM response function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
 ]
 
 extra = ["dipy[viz, ml]",
-         "cvxpy<=1.4.4",
+         "cvxpy",
          "scikit-image",
          "boto3"
         ]

--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -8,6 +8,7 @@ set -ex
 echo "Run the tests"
 
 # Change into an innocuous directory and find tests from installation
+mkdir for_testing_results
 mkdir for_testing
 cd for_testing
 # We need the setup.cfg for the pytest settings
@@ -19,13 +20,14 @@ if [ "$COVERAGE" == "1" ] || [ "$COVERAGE" == true ]; then
     cp ../.codecov.yml .;
     chmod -R a-w .
     # Run the tests and check for test coverage.
-    coverage run -m pytest -c pyproject.toml -svv --doctest-modules --verbose --durations=10 --pyargs dipy
+    coverage run --data-file=../for_testing_results/.coverage -m pytest -o cache_dir=../for_testing_results -c pyproject.toml -svv --doctest-modules --verbose --durations=10 --pyargs dipy
     chmod -R a+w .
+    cd ../for_testing_results
     coverage report -m  # Generate test coverage report.
     coverage xml  # Generate coverage report in xml format for codecov upload.
 else
     chmod -R a-w .
-    pytest -c pyproject.toml -svv --doctest-modules --verbose --durations=10 --pyargs dipy
+    pytest -o cache_dir=../for_testing_results -c pyproject.toml -svv --doctest-modules --verbose --durations=10 --pyargs dipy
     chmod -R a+w .
 fi
 cd ..


### PR DESCRIPTION
This is a follow-up of #3415.

it should address the following warnings:
```
../venv/lib/python3.10/site-packages/_pytest/cacheprovider.py:445
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/_pytest/cacheprovider.py:445: PytestCacheWarning: could not create cache path /home/runner/work/dipy/dipy/for_testing/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/home/runner/work/dipy/dipy/for_testing/.pytest_cache'
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../venv/lib/python3.10/site-packages/_pytest/cacheprovider.py:397
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/_pytest/cacheprovider.py:397: PytestCacheWarning: could not create cache path /home/runner/work/dipy/dipy/for_testing/.pytest_cache/v/cache/lastfailed: [Errno 13] Permission denied: '/home/runner/work/dipy/dipy/for_testing/.pytest_cache'
    config.cache.set("cache/lastfailed", self.lastfailed)

../venv/lib/python3.10/site-packages/_pytest/stepwise.py:56
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/_pytest/stepwise.py:56: PytestCacheWarning: could not create cache path /home/runner/work/dipy/dipy/for_testing/.pytest_cache/v/cache/stepwise: [Errno 13] Permission denied: '/home/runner/work/dipy/dipy/for_testing/.pytest_cache'
    session.config.cache.set(STEPWISE_CACHE_DIR, [])
```