### PR TITLE
RF: Update ``scipy.special`` deprecated functions

### DIFF
--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -11,7 +11,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
 )
-from scipy.special import sph_harm as sph_harm_sp
 
 from dipy.core.gradients import gradient_table
 from dipy.core.interpolation import NearestNeighborInterpolator
@@ -171,7 +170,6 @@ def test_real_sh_descoteaux_from_index():
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-
         assert_equal(rsh(aa, bb, cc, dd).shape, (3, 4, 5, 6))
 
 
@@ -1060,8 +1058,12 @@ def test_faster_sph_harm():
         ]
     )
 
-    sh = spherical_harmonics(m_values, l_values, theta[:, None], phi[:, None])
-    sh2 = sph_harm_sp(m_values, l_values, theta[:, None], phi[:, None])
+    sh = spherical_harmonics(
+        m_values, l_values, theta[:, None], phi[:, None], use_scipy=False
+    )
+    sh2 = spherical_harmonics(
+        m_values, l_values, theta[:, None], phi[:, None], use_scipy=True
+    )
 
     assert_array_almost_equal(sh, sh2, 8)
     sh = spherical_harmonics(

--- a/dipy/utils/compatibility.py
+++ b/dipy/utils/compatibility.py
@@ -1,0 +1,72 @@
+"""Utility functions for checking different stuffs."""
+import operator
+
+from packaging import version
+
+
+def check_version(package_name, ver, *, operator=operator.ge):
+    """Check if the package is installed and the version satisfies the operator.
+
+    Parameters
+    ----------
+    package_name : str
+        The name of the package to check.
+    ver : str
+        The version to check against.
+    operator : callable, optional
+        The operator to use for the comparison.
+
+    Returns
+    -------
+    bool
+        True if the package is installed and the version satisfies the operator.
+    """
+    try:
+        pkg = __import__(package_name)
+    except ImportError:
+        return False
+    if hasattr(pkg, "__version__"):
+        return operator(version.parse(pkg.__version__), version.parse(ver))
+    return False
+
+
+def check_min_version(package_name, min_version, *, strict=False):
+    """Check if the package is installed and the version is at least min_version.
+
+    Parameters
+    ----------
+    package_name : str
+        The name of the package to check.
+    min_version : str
+        The minimum version required.
+    strict : bool, optional
+        If True, the version must be strictly greater than min_version.
+
+    Returns
+    -------
+    bool
+        True if the package is installed and the version is at least min_version.
+    """
+    op = operator.gt if strict else operator.ge
+    return check_version(package_name, min_version, operator=op)
+
+
+def check_max_version(package_name, max_version, *, strict=False):
+    """Check if the package is installed and the version is at most max_version.
+
+    Parameters
+    ----------
+    package_name : str
+        The name of the package to check.
+    max_version : str
+        The maximum version required.
+    strict : bool, optional
+        If True, the version must be strictly less than max_version.
+
+    Returns
+    -------
+    bool
+        True if the package is installed and the version is at most max_version.
+    """
+    op = operator.lt if strict else operator.le
+    return check_version(package_name, max_version, operator=op)

--- a/dipy/utils/compatibility.py
+++ b/dipy/utils/compatibility.py
@@ -1,4 +1,5 @@
 """Utility functions for checking different stuffs."""
+
 import operator
 
 from packaging import version

--- a/dipy/utils/meson.build
+++ b/dipy/utils/meson.build
@@ -26,6 +26,7 @@ endforeach
 python_sources = [
   '__init__.py',
   'arrfuncs.py',
+  'compatibility.py',
   'convert.py',
   'deprecator.py',
   'multiproc.py',

--- a/dipy/utils/tests/meson.build
+++ b/dipy/utils/tests/meson.build
@@ -19,6 +19,7 @@ endforeach
 python_sources = [
   '__init__.py',
   'test_arrfuncs.py',
+  'test_compatibility.py',
   'test_convert.py',
   'test_deprecator.py',
   'test_multiproc.py',

--- a/dipy/utils/tests/test_compatibility.py
+++ b/dipy/utils/tests/test_compatibility.py
@@ -1,0 +1,31 @@
+from numpy.testing import assert_equal
+
+from dipy.utils.compatibility import check_max_version, check_min_version
+
+
+def test_check_min_version():
+    assert_equal(check_min_version("dipy", "15.0.0"), False)
+    assert_equal(check_min_version("dipy", "0.8.0"), True)
+
+    assert_equal(check_min_version("numpy", "15.0.0"), False)
+    assert_equal(check_min_version("numpy", "1.8.0"), True)
+
+    assert_equal(check_min_version("scipy", "3.0.0"), False)
+    assert_equal(check_min_version("scipy", "1.8.0"), True)
+
+    assert_equal(check_min_version("fakepackage", "3.0.0"), False)
+    assert_equal(check_min_version("fakepackage", "0.8.0"), False)
+
+
+def test_check_max_version():
+    assert_equal(check_max_version("dipy", "15.0.0"), True)
+    assert_equal(check_max_version("dipy", "0.8.0"), False)
+
+    assert_equal(check_max_version("numpy", "15.0.0"), True)
+    assert_equal(check_max_version("numpy", "1.8.0"), False)
+
+    assert_equal(check_max_version("scipy", "3.0.0"), True)
+    assert_equal(check_max_version("scipy", "1.8.0"), False)
+
+    assert_equal(check_max_version("fakepackage", "3.0.0"), False)
+    assert_equal(check_max_version("fakepackage", "0.8.0"), False)


### PR DESCRIPTION
Since the last release of Scipy (1.15.0, on January 3, 2025), many functions have been deprecated in `scipy.special` module.

for this reason, we encounter a bunch of warnings as you can see below. 

This PR fixes those issues.

```python
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/shm.py:235: DeprecationWarning: `scipy.special.sph_harm` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.sph_harm_y` instead.
    return sps.sph_harm(m_values, l_values, theta, phi, dtype=complex)

direction/tests/test_peaks.py: 2 warnings
reconst/tests/test_csdeconv.py: 1 warning
reconst/tests/test_shm.py: 24 warnings
workflows/tests/test_reconst_csa_csd.py: 9 warnings
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/shm.py:909: DeprecationWarning: `scipy.special.lpn` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.legendre_p_all` instead.
    legendre0 = sps.lpn(sh_order_max, 0)[0]

reconst/tests/test_csdeconv.py: 2331 warnings
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/csdeconv.py:428: DeprecationWarning: `scipy.special.lpn` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.legendre_p_all` instead.
    lambda z, j=j: lpn(j, z)[0][-1]

reconst/tests/test_csdeconv.py: 20 warnings
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/csdeconv.py:435: DeprecationWarning: `scipy.special.lpn` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.legendre_p_all` instead.
    frt[j // 2] = 2 * np.pi * lpn(j, 0)[0][-1]

reconst/tests/test_csdeconv.py: 945 warnings
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/csdeconv.py:419: DeprecationWarning: `scipy.special.lpn` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.legendre_p_all` instead.
    lambda z, j=j: lpn(j, z)[0][-1]

reconst/tests/test_shm.py: 2880 warnings
  /home/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/reconst/tests/test_shm.py:1064: DeprecationWarning: `scipy.special.sph_harm` is deprecated as of SciPy 1.15.0 and will be removed in SciPy 1.17.0. Please use `scipy.special.sph_harm_y` instead.
    sh2 = sph_harm_sp(m_values, l_values, theta[:, None], phi[:, None])
```

Concerning the new module, the version checker will be propogated in the rest of the codebase later on. I was tired to duplicate some code to check a specific package version.
