### PR TITLE
STYLE: Apply `ruff` manually to all files

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -547,7 +547,7 @@ def affine_registration(
                     break
         if not isinstance(func, str) or func not in _METHOD_DICT:
             raise ValueError(
-                f"pipeline[{fi}] must be one of " f"{list(_METHOD_DICT)}, got {func!r}"
+                f"pipeline[{fi}] must be one of {list(_METHOD_DICT)}, got {func!r}"
             )
 
     if pipeline == ["center_of_mass"] and ret_metric:
@@ -812,9 +812,7 @@ motion_correction = partial(
 )
 motion_correction.__doc__ = re.sub(
     "Register.*?volume",
-    "Apply a motion "
-    "correction to a DWI dataset "
-    "(Between-Volumes Motion correction)",
+    "Apply a motion correction to a DWI dataset (Between-Volumes Motion correction)",
     register_dwi_series.__doc__,
     flags=re.DOTALL,
 )

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1351,7 +1351,7 @@ def groupwise_slr(
             centroids[ind2] = centroids2
 
             if verbose:
-                logging.info(f"Iteration: {i_iter} pair: {i_pair+1}/{n_pair}.")
+                logging.info(f"Iteration: {i_iter} pair: {i_pair + 1}/{n_pair}.")
 
         d = np.vstack((d, group_distance(centroids, n_bundle)))
 

--- a/dipy/conftest.py
+++ b/dipy/conftest.py
@@ -71,7 +71,7 @@ class PyxFile(pytest.File):
             match = re.search(r"(dipy/[^\/]+/tests/test_\w+)", str(self.path))
             mod_name = match.group(1) if match else None
             if mod_name is None:
-                raise PyxException("Could not find test module for " f"{self.path}.")
+                raise PyxException(f"Could not find test module for {self.path}.")
             mod_name = mod_name.replace("/", ".")
             mod = importlib.import_module(mod_name)
             for name in dir(mod):

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1384,7 +1384,7 @@ def extract_b0(dwi, b0_mask, *, group_contiguous_b0=False, strategy="mean"):
     strategy = strategy.lower()
     if strategy not in ["first", "all", "mean"]:
         raise ValueError(
-            "Invalid strategy: {}. Valid strategies are: " "first, all, mean.".format(
+            "Invalid strategy: {}. Valid strategies are: first, all, mean.".format(
                 strategy
             )
         )

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -174,8 +174,7 @@ class Sphere:
 
         if not (all_specified == 1 and one_complete == 1):
             raise ValueError(
-                "Sphere must be constructed using either "
-                "(x,y,z), (theta, phi) or xyz."
+                "Sphere must be constructed using either (x,y,z), (theta, phi) or xyz."
             )
 
         if edges is not None and faces is None:

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -29,8 +29,7 @@ def _safe_save(group, array, name):
 
 
 @deprecate_with_version(
-    "dipy.io.peaks.load_peaks is deprecated, Please use"
-    "dipy.io.peaks.load_pam instead",
+    "dipy.io.peaks.load_peaks is deprecated, Please usedipy.io.peaks.load_pam instead",
     since="1.10",
     until="1.12",
 )
@@ -132,8 +131,7 @@ def load_pam(fname, *, verbose=False):
 
 
 @deprecate_with_version(
-    "dipy.io.peaks.save_peaks is deprecated, Please use "
-    "dipy.io.peaks.save_pam instead",
+    "dipy.io.peaks.save_peaks is deprecated, Please use dipy.io.peaks.save_pam instead",
     since="1.10.0",
     until="1.12.0",
 )

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -146,7 +146,7 @@ def load_tractogram(
             reference = filename
         else:
             logging.error(
-                'Reference must be provided, "same" is only ' "available for Trk file."
+                'Reference must be provided, "same" is only available for Trk file.'
             )
             return False
 

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -1069,8 +1069,7 @@ def test_set_partial_dtype_dict_attributes():
     except ValueError:
         assert_(
             False,
-            msg="Partial use of dtype_dict should apply only to the "
-            "relevant portions.",
+            msg="Partial use of dtype_dict should apply only to the relevant portions.",
         )
 
 

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -242,8 +242,7 @@ class MapmriModel(ReconstModel, Cache):
             if global_constraints:
                 if not anisotropic_scaling:
                     raise ValueError(
-                        "Global constraints only available for"
-                        " anistropic_scaling=True."
+                        "Global constraints only available for anistropic_scaling=True."
                     )
                 if radial_order > 10:
                     self.sdp_constraints = load_sdp_constraints("hermite", order=10)

--- a/dipy/reconst/tests/test_cti.py
+++ b/dipy/reconst/tests/test_cti.py
@@ -410,7 +410,6 @@ def test_cti_design_matrix():
     A1 = design_matrix(gtab1, gtab2)
     A2 = design_matrix(gtab2, gtab1)
     # Check if the two matrices are the same
-    assert np.allclose(A1, A2), (
-        "The design matrices are not symmetric for different gradient"
-        "directions order."
-    )
+    assert np.allclose(
+        A1, A2
+    ), "The design matrices are not symmetric for different gradientdirections order."

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -389,8 +389,7 @@ def test_wls_and_ls_fit():
     npt.assert_array_almost_equal(
         tensor_est.quadratic_form[0],
         tensor,
-        err_msg="Calculation of tensor from Y does "
-        "not compare to analytical solution",
+        err_msg="Calculation of tensor from Y does not compare to analytical solution",
     )
     npt.assert_almost_equal(tensor_est.md[0], md)
     npt.assert_array_almost_equal(tensor_est.S0_hat[0], b0, decimal=3)

--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -474,9 +474,7 @@ class RecoBundles:
             pruning_distance=pruning_distance,
         )
         if self.verbose:
-            logger.info(
-                f"Total duration of recognition time" f" is {time()-t:0.3f} s\n"
-            )
+            logger.info(f"Total duration of recognition time is {time() - t:0.3f} s\n")
 
         return pruned_streamlines, self.filtered_indices[labels]
 
@@ -628,9 +626,7 @@ class RecoBundles:
         )
 
         if self.verbose:
-            logger.info(
-                f"Total duration of recognition time" f" is {time()-t:0.3f} s\n"
-            )
+            logger.info(f"Total duration of recognition time is {time() - t:0.3f} s\n")
 
         return pruned_streamlines, self.filtered_indices[labels]
 
@@ -747,7 +743,7 @@ class RecoBundles:
                 logger.info("You have no neighbor streamlines... No bundle recognition")
             return Streamlines([]), []
         if self.verbose:
-            logger.info(f" Number of neighbor streamlines" f" {nb_neighb_streamlines}")
+            logger.info(f" Number of neighbor streamlines {nb_neighb_streamlines}")
             logger.info(f" Duration {time() - t:0.3f} s\n")
 
         return neighb_streamlines, neighb_indices
@@ -899,7 +895,7 @@ class RecoBundles:
         if self.verbose:
             logger.info(f" Number of centroids: {len(rtransf_centroids)}")
             logger.info(
-                f" Number of streamlines after pruning:" f" {len(pruned_streamlines)}"
+                f" Number of streamlines after pruning: {len(pruned_streamlines)}"
             )
             logger.info(f" Duration {time() - t:0.3f} s\n")
 

--- a/dipy/tracking/_utils.py
+++ b/dipy/tracking/_utils.py
@@ -47,5 +47,5 @@ def _to_voxel_coordinates(streamline, lin_T, offset):
     inds = np.dot(streamline, lin_T)
     inds += offset
     if inds.min().round(decimals=6) < 0:
-        raise IndexError("streamline has points that map to negative voxel" " indices")
+        raise IndexError("streamline has points that map to negative voxel indices")
     return inds.astype(np.intp)

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -162,7 +162,7 @@ def connectivity_matrix(
     valid_label_volume = labels_positive and label_volume.ndim == 3
     if not valid_label_volume:
         raise ValueError(
-            "label_volume must be a 3d integer array with" "non-negative label values"
+            "label_volume must be a 3d integer array with non-negative label values"
         )
 
     matrix = np.zeros(

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -42,8 +42,7 @@ def check_dimensions(static, moving):
     """
     if len(static.shape) != len(moving.shape):
         raise ValueError(
-            "Dimension mismatch: The input images must "
-            "have same number of dimensions."
+            "Dimension mismatch: The input images must have same number of dimensions."
         )
 
     if len(static.shape) > 3 and len(moving.shape) > 3:
@@ -366,9 +365,7 @@ class ImageRegistrationFlow(Workflow):
         transform = transform.lower()
         metric = metric.upper()
         if metric != "MI":
-            raise ValueError(
-                "Invalid similarity metric: Please provide a" "valid metric."
-            )
+            raise ValueError("Invalid similarity metric: Please provide avalid metric.")
 
         if progressive:
             pipeline_opt = {

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -1028,8 +1028,7 @@ class ConcatenateTractogramFlow(Workflow):
 
             if not reference:
                 raise ValueError(
-                    "No reference provided. It is needed for tck,"
-                    "fib, dpy or vtk files"
+                    "No reference provided. It is needed for tck,fib, dpy or vtk files"
                 )
 
             tractogram_obj = load_tractogram(fpath, reference, bbox_valid_check=False)
@@ -1186,8 +1185,7 @@ class ConvertTractogramFlow(Workflow):
 
             if not reference and in_extension not in ["trx", "trk"]:
                 raise ValueError(
-                    "No reference provided. It is needed for tck,"
-                    "fib, dpy or vtk files"
+                    "No reference provided. It is needed for tck,fib, dpy or vtk files"
                 )
 
             sft = load_tractogram(fpath, reference, bbox_valid_check=False)

--- a/dipy/workflows/workflow.py
+++ b/dipy/workflows/workflow.py
@@ -103,9 +103,7 @@ class Workflow:
 
         if len(duplicates) > 0:
             if self._force_overwrite:
-                logging.info(
-                    "The following output files are about to be" " overwritten."
-                )
+                logging.info("The following output files are about to be overwritten.")
 
             else:
                 logging.info(

--- a/doc/examples/reconst_ivim.py
+++ b/doc/examples/reconst_ivim.py
@@ -252,7 +252,7 @@ ax.plot(gtab.bvals, ivim_trr_predict, label="trr prediction")
 S0_est, f_est, D_star_est, D_est = ivimfit.model_params[i, j, :]
 
 trr_pro_param_est = (
-    f"S0={S0_est:06.3f} f={f_est:06.4f}\n" f"D*={D_star_est:06.5f} D={D_est:06.5f}"
+    f"S0={S0_est:06.3f} f={f_est:06.4f}\nD*={D_star_est:06.5f} D={D_est:06.5f}"
 )
 text_fit = f"""trr param estimates:\n {trr_pro_param_est}"""
 
@@ -274,7 +274,7 @@ ax.set_ylabel("Signals")
 S0_est, f_est, D_star_est, D_est = ivimfit_vp.model_params[i, j, :]
 
 var_pro_param_est = (
-    f"S0={S0_est:06.3f} f={f_est:06.4f}\n" f"D*={D_star_est:06.5f} D={D_est:06.5f}"
+    f"S0={S0_est:06.3f} f={f_est:06.4f}\nD*={D_star_est:06.5f} D={D_est:06.5f}"
 )
 text_fit = f"""VarPro param estimates:\n{var_pro_param_est}"""
 


### PR DESCRIPTION
Apply `ruff` manually to all files.

Fixes some minor issues where the same sentence had been split into multiple parts unnecessarily.