### PR TITLE
RF: Deprecate autocrop in median_otsu

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -11,6 +11,7 @@ except Exception:
 from dipy.reconst.dti import color_fa, fractional_anisotropy
 from dipy.segment.utils import remove_holes_and_islands
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils.deprecator import deprecated_params
 
 
 def multi_median(data, median_radius, numpass):
@@ -126,6 +127,7 @@ def crop(vol, mins, maxs):
     return vol[tuple(slice(i, j) for i, j in zip(mins, maxs))]
 
 
+@deprecated_params("autocrop", since="1.11.0", until="1.13.0")
 @warning_for_keywords()
 def median_otsu(
     input_volume,
@@ -160,6 +162,9 @@ def median_otsu(
     numpass: int, optional
         Number of pass of the median filter.
     autocrop: bool, optional
+        .. deprecated:: 1.11.0
+           This parameter is deprecated and will be removed in 1.13.0.
+
         if True, the masked input_volume will also be cropped using the
         bounding box defined by the masked data. Should be on if DWI is
         upsampled to 1x1x1 resolution.

--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -91,7 +91,7 @@ def test_median_otsu():
     data = np.squeeze(data.astype("f8"))
     dummy_mask = data > data.mean()
     data_masked, mask = median_otsu(
-        data, median_radius=3, numpass=2, autocrop=False, vol_idx=None, dilate=None
+        data, median_radius=3, numpass=2, vol_idx=None, dilate=None
     )
     assert_equal(mask.sum() < dummy_mask.sum(), True)
     data2 = np.zeros(data.shape + (2,))
@@ -99,18 +99,14 @@ def test_median_otsu():
     data2[..., 1] = data
 
     data2_masked, mask2 = median_otsu(
-        data2, median_radius=3, numpass=2, autocrop=False, vol_idx=[0, 1], dilate=None
+        data2, median_radius=3, numpass=2, vol_idx=[0, 1], dilate=None
     )
     assert_almost_equal(mask.sum(), mask2.sum())
 
-    _, mask3 = median_otsu(
-        data2, median_radius=3, numpass=2, autocrop=False, vol_idx=[0, 1], dilate=1
-    )
+    _, mask3 = median_otsu(data2, median_radius=3, numpass=2, vol_idx=[0, 1], dilate=1)
     assert_equal(mask2.sum() < mask3.sum(), True)
 
-    _, mask4 = median_otsu(
-        data2, median_radius=3, numpass=2, autocrop=False, vol_idx=[0, 1], dilate=2
-    )
+    _, mask4 = median_otsu(data2, median_radius=3, numpass=2, vol_idx=[0, 1], dilate=2)
     assert_equal(mask3.sum() < mask4.sum(), True)
 
     # For 4D volumes, can't call without vol_idx input:

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -13,6 +13,7 @@ from dipy.segment.bundles import RecoBundles
 from dipy.segment.mask import median_otsu
 from dipy.segment.tissue import TissueClassifierHMRF, dam_classifier
 from dipy.tracking import Streamlines
+from dipy.utils.deprecator import deprecated_params
 from dipy.workflows.utils import handle_vol_idx
 from dipy.workflows.workflow import Workflow
 
@@ -22,6 +23,7 @@ class MedianOtsuFlow(Workflow):
     def get_short_name(cls):
         return "medotsu"
 
+    @deprecated_params(["autocrop"], since="1.11.0", until="1.13.0")
     def run(
         self,
         input_files,
@@ -54,10 +56,13 @@ class MedianOtsuFlow(Workflow):
         numpass : int, optional
             Number of pass of the median filter.
         autocrop : bool, optional
-            If True, the masked input_volumes will also be cropped using the
-            bounding box defined by the masked data. For example, if diffusion
-            images are of 1x1x1 (mm^3) or higher resolution auto-cropping could
-            reduce their size in memory and speed up some of the analysis.
+            .. deprecated:: 1.11.0
+               This parameter is deprecated and will be removed in 1.13.0.
+
+            If True, the mask is cropped to the bounding box of the
+            non-zero elements. This is useful for large 3D volumes
+            (e.g. 4D volumes) where the mask is not the same size as
+            the input volume.
         vol_idx : str, optional
             1D array representing indices of ``axis=-1`` of a 4D
             `input_volume`. From the command line use something like
@@ -86,9 +91,9 @@ class MedianOtsuFlow(Workflow):
                 vol_idx=vol_idx,
                 median_radius=median_radius,
                 numpass=numpass,
-                autocrop=autocrop,
                 dilate=dilate,
                 finalize_mask=finalize_mask,
+                autocrop=autocrop,
             )
 
             save_nifti(mask_out_path, mask_volume.astype(np.float64), affine)

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -13,6 +13,7 @@ from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.segment.mask import median_otsu
 from dipy.segment.tests.test_mrf import create_image
 from dipy.tracking.streamline import Streamlines, set_number_of_points
+from dipy.utils.deprecator import ArgsDeprecationWarning
 from dipy.utils.optpkg import optional_package
 from dipy.workflows.segment import (
     ClassifyTissueFlow,
@@ -31,23 +32,22 @@ def test_median_otsu_flow():
         save_masked = True
         median_radius = 3
         numpass = 3
-        autocrop = False
         vol_idx = "0,"
         dilate = 0
         finalize_mask = False
 
         mo_flow = MedianOtsuFlow()
-        mo_flow.run(
-            data_path,
-            out_dir=out_dir,
-            save_masked=save_masked,
-            median_radius=median_radius,
-            numpass=numpass,
-            autocrop=autocrop,
-            vol_idx=vol_idx,
-            dilate=dilate,
-            finalize_mask=finalize_mask,
-        )
+        with npt.assert_warns(ArgsDeprecationWarning):
+            mo_flow.run(
+                data_path,
+                out_dir=out_dir,
+                save_masked=save_masked,
+                median_radius=median_radius,
+                numpass=numpass,
+                vol_idx=vol_idx,
+                dilate=dilate,
+                finalize_mask=finalize_mask,
+            )
 
         mask_name = mo_flow.last_generated_outputs["out_mask"]
         masked_name = mo_flow.last_generated_outputs["out_masked"]
@@ -60,7 +60,6 @@ def test_median_otsu_flow():
             vol_idx=vol_idx,
             median_radius=median_radius,
             numpass=numpass,
-            autocrop=autocrop,
             dilate=dilate,
         )
 

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -6,6 +6,7 @@ import time
 import numpy.testing as npt
 
 from dipy.data import get_fnames
+from dipy.utils.deprecator import ArgsDeprecationWarning
 from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.workflow import Workflow
 
@@ -16,7 +17,8 @@ def test_force_overwrite():
         mo_flow = MedianOtsuFlow(output_strategy="absolute")
 
         # Generate the first results
-        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+        with npt.assert_warns(ArgsDeprecationWarning):
+            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         first_time = os.path.getmtime(mask_file)
 
@@ -31,7 +33,8 @@ def test_force_overwrite():
         # Make sure that at least one second elapsed, so that time-stamp is
         # different (sometimes measured in whole seconds)
         time.sleep(1)
-        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+        with npt.assert_warns(ArgsDeprecationWarning):
+            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         third_time = os.path.getmtime(mask_file)
         assert third_time != second_time


### PR DESCRIPTION
This PR deprecate `autocrop` from `median_otsu` function. 

this feature brings a lot of errors and confusion when the  voxel size is not isotropic and size (1,1,1). You endup with a image with a different size of the original image and the mask.  it exists a crop function if the user wishes to do so.

fixes  #3537


 