### PR TITLE
NF: allow broadcasting in dipy_math

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -2,6 +2,7 @@ import importlib
 from inspect import getmembers, isfunction
 import logging
 import os
+import re
 import sys
 import warnings
 
@@ -1106,8 +1107,39 @@ class MathFlow(Workflow):
     def get_short_name(cls):
         return "math_flow"
 
+    def broadcast_arrays(self, vol_dict, operation):
+        variables = re.findall(r"\b\w+\b", operation)
+        variables = [var for var in variables if var in vol_dict]
+
+        shapes = [vol_dict[var].shape for var in variables]
+        max_dims = max(len(shape) for shape in shapes)
+
+        for var in variables:
+            shape = vol_dict[var].shape
+            if len(shape) < max_dims:
+                new_shape = shape + (1,) * (max_dims - len(shape))
+                vol_dict[var] = vol_dict[var].reshape(new_shape)
+
+        updated_shapes = [vol_dict[var].shape for var in variables]
+        try:
+            broadcast_shape = np.broadcast_shapes(*updated_shapes)
+        except ValueError as e:
+            raise ValueError(f"Shape mismatch after adding dimensions: {e}") from e
+
+        for var in variables:
+            if vol_dict[var].shape != broadcast_shape:
+                vol_dict[var] = np.broadcast_to(vol_dict[var], broadcast_shape)
+
+        return vol_dict
+
     def run(
-        self, operation, input_files, dtype=None, out_dir="", out_file="math_out.nii.gz"
+        self,
+        operation,
+        input_files,
+        dtype=None,
+        disable_check=False,
+        out_dir="",
+        out_file="math_out.nii.gz",
     ):
         """Perform mathematical operations on volume input files.
 
@@ -1153,6 +1185,9 @@ class MathFlow(Workflow):
             Any number of Nifti1 files
         dtype : string, optional
             Data type of the resulting file.
+        disable_check : bool, optional
+            If True, the workflow will not check if all input files have the same
+            shape and affine matrix.
         out_dir : string, optional
             Output directory
         out_file : string, optional
@@ -1193,11 +1228,14 @@ class MathFlow(Workflow):
 
         if have_errors:
             logging.warning(info_msg)
-            msg = "All input files must have the same shape and affine matrix."
-            logging.error(msg)
-            raise SystemExit()
+            if not disable_check:
+                msg = "All input files must have the same shape and affine matrix."
+                logging.error(msg)
+                raise SystemExit()
 
         try:
+            if disable_check:
+                vol_dict = self.broadcast_arrays(vol_dict, operation)
             res = ne.evaluate(operation, local_dict=vol_dict)
         except KeyError as e:
             msg = (

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -1256,6 +1256,8 @@ class MathFlow(Workflow):
                 logging.error(msg)
                 raise SystemExit() from e
 
+        if res.dtype == bool:
+            res = res.astype(np.uint8)
         out_fname = os.path.join(out_dir, out_file)
         logging.info(f"Saving result to {out_fname}")
         save_nifti(out_fname, res, affine)

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -378,6 +378,17 @@ def test_math():
                 if kwarg:
                     npt.assert_equal(out_data.dtype, np.dtype(kwarg["dtype"]))
 
+            data_3d = np.ones(data.shape[:-1]) * 15
+            data_3d_path = pjoin(out_dir, "data_3d.nii.gz")
+            save_nifti(data_3d_path, data_3d, np.eye(4))
+            math_flow = MathFlow()
+            math_flow.run(
+                "vol1*vol2",
+                [data_path_a, data_3d_path],
+                disable_check=True,
+                out_dir=out_dir,
+            )
+
         else:
             math_flow = MathFlow()
             npt.assert_raises(TripWireError, math_flow.run, "vol1*3", [data_path_a])

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -378,6 +378,7 @@ def test_math():
                 if kwarg:
                     npt.assert_equal(out_data.dtype, np.dtype(kwarg["dtype"]))
 
+            # Test broadcasting 3D/4D
             data_3d = np.ones(data.shape[:-1]) * 15
             data_3d_path = pjoin(out_dir, "data_3d.nii.gz")
             save_nifti(data_3d_path, data_3d, np.eye(4))
@@ -388,6 +389,26 @@ def test_math():
                 disable_check=True,
                 out_dir=out_dir,
             )
+
+            # Test boolean data type
+            data_bool = np.ones(data.shape, dtype=np.uint8)
+            data_bool_2 = np.zeros(data.shape, dtype=np.uint8)
+            data_bool_path = pjoin(out_dir, "data_bool.nii.gz")
+            data_bool_2_path = pjoin(out_dir, "data_bool_2.nii.gz")
+            save_nifti(data_bool_path, data_bool, np.eye(4))
+            save_nifti(data_bool_2_path, data_bool_2, np.eye(4))
+            math_flow = MathFlow()
+            math_flow.run(
+                "vol1*vol2",
+                [data_bool_path, data_bool_2_path],
+                disable_check=True,
+                dtype="bool",
+                out_dir=out_dir,
+            )
+            out_path = pjoin(out_dir, "math_out.nii.gz")
+            out_data, _ = load_nifti(out_path)
+            npt.assert_array_equal(out_data, data_bool * data_bool_2)
+            npt.assert_equal(out_data.dtype, np.uint8)
 
         else:
             math_flow = MathFlow()


### PR DESCRIPTION
This is a small PR to allow unsafe use of dipy_math via a flag, and also, to allow broadcasting. 

Array with different dimension can be used. a `None` dimension will be added to the smallest one automatically. 

all of this is possible only by using the flag `--disable_check`