### PR TITLE
BF: Fixing minor issue in dipy_classify_tissue dam option

### DIFF
--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -304,8 +304,8 @@ def patch2self(
         Array of the bvals from the DWI acquisition
     patch_radius : int or array of shape (3,), optional
         The radius of the local patch to be taken around each voxel (in
-        voxels). Default: 0 (denoise in blocks of 1x1x1 voxels).
-    model : string, or sklearn.base.RegressorMixin
+        voxels).
+    model : string, or sklearn.base.RegressorMixin, optional
         This will determine the algorithm used to solve the set of linear
         equations underlying this model. If it is a string it needs to be
         one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
@@ -333,9 +333,9 @@ def patch2self(
         non-negative values.
     tmp_dir : str, optional
         The directory to save the temporary files. If None, the temporary
-        files are saved in the system's default temporary directory. Default: None.
+        files are saved in the system's default temporary directory.
     version : int, optional
-        Version 1 or 3 of Patch2Self to use. Default: 3
+        Version 1 or 3 of Patch2Self to use.
 
     Returns
     -------

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -52,7 +52,7 @@ class Patch2SelfFlow(Workflow):
             process multiple inputs at once.
         bval_files : string
             bval file associated with the diffusion data.
-        model : string, or initialized linear model object.
+        model : string, or initialized linear model object, optional
             This will determine the algorithm used to solve the set of linear
             equations underlying this model. If it is a string it needs to be
             one of the following: {'ols', 'ridge', 'lasso'}. Otherwise,
@@ -62,7 +62,6 @@ class Patch2SelfFlow(Workflow):
             `sklearn.linear_model.LinearRegression`,
             `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
             and other objects that inherit from `sklearn.base.RegressorMixin`.
-            Default: 'ols'.
         b0_threshold : int, optional
             Threshold for considering volumes as b0.
         alpha : float, optional
@@ -84,7 +83,6 @@ class Patch2SelfFlow(Workflow):
             Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume
-            (default: dwi_patch2self.nii.gz)
 
         References
         ----------

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -509,7 +509,7 @@ class ClassifyTissueFlow(Workflow):
                     b0_threshold=b0_threshold,
                     low_signal_threshold=low_signal_threshold,
                 )
-                result = np.zeros(wm_mask.shape)
+                result = np.zeros(wm_mask.shape, dtype=np.int32)
                 result[wm_mask] = 1
                 result[gm_mask] = 2
                 save_nifti(tissue_out_path, result, affine)


### PR DESCRIPTION
This PR fixes an issue where dipy_classify_tissue workflow with the dam option returns a float type array as output.
Instead, it returns it as np.int32 array now.
This solves problems when visualizing the labels on the image the labels had floating points, due to interpolation.

Some documentation errors in patch2self has been addressed as well.