### PR TITLE
RF - add pmf_gen argument to peaks_from_positions

### DIFF
--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -29,6 +29,9 @@ cdef class PmfGen:
             out = self.pmf
         return <double[:len(self.vertices)]>self.get_pmf_c(&point[0], &out[0])
 
+    def get_sphere(self):
+        return self.sphere      
+
     cdef double* get_pmf_c(self, double* point, double* out) noexcept nogil:
         pass
 
@@ -66,8 +69,6 @@ cdef class SimplePmfGen(PmfGen):
                  double[:, :, :, :] pmf_array,
                  object sphere):
         PmfGen.__init__(self, pmf_array, sphere)
-        if np.min(pmf_array) < 0:
-            raise ValueError("pmf should not have negative values.")
         if not pmf_array.shape[3] == sphere.vertices.shape[0]:
             raise ValueError("pmf should have the same number of values as the"
                              + " number of vertices of sphere.")

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -87,11 +87,6 @@ def test_pmf_from_array():
         np.zeros(len(sphere.vertices)),
     )
 
-    # Test ValueError for negative pmf
-    npt.assert_raises(
-        ValueError,
-        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]) * -1, sphere),
-    )
     # Test ValueError for non matching pmf and sphere
     npt.assert_raises(
         ValueError,

--- a/dipy/direction/tests/test_prob_direction_getter.py
+++ b/dipy/direction/tests/test_prob_direction_getter.py
@@ -91,11 +91,6 @@ def test_ProbabilisticDirectionGetter():
             90,
             unit_octahedron,
         )
-        # pmf cannot have negative values
-        pmf[0, 0, 0, 0] = -1
-        npt.assert_raises(
-            ValueError, ProbabilisticDirectionGetter.from_pmf, pmf, 90, unit_octahedron
-        )
 
         # Check basis_type keyword
         with warnings.catch_warnings():


### PR DESCRIPTION
This PR adds a new optional argument to `dipy.direction.peaks.peaks_from_positions`. When provided, positional arguments `odfs` and `sphere` are ignored. This is needed in PR #3089.

-added the corresponding tests
-The error `ValueError("pmf should not have negative values.")`  was removed from `SimplePmfGen` for consistency with `SHCoeffPmfGen` and to allow interpolation of odfs with negative value. Negative values were already tolerated/managed in the tracking functions using `pmf_gen` because of `SHCoeffPmfGen`.