### PR TITLE
BF: Improves Cython enum management.

### DIFF
--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -29,8 +29,7 @@ from dipy.utils.fast_numpy cimport (
     where_to_insert,
 )
 from dipy.tracking.tractogen cimport prepare_pmf
-from dipy.tracking.tracker_parameters cimport (TrackerParameters, TrackerStatus,
-                                               SUCCESS, FAIL)
+from dipy.tracking.tracker_parameters cimport TrackerParameters, TrackerStatus
 
 from libc.stdlib cimport malloc, free
 from libc.math cimport M_PI, pow, sin, cos, fabs
@@ -731,7 +730,7 @@ cdef TrackerStatus deterministic_propagator(double* point,
         cnp.npy_intp len_pmf=pmf_gen.pmf.shape[0]
 
     if norm(direction) == 0:
-        return FAIL
+        return TrackerStatus.FAIL
     normalize(direction)
 
     pmf = <double*> malloc(len_pmf * sizeof(double))
@@ -749,7 +748,7 @@ cdef TrackerStatus deterministic_propagator(double* point,
 
     if max_value <= 0:
         free(pmf)
-        return FAIL
+        return TrackerStatus.FAIL
 
     newdir = &pmf_gen.vertices[max_idx][0]
     # Update direction
@@ -763,7 +762,7 @@ cdef TrackerStatus deterministic_propagator(double* point,
         direction[1] = direction[1] * -1
         direction[2] = direction[2] * -1
     free(pmf)
-    return SUCCESS
+    return TrackerStatus.SUCCESS
 
 
 cdef TrackerStatus probabilistic_propagator(double* point,
@@ -807,7 +806,7 @@ cdef TrackerStatus probabilistic_propagator(double* point,
 
 
     if norm(direction) == 0:
-        return FAIL
+        return TrackerStatus.FAIL
     normalize(direction)
 
     pmf = <double*> malloc(len_pmf * sizeof(double))
@@ -826,7 +825,7 @@ cdef TrackerStatus probabilistic_propagator(double* point,
     last_cdf = pmf[len_pmf - 1]
     if last_cdf == 0:
         free(pmf)
-        return FAIL
+        return TrackerStatus.FAIL
 
     idx = where_to_insert(pmf, random_float(rng) * last_cdf, len_pmf)
     newdir = &pmf_gen.vertices[idx][0]
@@ -841,7 +840,7 @@ cdef TrackerStatus probabilistic_propagator(double* point,
         direction[1] = direction[1] * -1
         direction[2] = direction[2] * -1
     free(pmf)
-    return SUCCESS
+    return TrackerStatus.SUCCESS
 
 
 cdef TrackerStatus parallel_transport_propagator(double* point,
@@ -948,6 +947,6 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
             # within the trial limit
             # update the point and return
             copy_point(&stream_data[19], point)
-            return SUCCESS
+            return TrackerStatus.SUCCESS
 
-    return FAIL
+    return TrackerStatus.FAIL

--- a/dipy/tracking/tests/test_propspeed.pyx
+++ b/dipy/tracking/tests/test_propspeed.pyx
@@ -18,7 +18,7 @@ from dipy.tracking.propspeed cimport (
     parallel_transport_propagator,
 )
 
-from dipy.tracking.tracker_parameters import generate_tracking_parameters, FAIL
+from dipy.tracking.tracker_parameters import generate_tracking_parameters, TrackerStatus
 from dipy.tracking.tests.test_tractogen import get_fast_tracking_performances
 from dipy.utils.fast_numpy cimport RNGState, seed_rng
 
@@ -70,7 +70,7 @@ def test_tracker_deterministic():
                                           &stream_data[0],
                                           sh_pmf_gen,
                                           &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
         # Test using SF pmf
         status = deterministic_propagator(&point[0],
@@ -79,7 +79,7 @@ def test_tracker_deterministic():
                                           &stream_data[0],
                                           sf_pmf_gen,
                                           &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
 
 def test_deterministic_performances():
@@ -142,7 +142,7 @@ def test_tracker_probabilistic():
                                           &stream_data[0],
                                           sh_pmf_gen,
                                           &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
         # Test using SF pmf
         status = probabilistic_propagator(&point[0],
@@ -151,7 +151,7 @@ def test_tracker_probabilistic():
                                           &stream_data[0],
                                           sf_pmf_gen,
                                           &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
 
 def test_probabilistic_performances():
@@ -215,7 +215,7 @@ def test_tracker_ptt():
                                                &stream_data[0],
                                                sh_pmf_gen,
                                                &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
         # Test using SF pmf
         status = parallel_transport_propagator(&point[0],
@@ -224,7 +224,7 @@ def test_tracker_ptt():
                                                &stream_data[0],
                                                sf_pmf_gen,
                                                &rng)
-        npt.assert_equal(status, FAIL)
+        npt.assert_equal(status, TrackerStatus.FAIL)
 
 
 def test_ptt_performances():

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -24,9 +24,8 @@ from dipy.tracking.stopping_criterion cimport (StreamlineStatus,
                                                VALIDSTREAMLIME,
                                                INVALIDSTREAMLIME)
 from dipy.tracking.tracker_parameters cimport (TrackerParameters,
-                                               func_ptr,
-                                               SUCCESS,
-                                               FAIL)
+                                               TrackerStatus,
+                                               func_ptr)
 
 from nibabel.streamlines import ArraySequence as Streamlines
 
@@ -256,7 +255,7 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
     memset(stream_data, 0, 100 * sizeof(double))
     status_forward = TRACKPOINT
     for i in range(1, params.max_nbr_pts):
-        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == FAIL:
+        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == TrackerStatus.FAIL:
             break
         # update position
         for j in range(3):
@@ -290,7 +289,7 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
 
     status_backward = TRACKPOINT
     for i in range(1, params.max_nbr_pts):
-        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == FAIL:
+        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == TrackerStatus.FAIL:
             break
         # update position
         for j in range(3):


### PR DESCRIPTION
since the last release of cython, our current CI's are failing because Cython is more sensitive. This PR improves the TrackerStatus enum management to avoid the error below. it should fix many of our CI's

```
==================================== ERRORS ====================================
_____ ERROR collecting tracking/tests/test_propspeed.cpython-310-darwin.so _____
../venv/lib/python3.10/site-packages/dipy/conftest.py:76: in collect
    mod = importlib.import_module(mod_name)
/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:1184: in exec_module
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
dipy/tracking/tests/test_propspeed.pyx:21: in init dipy.tracking.tests.test_propspeed
    ???
E   ImportError: cannot import name FAIL

The above exception was the direct cause of the following exception:
../venv/lib/python3.10/site-packages/dipy/conftest.py:86: in collect
    raise PyxException(msg, self.path, 0) from e
E   dipy.conftest.PyxException: ('Import failed for /Users/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/tracking/tests/test_propspeed.cpython-310-darwin.so. Make sure you cython file has been compiled.', PosixPath('/Users/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/dipy/tracking/tests/test_propspeed.cpython-310-darwin.so'), 0)
```