### PR TITLE
RF: bump tensorflow minimal version to 2.18.0.

### DIFF
--- a/dipy/nn/__init__.py
+++ b/dipy/nn/__init__.py
@@ -9,7 +9,7 @@ from dipy.utils.optpkg import optional_package
 def _load_backend():
     """Dynamically load the preferred backend based on the environment variable."""
     preferred_backend = os.getenv("DIPY_NN_BACKEND", "torch").lower()
-    tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+    tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
     torch, have_torch, _ = optional_package("torch", min_version="2.2.0")
 
     __all__ = []

--- a/dipy/nn/tests/test_cnn_1denoiser.py
+++ b/dipy/nn/tests/test_cnn_1denoiser.py
@@ -8,7 +8,7 @@ import pytest
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 sklearn, have_sklearn, _ = optional_package("sklearn.model_selection")
 original_backend = os.environ.get("DIPY_NN_BACKEND")
 cnnden_mod = None

--- a/dipy/nn/tests/test_deepn4.py
+++ b/dipy/nn/tests/test_deepn4.py
@@ -10,7 +10,7 @@ import pytest
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 original_backend = os.environ.get("DIPY_NN_BACKEND")
 deepn4_mod = None
 

--- a/dipy/nn/tests/test_evac.py
+++ b/dipy/nn/tests/test_evac.py
@@ -9,7 +9,7 @@ import pytest
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 torch, have_torch, _ = optional_package("torch", min_version="2.2.0")
 have_nn = have_tf or have_torch
 BACKENDS = [

--- a/dipy/nn/tests/test_histo_resdnn.py
+++ b/dipy/nn/tests/test_histo_resdnn.py
@@ -13,7 +13,7 @@ from dipy.io.image import load_nifti
 from dipy.reconst.shm import tournier07_legacy_msg
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 torch, have_torch, _ = optional_package("torch", min_version="2.2.0")
 have_nn = have_tf or have_torch
 BACKENDS = [

--- a/dipy/nn/tests/test_synb0.py
+++ b/dipy/nn/tests/test_synb0.py
@@ -10,7 +10,7 @@ import pytest
 from dipy.data import get_fnames
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 original_backend = os.environ.get("DIPY_NN_BACKEND")
 synb0_mod = None
 

--- a/dipy/nn/tests/test_tf.py
+++ b/dipy/nn/tests/test_tf.py
@@ -8,7 +8,7 @@ import pytest
 
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 original_backend = os.environ.get("DIPY_NN_BACKEND")
 model_mod = None
 

--- a/dipy/nn/tf/cnn_1d_denoising.py
+++ b/dipy/nn/tf/cnn_1d_denoising.py
@@ -30,7 +30,7 @@ import numpy as np
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 if have_tf:
     from tensorflow.keras.initializers import Orthogonal
     from tensorflow.keras.layers import Activation, Conv1D, Input

--- a/dipy/nn/tf/deepn4.py
+++ b/dipy/nn/tf/deepn4.py
@@ -13,7 +13,7 @@ from dipy.nn.utils import normalize, recover_img, set_logger_level, transform_im
 from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 if have_tf:
     from tensorflow.keras.layers import (
         Concatenate,

--- a/dipy/nn/tf/evac.py
+++ b/dipy/nn/tf/evac.py
@@ -20,7 +20,7 @@ from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 if have_tf:
     from tensorflow.keras.layers import (
         Add,

--- a/dipy/nn/tf/histo_resdnn.py
+++ b/dipy/nn/tf/histo_resdnn.py
@@ -16,7 +16,7 @@ from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 if have_tf:
     from tensorflow.keras.layers import Add, Dense, Input
     from tensorflow.keras.models import Model

--- a/dipy/nn/tf/model.py
+++ b/dipy/nn/tf/model.py
@@ -1,7 +1,7 @@
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 
 
 class SingleLayerPerceptron:

--- a/dipy/nn/tf/synb0.py
+++ b/dipy/nn/tf/synb0.py
@@ -12,7 +12,7 @@ from dipy.nn.utils import normalize, set_logger_level, unnormalize
 from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
 from dipy.utils.optpkg import optional_package
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 if have_tf:
     from tensorflow.keras.layers import (
         Concatenate,

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -11,7 +11,7 @@ from dipy.nn.evac import EVACPlus
 from dipy.utils.optpkg import optional_package
 from dipy.workflows.nn import EVACPlusFlow
 
-tf, have_tf, _ = optional_package("tensorflow", min_version="2.0.0")
+tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
 
 
 @pytest.mark.skipif(not have_tf, reason="Requires TensorFlow")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ all = ["dipy[dev,doc,style,test, viz, ml, extra]"]
 style = ["ruff", "pre-commit"]
 viz = ["fury>=0.10.0", "matplotlib"]
 test = ["pytest", "coverage", "coveralls", "codecov", "asv"]
-ml = ["scikit_learn", "pandas", "statsmodels>=0.14.0", "tables", "tensorflow", "torch"]
+ml = ["scikit_learn", "pandas", "statsmodels>=0.14.0", "tables", "tensorflow>=2.18.0", "torch"]
 dev = [
     # Also update [build-system] -> requires
     'meson-python>=0.13',


### PR DESCRIPTION
This PR just bumps TensorFlow minimal version to 2.18.0. This is the first version compatible to numpy 2.0 and we need to enforce that to avoid weird error. 
