### PR TITLE
BF: Handling binary and small intensity value range and Volume slider not be shown if single channel provided.

### DIFF
--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -316,9 +316,6 @@ class SlicesTab(HorizonTab):
                 self._volume.obj.value = self._volume.selected_value
             else:
                 intensities_range = self._visualizer.intensities_range
-                print(intensities_range)
-                print(self._visualizer.volume_min)
-                print(self._visualizer.volume_max)
 
                 # Updating the colormap
                 self._intensities.selected_value[0] = intensities_range[0]

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -316,6 +316,9 @@ class SlicesTab(HorizonTab):
                 self._volume.obj.value = self._volume.selected_value
             else:
                 intensities_range = self._visualizer.intensities_range
+                print(intensities_range)
+                print(self._visualizer.volume_min)
+                print(self._visualizer.volume_max)
 
                 # Updating the colormap
                 self._intensities.selected_value[0] = intensities_range[0]
@@ -323,7 +326,8 @@ class SlicesTab(HorizonTab):
                 self._update_colormap()
 
                 # Updating intensities slider
-                self._intensities.obj.initial_values = intensities_range
+                self._intensities.obj.left_disk_value = intensities_range[0]
+                self._intensities.obj.right_disk_value = intensities_range[1]
                 self._intensities.obj.min_value = self._visualizer.volume_min
                 self._intensities.obj.max_value = self._visualizer.volume_max
                 self._intensities.obj.update(0)

--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -296,13 +296,9 @@ class SlicesTab(HorizonTab):
                 self._slice_y.selected_value,
                 self._slice_z.selected_value,
             )
-            valid_vol = self._visualizer.change_volume(
-                self._volume.selected_value,
+            valid_vol, default_range = self._visualizer.change_volume(
                 value,
-                [
-                    self._intensities.selected_value[0],
-                    self._intensities.selected_value[1],
-                ],
+                np.asarray(self._intensities.obj._ratio),
                 visible_slices,
             )
             self._register_visualize_partials()
@@ -323,8 +319,9 @@ class SlicesTab(HorizonTab):
                 self._update_colormap()
 
                 # Updating intensities slider
-                self._intensities.obj.left_disk_value = intensities_range[0]
-                self._intensities.obj.right_disk_value = intensities_range[1]
+                if default_range:
+                    self._intensities.obj.left_disk_value = self._visualizer.volume_min
+                    self._intensities.obj.right_disk_value = self._visualizer.volume_max
                 self._intensities.obj.min_value = self._visualizer.volume_min
                 self._intensities.obj.max_value = self._visualizer.volume_max
                 self._intensities.obj.update(0)

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -181,7 +181,7 @@ class SlicesVisualizer:
         if np.sum(np.diff(value_range)) == 0:
             warnings.warn(
                 f"The selected intensity range have no contrast for Volume N°{idx}."
-                "The selection intensities will be ignored.",
+                "The selection of intensities will be ignored and changed to default.",
                 stacklevel=2,
             )
             value_range = np.asarray((np.min(vol_data), np.max(vol_data)))

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -35,8 +35,11 @@ class SlicesVisualizer:
 
         self._slice_actors = [None] * 3
 
-        self._data_ndim = data.ndim
-        self._data_shape = data.shape
+        if len(self._data.shape) == 4 and self._data.shape[-1]:
+            self._data = self._data[:, :, :, 0]
+
+        self._data_ndim = self._data.ndim
+        self._data_shape = self._data.shape
         self._rgb = False
         self._percentiles = percentiles
 

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-from scipy import stats
 
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.optpkg import optional_package


### PR DESCRIPTION
### BF: Handling binary and small intensity value range.

**Resolves**
#3371 Horizon miscalculating contrast when returning to previous volume.
#3112 Horizon fails with a single channel 4D volume.

**PR Contents**

- Replaces the percentile based placement of the sliders from previous volume to new volume. It provides support for the smaller range of the intensities.
- Ignores the selection of the intensity range with a warning. If the intensity range selection does not have any contrast in it while changing to newer volume.
- Ignores the volume slider if only single channel provided in volume.

**Local Testing**

- The changes have been tested on the `provided example`, `stanford hardi` and `cenir_multib` datasets.
- To get the warning from the _adaptive_percentile method please move both the sliders of the intensities super close in the example given, which will lead to only single value in the selection and will result in to the warning but as the entire data has more intensity value it will not result into warning as it will fallback to entire intensity range and update the slider. 