### PR TITLE
NF: Add default value to docstring for the CLI

### DIFF
--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -93,7 +93,7 @@ class ResliceFlow(Workflow):
             number of cores minus ``num_processes + 1`` is used (enter -1 to
             use as many cores as possible). 0 raises an error.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_resliced : string, optional
             Name of the resliced dataset to be saved.
         """
@@ -179,7 +179,7 @@ class SlrWithQbxFlow(Workflow):
         progressive : boolean, optional
             True to enable progressive registration.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_moved : string, optional
             Filename of moved tractogram.
         out_affine : string, optional
@@ -313,69 +313,52 @@ class ImageRegistrationFlow(Workflow):
         ----------
         static_image_files : string
             Path to the static image file.
-
         moving_image_files : string
             Path to the moving image file.
-
         transform : string, optional
             ``'com'``: center of mass; ``'trans'``: translation; ``'rigid'``:
             rigid body; ``'rigid_isoscaling'``: rigid body + isotropic scaling,
             ``'rigid_scaling'``: rigid body + scaling; ``'affine'``: full affine
             including translation, rotation, shearing and scaling.
-
         nbins : int, optional
             Number of bins to discretize the joint and marginal PDF.
-
         sampling_prop : int, optional
             Number ([0-100]) of voxels for calculating the PDF. None implies all
             voxels.
-
         metric : string, optional
             Similarity metric for gathering mutual information.
-
         level_iters : variable int, optional
             The number of iterations at each scale of the scale space.
             `level_iters[0]` corresponds to the coarsest scale,
             `level_iters[-1]` the finest, where n is the length of the
             sequence.
-
         sigmas : variable floats, optional
             Custom smoothing parameter to build the scale space (one parameter
              for each scale).
-
         factors : variable floats, optional
             Custom scale factors to build the scale space (one factor for each
              scale).
-
         progressive : boolean, optional
             Enable/Disable the progressive registration.
-
         save_metric : boolean, optional
             If true, quality assessment metric are saved in
             'quality_metric.txt'.
-
         static_vol_idx : str, optional
             1D array representing indices of ``axis=-1`` of a 4D
             `static` input volume. From the command line use something like
             `3 4 5 6`. From script use something like `[3, 4, 5, 6]`. This
             input is required for 4D volumes.
-
         moving_vol_idx : str, optional
             1D array representing indices of ``axis=-1`` of a 4D
             `moving` input volume. From the command line use something like
             `3 4 5 6`. From script use something like `[3, 4, 5, 6]`. This
             input is required for 4D volumes.
-
         out_dir : string, optional
             Directory to save the transformed image and the affine matrix
-             (default current directory).
-
         out_moved : string, optional
             Name for the saved transformed image.
-
         out_affine : string, optional
             Name for the saved affine matrix.
-
         out_quality : string, optional
             Name of the file containing the saved quality metric.
         """
@@ -500,24 +483,19 @@ class ApplyTransformFlow(Workflow):
         ----------
         static_image_files : string
             Path of the static image file.
-
         moving_image_files : string
             Path of the moving image(s). It can be a single image or a
             folder containing multiple images.
-
         transform_map_file : string
             For the affine case, it should be a text(``*.txt``) file containing
             the affine matrix. For the diffeomorphic case,
             it should be a nifti file containing the mapping displacement
             field in each voxel with this shape (x, y, z, 3, 2).
-
         transform_type : string, optional
             Select the transformation type to apply between 'affine' or
             'diffeomorphic'.
-
         out_dir : string, optional
-            Directory to save the transformed files (default current directory).
-
+            Directory to save the transformed files.
         out_file : string, optional
             Name of the transformed file.
             It is recommended to use the flag --mix-names to
@@ -626,41 +604,32 @@ class SynRegistrationFlow(Workflow):
         ----------
         static_image_files : string
             Path of the static image file.
-
         moving_image_files : string
             Path to the moving image file.
-
         prealign_file : string, optional
             The text file containing pre alignment information via an
              affine matrix.
-
         inv_static : boolean, optional
             Apply the inverse mapping to the static image.
-
         level_iters : variable int, optional
             The number of iterations at each level of the gaussian pyramid.
-
         metric : string, optional
             The metric to be used.
             metric available: cc (Cross Correlation), ssd (Sum Squared
             Difference), em (Expectation-Maximization).
-
         mopt_sigma_diff : float, optional
             Metric option applied on Cross correlation (CC).
             The standard deviation of the Gaussian smoothing kernel to be
             applied to the update field at each iteration.
-
         mopt_radius : int, optional
             Metric option applied on Cross correlation (CC).
             the radius of the squared (cubic) neighborhood at each voxel to
             be considered to compute the cross correlation.
-
         mopt_smooth : float, optional
             Metric option applied on Sum Squared Difference (SSD) and
             Expectation Maximization (EM). Smoothness parameter, the
             larger the value the smoother the deformation field.
             (default 1.0 for EM, 4.0 for SSD)
-
         mopt_inner_iter : int, optional
             Metric option applied on Sum Squared Difference (SSD) and
             Expectation Maximization (EM). This is number of iterations to be
@@ -668,18 +637,15 @@ class SynRegistrationFlow(Workflow):
             optimization algorithm (this is not the number of steps per
             Gaussian Pyramid level, that parameter must be set for the
             optimizer, not the metric). Default 5 for EM, 10 for SSD.
-
         mopt_q_levels : int, optional
             Metric option applied on Expectation Maximization (EM).
             Number of quantization levels (Default: 256 for EM)
-
         mopt_double_gradient : bool, optional
             Metric option applied on Expectation Maximization (EM).
             if True, the gradient of the expected static image under the moving
             modality will be added to the gradient of the moving image,
             similarly, the gradient of the expected moving image under the
             static modality will be added to the gradient of the static image.
-
         mopt_step_type : string, optional
             Metric option applied on Sum Squared Difference (SSD) and
             Expectation Maximization (EM). The optimization schedule to be
@@ -687,38 +653,29 @@ class SynRegistrationFlow(Workflow):
             (not used if Demons Step is selected). Possible value:
             ('gauss_newton', 'demons'). default: 'gauss_newton' for EM,
             'demons' for SSD.
-
         step_length : float, optional
             the length of the maximum displacement vector of the update
              displacement field at each iteration.
-
         ss_sigma_factor : float, optional
             parameter of the scale-space smoothing kernel. For example, the
              std. dev. of the kernel will be factor*(2^i) in the isotropic case
              where i = 0, 1, ..., n_scales is the scale.
-
         opt_tol : float, optional
             the optimization will stop when the estimated derivative of the
              energy profile w.r.t. time falls below this threshold.
-
         inv_iter : int, optional
             the number of iterations to be performed by the displacement field
              inversion algorithm.
-
         inv_tol : float, optional
             the displacement field inversion algorithm will stop iterating
              when the inversion error falls below this threshold.
-
         out_dir : string, optional
-            Directory to save the transformed files (default current directory).
-
+            Directory to save the transformed files.
         out_warped : string, optional
             Name of the warped file.
-
         out_inv_static : string, optional
             Name of the file to save the static image after applying the
              inverse mapping.
-
         out_field : string, optional
             Name of the file to save the diffeomorphic map.
 
@@ -882,8 +839,7 @@ class MotionCorrectionFlow(Workflow):
             Threshold used to check that norm(bvec) = 1 +/- bvecs_tol
             b-vectors are unit vectors
         out_dir : string, optional
-            Directory to save the transformed image and the affine matrix
-             (default current directory).
+            Directory to save the transformed image and the affine matrix.
         out_moved : string, optional
             Name for the saved transformed image.
         out_affine : string, optional
@@ -977,7 +933,7 @@ class BundleWarpFlow(Workflow):
         affine : boolean, optional
             If False, use rigid registration as starting point. (default True)
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_linear_moved : string, optional
             Filename of linearly moved bundle.
         out_nonlinear_moved : string, optional

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -334,10 +334,9 @@ class ImageRegistrationFlow(Workflow):
             sequence.
         sigmas : variable floats, optional
             Custom smoothing parameter to build the scale space (one parameter
-             for each scale).
+            for each scale).
         factors : variable floats, optional
-            Custom scale factors to build the scale space (one factor for each
-             scale).
+            Custom scale factors to build the scale space (one factor for each scale).
         progressive : boolean, optional
             Enable/Disable the progressive registration.
         save_metric : boolean, optional
@@ -607,8 +606,7 @@ class SynRegistrationFlow(Workflow):
         moving_image_files : string
             Path to the moving image file.
         prealign_file : string, optional
-            The text file containing pre alignment information via an
-             affine matrix.
+            The text file containing pre alignment information via an affine matrix.
         inv_static : boolean, optional
             Apply the inverse mapping to the static image.
         level_iters : variable int, optional
@@ -655,27 +653,27 @@ class SynRegistrationFlow(Workflow):
             'demons' for SSD.
         step_length : float, optional
             the length of the maximum displacement vector of the update
-             displacement field at each iteration.
+            displacement field at each iteration.
         ss_sigma_factor : float, optional
             parameter of the scale-space smoothing kernel. For example, the
-             std. dev. of the kernel will be factor*(2^i) in the isotropic case
-             where i = 0, 1, ..., n_scales is the scale.
+            std. dev. of the kernel will be factor*(2^i) in the isotropic case
+            where i = 0, 1, ..., n_scales is the scale.
         opt_tol : float, optional
             the optimization will stop when the estimated derivative of the
-             energy profile w.r.t. time falls below this threshold.
+            energy profile w.r.t. time falls below this threshold.
         inv_iter : int, optional
             the number of iterations to be performed by the displacement field
-             inversion algorithm.
+            inversion algorithm.
         inv_tol : float, optional
             the displacement field inversion algorithm will stop iterating
-             when the inversion error falls below this threshold.
+            when the inversion error falls below this threshold.
         out_dir : string, optional
             Directory to save the transformed files.
         out_warped : string, optional
             Name of the warped file.
         out_inv_static : string, optional
             Name of the file to save the static image after applying the
-             inverse mapping.
+            inverse mapping.
         out_field : string, optional
             Name of the file to save the diffeomorphic map.
 

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -81,7 +81,7 @@ class Patch2SelfFlow(Workflow):
         ver : int, optional
             Version of the Patch2Self algorithm to use between  1 or 3.
         out_dir : string, optional
-            Output directory (default current directory)
+            Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume
             (default: dwi_patch2self.nii.gz)
@@ -157,7 +157,7 @@ class NLMeansFlow(Workflow):
             If True the noise is estimated as Rician, otherwise Gaussian noise
             is assumed.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
 
@@ -258,7 +258,7 @@ class LPCAFlow(Workflow):
             $\tau_{factor}$ is set to None, it will be automatically calculated
             using the Marcenko-Pastur distribution :footcite:p`Veraart2016b`.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
 
@@ -333,7 +333,7 @@ class MPPCAFlow(Workflow):
             If true, a noise standard deviation estimate based on the
             Marcenko-Pastur distribution is returned :footcite:p:`Veraart2016b`.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
         out_sigma : string, optional
@@ -402,7 +402,7 @@ class GibbsRingingFlow(Workflow):
             number of cores minus ``num_processes + 1`` is used (enter -1 to
             use as many cores as possible). 0 raises an error.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_unring : string, optional
             Name of the resulting denoised volume.
 

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -240,7 +240,7 @@ class FetchFlow(Workflow):
         data_names : variable string
             Any number of Nifti1, bvals or bvecs files.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
 
         """
         if out_dir:
@@ -313,7 +313,7 @@ class SplitFlow(Workflow):
         vol_idx : int, optional
             Index of the 3D volume to extract.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_split : string, optional
             Name of the resulting split volume
 
@@ -612,7 +612,7 @@ class ConcatenateTractogramFlow(Workflow):
             element in trx_list (Note: delete_groups must be set to True as
             well)
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_extension : string, optional
             Extension of the resulting tractogram
         out_tractogram : string, optional
@@ -723,7 +723,7 @@ class ConvertTensorsFlow(Workflow):
             Format of the output tensor files. Valid options are 'dipy',
             'mrtrix', 'ants', 'fsl'.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_tensor : string, optional
             Name of the resulting tensor file
 
@@ -764,7 +764,7 @@ class ConvertTractogramFlow(Workflow):
         offsets_dtype : string, optional
             Data type of the tractogram offsets, used for vtk files.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_tractogram : string, optional
             Name of the resulting tractogram
 

--- a/dipy/workflows/mask.py
+++ b/dipy/workflows/mask.py
@@ -25,7 +25,7 @@ class MaskFlow(Workflow):
         ub : float, optional
             Upper bound value.
         out_dir : string, optional
-           Output directory. (default current directory)
+           Output directory.
         out_mask : string, optional
            Name of the masked file.
         """

--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -32,7 +32,7 @@ class EVACPlusFlow(Workflow):
         save_masked : bool, optional
             Save mask.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_mask : string, optional
             Name of the mask volume to be saved.
         out_masked : string, optional

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -137,7 +137,7 @@ class ReconstMAPMRIFlow(Workflow):
         extract_pam_values : bool, optional
             Save or not to save pam volumes as single nifti files.
         out_dir : string, optional
-            Output directory. (default: current directory)
+            Output directory.
         out_rtop : string, optional
             Name of the rtop to be saved.
         out_lapnorm : string, optional
@@ -390,7 +390,7 @@ class ReconstDtiFlow(Workflow):
         extract_pam_values : bool, optional
             Save or not to save pam volumes as single nifti files.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_tensor : string, optional
             Name of the tensors volume to be saved.
             Per default, this will be saved following the nifti standard:
@@ -685,7 +685,7 @@ class ReconstDsiFlow(Workflow):
             of cores minus ``num_processes + 1`` is used (enter -1 to use as
             many cores as possible). 0 raises an error.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
         out_shm : string, optional
@@ -869,7 +869,7 @@ class ReconstCSDFlow(Workflow):
             of cores minus ``num_processes + 1`` is used (enter -1 to use as
             many cores as possible). 0 raises an error.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
         out_shm : string, optional
@@ -1096,7 +1096,7 @@ class ReconstCSAFlow(Workflow):
             of cores minus ``num_processes + 1`` is used (enter -1 to use as
             many cores as possible). 0 raises an error.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
         out_shm : string, optional
@@ -1285,7 +1285,7 @@ class ReconstDkiFlow(Workflow):
         npeaks : int, optional
             Number of peaks to fit in each voxel.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_dt_tensor : string, optional
             Name of the tensors volume to be saved.
         out_dk_tensor : string, optional
@@ -1560,7 +1560,7 @@ class ReconstIvimFlow(Workflow):
             List of metrics to save.
             Possible values: S0_predicted, perfusion_fraction, D_star, D
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_S0_predicted : string, optional
             Name of the S0 signal estimated to be saved.
         out_perfusion_fraction : string, optional
@@ -1773,7 +1773,7 @@ class ReconstRUMBAFlow(Workflow):
             The minimum distance between directions. If two peaks are too close
             only the larger of the two is returned.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
         out_shm : string, optional

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -64,7 +64,7 @@ class MedianOtsuFlow(Workflow):
             Whether to remove potential holes or islands.
             Useful for solving minor errors.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_mask : string, optional
             Name of the mask volume to be saved.
         out_masked : string, optional
@@ -176,7 +176,7 @@ class RecoBundlesFlow(Workflow):
             Don't enable Refine local Streamline-based Linear
             Registration.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_recognized_transf : string, optional
             Recognized bundle in the space of the model bundle.
         out_recognized_labels : string, optional
@@ -340,7 +340,7 @@ class LabelsBundlesFlow(Workflow):
         labels_files : string
             The path of model bundle files.
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
         out_bundle : string, optional
             Recognized bundle in the space of the model bundle.
 

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -62,7 +62,7 @@ class SNRinCCFlow(Workflow):
             Threshold for bounding box, values separated with commas for ex.
             [0.6,1,0,0.1,0,0.1].
         out_dir : string, optional
-            Where the resulting file will be saved. (default current directory)
+            Where the resulting file will be saved.
         out_file : string, optional
             Name of the result file to be saved.
         out_mask_cc : string, optional
@@ -215,7 +215,7 @@ def buan_bundle_profiles(
     no_disks : integer, optional
         Number of disks used for dividing bundle into disks.
     out_dir : string, optional
-        Output directory. (default current directory)
+        Output directory.
 
     References
     ----------
@@ -333,20 +333,16 @@ class BundleAnalysisTractometryFlow(Workflow):
 
         Parameters
         ----------
-
         model_bundle_folder : string
             Path to the input model bundle files. This path may
             contain wildcards to process multiple inputs at once.
-
         subject_folder : string
             Path to the input subject folder. This path may contain
             wildcards to process multiple inputs at once.
-
         no_disks : integer, optional
             Number of disks used for dividing bundle into disks.
-
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
 
         References
         ----------
@@ -498,16 +494,13 @@ class LinearMixedModelsFlow(Workflow):
 
         Parameters
         ----------
-
         h5_files : string
             Path to the input metric files. This path may
             contain wildcards to process multiple inputs at once.
-
         no_disks : integer, optional
             Number of disks used for dividing bundle into disks.
-
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
 
         """
 
@@ -568,19 +561,15 @@ class BundleShapeAnalysis(Workflow):
 
         Parameters
         ----------
-
         subject_folder : string
             Path to the input subject folder. This path may contain
             wildcards to process multiple inputs at once.
-
         clust_thr : variable float, optional
             list of bundle clustering thresholds used in QuickBundlesX.
-
         threshold : float, optional
             Bundle shape similarity threshold.
-
         out_dir : string, optional
-            Output directory. (default current directory)
+            Output directory.
 
         References
         ----------

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -4,7 +4,11 @@ from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
 
-from dipy.workflows.base import IntrospectiveArgumentParser, none_or_dtype
+from dipy.workflows.base import (
+    IntrospectiveArgumentParser,
+    add_default_args_to_docstring,
+    none_or_dtype,
+)
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import (
     DummyCombinedWorkflow,
@@ -221,3 +225,108 @@ def inputs_from_results(results, keys=None, optional=False):
         inputs.append(str(result))
 
     return inputs
+
+
+def test_add_default_args_to_docstring():
+    # --- Test 1: Adds default values correctly ---
+    def func1(a, b=10, c="hello"):
+        """Sample function."""
+        pass
+
+    npds1 = {"Parameters": [("a", "int", []), ("b", "int", []), ("c", "str", [])]}
+    add_default_args_to_docstring(npds1, func1)
+    assert npds1["Parameters"][1][2] == ["(default: 10)"]
+    assert npds1["Parameters"][2][2] == ["(default: hello)"]
+
+    # --- Test 2: Ignores non-default parameters ---
+    def func2(x, y):
+        """Function without defaults."""
+        pass
+
+    npds2 = {"Parameters": [("x", "int", []), ("y", "int", [])]}
+
+    add_default_args_to_docstring(npds2, func2)
+
+    assert npds2["Parameters"][0][2] == []
+    assert npds2["Parameters"][1][2] == []
+
+    # --- Test 3: Handles 'out_dir' special case ---
+    def func3(out_dir="."):
+        """Handles out_dir default properly."""
+        pass
+
+    npds3 = {"Parameters": [("out_dir", "str", [])]}
+
+    add_default_args_to_docstring(npds3, func3)
+
+    assert npds3["Parameters"][0][2] == ["(default:  current directory)"]
+
+    # --- Test 4: Handles empty docstring parameters ---
+    def func4(a=42):
+        """Function with an empty parameter list in docstring."""
+        pass
+
+    npds4 = {"Parameters": []}  # No parameters in docstring
+
+    add_default_args_to_docstring(npds4, func4)
+
+    assert npds4["Parameters"] == []  # Should remain unchanged
+
+    # --- Test 5: Missing parameter in docstring ---
+    def func5(a=42, b="test"):
+        """Function with some missing parameters in docstring."""
+        pass
+
+    npds5 = {
+        "Parameters": [
+            ("a", "int", [])  # 'b' is missing
+        ]
+    }
+
+    add_default_args_to_docstring(npds5, func5)
+
+    assert npds5["Parameters"][0][2] == ["(default: 42)"]  # Only 'a' updated
+    assert len(npds5["Parameters"]) == 1  # 'b' should not be added automatically
+
+    # --- Test 6: Handles multi-line parameter descriptions ---
+    def func6(alpha=0.5, beta=0.3):
+        """Function with multi-line parameter descriptions.
+
+        Parameters
+        ----------
+        alpha : float
+            Learning rate parameter.
+            This value controls step size.
+        beta : float
+            Another parameter with
+            multiple lines of description.
+        """
+        pass
+
+    npds6 = {
+        "Parameters": [
+            (
+                "alpha",
+                "float",
+                ["Learning rate parameter.", "This value controls step size."],
+            ),
+            (
+                "beta",
+                "float",
+                ["Another parameter with", "multiple lines of description."],
+            ),
+        ]
+    }
+
+    add_default_args_to_docstring(npds6, func6)
+
+    assert npds6["Parameters"][0][2] == [
+        "Learning rate parameter.",
+        "This value controls step size.",
+        "(default: 0.5)",
+    ]
+    assert npds6["Parameters"][1][2] == [
+        "Another parameter with",
+        "multiple lines of description.",
+        "(default: 0.3)",
+    ]

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -173,20 +173,19 @@ class LocalFiberTrackingPAMFlow(Workflow):
             tracking has to stop.
         seed_density : int, optional
             Number of seeds per dimension inside voxel.
-             For example, seed_density of 2 means 8 regularly distributed
-             points in the voxel. And seed density of 1 means 1 point at the
-             center of the voxel.
+            For example, seed_density of 2 means 8 regularly distributed
+            points in the voxel. And seed density of 1 means 1 point at the
+            center of the voxel.
         step_size : float, optional
             Step size (in mm) used for tracking.
         tracking_method : string, optional
-            Select direction getter strategy :
-             - "eudx" (Uses the peaks saved in the pam_files)
-             - "deterministic" or "det" for a deterministic tracking
-               (Uses the sh saved in the pam_files, default)
-             - "probabilistic" or "prob" for a Probabilistic tracking
-               (Uses the sh saved in the pam_files)
-             - "closestpeaks" or "cp" for a ClosestPeaks tracking
-               (Uses the sh saved in the pam_files)
+            Select direction getter strategy:
+                - "eudx" (Uses the peaks saved in the pam_files)
+                - "deterministic" or "det" for a deterministic tracking
+                - "probabilistic" or "prob" for a Probabilistic tracking
+                - "closestpeaks" or "cp" for a ClosestPeaks tracking
+
+            By default, the sh coefficients saved in the pam_files are used.
         pmf_threshold : float, optional
             Threshold for ODF functions.
         max_angle : float, optional
@@ -276,9 +275,9 @@ class PFTrackingPAMFlow(Workflow):
             Step size (in mm) used for tracking.
         seed_density : int, optional
             Number of seeds per dimension inside voxel.
-             For example, seed_density of 2 means 8 regularly distributed
-             points in the voxel. And seed density of 1 means 1 point at the
-             center of the voxel.
+            For example, seed_density of 2 means 8 regularly distributed
+            points in the voxel. And seed density of 1 means 1 point at the
+            center of the voxel.
         pmf_threshold : float, optional
             Threshold for ODF functions.
         max_angle : float, optional

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -192,7 +192,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
         max_angle : float, optional
             Maximum angle between streamline segments (range [0, 90]).
         out_dir : string, optional
-           Output directory. (default current directory)
+           Output directory.
         out_tractogram : string, optional
            Name of the tractogram file to be saved.
         save_seeds : bool, optional
@@ -296,7 +296,7 @@ class PFTrackingPAMFlow(Workflow):
         pft_count : int, optional
             Number of particles to use in the particle filter.
         out_dir : string, optional
-           Output directory. (default current directory)
+           Output directory.
         out_tractogram : string, optional
            Name of the tractogram file to be saved.
         save_seeds : bool, optional

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -118,7 +118,7 @@ class HorizonFlow(Workflow):
             with 1 or 3 values and should be between [0-1]. For example, a
             value of (1, 0, 0) would mean the red color.
         out_dir : str, optional
-            Output directory. (default current directory)
+            Output directory.
         out_stealth_png : str, optional
             Filename of saved picture.
 


### PR DESCRIPTION
When an user is calling the help of a CLI, having the default value of argument can be very helpful, especially when you want to tune it.

This PR adds a function to automatically adds the default value in the docstring.

to check it, just call the help of a cli (e.g `dipy_fit_csa --help`) and you should see all the default value of a CLI.

fixes #3454 