### PR TITLE
RF: Address some Zero division warnings

### DIFF
--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -249,7 +249,8 @@ def _piesno_3D(
     lambda_plus = _inv_nchi_cdf(N, K, 1 - alpha / 2)
 
     for sigma_init in phi:
-        s = sum_m2 / (2 * K * sigma_init**2)
+        denominator = 2 * K * sigma_init**2
+        s = (sum_m2 / denominator) if denominator != 0 else np.zeros_like(sum_m2)
         found_idx = np.sum(
             np.logical_and(lambda_minus <= s, s <= lambda_plus), dtype=np.int16
         )

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -2373,11 +2373,17 @@ def lower_triangular(tensor, *, b0=None):
         raise ValueError("Diffusion tensors should be (..., 3, 3)")
     if b0 is None:
         return tensor[..., _lt_rows, _lt_cols]
-    else:
-        D = np.empty(tensor.shape[:-2] + (7,), dtype=tensor.dtype)
-        D[..., 6] = -np.log(b0)
-        D[..., :6] = tensor[..., _lt_rows, _lt_cols]
-        return D
+
+    if not isinstance(b0, (int, float, np.ndarray)):
+        raise TypeError("b0 should be a number")
+
+    if isinstance(b0, np.ndarray):
+        b0 = b0.mean()
+
+    D = np.empty(tensor.shape[:-2] + (7,), dtype=tensor.dtype)
+    D[..., 6] = -np.log(b0 if b0 > 0 else 1.0)
+    D[..., :6] = tensor[..., _lt_rows, _lt_cols]
+    return D
 
 
 @warning_for_keywords()

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -622,7 +622,10 @@ def test_lower_triangular():
     npt.assert_array_equal(D, [0, 3, 4, 6, 7, 8])
     D = lower_triangular(tensor, b0=1)
     npt.assert_array_equal(D, [0, 3, 4, 6, 7, 8, 0])
+    D = lower_triangular(tensor, b0=0)
+    npt.assert_array_equal(D, [0, 3, 4, 6, 7, 8, 0])
     npt.assert_raises(ValueError, lower_triangular, np.zeros((2, 3)))
+    npt.assert_raises(TypeError, lower_triangular, tensor, b0="not a number")
     shape = (4, 5, 6)
     many_tensors = np.empty(shape + (3, 3))
     many_tensors[:] = tensor


### PR DESCRIPTION
this PR fixes #3418.

it addresses some zero division warnings and update some tests.
