### PR TITLE
CI: Ignore specific cvxpy warnings to avoid CI failure.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,4 +210,7 @@ filterwarnings = [
     "ignore:Implementing implicit namespace packages.*:DeprecationWarning",
     "ignore:Deprecated call to `pkg_resources.*:DeprecationWarning",
     "ignore:pkg_resources is deprecated as an API.*:DeprecationWarning",
+    # CVXPY. see #2770 in the CVXPY repo
+    "ignore:\"polish\" is deprecated. Please use \"polishing\".*:DeprecationWarning",
+    "ignore:The default value of raise_error will change.*:PendingDeprecationWarning",
 ]


### PR DESCRIPTION
CVXPY generates warning that we can not control. this PR ignore them.  they should be fixed on a new CVXPY release. 
we might need to keep this until our minimal version of CVXPY contain this update.

See the warnings below not due to our codebase:
```
reconst/tests/test_forecast.py: 1 warning
reconst/tests/test_ivim.py: 3 warnings
reconst/tests/test_mapmri.py: 3 warnings
reconst/tests/test_mcsd.py: 3 warnings
reconst/tests/test_shore.py: 2 warnings
workflows/tests/test_reconst_mapmri.py: 320 warnings
  /Users/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/osqp/interface.py:290: DeprecationWarning: "polish" is deprecated. Please use "polishing" instead.
    warnings.warn(

reconst/tests/test_forecast.py: 1 warning
reconst/tests/test_ivim.py: 3 warnings
reconst/tests/test_mapmri.py: 3 warnings
reconst/tests/test_mcsd.py: 3 warnings
reconst/tests/test_shore.py: 2 warnings
workflows/tests/test_reconst_mapmri.py: 320 warnings
  /Users/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/osqp/interface.py:405: PendingDeprecationWarning: The default value of raise_error will change to True in the future.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== Werrors ====================================
Warnings as errors: Activated.
664 warnings were raised and treated as errors.
```

see also https://github.com/cvxpy/cvxpy/issues/2770