### PR TITLE
RF: allow the saving of S0 estimate for dti workflow

### DIFF
--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -79,7 +79,7 @@ def reconst_flow_core(flow, extra_args=None, extra_kwargs=None):
             assert_equal(tensor_data.shape[-1], 6)
             assert_equal(tensor_data.shape[:-1], volume.shape[:-1])
 
-        for out_name in ["out_ga", "out_md", "out_ad", "out_rd", "out_mode"]:
+        for out_name in ["out_ga", "out_md", "out_ad", "out_rd", "out_mode", "out_s0"]:
             out_path = dti_flow.last_generated_outputs[out_name]
             out_data = load_nifti_data(out_path)
             assert_equal(out_data.shape, volume.shape[:-1])


### PR DESCRIPTION
This PR fixes #3497.

As explain in the issue, the goal is just to allow the saving of the S0 estimate. 

It was already possible in python, so I just enabled it in the CLI
