### PR TITLE
ENH: Add use_cuda option to torch models

### DIFF
--- a/dipy/nn/torch/deepn4.py
+++ b/dipy/nn/torch/deepn4.py
@@ -172,7 +172,7 @@ class DeepN4:
     """
 
     @doctest_skip_parser
-    def __init__(self, *, verbose=False):
+    def __init__(self, *, verbose=False, use_cuda=False):
         """Model initialization
 
         To obtain the pre-trained model, use fetch_default_weights() like:
@@ -186,6 +186,9 @@ class DeepN4:
         ----------
         verbose : bool, optional
             Whether to show information about the processing.
+        use_cuda : bool, optional
+            Whether to use GPU for processing.
+            If False or no CUDA is detected, CPU will be used.
         """
         if not have_torch:
             raise torch()
@@ -196,7 +199,10 @@ class DeepN4:
         # DeepN4 network load
 
         self.model = UNet3D(1, 1)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if use_cuda and torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
         self.model = self.model.to(self.device)
 
     def fetch_default_weights(self):

--- a/dipy/nn/torch/evac.py
+++ b/dipy/nn/torch/evac.py
@@ -322,7 +322,7 @@ class EVACPlus:
     """
 
     @doctest_skip_parser
-    def __init__(self, *, verbose=False):
+    def __init__(self, *, verbose=False, use_cuda=False):
         """Model initialization
 
         The model was pre-trained for usage on
@@ -335,6 +335,9 @@ class EVACPlus:
         ----------
         verbose : bool, optional
             Whether to show information about the processing.
+        use_cuda : bool, optional
+            Whether to use GPU for processing.
+            If False or no CUDA is detected, CPU will be used.
         """
         if not have_torch:
             raise torch()
@@ -345,7 +348,10 @@ class EVACPlus:
         # EVAC+ network load
 
         self.model = self.init_model()
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if use_cuda and torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
         self.model = self.model.to(self.device)
         self.fetch_default_weights()
 

--- a/dipy/nn/torch/histo_resdnn.py
+++ b/dipy/nn/torch/histo_resdnn.py
@@ -72,7 +72,9 @@ class HistoResDNN:
     """
 
     @doctest_skip_parser
-    def __init__(self, *, sh_order_max=8, basis_type="tournier07", verbose=False):
+    def __init__(
+        self, *, sh_order_max=8, basis_type="tournier07", verbose=False, use_cuda=False
+    ):
         """Model initialization
 
         The model was re-trained for usage with a different basis function
@@ -99,6 +101,9 @@ class HistoResDNN:
             ``tournier07`` (default) or ``descoteaux07``.
         verbose : bool, optional
             Whether to show information about the processing.
+        use_cuda : bool, optional
+            Whether to use GPU for processing.
+            If False or no CUDA is detected, CPU will be used.
 
         References
         ----------
@@ -124,7 +129,10 @@ class HistoResDNN:
         # ResDNN Network Flow
         num_hidden = self.sh_size
         self.model = DenseModel(self.sh_size, num_hidden).type(torch.float64)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if use_cuda and torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
         self.model = self.model.to(self.device)
 
     def fetch_default_weights(self):


### PR DESCRIPTION
This PR adds a use_cuda option when initializing torch models so that one can avoid using the GPU.
Tensorflow models do not have this option because 1. they do not have a way of doing this without changing a variable and 2. will be deprecated soon.

Related to https://github.com/dipy/dipy/pull/3475#discussion_r1987966358