### PR TITLE
SciPy deprecation of "disp" in optimizer

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -1313,7 +1313,7 @@ class AffineRegistration:
 
             # Optimize this level
             if self.options is None:
-                self.options = {"gtol": 1e-4, "disp": False}
+                self.options = {"gtol": 1e-4}
 
             if self.method == "L-BFGS-B":
                 self.options["maxfun"] = max_iter

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -180,7 +180,7 @@ class AffineMap:
             affine = np.array(affine)
         except Exception as e:
             raise TypeError(
-                "Input must be type ndarray, or be convertible" " to one."
+                "Input must be type ndarray, or be convertible to one."
             ) from e
 
         if len(affine.shape) != _number_dim_affine_matrix:
@@ -203,7 +203,7 @@ class AffineMap:
         # Last row, last column in matrix must be 1.0!
         if affine[-1, -1] != 1.0:
             raise AffineInvalidValuesError(
-                "Last row, last column in matrix" " is not 1.0!"
+                "Last row, last column in matrix is not 1.0!"
             )
 
         # making a copy to insulate it from changes outside object

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1917,7 +1917,6 @@ def generalized_crossvalidation(data, M, LR, *, startpoint=5e-4):
         args=(input_stuff,),
         approx_grad=True,
         bounds=bounds,
-        disp=False,
         pgtol=1e-10,
         factr=10.0,
     )


### PR DESCRIPTION
we're seeing an MNE-Python CI failure:

> DeprecationWarning: scipy.optimize: The `disp` and `iprint` options of the L-BFGS-B solver are deprecated and will be removed in SciPy 1.18.0.

It's coming from the init of `dipy.core.optimize.Optimizer`. Full traceback:

<details>

```
        ../examples/inverse/morph_volume_stc.py failed leaving traceback:
    
        Traceback (most recent call last):
          File "/home/circleci/project/examples/inverse/morph_volume_stc.py", line 86, in <module>
            morph = mne.compute_source_morph(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
          File "<decorator-gen-501>", line 10, in compute_source_morph
          File "/home/circleci/project/mne/morph.py", line 258, in compute_source_morph
            shape, zooms, affine, pre_affine, sdr_morph = _compute_morph_sdr(
                                                          ^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/project/mne/morph.py", line 1159, in _compute_morph_sdr
            ) = _compute_volume_registration(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/project/mne/transforms.py", line 1862, in _compute_volume_registration
            moved_zoomed, reg_affine = affine_registration(
                                       ^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 201, in wrapper
            return convert_positional_to_keyword(func, args, kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 192, in convert_positional_to_keyword
            return func(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/align/_public.py", line 579, in affine_registration
            xform, xopt, fopt = affreg.optimize(
                                ^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 201, in wrapper
            return convert_positional_to_keyword(func, args, kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 192, in convert_positional_to_keyword
            return func(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/align/imaffine.py", line 1323, in optimize
            opt = Optimizer(
                  ^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 201, in wrapper
            return convert_positional_to_keyword(func, args, kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/testing/decorators.py", line 192, in convert_positional_to_keyword
            return func(*args, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/dipy/core/optimize.py", line 163, in __init__
            res = minimize(
                  ^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/scipy/optimize/_minimize.py", line 785, in minimize
            res = _minimize_lbfgsb(fun, x0, args, jac, bounds,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/circleci/python_env/lib/python3.12/site-packages/scipy/optimize/_lbfgsb_py.py", line 381, in _minimize_lbfgsb
            warnings.warn("scipy.optimize: The `disp` and `iprint` options of the "
        DeprecationWarning: scipy.optimize: The `disp` and `iprint` options of the L-BFGS-B solver are deprecated and will be removed in SciPy 1.18.0.
```

</details>

This PR is my best guess as to the source of the problem, but I haven't yet looked closely to see if the same thing is happening elsewhere in dipy's codebase.  Would be happy if a regular dipy contrib / maintainer took over this PR as it may be a while before I have time to do a thorough job of this.