### PR TITLE
BF: Import fixes

### DIFF
--- a/dipy/viz/projections.py
+++ b/dipy/viz/projections.py
@@ -14,7 +14,6 @@ from dipy.utils.optpkg import optional_package
 
 matplotlib, has_mpl, setup_module = optional_package("matplotlib")
 plt, _, _ = optional_package("matplotlib.pyplot")
-mpl_tri, _, _ = optional_package("matplotlib.tri")
 bm, has_basemap, _ = optional_package("mpl_toolkits.basemap")
 
 
@@ -81,9 +80,7 @@ def sph_project(
     basemap_args.setdefault("lon_0", 0)
     basemap_args.setdefault("resolution", "c")
 
-    from mpl_toolkits.basemap import Basemap
-
-    m = Basemap(**basemap_args)
+    m = bm.Basemap(**basemap_args)
     if boundary:
         m.drawmapboundary()
 


### PR DESCRIPTION
### BF: Import fixes

**Resolves**
#3164 Simplify or remove the use of mpl_tri in viz module.

**PR Contents**
- mpl_toolkits.basemap was not used using the `optional_package` and had a separate import.
- `mpl_tri` is not required to be install separately as it is already included in the basemap import.

