### PR TITLE
Doc: Fix typo in multiple tutorial

### DIFF
--- a/doc/examples/reconst_gqi.py
+++ b/doc/examples/reconst_gqi.py
@@ -47,7 +47,11 @@ print(f"data.shape {data.shape}")
 gqmodel = GeneralizedQSamplingModel(gtab, sampling_length=3)
 
 ###############################################################################
-# The parameter ``sampling_length`` is used here to
+# The parameter ``sampling_length`` is used here to control the diffusion
+# sampling length (lambda) in the GQI reconstruction. This parameter affects
+# the shape and smoothness of the resulting ODFs. The optimal value typically
+# ranges from 1-1.3 for GQI2 method, but higher values can be used depending on
+# the dataset characteristics.
 #
 # Lets just use one slice only from the data.
 

--- a/doc/interfaces/reconstruction_flow.rst
+++ b/doc/interfaces/reconstruction_flow.rst
@@ -48,7 +48,7 @@ output directory (``out_dir``).
 To get the mask file, we will use the median Otsu thresholding method by
 calling the ``dipy_median_otsu`` command::
 
-    dipy_median_otsu data/stanford_hardi/HARDI150.nii.gz --vol_idx 10-50 --out_dir "stanford_hardi_mask"
+    dipy_median_otsu data/stanford_hardi/HARDI150.nii.gz --vol_idx "10-50" --out_dir "stanford_hardi_mask"
 
 Then, to perform the CSD reconstruction we will run the ``dipy_fit_csd``
 command as::

--- a/doc/interfaces/tracking_flow.rst
+++ b/doc/interfaces/tracking_flow.rst
@@ -43,6 +43,8 @@ number of optional arguments, such as the number of seeds per dimension within
 a voxel (``seed_density``), or the output directory (``out_dir``), can also be
 provided.
 
+First, locate the GFA volume previously created in the
+:ref:`reconstruction tutorial<reconstruction_flow>` (CSA chapter).
 To get the stopping file, we will create a binary file of the GFA of the CSA
 reconstruction method and set a stopping criterion by calling the ``dipy_mask``
 command::

--- a/doc/reconstruction_models_list.rst
+++ b/doc/reconstruction_models_list.rst
@@ -140,7 +140,7 @@
      - :bdg-danger:`No`
      - Minimum: 20 gradient directions and a b-value of 1000 s/mm^2; benefits additionally from 60 direction HARDI data with b-value = 3000 s/mm^2 or multi-shell
      - :cite:t:`Tournier2004`, :cite:t:`Tournier2007`, :cite:t:`Descoteaux2007`
-   * - :ref:`SMS/MT CSD <sphx_glr_examples_built_reconstruction_reconst_mcsd.py>`
+   * - :ref:`MS/MT CSD <sphx_glr_examples_built_reconstruction_reconst_mcsd.py>`
      - :bdg-danger:`No`
      - :bdg-success:`Yes`
      - :bdg-danger:`No`


### PR DESCRIPTION
Quick PR to fix some typos. it should fix #3413

- Reconstruction Tab: MSMT typo fixed
-  Reconstruction > Reconstruct with Generalized Q-Sampling Imaging, the line 'The parameter sampling_length is used here to" ompleted.
- Interfaces > reconstruction_flow, "the vol_idx" is in form a string now.
- Interfaces/tracking_flow, clarification of the GFA origin.