### PR TITLE
RF - changed min/max len from nbr pts to mm

### DIFF
--- a/dipy/tracking/tracker.py
+++ b/dipy/tracking/tracker.py
@@ -516,9 +516,9 @@ def closestpeak_tracking(
     sf : ndarray, optional
         Spherical Function (SF).
     min_len : int, optional
-        Minimum length (nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -575,6 +575,10 @@ def closestpeak_tracking(
         )
     else:
         raise ValueError("SH or SF should be defined. Not implemented yet for peaks.")
+
+    # convert length in mm to number of points
+    min_len = int(min_len / step_size)
+    max_len = int(max_len / step_size)
 
     return LocalTracking(
         dg,
@@ -638,9 +642,9 @@ def bootstrap_tracking(
     sf : ndarray, optional
         Spherical Function (SF).
     min_len : int, optional
-        Minimum length (nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -689,6 +693,11 @@ def bootstrap_tracking(
         model,
         max_angle=max_angle,
     )
+
+    # convert length in mm to number of points
+    min_len = int(min_len / step_size)
+    max_len = int(max_len / step_size)
+
     return LocalTracking(
         dg,
         sc,
@@ -748,9 +757,9 @@ def eudx_tracking(
     pam : PeakAndMetrics, optional
         Peaks and Metrics object
     min_len : int, optional
-        Minimum length (nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -793,6 +802,10 @@ def eudx_tracking(
     sphere = sphere if sphere is not None else default_sphere
     if pam is None:
         raise ValueError("PAM should be defined.")
+
+    # convert length in mm to number of points
+    min_len = int(min_len / step_size)
+    max_len = int(max_len / step_size)
 
     return LocalTracking(
         pam,
@@ -863,9 +876,9 @@ def pft_tracking(
     max_cross : int, optional
         Maximum number of crossing fibers.
     min_len : int, optional
-        Minimum length (nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -941,6 +954,10 @@ def pft_tracking(
     else:
         msg = "SH, SF or PAM should be defined. Not implemented yet for peaks."
         raise ValueError(msg)
+
+    # convert length in mm to number of points
+    min_len = int(min_len / step_size)
+    max_len = int(max_len / step_size)
 
     return ParticleFilteringTracking(
         dg,

--- a/dipy/tracking/tracker.py
+++ b/dipy/tracking/tracker.py
@@ -148,9 +148,9 @@ def probabilistic_tracking(
     sf : ndarray, optional
         Spherical Function (SF).
     min_len : int, optional
-        Minimum length (Nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (Nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -265,9 +265,9 @@ def deterministic_tracking(
     sf : ndarray, optional
         Spherical Function (SF).
     min_len : int, optional
-        Minimum length (nb points) of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length (nb points) of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional
@@ -386,9 +386,9 @@ def ptt_tracking(
     sf : ndarray, optional
         Spherical Function (SF).
     min_len : int, optional
-        Minimum length of the streamlines.
+        Minimum length (mm) of the streamlines.
     max_len : int, optional
-        Maximum length of the streamlines.
+        Maximum length (mm) of the streamlines.
     step_size : float, optional
         Step size of the tracking.
     voxel_size : ndarray, optional

--- a/dipy/tracking/tracker_parameters.pxd
+++ b/dipy/tracking/tracker_parameters.pxd
@@ -35,8 +35,8 @@ cdef class TrackerParameters:
     cdef public double cos_similarity
     cdef public double max_angle
     cdef public double max_curvature
-    cdef public int max_len
-    cdef public int min_len
+    cdef public int max_nbr_pts
+    cdef public int min_nbr_pts
     cdef public int random_seed
     cdef public double step_size
     cdef public double average_voxel_size

--- a/dipy/tracking/tracker_parameters.pyx
+++ b/dipy/tracking/tracker_parameters.pyx
@@ -74,8 +74,8 @@ cdef class TrackerParameters:
                  data_support_exponent=None, random_seed=None):
         cdef cnp.npy_intp i
 
-        self.max_len = max_len
-        self.min_len = min_len
+        self.max_len = int(max_len/step_size)
+        self.min_len = int(min_len/step_size)
         self.return_all = return_all
         self.random_seed = random_seed
         self.step_size = step_size

--- a/dipy/tracking/tracker_parameters.pyx
+++ b/dipy/tracking/tracker_parameters.pyx
@@ -74,8 +74,8 @@ cdef class TrackerParameters:
                  data_support_exponent=None, random_seed=None):
         cdef cnp.npy_intp i
 
-        self.max_len = int(max_len/step_size)
-        self.min_len = int(min_len/step_size)
+        self.max_nbr_pts = int(max_len/step_size)
+        self.min_nbr_pts = int(min_len/step_size)
         self.return_all = return_all
         self.random_seed = random_seed
         self.step_size = step_size

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -111,8 +111,8 @@ def generate_tractogram(double[:,::1] seed_positions,
 
         for i in range(seed_end - seed_start):
             if ((status_arr[i] == VALIDSTREAMLIME or params.return_all)
-                and (length_arr[i] >= params.min_len
-                     and length_arr[i] <= params.max_len)):
+                and (length_arr[i] >= params.min_nbr_pts
+                     and length_arr[i] <= params.max_nbr_pts)):
                 s = np.asarray(<cnp.float_t[:length_arr[i]*3]> streamlines_arr[i])
                 track = s.copy().reshape((-1,3))
                 if save_seeds:
@@ -173,7 +173,7 @@ cdef void generate_tractogram_c(double[:,::1] seed_positions,
     if nbr_threads<= 0:
         nbr_threads = 0
     for i in prange(_len, nogil=True, num_threads=nbr_threads):
-        stream = <double*> malloc((params.max_len * 3 * 2 + 1) * sizeof(double))
+        stream = <double*> malloc((params.max_nbr_pts * 3 * 2 + 1) * sizeof(double))
         stream_idx = <int*> malloc(2 * sizeof(int))
         status[i] = generate_local_streamline(&seed_positions[i][0],
                                               &seed_directions[i][0],
@@ -243,8 +243,8 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
     # set the initial position
     fast_numpy.copy_point(seed, point)
     fast_numpy.copy_point(direction, voxdir)
-    fast_numpy.copy_point(seed, &stream[params.max_len * 3])
-    stream_idx[0] = stream_idx[1] = params.max_len
+    fast_numpy.copy_point(seed, &stream[params.max_nbr_pts * 3])
+    stream_idx[0] = stream_idx[1] = params.max_nbr_pts
 
     # the input direction is invalid
     voxdir_norm = fast_numpy.norm(voxdir)
@@ -255,20 +255,20 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
     stream_data = <double*> malloc(100 * sizeof(double))
     memset(stream_data, 0, 100 * sizeof(double))
     status_forward = TRACKPOINT
-    for i in range(1, params.max_len):
+    for i in range(1, params.max_nbr_pts):
         if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == FAIL:
             break
         # update position
         for j in range(3):
             point[j] += voxdir[j] * params.inv_voxel_size[j] * params.step_size
-        fast_numpy.copy_point(point, &stream[(params.max_len + i )* 3])
+        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts + i )* 3])
 
         status_forward = sc.check_point_c(point, &rng)
         if (status_forward == ENDPOINT or
             status_forward == INVALIDPOINT or
             status_forward == OUTSIDEIMAGE):
             break
-    stream_idx[1] = params.max_len + i - 1
+    stream_idx[1] = params.max_nbr_pts + i - 1
     free(stream_data)
 
     # backward tracking
@@ -280,7 +280,8 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
     if i > 1:
         # Use the first selected orientation for the backward tracking segment
         for j in range(3):
-            voxdir[j] = stream[(params.max_len + 1) * 3 + j] - stream[params.max_len * 3 + j]
+            voxdir[j] = (stream[(params.max_nbr_pts + 1) * 3 + j]
+                         - stream[params.max_nbr_pts * 3 + j])
         fast_numpy.normalize(voxdir)
 
     # flip the initial direction for backward streamline segment
@@ -288,20 +289,20 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
         voxdir[j] = voxdir[j] * -1
 
     status_backward = TRACKPOINT
-    for i in range(1, params.max_len):
+    for i in range(1, params.max_nbr_pts):
         if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == FAIL:
             break
         # update position
         for j in range(3):
             point[j] += voxdir[j] * params.inv_voxel_size[j] * params.step_size
-        fast_numpy.copy_point(point, &stream[(params.max_len - i )* 3])
+        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts - i )* 3])
 
         status_backward = sc.check_point_c(point, &rng)
         if (status_backward == ENDPOINT or
             status_backward == INVALIDPOINT or
             status_backward == OUTSIDEIMAGE):
             break
-    stream_idx[0] = params.max_len - i + 1
+    stream_idx[0] = params.max_nbr_pts - i + 1
     free(stream_data)
 
     # check for valid streamline ending status

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -81,9 +81,9 @@ class LocalFiberTrackingPAMFlow(Workflow):
             points in the voxel. And seed density of 1 means 1 point at the
             center of the voxel.
         minlen : int, optional
-            Minimum length (nb points) of the streamlines.
+            Minimum length (mm) of the streamlines.
         maxlen : int, optional
-            Maximum length (nb points) of the streamlines.
+            Maximum length (mm) of the streamlines.
         step_size : float, optional
             Step size (in mm) used for tracking.
         tracking_method : string, optional

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -1,12 +1,12 @@
 """
 ====================================================
-Bootstrap and Closest Peak Direction Getters Example
+Bootstrap and Closest Peak Tracker Example
 ====================================================
 
-This example shows how choices in direction-getter impact fiber
-tracking results by demonstrating the bootstrap direction getter (a type of
+This example shows how choices in tracker impact fiber
+tracking results by demonstrating the bootstrap tracker (a type of
 probabilistic tracking, as described in :footcite:p:`Berman2008` and the closest
-peak direction getter (a type of deterministic tracking)
+peak tracker (a type of deterministic tracking)
 :footcite:p:`Amirbekian2016`.
 
 This example is an extension of the
@@ -61,10 +61,10 @@ gfa = csa_model.fit(data, mask=white_matter).gfa
 stopping_criterion = ThresholdStoppingCriterion(gfa, 0.25)
 
 ###############################################################################
-# Next, we need to set up our two direction getters
+# Next, we need to set up our two trackers
 #
 #
-# Example #1: Bootstrap direction getter with CSD Model
+# Example #1: Bootstrap tracker with CSD Model
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 boot_streamline_generator = bootstrap_tracking(
     seeds,
@@ -90,7 +90,7 @@ if has_fury:
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Corpus Callosum Bootstrap Probabilistic Direction Getter
+# Corpus Callosum Bootstrap Probabilistic Tracker
 #
 #
 # We have created a bootstrapped probabilistic set of streamlines. If you
@@ -99,7 +99,7 @@ if has_fury:
 #
 #
 #
-# Example #2: Closest peak direction getter with CSD Model
+# Example #2: Closest peak tracker with CSD Model
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 pmf = csd_fit.odf(small_sphere).clip(min=0)
@@ -128,10 +128,10 @@ if has_fury:
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Corpus Callosum Closest Peak Deterministic Direction Getter
+# Corpus Callosum Closest Peak Tracker
 #
 #
-# We have created a set of streamlines using the closest peak direction getter,
+# We have created a set of streamlines using the closest peak tracker,
 # which is a type of deterministic tracking. If you repeat the fiber tracking
 # (keeping all inputs the same) you will get exactly the same set of
 # streamlines.

--- a/doc/examples/tracking_deterministic.py
+++ b/doc/examples/tracking_deterministic.py
@@ -93,4 +93,4 @@ if has_fury:
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Corpus Callosum using deterministic maximum direction getter
+# Corpus Callosum using deterministic tracker

--- a/doc/examples/tracking_pft.py
+++ b/doc/examples/tracking_pft.py
@@ -20,8 +20,7 @@ This example is an extension of
 :ref:`sphx_glr_examples_built_fiber_tracking_tracking_probabilistic.py` and
 :ref:`sphx_glr_examples_built_fiber_tracking_tracking_stopping_criterion.py`
 examples. We begin by loading the data, fitting a Constrained Spherical
-Deconvolution (CSD) reconstruction model, creating the probabilistic direction
-getter and defining the seeds.
+Deconvolution (CSD) reconstruction model, and defining the seeds.
 """
 
 import numpy as np
@@ -112,7 +111,6 @@ pft_streamline_gen = pft_tracking(
     affine,
     max_cross=1,
     step_size=step_size,
-    max_len=1000,
     pft_back_tracking_dist=2,
     pft_front_tracking_dist=1,
     particle_count=15,
@@ -144,7 +142,6 @@ prob_streamline_generator = probabilistic_tracking(
     cmc_criterion,
     affine,
     step_size=step_size,
-    max_len=1000,
     return_all=False,
     sh=csd_fit.shm_coeff,
     max_angle=20.0,

--- a/doc/examples/tracking_probabilistic.py
+++ b/doc/examples/tracking_probabilistic.py
@@ -183,5 +183,5 @@ if has_fury:
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Corpus Callosum using probabilistic tractography from SH
+# Corpus Callosum using probabilistic tracker from SH
 # (peaks_from_model)

--- a/doc/examples/tracking_ptt.py
+++ b/doc/examples/tracking_ptt.py
@@ -74,7 +74,7 @@ if has_fury:
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Corpus Callosum using ptt direction getter from PMF
+# Corpus Callosum using ptt direction tracker from PMF
 #
 #
 #

--- a/doc/examples/tracking_rumba.py
+++ b/doc/examples/tracking_rumba.py
@@ -3,7 +3,7 @@
 Tracking with Robust Unbiased Model-BAsed Spherical Deconvolution (RUMBA-SD)
 ============================================================================
 
-Here, we demonstrate fiber tracking using a probabilistic direction getter
+Here, we demonstrate fiber tracking using a probabilistic tracker
 and RUMBA-SD, a model introduced in :footcite:p:`CanalesRodriguez2015`. This
 model adapts Richardson-Lucy deconvolution by assuming Rician or Noncentral Chi
 noise instead of Gaussian, which more accurately reflects the noise from MRI

--- a/doc/examples/tracking_stopping_criterion.py
+++ b/doc/examples/tracking_stopping_criterion.py
@@ -5,7 +5,7 @@ Using Various Stopping Criterion for Tractography
 The stopping criterion determines if the tracking stops or continues at each
 tracking position. The tracking stops when it reaches an ending region
 (e.g. low FA, gray matter or corticospinal fluid regions) or exits the image
-boundaries. The tracking also stops if the direction getter has no direction
+boundaries. The tracking also stops if the tracker has no direction
 to follow.
 
 Each stopping criterion determines if the stopping is 'valid' or
@@ -21,8 +21,8 @@ This example is an extension of the
 :ref:`sphx_glr_examples_built_fiber_tracking_tracking_deterministic.py`
 example. We begin by loading the data, creating a seeding mask from white
 matter voxels of the corpus callosum, fitting a Constrained Spherical
-Deconvolution (CSD) reconstruction model and creating the maximum
-deterministic direction getter.
+Deconvolution (CSD) reconstruction model and creating the
+deterministic tracker.
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR changes the min/max length tracking parameter from number of points to mm. Variables were renamed for clarity.

Working in number of points requires the user to adapt those parameters when changing the step size. The default `max_len` is set to 500, which is not enough when tracking at 0.2mm `step_size` on human data.