### PR TITLE
BF: Search bar should come bigger in the center.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,7 +170,11 @@ html_theme_options = {
     },
     "check_switcher": False,
     "show_version_warning_banner": True,
-    "navbar_end": ["search-field.html", "version-switcher", "navbar-icon-links.html"],
+    "navbar_end": [
+        "search-button-field.html",
+        "version-switcher",
+        "navbar-icon-links.html",
+    ],
     "secondary_sidebar_items": ["page-toc"],
     "show_toc_level": 1,
     "navbar_center": ["components/navbar-links.html"],


### PR DESCRIPTION
- Removed search-field.html from navbar_end.
- Added search-button-field.html from navbar_end.
- It provides a button which looks like the search field and opens up the search field in the screen.
- The shortcut ctrl + k would do the same.
![Screenshot from 2025-03-31 16-57-57](https://github.com/user-attachments/assets/5fc88c57-de29-48b3-89ad-46436bd1797a)
