### PR TITLE
RF: from TRK to TRX as default file format for tracks

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -35,7 +35,7 @@ from dipy.align.transforms import (
 import dipy.core.gradients as dpg
 import dipy.data as dpd
 from dipy.io.image import load_nifti, save_nifti
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 from dipy.io.utils import read_img_arr_or_path
 from dipy.testing.decorators import warning_for_keywords
 from dipy.tracking.streamline import set_number_of_points
@@ -848,9 +848,9 @@ def streamline_registration(moving, static, *, n_points=100, native_resampled=Fa
     """
     # Load the streamlines, if you were given a file-name
     if isinstance(moving, (str, Path)):
-        moving = load_trk(moving, "same", bbox_valid_check=False).streamlines
+        moving = load_tractogram(moving, "same", bbox_valid_check=False).streamlines
     if isinstance(static, (str, Path)):
-        static = load_trk(static, "same", bbox_valid_check=False).streamlines
+        static = load_tractogram(static, "same", bbox_valid_check=False).streamlines
 
     srr = StreamlineLinearRegistration()
     srm = srr.optimize(

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -29,7 +29,7 @@ import dipy.data as dpd
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.utils import transform_tracking_output
 
@@ -339,8 +339,8 @@ def test_streamline_registration(rng):
 
     with TemporaryDirectory() as tmpdir:
         for use_aff in [None, base_aff]:
-            fname1 = Path(tmpdir) / "sl1.trk"
-            fname2 = Path(tmpdir) / "sl2.trk"
+            fname1 = Path(tmpdir) / "sl1.trx"
+            fname2 = Path(tmpdir) / "sl2.trx"
             if use_aff is not None:
                 img = nib.Nifti1Image(np.zeros((2, 2, 2)), use_aff)
                 # Move the streamlines to this other space, and report it:
@@ -350,7 +350,7 @@ def test_streamline_registration(rng):
                     Space.VOX,
                 )
 
-                save_trk(tgm1, fname1, bbox_valid_check=False)
+                save_tractogram(tgm1, fname1, bbox_valid_check=False)
 
                 tgm2 = StatefulTractogram(
                     transform_tracking_output(sl2, np.linalg.inv(use_aff)),
@@ -358,14 +358,14 @@ def test_streamline_registration(rng):
                     Space.VOX,
                 )
 
-                save_trk(tgm2, fname2, bbox_valid_check=False)
+                save_tractogram(tgm2, fname2, bbox_valid_check=False)
 
             else:
                 img = nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4))
                 tgm1 = StatefulTractogram(sl1, img, Space.RASMM)
                 tgm2 = StatefulTractogram(sl2, img, Space.RASMM)
-                save_trk(tgm1, fname1, bbox_valid_check=False)
-                save_trk(tgm2, fname2, bbox_valid_check=False)
+                save_tractogram(tgm1, fname1, bbox_valid_check=False)
+                save_tractogram(tgm2, fname2, bbox_valid_check=False)
 
             aligned, matrix = streamline_registration(fname2, fname1)
             npt.assert_almost_equal(aligned[0], sl1[0], decimal=5)

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -20,7 +20,7 @@ from dipy.core.gradients import (
 )
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data, save_nifti
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.logging import logger
 from dipy.utils.optpkg import TripWire, optional_package
@@ -2581,7 +2581,6 @@ def read_bundles_2_subjects(
     """
     dname = Path(dipy_home) / "exp_bundles_and_maps", "bundles_2_subjects"
 
-    from dipy.io.streamline import load_tractogram
     from dipy.tracking.streamline import Streamlines
 
     res = {}
@@ -2889,7 +2888,7 @@ def read_five_af_bundles():
         bundles = []
         for sub in subjects:
             fname = Path(temp_dir) / sub / "AF_L.trk"
-            bundle_obj = load_trk(fname, "same", bbox_valid_check=False)
+            bundle_obj = load_tractogram(fname, "same", bbox_valid_check=False)
             bundles.append(bundle_obj.streamlines)
 
     return bundles

--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -388,13 +388,13 @@ class Horizon:
                 c = cluster_actors[bundle]["cluster"]
                 indices = tractogram_clusters[t][c]
                 saving_streamlines.extend(Streamlines(indices))
-        logger.info("Saving result in tmp.trk")
+        logger.info("Saving result in tmp.trx")
 
         # Using the header of the first of the tractograms
         sft_new = StatefulTractogram(
             saving_streamlines, self.tractograms[0], Space.RASMM
         )
-        save_tractogram(sft_new, "tmp.trk", bbox_valid_check=False)
+        save_tractogram(sft_new, "tmp.trx", bbox_valid_check=False)
         logger.info("Saved!")
 
     # TODO: Move to another class/module

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -134,7 +134,7 @@ class RecoBundlesFlow(Workflow):
         r_pruning_thr=6.0,
         no_r_slr=False,
         out_dir="",
-        out_recognized_transf="recognized.trk",
+        out_recognized_transf="recognized.trx",
         out_recognized_labels="labels.npy",
     ):
         """Recognize bundles
@@ -336,7 +336,7 @@ class LabelsBundlesFlow(Workflow):
         streamline_files,
         labels_files,
         out_dir="",
-        out_bundle="recognized_orig.trk",
+        out_bundle="recognized_orig.trx",
     ):
         """Extract bundles using existing indices (labels)
 

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -50,24 +50,15 @@ def test_slr_flow():
     with TemporaryDirectory() as out_dir:
         data_path = get_fnames(name="fornix")
 
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
-
-        f = Streamlines(fornix)
-        f1 = f.copy()
-
-        f1_path = Path(out_dir) / "f1.trk"
-        sft = StatefulTractogram(f1, data_path, Space.RASMM)
-        save_tractogram(sft, f1_path, bbox_valid_check=False)
-
-        f2 = f1.copy()
-        f2._data += np.array([50, 0, 0])
-
-        f2_path = Path(out_dir) / "f2.trk"
-        sft = StatefulTractogram(f2, data_path, Space.RASMM)
-        save_tractogram(sft, f2_path, bbox_valid_check=False)
+        sft = load_tractogram(data_path, "same", bbox_valid_check=False)
+        sft.streamlines._data += np.array([50, 0, 0])
+        moved_path = Path(out_dir) / "moved.trk"
+        save_tractogram(sft, moved_path, bbox_valid_check=False)
 
         slr_flow = SlrWithQbxFlow(force=True)
-        slr_flow.run(str(f1_path), str(f2_path), out_dir=out_dir)
+        slr_flow.run(
+            str(data_path), str(moved_path), out_dir=out_dir, bbox_valid_check=False
+        )
 
         out_path = slr_flow.last_generated_outputs["out_moved"]
 
@@ -586,10 +577,10 @@ def test_bundlewarp_flow():
         save_tractogram(sft, f2_path, bbox_valid_check=False)
 
         bw_flow = BundleWarpFlow(force=True)
-        bw_flow.run(str(f1_path), str(f2_path), out_dir=out_dir)
+        bw_flow.run(str(f1_path), str(f2_path), out_dir=out_dir, bbox_valid_check=False)
 
-        out_linearly_moved = Path(out_dir) / "linearly_moved.trk"
-        out_nonlinearly_moved = Path(out_dir) / "nonlinearly_moved.trk"
+        out_linearly_moved = Path(out_dir) / "linearly_moved.trx"
+        out_nonlinearly_moved = Path(out_dir) / "nonlinearly_moved.trx"
 
         assert out_linearly_moved.exists()
         assert out_nonlinearly_moved.exists()

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -2,7 +2,6 @@ from os.path import join
 from tempfile import TemporaryDirectory
 import warnings
 
-import nibabel as nib
 import numpy as np
 from numpy.testing import assert_equal
 
@@ -312,13 +311,12 @@ def test_local_fiber_tracking_workflow():
 
 
 def is_tractogram_empty(tractogram_path):
-    tractogram_file = nib.streamlines.load(tractogram_path)
-
-    return len(tractogram_file.tractogram) == 0
+    tractogram = load_tractogram(tractogram_path, "same", bbox_valid_check=False)
+    return len(tractogram) == 0
 
 
 def tractogram_has_seeds(tractogram_path):
-    tractogram = nib.streamlines.load(tractogram_path).tractogram
+    tractogram = load_tractogram(tractogram_path, "same", bbox_valid_check=False)
 
     return len(tractogram.data_per_streamline["seeds"]) > 0
 

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -49,7 +49,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
         random_seed=1,
         seed_buffer_fraction=1.0,
         out_dir="",
-        out_tractogram="tractogram.trk",
+        out_tractogram="out_tractogram.trx",
     ):
         """Workflow for Local Fiber Tracking.
 
@@ -292,7 +292,7 @@ class PFTrackingPAMFlow(Workflow):
         random_seed=1,
         seed_buffer_fraction=1.0,
         out_dir="",
-        out_tractogram="tractogram.trk",
+        out_tractogram="tractogram.trx",
     ):
         """Workflow for Particle Filtering Tracking.
 

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -56,7 +56,7 @@ class HorizonFlow(Workflow):
 
         See :footcite:p:`Garyfallidis2019` for further details about Horizon.
 
-        Interact with any number of .trk, .tck or .dpy tractograms and anatomy
+        Interact with any number of .trx, .trk, .tck or .dpy tractograms and anatomy
         files .nii or .nii.gz. Cluster streamlines on loading.
 
         Parameters

--- a/doc/examples/afq_tract_profiles.py
+++ b/doc/examples/afq_tract_profiles.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from dipy.data import fetch_hbn, get_two_hcp842_bundles
 from dipy.io.image import load_nifti
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metricspeed import AveragePointwiseEuclideanMetric
@@ -44,9 +44,9 @@ afq_path = path / "derivatives" / "afq" / f"sub-{subject}" / f"ses-{session}"
 
 ###############################################################################
 # We can use the `dipy.io` API to read in the bundles from file.
-# `load_trk` returns both the streamlines, as well as header information, and
-# the `streamlines` attribute will give us access to the sequence of arrays
-# that contain the streamline coordinates.
+# `load_tractogram` returns both the streamlines, as well as header
+# information, and the `streamlines` attribute will give us access to the
+# sequence of arrays that contain the streamline coordinates.
 
 cst_l_file = (
     afq_path
@@ -62,8 +62,12 @@ arc_l_file = (
     "-RASMM_model-CSD_desc-prob-afq-ARC_L_tractography.trk",
 )
 
-cst_l = load_trk(cst_l_file, reference="same", bbox_valid_check=False).streamlines
-arc_l = load_trk(arc_l_file, reference="same", bbox_valid_check=False).streamlines
+cst_l = load_tractogram(
+    cst_l_file, reference="same", bbox_valid_check=False
+).streamlines
+arc_l = load_tractogram(
+    arc_l_file, reference="same", bbox_valid_check=False
+).streamlines
 
 ###############################################################################
 # In the next step, we need to make sure that all the streamlines in each
@@ -81,10 +85,10 @@ arc_l = load_trk(arc_l_file, reference="same", bbox_valid_check=False).streamlin
 
 model_arc_l_file, model_cst_l_file = get_two_hcp842_bundles()
 
-model_arc_l = load_trk(
+model_arc_l = load_tractogram(
     model_arc_l_file, reference="same", bbox_valid_check=False
 ).streamlines
-model_cst_l = load_trk(
+model_cst_l = load_tractogram(
     model_cst_l_file, reference="same", bbox_valid_check=False
 ).streamlines
 

--- a/doc/examples/bundle_assignment_maps.py
+++ b/doc/examples/bundle_assignment_maps.py
@@ -13,7 +13,7 @@ First import the necessary modules.
 import numpy as np
 
 from dipy.data import fetch_bundle_atlas_hcp842, get_two_hcp842_bundles
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 from dipy.stats.analysis import assignment_map
 from dipy.viz import actor, window
 
@@ -28,7 +28,7 @@ atlas_file, atlas_folder = fetch_bundle_atlas_hcp842()
 
 model_af_l_file, model_cst_l_file = get_two_hcp842_bundles()
 
-sft_af_l = load_trk(model_af_l_file, reference="same", bbox_valid_check=False)
+sft_af_l = load_tractogram(model_af_l_file, reference="same", bbox_valid_check=False)
 model_af_l = sft_af_l.streamlines
 
 ###############################################################################

--- a/doc/examples/bundle_extraction.py
+++ b/doc/examples/bundle_extraction.py
@@ -20,7 +20,7 @@ from dipy.data import (
     get_two_hcp842_bundles,
 )
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import load_trk, save_trk
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.utils import create_tractogram_header
 from dipy.segment.bundles import RecoBundles
 from dipy.viz import actor, window
@@ -34,11 +34,11 @@ atlas_file, atlas_folder = fetch_bundle_atlas_hcp842()
 atlas_file, all_bundles_files = get_bundle_atlas_hcp842()
 target_file = get_target_tractogram_hcp()
 
-sft_atlas = load_trk(atlas_file, "same", bbox_valid_check=False)
+sft_atlas = load_tractogram(atlas_file, "same", bbox_valid_check=False)
 atlas = sft_atlas.streamlines
 atlas_header = create_tractogram_header(atlas_file, *sft_atlas.space_attributes)
 
-sft_target = load_trk(target_file, "same", bbox_valid_check=False)
+sft_target = load_tractogram(target_file, "same", bbox_valid_check=False)
 target = sft_target.streamlines
 target_header = create_tractogram_header(target_file, *sft_target.space_attributes)
 
@@ -144,7 +144,7 @@ if interactive:
 # Arcuate Fasciculus Left model bundle.
 
 model_af_l_file, model_cst_l_file = get_two_hcp842_bundles()
-sft_af_l = load_trk(model_af_l_file, reference="same", bbox_valid_check=False)
+sft_af_l = load_tractogram(model_af_l_file, reference="same", bbox_valid_check=False)
 model_af_l = sft_af_l.streamlines
 
 interactive = False
@@ -202,18 +202,18 @@ if interactive:
 #
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_af_l = StatefulTractogram(recognized_af_l, atlas_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_rec_1.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_rec_1.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_af_l = StatefulTractogram(target[af_l_labels], target_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_org_1.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_org_1.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Now, let's increase the reduction_thr and pruning_thr values.
@@ -251,18 +251,18 @@ if interactive:
 # Extracted Arcuate Fasciculus Left bundle
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_af_l = StatefulTractogram(recognized_af_l, atlas_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_rec_2.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_rec_2.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_af_l = StatefulTractogram(target[af_l_labels], target_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_org_2.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_org_2.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Now, let's increase the reduction_thr and pruning_thr values further.
@@ -300,18 +300,18 @@ if interactive:
 # Extracted Arcuate Fasciculus Left bundle
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_af_l = StatefulTractogram(recognized_af_l, atlas_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_rec_3.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_rec_3.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_af_l = StatefulTractogram(target[af_l_labels], target_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_org_3.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_org_3.trx", bbox_valid_check=False)
 
 
 ###############################################################################
@@ -358,23 +358,23 @@ if interactive:
 #
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_af_l = StatefulTractogram(r_recognized_af_l, atlas_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_rec_refine.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_rec_refine.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_af_l = StatefulTractogram(target[r_af_l_labels], target_header, Space.RASMM)
-save_trk(reco_af_l, "AF_L_org_refine.trk", bbox_valid_check=False)
+save_tractogram(reco_af_l, "AF_L_org_refine.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's load Corticospinal Tract Left model bundle and visualize it.
 
-sft_cst_l = load_trk(model_cst_l_file, "same", bbox_valid_check=False)
+sft_cst_l = load_tractogram(model_cst_l_file, "same", bbox_valid_check=False)
 model_cst_l = sft_cst_l.streamlines
 
 interactive = False
@@ -430,18 +430,18 @@ if interactive:
 #
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_cst_l = StatefulTractogram(recognized_cst_l, atlas_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_rec_1.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_rec_1.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_cst_l = StatefulTractogram(target[cst_l_labels], target_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_org_1.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_org_1.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Now, let's increase the reduction_thr and pruning_thr values.
@@ -479,18 +479,18 @@ if interactive:
 # Extracted Corticospinal tract Left bundle
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_cst_l = StatefulTractogram(recognized_cst_l, atlas_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_rec_2.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_rec_2.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_cst_l = StatefulTractogram(target[cst_l_labels], target_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_org_2.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_org_2.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Now, let's increase the reduction_thr and pruning_thr values further.
@@ -530,18 +530,18 @@ if interactive:
 #
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_cst_l = StatefulTractogram(recognized_cst_l, atlas_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_rec_3.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_rec_3.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_cst_l = StatefulTractogram(target[cst_l_labels], target_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_org_3.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_org_3.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's apply auto-calibrated RecoBundles on the output of standard
@@ -586,18 +586,18 @@ if interactive:
 # Extracted refined Corticospinal tract Left bundle
 #
 #
-# Save the bundle as a trk file. Let's save the recognized bundle in the
+# Save the bundle as a trx file. Let's save the recognized bundle in the
 # common space (atlas space), in this case, MNI space.
 
 reco_cst_l = StatefulTractogram(r_recognized_cst_l, atlas_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_rec_refine.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_rec_refine.trx", bbox_valid_check=False)
 
 ###############################################################################
 # Let's save the recognized bundle in the original space of the subject
 # anatomy.
 
 reco_cst_l = StatefulTractogram(target[r_cst_l_labels], target_header, Space.RASMM)
-save_trk(reco_cst_l, "CST_L_org_refine.trk", bbox_valid_check=False)
+save_tractogram(reco_cst_l, "CST_L_org_refine.trx", bbox_valid_check=False)
 
 ###############################################################################
 # This example shows how changing different threshold parameters can change the

--- a/doc/examples/bundlewarp_registration.py
+++ b/doc/examples/bundlewarp_registration.py
@@ -23,7 +23,7 @@ from dipy.align.streamwarp import (
 )
 from dipy.data import fetch_bundle_warp_dataset
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import load_trk, save_tractogram
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.tracking.streamline import (
     Streamlines,
     set_number_of_points,
@@ -40,8 +40,12 @@ bundle_warp_files = fetch_bundle_warp_dataset()
 s_UF_L_path = Path(bundle_warp_files[1]) / "s_UF_L.trk"
 m_UF_L_path = Path(bundle_warp_files[1]) / "m_UF_L.trk"
 
-uf_subj1 = load_trk(s_UF_L_path, reference="same", bbox_valid_check=False).streamlines
-uf_subj2 = load_trk(m_UF_L_path, reference="same", bbox_valid_check=False).streamlines
+uf_subj1 = load_tractogram(
+    s_UF_L_path, reference="same", bbox_valid_check=False
+).streamlines
+uf_subj2 = load_tractogram(
+    m_UF_L_path, reference="same", bbox_valid_check=False
+).streamlines
 
 ###############################################################################
 # Let's resample the streamlines so that they both have the same number of
@@ -132,7 +136,7 @@ viz_displacement_mag(moving_aligned, offsets, fname, interactive=False)
 # Saving partially warped bundle.
 
 new_tractogram = StatefulTractogram(deformed_bundle, m_UF_L_path, Space.RASMM)
-save_tractogram(new_tractogram, "partially_deformed_bundle.trk", bbox_valid_check=False)
+save_tractogram(new_tractogram, "partially_deformed_bundle.trx", bbox_valid_check=False)
 
 
 ###############################################################################
@@ -203,7 +207,7 @@ _, _ = bundlewarp_shape_analysis(
 # Saving fully warped bundle.
 
 new_tractogram = StatefulTractogram(deformed_bundle2, m_UF_L_path, Space.RASMM)
-save_tractogram(new_tractogram, "fully_deformed_bundle.trk", bbox_valid_check=False)
+save_tractogram(new_tractogram, "fully_deformed_bundle.trx", bbox_valid_check=False)
 
 ###############################################################################
 # References

--- a/doc/examples/fast_streamline_search.py
+++ b/doc/examples/fast_streamline_search.py
@@ -17,7 +17,7 @@ from dipy.data import (
     get_target_tractogram_hcp,
     get_two_hcp842_bundles,
 )
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 from dipy.segment.fss import FastStreamlineSearch, nearest_from_matrix_row
 from dipy.viz import actor, window
 
@@ -28,7 +28,7 @@ fetch_bundle_atlas_hcp842()
 fetch_target_tractogram_hcp()
 
 hcp_file = get_target_tractogram_hcp()
-streamlines = load_trk(hcp_file, "same", bbox_valid_check=False).streamlines
+streamlines = load_tractogram(hcp_file, "same", bbox_valid_check=False).streamlines
 
 ###############################################################################
 # Visualize the atlas (ref) bundle and full brain tractogram
@@ -55,7 +55,7 @@ else:
 # Arcuate Fasciculus Left model bundle.
 
 model_af_l_file, model_cst_l_file = get_two_hcp842_bundles()
-sft_af_l = load_trk(model_af_l_file, "same", bbox_valid_check=False)
+sft_af_l = load_tractogram(model_af_l_file, "same", bbox_valid_check=False)
 model_af_l = sft_af_l.streamlines
 
 scene = window.Scene()

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -34,7 +34,7 @@ import dipy.core.optimize as opt
 from dipy.data import fetch_stanford_tracks, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
-from dipy.io.streamline import load_trk
+from dipy.io.streamline import load_tractogram
 import dipy.tracking.life as life
 from dipy.viz import actor, colormap as cmap, window
 
@@ -58,7 +58,7 @@ cc_slice = labels == 2
 streamlines_files = fetch_stanford_tracks()
 lr_superiorfrontal_path = Path(streamlines_files[1]) / "hardi-lr-superiorfrontal.trk"
 
-candidate_sl_sft = load_trk(lr_superiorfrontal_path, "same")
+candidate_sl_sft = load_tractogram(lr_superiorfrontal_path, "same")
 candidate_sl_sft.to_vox()
 candidate_sl = candidate_sl_sft.streamlines
 

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -28,7 +28,7 @@ from dipy.direction import peaks
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst import shm
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
@@ -239,7 +239,7 @@ lr_sf_trk = Streamlines(lr_superiorfrontal_track)
 
 # Save streamlines
 sft = StatefulTractogram(lr_sf_trk, hardi_img, Space.RASMM)
-save_trk(sft, "lr-superiorfrontal.trk")
+save_tractogram(sft, "lr-superiorfrontal.trx")
 
 ###############################################################################
 # .. rubric:: Footnotes

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -20,7 +20,7 @@ from dipy.data import get_fnames, small_sphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
@@ -78,7 +78,7 @@ boot_streamline_generator = bootstrap_tracking(
 )
 streamlines = Streamlines(boot_streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_bootstrap_dg.trk")
+save_tractogram(sft, "tractogram_bootstrap_dg.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -114,7 +114,7 @@ peak_streamline_generator = closestpeak_tracking(
 )
 streamlines = Streamlines(peak_streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "closest_peak_dg_CSD.trk")
+save_tractogram(sft, "closest_peak_dg_CSD.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_deterministic.py
+++ b/doc/examples/tracking_deterministic.py
@@ -28,7 +28,7 @@ from dipy.data import default_sphere, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
@@ -81,7 +81,7 @@ streamline_generator = deterministic_tracking(
 streamlines = Streamlines(streamline_generator)
 
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_deterministic.trk")
+save_tractogram(sft, "tractogram_deterministic.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_disco_phantom.py
+++ b/doc/examples/tracking_disco_phantom.py
@@ -24,7 +24,7 @@ from dipy.core.gradients import gradient_table
 from dipy.data import default_sphere, get_fnames
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import load_tractogram, save_trk
+from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
@@ -156,7 +156,7 @@ streamline_generator = deterministic_tracking(
 
 det_streams = Streamlines(streamline_generator)
 sft = StatefulTractogram(det_streams, labels_img, Space.RASMM)
-save_trk(sft, "tractogram_disco_deterministic.trk")
+save_tractogram(sft, "tractogram_disco_deterministic.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -194,7 +194,7 @@ streamline_generator = probabilistic_tracking(
 )
 prob_streams = Streamlines(streamline_generator)
 sft = StatefulTractogram(prob_streams, labels_img, Space.RASMM)
-save_trk(sft, "tractogram_disco_probabilistic.trk")
+save_tractogram(sft, "tractogram_disco_probabilistic.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -239,7 +239,7 @@ streamline_generator = ptt_tracking(
 )
 ptt_streams = Streamlines(streamline_generator)
 sft = StatefulTractogram(ptt_streams, labels_img, Space.RASMM)
-save_trk(sft, "tractogram_disco_ptt.trk")
+save_tractogram(sft, "tractogram_disco_ptt.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_introduction_eudx.py
+++ b/doc/examples/tracking_introduction_eudx.py
@@ -30,7 +30,7 @@ from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.shm import CsaOdfModel
 from dipy.tracking import utils
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
@@ -201,7 +201,7 @@ if has_fury:
 # loaded into other software for visualization or further analysis.
 
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_EuDX.trk", streamlines)
+save_tractogram(sft, "tractogram_EuDX.trx")
 
 ###############################################################################
 # References

--- a/doc/examples/tracking_pft.py
+++ b/doc/examples/tracking_pft.py
@@ -30,7 +30,7 @@ from dipy.data import default_sphere, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking import utils
 from dipy.tracking.stopping_criterion import CmcStoppingCriterion
@@ -122,7 +122,7 @@ pft_streamline_gen = pft_tracking(
 )
 streamlines = Streamlines(pft_streamline_gen)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_pft.trk")
+save_tractogram(sft, "tractogram_pft.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -149,7 +149,7 @@ prob_streamline_generator = probabilistic_tracking(
 )
 streamlines = Streamlines(prob_streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_cmc.trk")
+save_tractogram(sft, "tractogram_probabilistic_cmc.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_probabilistic.py
+++ b/doc/examples/tracking_probabilistic.py
@@ -26,7 +26,7 @@ from dipy.direction import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
@@ -78,7 +78,7 @@ streamline_generator = probabilistic_tracking(
 
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_sf.trk")
+save_tractogram(sft, "tractogram_probabilistic_sf.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -120,7 +120,7 @@ streamline_generator = probabilistic_tracking(
 
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_sh.trk")
+save_tractogram(sft, "tractogram_probabilistic_sh.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -169,7 +169,7 @@ streamline_generator = probabilistic_tracking(
 
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_sh_pfm.trk")
+save_tractogram(sft, "tractogram_probabilistic_sh_pfm.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_ptt.py
+++ b/doc/examples/tracking_ptt.py
@@ -12,7 +12,7 @@ from dipy.data import default_sphere, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion
 from dipy.tracking.streamline import Streamlines
@@ -62,7 +62,7 @@ streamline_generator = ptt_tracking(
 
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_ptt.trk")
+save_tractogram(sft, "tractogram_ptt.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/examples/tracking_rumba.py
+++ b/doc/examples/tracking_rumba.py
@@ -23,7 +23,7 @@ from dipy.data import get_fnames, small_sphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import auto_response_ssst
 from dipy.reconst.rumba import RumbaSDModel
 from dipy.tracking import utils
@@ -142,7 +142,7 @@ window.record(
 )
 
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_rumba.trk")
+save_tractogram(sft, "tractogram_probabilistic_rumba.trx")
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold

--- a/doc/examples/tracking_sfm.py
+++ b/doc/examples/tracking_sfm.py
@@ -17,7 +17,7 @@ from dipy.direction.peaks import peaks_from_model
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst import sfm
 from dipy.reconst.csdeconv import auto_response_ssst
 from dipy.tracking import utils
@@ -157,11 +157,11 @@ if has_fury:
 # Sparse Fascicle Model tracks
 #
 #
-# Finally, we can save these streamlines to a 'trk' file, for use in other
+# Finally, we can save these streamlines to a 'trx' file, for use in other
 # software, or for further analysis.
 
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_sfm_detr.trk")
+save_tractogram(sft, "tractogram_sfm_detr.trx")
 
 ###############################################################################
 # References

--- a/doc/examples/tracking_stopping_criterion.py
+++ b/doc/examples/tracking_stopping_criterion.py
@@ -33,7 +33,7 @@ from dipy.data import default_sphere, get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import save_trk
+from dipy.io.streamline import save_tractogram
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel, auto_response_ssst
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.tracking import utils
@@ -132,7 +132,7 @@ streamline_generator = deterministic_tracking(
 )
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_probabilistic_thresh_all.trk")
+save_tractogram(sft, "tractogram_probabilistic_thresh_all.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -207,7 +207,7 @@ streamline_generator = deterministic_tracking(
 )
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_deterministic_binary_all.trk")
+save_tractogram(sft, "tractogram_deterministic_binary_all.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -312,7 +312,7 @@ streamline_generator = deterministic_tracking(
 )
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_deterministic_act_all.trk")
+save_tractogram(sft, "tractogram_deterministic_act_all.trx")
 
 if has_fury:
     scene = window.Scene()
@@ -341,7 +341,7 @@ streamline_generator = deterministic_tracking(
 )
 streamlines = Streamlines(streamline_generator)
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
-save_trk(sft, "tractogram_deterministic_act_valid.trk")
+save_tractogram(sft, "tractogram_deterministic_act_valid.trx")
 
 if has_fury:
     scene = window.Scene()

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -116,9 +116,9 @@ Practical
 
 4. **Which file formats do you support?**
 
-  Nifti (.nii), Dicom (Siemens(read-only)), Trackvis (.trk), DIPY (.dpy),
-  Numpy (.npy, ,npz), text and any other formats supported by nibabel and
-  pydicom.
+  Nifti (.nii), Dicom (Siemens(read-only)), Trackvis (.trk), DIPY (.dpy), Mrtrix (.tck),
+  TRX community file (.trx), Numpy (.npy, ,npz), text and any other formats supported
+  by nibabel and pydicom.
 
   You can also read/save in Matlab version v4 (Level 1.0), v6 and v7 to 7.2,
   using `scipy.io.loadmat`. For higher versions >= 7.3, you can use pytables_


### PR DESCRIPTION
This PR should fix https://github.com/dipy/dipy/issues/3506.

TRX becomes our new default file format. It shows better performance (memory and speeed). The only drawback could be few visualizations tool support this format but we provide already a CLI to convert TRX to the desired format.

Of course, all the others tracks file format will be always supported.