### PR TITLE
DOC: remove modulo in dipy_math docstring

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -1122,7 +1122,7 @@ class MathFlow(Workflow):
                 - Bitwise operators (and, or, not, xor): ``&, |, ~, ^``
                 - Comparison operators: ``<, <=, ==, !=, >=, >``
                 - Unary arithmetic operators: ``-``
-                - Binary arithmetic operators: ``+, -, *, /, **, %, <<, >>``
+                - Binary arithmetic operators: ``+, -, *, /, **, <<, >>``
             Supported functions are:
                 - ``where(bool, number1, number2) -> number``: number1 if the bool
                   condition is true, number2 otherwise.


### PR DESCRIPTION
The modulo in `dipy_math` docstring was causing an error was the help was called.

This is fixed now. 

`dipy_math -h`

```python
Traceback (most recent call last):
  File "/home/elef/miniconda3/bin/dipy_math", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/elef/Devel/dipy/dipy/workflows/cli.py", line 66, in run
    run_flow(getattr(mod, flow_name)())
  File "/home/elef/Devel/dipy/dipy/workflows/flow_runner.py", line 83, in run_flow
    args = parser.get_flow_args()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/Devel/dipy/dipy/workflows/base.py", line 351, in get_flow_args
    ns_args = self.parse_args(args, namespace)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 1869, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 1902, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 2114, in _parse_known_args
    start_index = consume_optional(start_index)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 2054, in consume_optional
    take_action(action, args, option_string)
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 1978, in take_action
    action(self, namespace, argument_values, option_string)
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 1119, in __call__
    parser.print_help()
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 2601, in print_help
    self._print_message(self.format_help(), file)
                        ^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 2585, in format_help
    return formatter.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 286, in format_help
    help = self._root_section.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 217, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 217, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 543, in _format_action
    help_text = self._expand_help(action)
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/elef/miniconda3/lib/python3.11/argparse.py", line 640, in _expand_help
    return self._get_help_string(action) % params
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
ValueError: unsupported format character ',' (0x2c) at index 267
```