### PR TITLE
RF: Avoid crash of `optional_package` when dirty install

### DIFF
--- a/dipy/utils/optpkg.py
+++ b/dipy/utils/optpkg.py
@@ -91,8 +91,10 @@ def optional_package(name, *, trip_msg=None, min_version=None):
             trip_msg = (
                 f"We need at least version {min_version} of "
                 f"package {name}, but ``import {name}`` "
-                f"found version {pkg.__version__}"
+                f"found version {current_version}."
             )
+            if current_version == "0.0.0":
+                trip_msg += "Your installation might be incomplete or corrupted."
 
     if trip_msg is None:
         trip_msg = (

--- a/dipy/utils/tests/test_optpkg.py
+++ b/dipy/utils/tests/test_optpkg.py
@@ -1,3 +1,6 @@
+import os
+from tempfile import TemporaryDirectory
+
 import pytest
 
 from dipy.testing import assert_false, assert_true
@@ -22,3 +25,17 @@ def test_optional_package():
 
     pkg, have_pkg, setup_module = optional_package("dipy", min_version="1.0.0")
     assert_true(have_pkg)
+
+    with TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "fake_package"))
+        open(os.path.join(tmpdir, "fake_package", "__init__.py"), "a").close()
+        current_dir = os.getcwd()
+        os.chdir(tmpdir)
+        pkg, have_pkg, setup_module = optional_package(
+            "fake_package", min_version="1.0.0"
+        )
+        assert_false(have_pkg)
+        assert_false(hasattr(pkg, "__version__"))
+        with pytest.raises(TripWireError):
+            pkg.some_function()
+        os.chdir(current_dir)


### PR DESCRIPTION
When you uninstall Tensorflow, there are  still many residual files that needs to be removed manually.

Our function `optional_package` get confused because it find an incomplete installation and crash. 

this PR fix that by warning the user if the installation seems corrupted.

See below the kind of error that you can received:

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 from dipy.nn.torch.deepn4 import DeepN4

File ~/Devel/dipy/dipy/nn/__init__.py:88
     80         print(
     81             "Warning: Neither TensorFlow nor PyTorch is installed. "
     82             "Please install one of these packages."
     83         )
     85     return __all__
---> 88 __all__ = _load_backend()

File ~/Devel/dipy/dipy/nn/__init__.py:12, in _load_backend()
     10 """Dynamically load the preferred backend based on the environment variable."""
     11 preferred_backend = os.getenv("DIPY_NN_BACKEND", "torch").lower()
---> 12 tf, have_tf, _ = optional_package("tensorflow", min_version="2.18.0")
     13 torch, have_torch, _ = optional_package("torch", min_version="2.2.0")
     15 __all__ = []

File ~/Devel/dipy/dipy/utils/optpkg.py:94, in optional_package(name, trip_msg, min_version)
     88         return pkg, True, lambda: None
     90     if trip_msg is None:
     91         trip_msg = (
     92             f"We need at least version {min_version} of "
     93             f"package {name}, but ``import {name}`` "
---> 94             f"found version {pkg.__version__}"
     95         )
     97 if trip_msg is None:
     98     trip_msg = (
     99         f"We need package {name} for these functions, but "
    100         f"``import {name}`` raised an ImportError"
    101     )

AttributeError: module 'tensorflow' has no attribute '__version__'
```