### PR TITLE
ENH: Add GitHub CI workflow file to run benchmarks using `asv`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,42 @@
+name: Benchmarks
+
+on: [push, pull_request]
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Linux
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.11' ]
+
+    steps:
+    - name: Set up system
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev,test,ml,extra,benchmark]
+    - name: Set threading parameters for reliable benchmarking
+      run: |
+        export OPENBLAS_NUM_THREADS=1
+        export MKL_NUM_THREADS=1
+        export OMP_NUM_THREADS=1
+    - name: Run benchmarks
+      run: |
+        asv machine --yes --config benchmarks/asv.conf.json
+        asv run --config benchmarks/asv.conf.json --show-stderr

--- a/benchmarks/benchmarks/bench_tracking.py
+++ b/benchmarks/benchmarks/bench_tracking.py
@@ -18,7 +18,7 @@ class BenchStreamlines:
 
         def generate_streamlines(nb_streamlines, min_nb_points, max_nb_points, rng):
             streamlines = [
-                rng.rand(*(rng.randint(min_nb_points, max_nb_points), 3))
+                rng.random((rng.integers(min_nb_points, max_nb_points), 3))
                 for _ in range(nb_streamlines)
             ]
             return streamlines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,10 +91,10 @@ dipy_pam2nifti = "dipy.workflows.cli:run"
 dipy_tensor2pam = "dipy.workflows.cli:run"
 
 [project.optional-dependencies]
-all = ["dipy[dev,doc,style,test, viz, ml, extra]"]
+all = ["dipy[dev,doc,style,test, viz, ml, extra, benchmark]"]
 style = ["ruff", "pre-commit"]
 viz = ["fury>=0.10.0", "matplotlib"]
-test = ["pytest", "coverage", "coveralls", "codecov", "asv"]
+test = ["pytest", "coverage", "coveralls", "codecov"]
 ml = ["scikit_learn", "pandas", "statsmodels>=0.14.0", "tables", "tensorflow>=2.18.0", "torch"]
 dev = [
     # Also update [build-system] -> requires
@@ -128,6 +128,11 @@ doc = [
     "tomli>=2.0.1",
     "grg-sphinx-theme>=0.4.0",
     "Jinja2"
+]
+benchmark = [
+    "asv",
+    "pyperf",
+    "virtualenv",
 ]
 
 


### PR DESCRIPTION
Add GitHub CI workflow file to run benchmarks using `asv`.

Add the corresponding new `benchmark` section to the project optional dependencies in `pyproject.toml`