### PR TITLE
RF: Fixed Warnings of Patch2self3

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -115,7 +115,7 @@ def _fit_denoising_model(train, vol_idx, model, alpha):
     """
     if isinstance(model, str):
         if model.lower() == "ols":
-            model_instance = linear_model.Ridge(copy_X=False, alpha=0)
+            model_instance = linear_model.Ridge(copy_X=False, alpha=1e-10)
         elif model.lower() == "ridge":
             model_instance = linear_model.Ridge(copy_X=False, alpha=alpha)
         elif model.lower() == "lasso":


### PR DESCRIPTION
- changed the alpha value from 0 to 1e-10 for performing ridge_regression which is faster than using ols. This is done when the model parameter is 'ols'.