### PR TITLE
Doc: explicit ``finalize_mask`` information in CLI tutorial

### DIFF
--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -35,6 +35,9 @@ data = np.squeeze(data)
 # (``median_radius`` and ``num_pass``) if extraction yields incorrect results
 # but the default parameters work well on most volumes. For this example,
 # we used 2 as ``median_radius`` and 1 as ``num_pass``
+# In case of holes or minor errors in the mask, add the argument
+# ``finalize_mask=True`` to apply a final step to the mask, which will fix those
+# issues.
 
 b0_mask, mask = median_otsu(data, median_radius=2, numpass=1)
 

--- a/doc/interfaces/basic_flow.rst
+++ b/doc/interfaces/basic_flow.rst
@@ -164,6 +164,9 @@ We can use ``dipy_median_otsu`` to build a brain mask for the diffusion data::
 
     dipy_median_otsu dwi.nii --median_radius 2 --numpass 1 --vol_idx 10-50 --out_dir out_work
 
+In case of holes in the mask, or minor errors, add the option ``--finalize_mask`` to
+apply a final step to the mask, which will remove small holes and fill in small gaps.
+
 Visualize the mask using ``dipy_horizon``::
 
     dipy_horizon out_work/brain_mask.nii.gz

--- a/doc/interfaces/reconstruction_flow.rst
+++ b/doc/interfaces/reconstruction_flow.rst
@@ -50,6 +50,9 @@ calling the ``dipy_median_otsu`` command::
 
     dipy_median_otsu data/stanford_hardi/HARDI150.nii.gz --vol_idx "10-50" --out_dir "stanford_hardi_mask"
 
+In case of holes in the mask, or minor errors, add the option ``--finalize_mask`` to
+apply a final step to the mask, which will remove small holes and fill in small gaps.
+
 Then, to perform the CSD reconstruction we will run the ``dipy_fit_csd``
 command as::
 
@@ -189,6 +192,9 @@ the ``dipy_median_otsu`` command::
 
     dipy_median_otsu data/cfin_multib/__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii --vol_idx 3-6 --out_dir "cfin_multib_mask"
 
+In case of holes in the mask, or minor errors, add the option ``--finalize_mask`` to
+apply a final step to the mask, which will remove small holes and fill in small gaps.
+
 To run the DKI reconstruction method on the data, execute the ``dipy_fit_dki``
 command, e.g.::
 
@@ -257,6 +263,9 @@ To get the mask file, we will use the median Otsu thresholding method by calling
 the ``dipy_median_otsu`` command::
 
     dipy_median_otsu data/ivim/HARDI150.nii.gz --vol_idx 10-50 --out_dir "ivim_mask"
+
+In case of holes in the mask, or minor errors, add the option ``--finalize_mask`` to
+apply a final step to the mask, which will remove small holes and fill in small gaps.
 
 Then, to perform the IVIM reconstruction we will run the command as::
 


### PR DESCRIPTION
This PR fixes #3124.

By expliciting the ``--finalize_mask`` parameter in the CLI, we provide a quick way to fix minor issues when generating a brain mask.