### PR TITLE
NF: Replace urllib by requests to improve fetcher stability. 

### DIFF
--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -30,7 +30,7 @@ def test_make_fetcher():
 
         # create local HTTP Server
         testfile_folder = op.split(symmetric362)[0] + os.sep
-        testfile_url = f"file:{pathname2url(testfile_folder)}"
+        testfile_url = "http://localhost:8000"
         print(testfile_url)
         print(symmetric362)
         current_dir = os.getcwd()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "packaging>=21",
     "tqdm>=4.30.0",
     "trx-python>=0.2.9",
+    "requests>=2.32.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
It has been at least  2 months that some of our tests are failing due error during fetching test data. 

This PR attempt to stabilize this

- I replaced the standard library `urllib` by 3rd party library named `requests`
- I added an extra step to retry download where it stops when it fails. It will retry 3 times.

