### PR TITLE
ENH: Transition remaining `NumPy` `RandomState` instances to `Generator`

### DIFF
--- a/benchmarks/benchmarks/bench_tracking.py
+++ b/benchmarks/benchmarks/bench_tracking.py
@@ -11,7 +11,7 @@ from dipy.tracking.streamlinespeed import compress_streamlines
 
 class BenchStreamlines:
     def setup(self):
-        rng = np.random.RandomState(42)
+        rng = np.random.default_rng(42)
         nb_streamlines = 20000
         min_nb_points = 2
         max_nb_points = 100

--- a/dipy/nn/tf/cnn_1d_denoising.py
+++ b/dipy/nn/tf/cnn_1d_denoising.py
@@ -187,7 +187,7 @@ class Cnn1DDenoiser:
             If int, represents the absolute number of train samples.
             If None, the value is automatically set to the complement of the
             test size.
-        random_state: int, RandomState instance or None, optional
+        random_state: int, np.random.Generator instance or None, optional
             Controls the shuffling applied to the data before applying
             the split. Pass an int for reproducible output across multiple
             function calls. See Glossary.

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -191,7 +191,7 @@ def select_random_set_of_streamlines(streamlines, select, *, rng=None):
         Number of streamlines to select. If there are less streamlines
         than ``select`` then ``select=len(streamlines)``.
 
-    rng : RandomState
+    rng : np.random.Generator
         Default None.
 
     Returns
@@ -204,7 +204,7 @@ def select_random_set_of_streamlines(streamlines, select, *, rng=None):
     """
     len_s = len(streamlines)
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
     index = rng.choice(len_s, min(select, len_s), replace=False)
     if isinstance(streamlines, Streamlines):
         return streamlines[index]

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -579,7 +579,7 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
     >>> from dipy.tracking.streamlinespeed import compress_streamlines
     >>> import numpy as np
     >>> # One streamline: a wiggling line
-    >>> rng = np.random.RandomState(42)
+    >>> rng = np.random.default_rng(42)
     >>> streamline = np.linspace(0, 10, 100*3).reshape((100, 3))
     >>> streamline += 0.2 * rng.rand(100, 3)
     >>> c_streamline = compress_streamlines(streamline, tol_error=0.2)

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -179,7 +179,7 @@ class Horizon:
         self.clusters_gt = clusters_gt
         self.world_coords = world_coords
         self.interactive = interactive
-        self.prng = np.random.RandomState(27)
+        self.prng = np.random.default_rng(27)
         self.tractograms = tractograms or []
         self.out_png = out_png
         self.images = images or []

--- a/doc/examples/bundle_extraction.py
+++ b/doc/examples/bundle_extraction.py
@@ -70,7 +70,7 @@ moved, transform, qb_centroids1, qb_centroids2 = whole_brain_slr(
     x0="affine",
     verbose=True,
     progressive=True,
-    rng=np.random.RandomState(1984),
+    rng=np.random.default_rng(1984),
 )
 
 
@@ -166,7 +166,7 @@ if interactive:
 #
 # Model Arcuate Fasciculus Left bundle
 
-rb = RecoBundles(moved, verbose=True, rng=np.random.RandomState(2001))
+rb = RecoBundles(moved, verbose=True, rng=np.random.default_rng(2001))
 
 recognized_af_l, af_l_labels = rb.recognize(
     model_bundle=model_af_l,


### PR DESCRIPTION
Transition remaining `NumPy` `random` module `RandomState` instances to `Generator` instances following the deprecation of the former.

Documentation:
https://numpy.org/doc/2.1/reference/random/new-or-different.html#what-s-new-or-different

Change the relevant docstrings accordingly.

Left behind in commit abbfbb6.