### PR TITLE
DOC: Change unused commit prefixes to some other more useful ones

### DIFF
--- a/doc/devel/commit_codes.rst
+++ b/doc/devel/commit_codes.rst
@@ -12,8 +12,8 @@ categories:
 * *NF* : new feature
 * *BW* : addresses backward-compatibility
 * *OPT* : optimization
-* *BK* : breaks something and/or tests fail
-* *PL* : making pylint happier
+* *CI* : continuous integration
+* *MNT* : maintenance tasks, such as release preparation
 * *DOC*: for all kinds of documentation related commits
 * *TEST* : for adding or changing tests
 * *STYLE* : PEP8 conformance, whitespace changes etc that do not affect


### PR DESCRIPTION
Change unused commit prefixes to some other more useful ones.

Original proposal: https://github.com/dipy/dipy/pull/3582#issuecomment-3011959757