### PR TITLE
ENH: Add type annotation information

### DIFF
--- a/dipy/meson.build
+++ b/dipy/meson.build
@@ -325,7 +325,8 @@ endif
 # ------------------------------------------------------------------------
 python_sources = [
   '__init__.py',
-  'conftest.py'
+  'conftest.py',
+  'py.typed'
 ]
 
 py3.install_sources(


### PR DESCRIPTION
Add type annotation information: add the `py.typed` file and distribute the type information with the package by adding the corresponding entry in the `pyproject.toml` file  so that third-party tools can use the DIPY type annotation information.

Documentation:
https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-typed-libraries