### PR TITLE
RF: fix joblib warning in sfm 

### DIFF
--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -556,7 +556,7 @@ class SparseFascicleModel(ReconstModel, Cache):
             ) as parallel:
                 out = parallel(
                     joblib.delayed(self._fit_solver2voxels)(
-                        isopredict, vox_data, vox, True
+                        isopredict, vox_data, vox, parallel=True
                     )
                     for vox, vox_data in enumerate(flat_S)
                 )


### PR DESCRIPTION
This PR address the following warning

```
/home/runner/work/dipy/dipy/venv/lib/python3.12/site-packages/joblib/parallel.py:598: UserWarning: Pass ['parallel'] as keyword args. From version 2.0.0 passing these as positional arguments will result in an error.
```

this is a warning that you can see in the PRE-CI's