### PR TITLE
ENH: improve dipy_info message when no reference for some streamline files.

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -147,6 +147,16 @@ class IoInfoFlow(Workflow):
                 if extension in [".trk", ".trx"]:
                     sft = load_tractogram(input_path, "same", bbox_valid_check=False)
                 else:
+                    if not reference or not os.path.exists(reference):
+                        msg = (
+                            "No reference provided. It is needed for tck, fib, dpy or "
+                            "vtk files to load properly. Please provide a reference, "
+                            "Nifti or Trk file using the option "
+                            "--reference my_files.nii.gz ."
+                        )
+                        logging.error(msg, stacklevel=2)
+                        sys.exit(1)
+
                     sft = load_tractogram(input_path, reference, bbox_valid_check=False)
 
                 lengths_mm = list(length(sft.streamlines))

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -76,7 +76,9 @@ def test_io_info():
     io_info_flow.run(filepath_dix["gs.trk"])
 
     io_info_flow = IoInfoFlow()
-    npt.assert_raises(TypeError, io_info_flow.run, filepath_dix["gs.tck"])
+    npt.assert_raises(SystemExit, io_info_flow.run, filepath_dix["gs.tck"])
+    io_info_flow = IoInfoFlow()
+    npt.assert_raises(OSError, io_info_flow.run, "fake.vtk")
 
     io_info_flow = IoInfoFlow()
     io_info_flow.run(filepath_dix["gs.tck"], reference=filepath_dix["gs.nii"])


### PR DESCRIPTION
This PR fixes #3517.

As explained in the issue. The error message was misleading and not clear. This PR addresses this problem with a clearer message and a better check

