### PR TITLE
RF: Editing tranform_img in dipy.nn.utils

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -465,9 +465,9 @@ fetch_deepn4_test = _make_fetcher(
     "fetch_deepn4_test",
     pjoin(dipy_home, "deepn4"),
     "https://ndownloader.figshare.com/files/",
-    ["48842938", "52454531"],
-    ["test_input_deepn4.npz", "new_test_output_deepn4.npz"],
-    md5_list=["07aa7cc7c7f839683a0aad5bb853605b", "6da15c4358fd13c99773eedeb93953c7"],
+    ["48842938", "53767670"],
+    ["test_input_deepn4.npz", "new2_test_output_deepn4.npz"],
+    md5_list=["07aa7cc7c7f839683a0aad5bb853605b", "2170a411716fa7621e262aef009eaa30"],
     doc="Download DeepN4 test data for Kanakaraj et. al 2024",
 )
 
@@ -1796,7 +1796,7 @@ def get_fnames(*, name="small_64D", include_optional=False):
     if name == "deepn4_test_data":
         files, folder = fetch_deepn4_test()
         input_array = pjoin(folder, "test_input_deepn4.npz")
-        target_array = pjoin(folder, "new_test_output_deepn4.npz")
+        target_array = pjoin(folder, "new2_test_output_deepn4.npz")
         return input_array, target_array
     if name == "evac_default_tf_weights":
         files, folder = fetch_evac_tf_weights()

--- a/dipy/nn/tests/test_deepn4.py
+++ b/dipy/nn/tests/test_deepn4.py
@@ -37,4 +37,8 @@ def test_default_weights(monkeypatch):
         deepn4_model = deepn4_mod.DeepN4()
         deepn4_model.fetch_default_weights()
         results_arr = deepn4_model.predict(input_arr, input_affine_arr)
-        assert_almost_equal(results_arr / 100, target_arr / 100, decimal=1)
+        assert_almost_equal(
+            results_arr / np.max(results_arr),
+            target_arr / np.max(target_arr),
+            decimal=3,
+        )

--- a/dipy/nn/tf/deepn4.py
+++ b/dipy/nn/tf/deepn4.py
@@ -286,8 +286,13 @@ class DeepN4:
             The volume has matching shape to the input data
         """
         # Preprocess input data (resample, normalize, and pad)
-        resampled_T1, inv_affine, mid_shape, offset_array, scale, crop_vs, pad_vs = (
-            transform_img(img, img_affine, voxsize=voxsize)
+        resampled_T1, params = transform_img(
+            img,
+            img_affine,
+            voxsize=voxsize,
+            ratio=2,
+            init_shape=(256, 256, 256),
+            target_voxsize=(1, 1, 1),
         )
         (in_features, lx, lX, ly, lY, lz, lZ, rx, rX, ry, rY, rz, rZ, in_max) = (
             self.load_resample(resampled_T1)
@@ -305,17 +310,7 @@ class DeepN4:
         )
         final_field[rx:rX, ry:rY, rz:rZ] = field[lx:lX, ly:lY, lz:lZ]
         final_fields = gaussian_filter(final_field, sigma=3)
-        upsample_final_field = recover_img(
-            final_fields,
-            inv_affine,
-            mid_shape,
-            img.shape,
-            offset_array,
-            voxsize,
-            scale,
-            crop_vs,
-            pad_vs,
-        )
+        upsample_final_field, _ = recover_img(final_fields, params)
 
         # Correct the image
         below_threshold_mask = np.abs(upsample_final_field) < threshold

--- a/dipy/nn/tf/evac.py
+++ b/dipy/nn/tf/evac.py
@@ -446,28 +446,22 @@ class EVACPlus:
             batch_size = 1
 
         input_data = np.zeros((128, 128, 128, len(T1)))
-        affines = np.zeros((len(T1), 4, 4))
-        mid_shapes = np.zeros((len(T1), 3)).astype(int)
-        offset_arrays = np.zeros((len(T1), 4, 4)).astype(int)
-        scales = np.zeros(len(T1))
-        crop_vss = np.zeros((len(T1), 3, 2))
-        pad_vss = np.zeros((len(T1), 3, 2))
+        params_list = []
 
         # Normalize the data.
         n_T1 = np.zeros(T1.shape)
         for i, T1_img in enumerate(T1):
             n_T1[i] = normalize(T1_img, new_min=0, new_max=1)
-            t_img, t_affine, mid_shape, offset_array, scale, crop_vs, pad_vs = (
-                transform_img(n_T1[i], affine[i], voxsize=voxsize[i])
+            t_img, params = transform_img(
+                n_T1[i],
+                affine[i],
+                voxsize=voxsize[i],
+                ratio=2,
+                init_shape=(256, 256, 256),
+                target_voxsize=(1, 1, 1),
             )
             input_data[..., i] = t_img
-            affines[i] = t_affine
-            mid_shapes[i] = mid_shape
-            offset_arrays[i] = offset_array
-            scales[i] = scale
-            crop_vss[i] = crop_vs
-            pad_vss[i] = pad_vs
-
+            params_list.append(params)
         # Prediction stage
         prediction = np.zeros((len(T1), 128, 128, 128), dtype=np.float32)
         for batch_idx in range(batch_size, len(T1) + 1, batch_size):
@@ -483,17 +477,7 @@ class EVACPlus:
 
         output_mask = []
         for i in range(len(T1)):
-            output = recover_img(
-                prediction[i],
-                affines[i],
-                mid_shapes[i],
-                n_T1[i].shape,
-                offset_arrays[i],
-                voxsize=voxsize[i],
-                scale=scales[i],
-                crop_vs=crop_vss[i],
-                pad_vs=pad_vss[i],
-            )
+            output, _ = recover_img(prediction[i], params_list[i])
             if not return_prob:
                 output = np.where(output >= 0.5, 1, 0)
                 if finalize_mask:

--- a/dipy/nn/torch/deepn4.py
+++ b/dipy/nn/torch/deepn4.py
@@ -330,8 +330,13 @@ class DeepN4:
             The volume has matching shape to the input data
         """
         # Preprocess input data (resample, normalize, and pad)
-        resampled_T1, inv_affine, mid_shape, offset_array, scale, crop_vs, pad_vs = (
-            transform_img(img, img_affine, voxsize=voxsize)
+        resampled_T1, params = transform_img(
+            img,
+            img_affine,
+            voxsize=voxsize,
+            ratio=2,
+            init_shape=(256, 256, 256),
+            target_voxsize=(1, 1, 1),
         )
         (in_features, lx, lX, ly, lY, lz, lZ, rx, rX, ry, rY, rz, rZ, in_max) = (
             self.load_resample(resampled_T1)
@@ -349,18 +354,7 @@ class DeepN4:
         )
         final_field[rx:rX, ry:rY, rz:rZ] = field[lx:lX, ly:lY, lz:lZ]
         final_fields = gaussian_filter(final_field, sigma=3)
-        upsample_final_field = recover_img(
-            final_fields,
-            inv_affine,
-            mid_shape,
-            img.shape,
-            offset_array,
-            voxsize,
-            scale,
-            crop_vs,
-            pad_vs,
-        )
-
+        upsample_final_field, _ = recover_img(final_fields, params)
         # Correct the image
         below_threshold_mask = np.abs(upsample_final_field) < threshold
         with np.errstate(divide="ignore", invalid="ignore"):

--- a/dipy/nn/torch/evac.py
+++ b/dipy/nn/torch/evac.py
@@ -484,28 +484,22 @@ class EVACPlus:
             batch_size = 1
 
         input_data = np.zeros((128, 128, 128, len(T1)))
-        affines = np.zeros((len(T1), 4, 4))
-        mid_shapes = np.zeros((len(T1), 3)).astype(int)
-        offset_arrays = np.zeros((len(T1), 4, 4)).astype(int)
-        scales = np.zeros(len(T1))
-        crop_vss = np.zeros((len(T1), 3, 2))
-        pad_vss = np.zeros((len(T1), 3, 2))
+        params_list = []
 
         # Normalize the data.
         n_T1 = np.zeros(T1.shape)
         for i, T1_img in enumerate(T1):
             n_T1[i] = normalize(T1_img, new_min=0, new_max=1)
-            t_img, t_affine, mid_shape, offset_array, scale, crop_vs, pad_vs = (
-                transform_img(n_T1[i], affine[i], voxsize=voxsize[i])
+            t_img, params = transform_img(
+                n_T1[i],
+                affine[i],
+                voxsize=voxsize[i],
+                ratio=2,
+                init_shape=(256, 256, 256),
+                target_voxsize=(1, 1, 1),
             )
             input_data[..., i] = t_img
-            affines[i] = t_affine
-            mid_shapes[i] = mid_shape
-            offset_arrays[i] = offset_array
-            scales[i] = scale
-            crop_vss[i] = crop_vs
-            pad_vss[i] = pad_vs
-
+            params_list.append(params)
         # Prediction stage
         prediction = np.zeros((len(T1), 128, 128, 128), dtype=np.float32)
         for batch_idx in range(batch_size, len(T1) + 1, batch_size):
@@ -521,17 +515,7 @@ class EVACPlus:
 
         output_mask = []
         for i in range(len(T1)):
-            output = recover_img(
-                prediction[i],
-                affines[i],
-                mid_shapes[i],
-                n_T1[i].shape,
-                offset_arrays[i],
-                voxsize=voxsize[i],
-                scale=scales[i],
-                crop_vs=crop_vss[i],
-                pad_vs=pad_vss[i],
-            )
+            output, _ = recover_img(prediction[i], params_list[i])
             if not return_prob:
                 output = np.where(output >= 0.5, 1, 0)
                 if finalize_mask:

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -3,6 +3,7 @@ from scipy.ndimage import affine_transform
 
 from dipy.align.reslice import reslice
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils.deprecator import deprecated_params
 
 
 @warning_for_keywords()
@@ -80,45 +81,66 @@ def set_logger_level(log_level, logger):
 
 
 @warning_for_keywords()
+@deprecated_params("scale", new_name="ratio", since="1.12", until="1.14")
 def transform_img(
     image,
     affine,
     *,
-    voxsize=None,
+    voxsize=(1, 1, 1),
+    target_voxsize=None,
     considered_points="corners",
-    init_shape=(256, 256, 256),
-    scale=2,
+    init_shape=None,
+    ratio=None,
+    set_size=None,
+    need_isotropic=False,
 ):
     """
-    Function to reshape image as an input to the model
+    Function to transform images for Deep Learning models
 
     Parameters
     ----------
     image : np.ndarray
-        Image to transform to voxelspace
+        Image to transform.
     affine : np.ndarray
-        Affine matrix provided by the file
-    voxsize : np.ndarray (3,), optional
-        Voxel size of the image
-    considered_points : str, optional
-        which points to consider when calculating
-        the boundary of the image. If there is shearing
-        in the affine, 'all' might be more accurate
-    init_shape : list, tuple or numpy array (3,), optional
-        Initial shape to transform the image to
-    scale : float, optional
-        How much we want to scale the image
+        Affine matrix provided by the image file.
+    voxsize : tuple (3,)
+        Voxel size provided by the image file.
+    target_voxsize : tuple (3,)
+        The voxel size we want to start from.
+        Ignored if need_isotropic is True.
+    considered_points : str
+        Considered points when calculating the transformed shape.
+        \"corners\" will consider only corners of the image shape.
+        \"all\" will consider all voxels. Might be needed when shearing is applied.
+    init_shape : tuple (3,)
+        What we want the initial shape to be before last resizing step.
+        Ignored if need_isotropic is True.
+    ratio : float
+        The ratio of change in the last resizing step.
+        Ignored if need_isotropic is True.
+    set_size : tuple (3,)
+        The final size of the image array.
+    need_isotropic : bool
+        Whether the output needs to be isotropic in the end.
+
+
 
     Returns
     -------
-    tuple
-        Tuple with variables for recover_img
+    new_image : np.ndarray
+        Transformed image to be used in the Deep Learning model.
+    params : tuple
+        Parameters that are used when recovering the original image space.
     """
-    if voxsize is not None and np.any(voxsize != np.ones(3)):
-        image2, affine2 = reslice(image, affine, voxsize, (1, 1, 1))
+    ori_shape = image.shape
+    if need_isotropic:
+        target_voxsize = tuple(np.max(voxsize) * np.ones(3))
+    if target_voxsize is not None and np.any(target_voxsize != np.ones(3)):
+        image2, affine2 = reslice(image, affine, voxsize, target_voxsize)
     else:
         image2 = image.copy()
         affine2 = affine.copy()
+
     shape = image2.shape
 
     if considered_points == "corners":
@@ -135,7 +157,7 @@ def transform_img(
             ],
             dtype=np.float64,
         )
-    else:
+    elif considered_points == "all":
         temp1 = np.arange(shape[0])
         temp2 = np.arange(shape[1])
         temp3 = np.arange(shape[2])
@@ -143,6 +165,8 @@ def transform_img(
         corners = np.vstack([grid1.ravel(), grid2.ravel(), grid3.ravel()]).T
         corners = np.hstack([corners, np.full((corners.shape[0], 1), 1)])
         corners = corners.astype(np.float64)
+    else:
+        ValueError('considered points should be "corners" or "all"')
 
     transformed_corners = (affine2 @ corners.T).T
     min_bounds = transformed_corners.min(axis=0)[:3]
@@ -150,7 +174,7 @@ def transform_img(
 
     # Calculate the required offset to ensure
     # all necessary coordinates are positive
-    offset = np.floor(-min_bounds)
+    offset = np.ceil(-min_bounds)
     new_shape = (np.ceil(max_bounds) + offset).astype(int)
     offset_array = np.array(
         [[1, 0, 0, offset[0]], [0, 1, 0, offset[1]], [0, 0, 1, offset[2]], [0, 0, 0, 1]]
@@ -165,82 +189,130 @@ def transform_img(
         image2, inv_affine, output_shape=tuple(new_shape), output=new_image
     )
 
-    new_image, pad_vs, crop_vs = pad_crop(new_image, init_shape)
+    mid_image = new_image.copy()
 
-    if scale != 1:
-        new_image, _ = reslice(new_image, np.eye(4), (1, 1, 1), (scale, scale, scale))
+    crop_vs = None
+    pad_vs = None
+    if not need_isotropic:
+        if init_shape:
+            new_image, pad_vs, crop_vs = pad_crop(new_image, init_shape)
 
-    return new_image, inv_affine, image2.shape, offset_array, scale, crop_vs, pad_vs
+        if (ratio is not None or ratio != 1) and set_size is None:
+            new_image, _ = reslice(
+                new_image, np.eye(4), (1, 1, 1), (ratio, ratio, ratio)
+            )
+        elif set_size:
+            new_image, _ = reslice(
+                new_image,
+                np.eye(4),
+                (1, 1, 1),
+                (
+                    new_image.shape[0] / set_size[0],
+                    new_image.shape[1] / set_size[1],
+                    new_image.shape[2] / set_size[2],
+                ),
+            )
+
+    else:
+        ratio = np.max(np.array(mid_image.shape) / np.array(set_size))
+        new_size = np.ceil(np.array(set_size) * ratio)
+        new_image, pad_vs, crop_vs = pad_crop(mid_image, tuple(new_size))
+        new_image, _ = reslice(new_image, np.eye(4), (1, 1, 1), (ratio, ratio, ratio))
+
+    params = (
+        inv_affine,
+        image2.shape,
+        offset_array,
+        crop_vs,
+        pad_vs,
+        ratio,
+        voxsize,
+        target_voxsize,
+        need_isotropic,
+        set_size,
+        ori_shape,
+    )
+
+    return new_image, params
 
 
-def recover_img(
-    image,
-    inv_affine,
-    mid_shape,
-    ori_shape,
-    offset_array,
-    voxsize,
-    scale,
-    crop_vs,
-    pad_vs,
-):
+def recover_img(image, params):
     """
     Function to recover image from transform_img
 
     Parameters
     ----------
     image : np.ndarray
-        Image to recover
-    inv_affine : np.ndarray
-        Affine matrix returned from transform_img
-    mid_shape : np.ndarray (3,)
-        shape of image returned from transform_img
-    ori_shape : tuple (3,)
-        original shape of the image
-    offset_array : np.ndarray
-        Affine matrix that was used in transform_img
-        to translate the center
-    voxsize : np.ndarray (3,)
-        Voxel size used in transform_img
-    scale : float
-        Scale used in transform_img
-    crop_vs : np.ndarray (3,2)
-        crop range used in transform_img
-    pad_vs : np.ndarray (3,2)
-        pad range used in transform_img
+        Image to recover.
+    params : tuple
+        Parameters for recover_img function.
+        Returned from transform_img.
 
     Returns
     -------
-    image2 : np.ndarray
+    new_image : np.ndarray
         Recovered image
+    affine : np.ndarray
+        Recovered affine.
+        This should be same as the original affine.
     """
+    (
+        inv_affine,
+        mid_shape,
+        offset_array,
+        crop_vs,
+        pad_vs,
+        ratio,
+        voxsize,
+        target_voxsize,
+        need_isotropic,
+        set_size,
+        ori_shape,
+    ) = params
     new_affine = np.linalg.inv(inv_affine)
-    new_image, _ = reslice(image, np.eye(4), (scale, scale, scale), (1, 1, 1))
-    crop_vs = crop_vs.astype(int)
-    pad_vs = pad_vs.astype(int)
-    new_image = np.pad(
-        new_image,
-        (
-            (crop_vs[0, 0], crop_vs[0, 1]),
-            (crop_vs[1, 0], crop_vs[1, 1]),
-            (crop_vs[2, 0], crop_vs[2, 1]),
-        ),
-    )
-    new_image = new_image[
-        pad_vs[0, 0] : new_image.shape[0] - pad_vs[0, 1],
-        pad_vs[1, 0] : new_image.shape[1] - pad_vs[1, 1],
-        pad_vs[2, 0] : new_image.shape[2] - pad_vs[2, 1],
-    ]
+    if need_isotropic:
+        new_image, _ = reslice(image, np.eye(4), (ratio, ratio, ratio), (1, 1, 1))
+    else:
+        if (ratio is not None or ratio != 1) and set_size is None:
+            new_image, _ = reslice(image, np.eye(4), (ratio, ratio, ratio), (1, 1, 1))
+        elif set_size:
+            new_image, _ = reslice(
+                image,
+                np.eye(4),
+                (
+                    new_image.shape[0] / set_size[0],
+                    new_image.shape[1] / set_size[1],
+                    new_image.shape[2] / set_size[2],
+                ),
+                (1, 1, 1),
+            )
+
+    if crop_vs is not None and pad_vs is not None:
+        crop_vs = crop_vs.astype(int)
+        pad_vs = pad_vs.astype(int)
+        new_image = np.pad(
+            new_image,
+            (
+                (crop_vs[0, 0], crop_vs[0, 1]),
+                (crop_vs[1, 0], crop_vs[1, 1]),
+                (crop_vs[2, 0], crop_vs[2, 1]),
+            ),
+        )
+        new_image = new_image[
+            pad_vs[0, 0] : new_image.shape[0] - pad_vs[0, 1],
+            pad_vs[1, 0] : new_image.shape[1] - pad_vs[1, 1],
+            pad_vs[2, 0] : new_image.shape[2] - pad_vs[2, 1],
+        ]
+
     new_image = affine_transform(new_image, new_affine, output_shape=mid_shape)
     affine = np.matmul(np.linalg.inv(offset_array), new_affine)
-    if voxsize is not None and np.any(voxsize != np.ones(3)):
-        image2, _ = reslice(new_image, affine, (1, 1, 1), voxsize)
-    else:
-        image2 = new_image
 
-    # because of zoom rounding errors
-    image2, _, _ = pad_crop(image2, ori_shape)
-    return image2
+    if target_voxsize is not None and np.any(target_voxsize != np.ones(3)):
+        new_image, affine = reslice(new_image, affine, target_voxsize, voxsize)
+        if new_image.shape != ori_shape:
+            new_image = pad_crop(new_image, ori_shape)
+
+    return new_image, affine
 
 
 def pad_crop(image, target_shape):


### PR DESCRIPTION
The transform_img function did not have an option to make an image isotropic and have a fixed size.
This adds a way of doing this by padding to a multiple of that shape and resizing. Recover_img has been changed to compensate for the difference as well.
The parameters returned by transform_img, which was only used in recover_img, was simplified to make the code cleaner. 
Deepn4 strangely had different results between the old transform_img and new, but the output when checked did not have meaningful differences. Hence, test output was edited to make the test functional.