### PR TITLE
STYLE: Log message instead of printing orphan string

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -269,7 +269,7 @@ class FetchFlow(Workflow):
                 available_data[data_name]()
 
             nb_success = len(data_names) - len(skipped_names)
-            print("\n")
+            logging.info("\n")
             logging.info(f"Fetched {nb_success} / {len(data_names)} Files ")
             if skipped_names:
                 logging.warn(f"Skipped data name(s): {' '.join(skipped_names)}")


### PR DESCRIPTION
Log message instead of printing an orphan string to the standard output in `FetchFlow`.