### PR TITLE
BF: Make `StoppingCriterion` reproducible for multi-thread execution

### DIFF
--- a/dipy/tracking/stopping_criterion.pxd
+++ b/dipy/tracking/stopping_criterion.pxd
@@ -11,9 +11,6 @@ cpdef enum StreamlineStatus:
 
 
 cdef class StoppingCriterion:
-    cdef:
-        double interp_out_double[1]
-        double[::1] interp_out_view
 
     cpdef StreamlineStatus check_point(self, double[::1] point)
     cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=*) noexcept nogil


### PR DESCRIPTION
Make `StoppingCriterion` reproducible for multi-thread execution: instantiate the resulting interpolation array at each call.

In single-thread mode the maps created by the criterion are reproducible; however, in multi-thread execution the `self.interp_out_view` is modified in parallel by the multiple threads, and since it is instantiated only once, the maps are not reproducible across runs.

This effect is only observed in criterion objects that use the `self.interp_out_view` array: i.e. it is not observed in the `BinaryStoppingCriterion` objects.

Fixes #3540.