### PR TITLE
RF: Enforce bvecs for the cli extract_b0 

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -392,7 +392,11 @@ class ExtractB0Flow(Workflow):
                         f"first b0 value ({bvals.min()}).",
                         stacklevel=2,
                     )
-            gtab = gradient_table(bvals, b0_threshold=b0_threshold)
+
+            bvecs = np.random.randn(bvals.shape[0], 3)
+            norms = np.linalg.norm(bvecs, axis=1, keepdims=True)
+            bvecs = bvecs / norms
+            gtab = gradient_table(bvals, bvecs=bvecs, b0_threshold=b0_threshold)
             b0s_result = extract_b0(
                 data,
                 gtab.b0s_mask,

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -429,12 +429,15 @@ def test_extract_b0_flow():
         fdata, fbval, fbvec = get_fnames(name="small_25")
         data, affine = load_nifti(fdata)
         b0_data = data[..., 0]
-        b0_path = pjoin(out_dir, "b0.nii.gz")
+        b0_path = pjoin(out_dir, "b0_expected.nii.gz")
         save_nifti(b0_path, b0_data, affine)
 
         extract_b0_flow = ExtractB0Flow()
-        extract_b0_flow.run(fdata, fbval, out_dir=out_dir)
-        npt.assert_equal(extract_b0_flow.last_generated_outputs["out_b0"], b0_path)
+        extract_b0_flow.run(fdata, fbval, out_dir=out_dir, strategy="first")
+        npt.assert_equal(
+            extract_b0_flow.last_generated_outputs["out_b0"],
+            pjoin(out_dir, "b0.nii.gz"),
+        )
         res, _ = load_nifti(extract_b0_flow.last_generated_outputs["out_b0"])
         npt.assert_array_equal(res, b0_data)
 


### PR DESCRIPTION
In some case, this cli was failing because a `bvecs` were missing. 

However, bvecs are not really needed in this case so we generate a random one to avoid any issue.

Can you try @iprajwalreddy?