### PR TITLE
STYLE: Adopt `pathlib` for path manipulation

### DIFF
--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -39,7 +39,7 @@ from dipy.version import version as __version__
 
 
 def get_info():
-    from os.path import dirname
+    from pathlib import Path
     import sys
 
     import numpy
@@ -47,7 +47,7 @@ def get_info():
     import dipy
 
     return {
-        "pkg_path": dirname(__file__),
+        "pkg_path": Path(__file__).resolve().parent,
         "commit_hash": dipy.version.git_revision,
         "sys_version": sys.version,
         "sys_executable": sys.executable,

--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -9,6 +9,7 @@ streamlines.
 import collections.abc
 from functools import partial
 import numbers
+from pathlib import Path
 import re
 from warnings import warn
 
@@ -186,16 +187,16 @@ def register_dwi_to_template(
 
     Parameters
     ----------
-    dwi : 4D array, nifti image or str
+    dwi : 4D array, nifti image, str or Path
         Containing the DWI data, or full path to a nifti file with DWI.
-    gtab : GradientTable or sequence of strings
+    gtab : GradientTable or sequence of strings or Paths
         The gradients associated with the DWI data, or a sequence with
         (fbval, fbvec), full paths to bvals and bvecs files.
     dwi_affine : 4x4 array, optional
         An affine transformation associated with the DWI. Required if data
         is provided as an array. If provided together with nifti/path,
         will over-ride the affine that is in the nifti.
-    template : 3D array, nifti image or str
+    template : 3D array, nifti image, str or Path
         Containing the data for the template, or full path to a nifti file
         with the template data.
     template_affine : 4x4 array, optional
@@ -296,13 +297,13 @@ def read_mapping(disp, domain_img, codomain_img, *, prealign=None):
 
     Parameters
     ----------
-    disp : str or Nifti1Image
+    disp : str, Path or Nifti1Image
         A file of image containing the mapping displacement field in each voxel
         Shape (x, y, z, 3, 2)
 
-    domain_img : str or Nifti1Image
+    domain_img : str, Path or Nifti1Image
 
-    codomain_img : str or Nifti1Image
+    codomain_img : str, Path or Nifti1Image
 
     Returns
     -------
@@ -313,13 +314,13 @@ def read_mapping(disp, domain_img, codomain_img, *, prealign=None):
     See :func:`write_mapping` for the data format expected.
 
     """
-    if isinstance(disp, str):
+    if isinstance(disp, (str, Path)):
         disp_data, disp_affine = load_nifti(disp)
 
-    if isinstance(domain_img, str):
+    if isinstance(domain_img, (str, Path)):
         domain_img = nib.load(domain_img)
 
-    if isinstance(codomain_img, str):
+    if isinstance(codomain_img, (str, Path)):
         codomain_img = nib.load(codomain_img)
 
     mapping = DiffeomorphicMap(
@@ -824,7 +825,7 @@ def streamline_registration(moving, static, *, n_points=100, native_resampled=Fa
 
     Parameters
     ----------
-    moving, static : lists of 3 by n, or str
+    moving, static : lists of 3 by n, str or Path
         The two bundles to be registered. Given either as lists of arrays with
         3D coordinates, or strings containing full paths to these files.
 
@@ -846,9 +847,9 @@ def streamline_registration(moving, static, *, n_points=100, native_resampled=Fa
 
     """
     # Load the streamlines, if you were given a file-name
-    if isinstance(moving, str):
+    if isinstance(moving, (str, Path)):
         moving = load_trk(moving, "same", bbox_valid_check=False).streamlines
-    if isinstance(static, str):
+    if isinstance(static, (str, Path)):
         static = load_trk(static, "same", bbox_valid_check=False).streamlines
 
     srr = StreamlineLinearRegistration()

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -1,4 +1,4 @@
-import os.path as op
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import nibabel as nib
@@ -78,7 +78,7 @@ def test_syn_registration():
         )
 
         npt.assert_equal(warped_moving.shape, subset_t2.shape)
-        mapping_fname = op.join(tmpdir, "mapping.nii.gz")
+        mapping_fname = Path(tmpdir) / "mapping.nii.gz"
         write_mapping(mapping, mapping_fname)
         file_mapping = read_mapping(mapping_fname, subset_b0_img, subset_t2_img)
 
@@ -300,14 +300,14 @@ def test_register_dwi_series_and_motion_correction():
         # Use an abbreviated data-set:
         img = nib.load(fdata)
         data = img.get_fdata()[..., :10]
-        nib.save(nib.Nifti1Image(data, img.affine), op.join(tmpdir, "data.nii.gz"))
+        nib.save(nib.Nifti1Image(data, img.affine), Path(tmpdir) / "data.nii.gz")
         # Save a subset:
         bvals = np.loadtxt(fbval)
         bvecs = np.loadtxt(fbvec)
-        np.savetxt(op.join(tmpdir, "bvals.txt"), bvals[:10])
-        np.savetxt(op.join(tmpdir, "bvecs.txt"), bvecs[:10])
+        np.savetxt(Path(tmpdir) / "bvals.txt", bvals[:10])
+        np.savetxt(Path(tmpdir) / "bvecs.txt", bvecs[:10])
         gtab = dpg.gradient_table(
-            op.join(tmpdir, "bvals.txt"), bvecs=op.join(tmpdir, "bvecs.txt")
+            Path(tmpdir) / "bvals.txt", bvecs=Path(tmpdir) / "bvecs.txt"
         )
         reg_img, reg_affines = register_dwi_series(data, gtab, affine=img.affine)
         reg_img_2, reg_affines_2 = motion_correction(data, gtab, affine=img.affine)
@@ -339,8 +339,8 @@ def test_streamline_registration(rng):
 
     with TemporaryDirectory() as tmpdir:
         for use_aff in [None, base_aff]:
-            fname1 = op.join(tmpdir, "sl1.trk")
-            fname2 = op.join(tmpdir, "sl2.trk")
+            fname1 = Path(tmpdir) / "sl1.trk"
+            fname2 = Path(tmpdir) / "sl2.trk"
             if use_aff is not None:
                 img = nib.Nifti1Image(np.zeros((2, 2, 2)), use_aff)
                 # Move the streamlines to this other space, and report it:

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from warnings import warn
 
 import numpy as np
@@ -705,9 +706,9 @@ def gradient_table(
 
     # If you provided strings with full paths, we go and load those from
     # the files:
-    if isinstance(bvals, str):
+    if isinstance(bvals, (str, Path)):
         bvals, _ = io.read_bvals_bvecs(bvals, None)
-    if isinstance(bvecs, str):
+    if isinstance(bvecs, (str, Path)):
         _, bvecs = io.read_bvals_bvecs(None, bvecs)
 
     bvals = np.asarray(bvals)

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -2,7 +2,8 @@
 
 import gzip
 import json
-from os.path import dirname, exists, join as pjoin
+from os.path import dirname, exists
+from pathlib import Path
 import pickle
 
 import numpy as np
@@ -151,14 +152,14 @@ def loads_compat(byte_data):
     return pickle.loads(byte_data, encoding="latin1")
 
 
-DATA_DIR = pjoin(dirname(__file__), "files")
+DATA_DIR = Path(dirname(__file__)) / "files"
 SPHERE_FILES = {
-    "symmetric362": pjoin(DATA_DIR, "evenly_distributed_sphere_362.npz"),
-    "symmetric642": pjoin(DATA_DIR, "evenly_distributed_sphere_642.npz"),
-    "symmetric724": pjoin(DATA_DIR, "evenly_distributed_sphere_724.npz"),
-    "repulsion724": pjoin(DATA_DIR, "repulsion724.npz"),
-    "repulsion100": pjoin(DATA_DIR, "repulsion100.npz"),
-    "repulsion200": pjoin(DATA_DIR, "repulsion200.npz"),
+    "symmetric362": Path(DATA_DIR) / "evenly_distributed_sphere_362.npz",
+    "symmetric642": Path(DATA_DIR) / "evenly_distributed_sphere_642.npz",
+    "symmetric724": Path(DATA_DIR) / "evenly_distributed_sphere_724.npz",
+    "repulsion724": Path(DATA_DIR) / "repulsion724.npz",
+    "repulsion100": Path(DATA_DIR) / "repulsion100.npz",
+    "repulsion200": Path(DATA_DIR) / "repulsion200.npz",
 }
 
 
@@ -206,11 +207,11 @@ def get_sim_voxels(*, name="fib1"):
 
     """
     if name == "fib0":
-        fname = pjoin(DATA_DIR, "fib0.pkl.gz")
+        fname = Path(DATA_DIR) / "fib0.pkl.gz"
     if name == "fib1":
-        fname = pjoin(DATA_DIR, "fib1.pkl.gz")
+        fname = Path(DATA_DIR) / "fib1.pkl.gz"
     if name == "fib2":
-        fname = pjoin(DATA_DIR, "fib2.pkl.gz")
+        fname = Path(DATA_DIR) / "fib2.pkl.gz"
     return loads_compat(gzip.open(fname, "rb").read())
 
 
@@ -238,9 +239,9 @@ def get_skeleton(*, name="C1"):
 
     """
     if name == "C1":
-        fname = pjoin(DATA_DIR, "C1.pkl.gz")
+        fname = Path(DATA_DIR) / "C1.pkl.gz"
     if name == "C3":
-        fname = pjoin(DATA_DIR, "C3.pkl.gz")
+        fname = Path(DATA_DIR) / "C3.pkl.gz"
     return loads_compat(gzip.open(fname, "rb").read())
 
 
@@ -299,7 +300,7 @@ def _gradient_from_file(filename):
     and saved in the dipy data directory"""
 
     def gtab_getter():
-        gradfile = pjoin(DATA_DIR, filename)
+        gradfile = Path(DATA_DIR) / filename
         grad = np.loadtxt(gradfile, delimiter=",")
         gtab = GradientTable(grad)
         return gtab
@@ -360,9 +361,9 @@ def mrtrix_spherical_functions():
     These coefficients were obtained by using the dwi2SH command of mrtrix.
 
     """
-    func_discrete, _ = load_nifti(pjoin(DATA_DIR, "func_discrete.nii.gz"))
-    func_coef, _ = load_nifti(pjoin(DATA_DIR, "func_coef.nii.gz"))
-    gradients = np.loadtxt(pjoin(DATA_DIR, "sphere_grad.txt"))
+    func_discrete, _ = load_nifti(Path(DATA_DIR) / "func_discrete.nii.gz")
+    func_coef, _ = load_nifti(Path(DATA_DIR) / "func_coef.nii.gz")
+    gradients = np.loadtxt(Path(DATA_DIR) / "sphere_grad.txt")
     # gradients[0] and the first volume of func_discrete,
     # func_discrete[..., 0], are associated with the b=0 signal.
     # gradients[:, 3] are the b-values for each gradient/volume.
@@ -377,7 +378,7 @@ def get_cmap(name):
     """Make a callable, similar to maptlotlib.pyplot.get_cmap."""
     global dipy_cmaps
     if dipy_cmaps is None:
-        filename = pjoin(DATA_DIR, "dipy_colormaps.json")
+        filename = Path(DATA_DIR) / "dipy_colormaps.json"
         with open(filename) as f:
             dipy_cmaps = json.load(f)
 
@@ -409,8 +410,8 @@ def two_cingulum_bundles():
 
 
 def matlab_life_results():
-    matlab_rmse = np.load(pjoin(DATA_DIR, "life_matlab_rmse.npy"))
-    matlab_weights = np.load(pjoin(DATA_DIR, "life_matlab_weights.npy"))
+    matlab_rmse = np.load(Path(DATA_DIR) / "life_matlab_rmse.npy")
+    matlab_weights = np.load(Path(DATA_DIR) / "life_matlab_weights.npy")
     return matlab_rmse, matlab_weights
 
 
@@ -451,7 +452,7 @@ def load_sdp_constraints(model_name, *, order=None):
         file += "_SC"
     file += ".npz"
 
-    path = pjoin(DATA_DIR, file)
+    path = Path(DATA_DIR) / file
 
     if not exists(path):
         raise ValueError(f"Constraints file '{file}' not found.")

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -2,8 +2,7 @@ import contextlib
 from hashlib import md5
 import json
 import os
-import os.path as op
-from os.path import join as pjoin
+from pathlib import Path
 import random
 from shutil import copyfileobj
 import tarfile
@@ -30,7 +29,7 @@ from dipy.utils.optpkg import TripWire, optional_package
 if "DIPY_HOME" in os.environ:
     dipy_home = os.environ["DIPY_HOME"]
 else:
-    dipy_home = pjoin(op.expanduser("~"), ".dipy")
+    dipy_home = Path("~").expanduser() / ".dipy"
 
 # The URL to the University of Washington Researchworks repository:
 UW_RW_URL = "https://digital.lib.washington.edu/researchworks/bitstream/handle/"
@@ -192,7 +191,7 @@ def fetch_data(files, folder, *, data_size=None, use_headers=False):
         For each file in `files` the value should be (url, md5). The file will
         be downloaded from url if the file does not already exist or if the
         file exists but the md5 checksum does not match.
-    folder : str
+    folder : str or Path
         The directory where to save the file, the directory will be created if
         it does not already exist.
     data_size : str, optional
@@ -208,7 +207,7 @@ def fetch_data(files, folder, *, data_size=None, use_headers=False):
         value. The downloaded file is not deleted when this error is raised.
 
     """
-    if not op.exists(folder):
+    if not Path(folder).exists():
         logger.info(f"Creating new folder {folder}")
         os.makedirs(folder)
 
@@ -218,8 +217,8 @@ def fetch_data(files, folder, *, data_size=None, use_headers=False):
     all_skip = True
     for f in files:
         url, md5 = files[f]
-        fullpath = pjoin(folder, f)
-        if op.exists(fullpath) and (_get_file_md5(fullpath) == md5):
+        fullpath = Path(folder) / f
+        if fullpath.exists() and (_get_file_md5(fullpath) == md5):
             continue
         all_skip = False
         logger.info(f'Downloading "{f}" to {folder}')
@@ -254,14 +253,14 @@ def _make_fetcher(
     ----------
     name : str
         The name of the fetcher function.
-    folder : str
+    folder : str or Path
         The full path to the folder in which the files would be placed locally.
-        Typically, this is something like 'pjoin(dipy_home, 'foo')'
+        Typically, this is something like 'Path(dipy_home) / 'foo''
     baseurl : str
         The URL from which this fetcher reads files
     remote_fnames : list of strings
         The names of the files in the baseurl location
-    local_fnames : list of strings
+    local_fnames : list of strings or Paths
         The names of the files to be saved on the local filesystem
     md5_list : list of strings, optional
         The md5 checksums of the files. Used to verify the content of the
@@ -298,7 +297,7 @@ def _make_fetcher(
         ) in enumerate(zip(remote_fnames, local_fnames)):
             if n in optional_fnames and not include_optional:
                 continue
-            files[n] = (baseurl + f, md5_list[i] if md5_list is not None else None)
+            files[str(n)] = (baseurl + f, md5_list[i] if md5_list is not None else None)
 
         fetch_data(files, folder, data_size=data_size, use_headers=use_headers)
 
@@ -306,17 +305,17 @@ def _make_fetcher(
             logger.info(msg)
         if unzip:
             for f in local_fnames:
-                split_ext = op.splitext(f)
-                if split_ext[-1] in (".gz", ".bz2"):
-                    if op.splitext(split_ext[0])[-1] == ".tar":
-                        ar = tarfile.open(pjoin(folder, f))
+                p = Path(f)
+                if p.suffix in (".gz", ".bz2"):
+                    if p.with_suffix("").suffix == ".tar":
+                        ar = tarfile.open(Path(folder) / f)
                         ar.extractall(path=folder)
                         ar.close()
                     else:
                         raise ValueError("File extension is not recognized")
-                elif split_ext[-1] == ".zip":
-                    z = zipfile.ZipFile(pjoin(folder, f), "r")
-                    files[f] += (tuple(z.namelist()),)
+                elif p.suffix == ".zip":
+                    z = zipfile.ZipFile(Path(folder) / f, "r")
+                    files[str(f)] += (tuple(z.namelist()),)
                     z.extractall(folder)
                     z.close()
                 else:
@@ -331,10 +330,10 @@ def _make_fetcher(
 
 fetch_isbi2013_2shell = _make_fetcher(
     "fetch_isbi2013_2shell",
-    pjoin(dipy_home, "isbi2013"),
+    Path(dipy_home) / "isbi2013",
     UW_RW_URL + "1773/38465/",
     ["phantom64.nii.gz", "phantom64.bval", "phantom64.bvec"],
-    ["phantom64.nii.gz", "phantom64.bval", "phantom64.bvec"],
+    [Path("phantom64.nii.gz"), Path("phantom64.bval"), Path("phantom64.bvec")],
     md5_list=[
         "42911a70f232321cf246315192d69c42",
         "90e8cf66e0f4d9737a3b3c0da24df5ea",
@@ -346,20 +345,20 @@ fetch_isbi2013_2shell = _make_fetcher(
 
 fetch_stanford_labels = _make_fetcher(
     "fetch_stanford_labels",
-    pjoin(dipy_home, "stanford_hardi"),
+    Path(dipy_home) / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["aparc-reduced.nii.gz", "label_info.txt"],
-    ["aparc-reduced.nii.gz", "label_info.txt"],
+    [Path("aparc-reduced.nii.gz"), Path("label_info.txt")],
     md5_list=["742de90090d06e687ce486f680f6d71a", "39db9f0f5e173d7a2c2e51b07d5d711b"],
     doc="Download reduced freesurfer aparc image from stanford web site",
 )
 
 fetch_sherbrooke_3shell = _make_fetcher(
     "fetch_sherbrooke_3shell",
-    pjoin(dipy_home, "sherbrooke_3shell"),
+    Path(dipy_home) / "sherbrooke_3shell",
     UW_RW_URL + "1773/38475/",
     ["HARDI193.nii.gz", "HARDI193.bval", "HARDI193.bvec"],
-    ["HARDI193.nii.gz", "HARDI193.bval", "HARDI193.bvec"],
+    [Path("HARDI193.nii.gz"), Path("HARDI193.bval"), Path("HARDI193.bvec")],
     md5_list=[
         "0b735e8f16695a37bfbd66aab136eb66",
         "e9b9bb56252503ea49d31fb30a0ac637",
@@ -371,10 +370,10 @@ fetch_sherbrooke_3shell = _make_fetcher(
 
 fetch_stanford_hardi = _make_fetcher(
     "fetch_stanford_hardi",
-    pjoin(dipy_home, "stanford_hardi"),
+    Path(dipy_home) / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["dwi.nii.gz", "dwi.bvals", "dwi.bvecs"],
-    ["HARDI150.nii.gz", "HARDI150.bval", "HARDI150.bvec"],
+    [Path("HARDI150.nii.gz"), Path("HARDI150.bval"), Path("HARDI150.bvec")],
     md5_list=[
         "0b18513b46132b4d1051ed3364f2acbc",
         "4e08ee9e2b1d2ec3fddb68c70ae23c36",
@@ -385,35 +384,35 @@ fetch_stanford_hardi = _make_fetcher(
 
 fetch_resdnn_tf_weights = _make_fetcher(
     "fetch_resdnn_tf_weights",
-    pjoin(dipy_home, "histo_resdnn_weights"),
+    Path(dipy_home) / "histo_resdnn_weights",
     "https://ndownloader.figshare.com/files/",
     ["22736240"],
-    ["resdnn_weights_mri_2018.h5"],
+    [Path("resdnn_weights_mri_2018.h5")],
     md5_list=["f0e118d72ab804a464494bd9015227f4"],
     doc="Download ResDNN Tensorflow model weights for Nath et. al 2018",
 )
 
 fetch_resdnn_torch_weights = _make_fetcher(
     "fetch_resdnn_torch_weights",
-    pjoin(dipy_home, "histo_resdnn_weights"),
+    Path(dipy_home) / "histo_resdnn_weights",
     "https://ndownloader.figshare.com/files/",
     ["50019429"],
-    ["histo_weights.pth"],
+    [Path("histo_weights.pth")],
     md5_list=["ca13692bbbaea725ff8b5df2d3a2779a"],
     doc="Download ResDNN Pytorch model weights for Nath et. al 2018",
 )
 
 fetch_synb0_weights = _make_fetcher(
     "fetch_synb0_weights",
-    pjoin(dipy_home, "synb0"),
+    Path(dipy_home) / "synb0",
     "https://ndownloader.figshare.com/files/",
     ["36379914", "36379917", "36379920", "36379923", "36379926"],
     [
-        "synb0_default_weights1.h5",
-        "synb0_default_weights2.h5",
-        "synb0_default_weights3.h5",
-        "synb0_default_weights4.h5",
-        "synb0_default_weights5.h5",
+        Path("synb0_default_weights1.h5"),
+        Path("synb0_default_weights2.h5"),
+        Path("synb0_default_weights3.h5"),
+        Path("synb0_default_weights4.h5"),
+        Path("synb0_default_weights5.h5"),
     ],
     md5_list=[
         "a9362c75bc28616167a11a42fe5d004e",
@@ -427,67 +426,67 @@ fetch_synb0_weights = _make_fetcher(
 
 fetch_synb0_test = _make_fetcher(
     "fetch_synb0_test",
-    pjoin(dipy_home, "synb0"),
+    Path(dipy_home) / "synb0",
     "https://ndownloader.figshare.com/files/",
     ["36379911", "36671850"],
-    ["test_input_synb0.npz", "test_output_synb0.npz"],
+    [Path("test_input_synb0.npz"), Path("test_output_synb0.npz")],
     md5_list=["987203aa73de2dac8770f39ed506dc0c", "515544fbcafd9769785502821b47b661"],
     doc="Download Synb0 test data for Schilling et. al 2019",
 )
 
 fetch_deepn4_tf_weights = _make_fetcher(
     "fetch_deepn4_tf_weights",
-    pjoin(dipy_home, "deepn4"),
+    Path(dipy_home) / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["44673313"],
-    ["model_weights.h5"],
+    [Path("model_weights.h5")],
     md5_list=["ef264edd554177a180cf99162dbd2745"],
     doc="Download DeepN4 model weights for Kanakaraj et. al 2024",
 )
 
 fetch_deepn4_torch_weights = _make_fetcher(
     "fetch_deepn4_torch_weights",
-    pjoin(dipy_home, "deepn4"),
+    Path(dipy_home) / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["52285805"],
-    ["deepn4_torch_weights"],
+    [Path("deepn4_torch_weights")],
     md5_list=["97c5a5f8356a3d0eeca1c6bb7949c8b8"],
     doc="Download DeepN4 model weights for Kanakaraj et. al 2024",
 )
 
 fetch_deepn4_test = _make_fetcher(
     "fetch_deepn4_test",
-    pjoin(dipy_home, "deepn4"),
+    Path(dipy_home) / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["48842938", "52454531"],
-    ["test_input_deepn4.npz", "new_test_output_deepn4.npz"],
+    [Path("test_input_deepn4.npz"), Path("new_test_output_deepn4.npz")],
     md5_list=["07aa7cc7c7f839683a0aad5bb853605b", "6da15c4358fd13c99773eedeb93953c7"],
     doc="Download DeepN4 test data for Kanakaraj et. al 2024",
 )
 
 fetch_evac_tf_weights = _make_fetcher(
     "fetch_evac_tf_weights",
-    pjoin(dipy_home, "evac"),
+    Path(dipy_home) / "evac",
     "https://ndownloader.figshare.com/files/",
     ["43037191"],
-    ["evac_default_weights.h5"],
+    [Path("evac_default_weights.h5")],
     md5_list=["491cfa4f9a2860fad6c19f2b71b918e1"],
     doc="Download EVAC+ model weights for Park et. al 2022",
 )
 
 fetch_evac_torch_weights = _make_fetcher(
     "fetch_evac_torch_weights",
-    pjoin(dipy_home, "evac"),
+    Path(dipy_home) / "evac",
     "https://ndownloader.figshare.com/files/",
     ["50019432"],
-    ["evac_weights.pth"],
+    [Path("evac_weights.pth")],
     md5_list=["b2bab512a0f899f089d9dd9ffc44f65b"],
     doc="Download EVAC+ model weights for Park et. al 2022",
 )
 
 fetch_evac_test = _make_fetcher(
     "fetch_evac_test",
-    pjoin(dipy_home, "evac"),
+    Path(dipy_home) / "evac",
     "https://ndownloader.figshare.com/files/",
     ["48891958"],
     ["evac_test_data.npz"],
@@ -497,7 +496,7 @@ fetch_evac_test = _make_fetcher(
 
 fetch_stanford_t1 = _make_fetcher(
     "fetch_stanford_t1",
-    pjoin(dipy_home, "stanford_hardi"),
+    Path(dipy_home) / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["t1.nii.gz"],
     ["t1.nii.gz"],
@@ -506,10 +505,10 @@ fetch_stanford_t1 = _make_fetcher(
 
 fetch_stanford_pve_maps = _make_fetcher(
     "fetch_stanford_pve_maps",
-    pjoin(dipy_home, "stanford_hardi"),
+    Path(dipy_home) / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["pve_csf.nii.gz", "pve_gm.nii.gz", "pve_wm.nii.gz"],
-    ["pve_csf.nii.gz", "pve_gm.nii.gz", "pve_wm.nii.gz"],
+    [Path("pve_csf.nii.gz"), Path("pve_gm.nii.gz"), Path("pve_wm.nii.gz")],
     md5_list=[
         "2c498e4fed32bca7f726e28aa86e9c18",
         "1654b20aeb35fc2734a0d7928b713874",
@@ -519,13 +518,13 @@ fetch_stanford_pve_maps = _make_fetcher(
 
 fetch_stanford_tracks = _make_fetcher(
     "fetch_stanford_tracks",
-    pjoin(dipy_home, "stanford_hardi"),
+    Path(dipy_home) / "stanford_hardi",
     "https://raw.githubusercontent.com/dipy/dipy_datatest/main/",
     [
         "hardi-lr-superiorfrontal.trk",
     ],
     [
-        "hardi-lr-superiorfrontal.trk",
+        Path("hardi-lr-superiorfrontal.trk"),
     ],
     md5_list=[
         "2d49aaf6ad6c10d8d069bfb319bf3541",
@@ -536,10 +535,15 @@ fetch_stanford_tracks = _make_fetcher(
 
 fetch_taiwan_ntu_dsi = _make_fetcher(
     "fetch_taiwan_ntu_dsi",
-    pjoin(dipy_home, "taiwan_ntu_dsi"),
+    Path(dipy_home) / "taiwan_ntu_dsi",
     UW_RW_URL + "1773/38480/",
     ["DSI203.nii.gz", "DSI203.bval", "DSI203.bvec", "DSI203_license.txt"],
-    ["DSI203.nii.gz", "DSI203.bval", "DSI203.bvec", "DSI203_license.txt"],
+    [
+        Path("DSI203.nii.gz"),
+        Path("DSI203.bval"),
+        Path("DSI203.bvec"),
+        Path("DSI203_license.txt"),
+    ],
     md5_list=[
         "950408c0980a7154cb188666a885a91f",
         "602e5cb5fad2e7163e8025011d8a6755",
@@ -554,10 +558,10 @@ fetch_taiwan_ntu_dsi = _make_fetcher(
 
 fetch_syn_data = _make_fetcher(
     "fetch_syn_data",
-    pjoin(dipy_home, "syn_test"),
+    Path(dipy_home) / "syn_test",
     UW_RW_URL + "1773/38476/",
     ["t1.nii.gz", "b0.nii.gz"],
-    ["t1.nii.gz", "b0.nii.gz"],
+    [Path("t1.nii.gz"), Path("b0.nii.gz")],
     md5_list=["701bda02bb769655c7d4a9b1df2b73a6", "e4b741f0c77b6039e67abb2885c97a78"],
     data_size="12MB",
     doc="Download t1 and b0 volumes from the same session",
@@ -565,7 +569,7 @@ fetch_syn_data = _make_fetcher(
 
 fetch_mni_template = _make_fetcher(
     "fetch_mni_template",
-    pjoin(dipy_home, "mni_template"),
+    Path(dipy_home) / "mni_template",
     "https://ndownloader.figshare.com/files/",
     [
         "5572676?private_link=4b8666116a0128560fb5",
@@ -574,10 +578,10 @@ fetch_mni_template = _make_fetcher(
         "5572661?private_link=584319b23e7343fed707",
     ],
     [
-        "mni_icbm152_t2_tal_nlin_asym_09a.nii",
-        "mni_icbm152_t1_tal_nlin_asym_09a.nii",
-        "mni_icbm152_t1_tal_nlin_asym_09c_mask.nii",
-        "mni_icbm152_t1_tal_nlin_asym_09c.nii",
+        Path("mni_icbm152_t2_tal_nlin_asym_09a.nii"),
+        Path("mni_icbm152_t1_tal_nlin_asym_09a.nii"),
+        Path("mni_icbm152_t1_tal_nlin_asym_09c_mask.nii"),
+        Path("mni_icbm152_t1_tal_nlin_asym_09c.nii"),
     ],
     md5_list=[
         "f41f2e1516d880547fbf7d6a83884f0d",
@@ -594,7 +598,7 @@ fetch_scil_b0 = _make_fetcher(
     dipy_home,
     UW_RW_URL + "1773/38479/",
     ["datasets_multi-site_all_companies.zip"],
-    ["datasets_multi-site_all_companies.zip"],
+    [Path("datasets_multi-site_all_companies.zip")],
     md5_list=["e9810fa5bf21b99da786647994d7d5b7"],
     doc="Download b=0 datasets from multiple MR systems (GE, Philips, "
     + "Siemens) and different magnetic fields (1.5T and 3T)",
@@ -604,10 +608,10 @@ fetch_scil_b0 = _make_fetcher(
 
 fetch_bundles_2_subjects = _make_fetcher(
     "fetch_bundles_2_subjects",
-    pjoin(dipy_home, "exp_bundles_and_maps"),
+    Path(dipy_home) / "exp_bundles_and_maps",
     UW_RW_URL + "1773/38477/",
     ["bundles_2_subjects.tar.gz"],
-    ["bundles_2_subjects.tar.gz"],
+    [Path("bundles_2_subjects.tar.gz")],
     md5_list=["97756fbef11ce2df31f1bedf1fc7aac7"],
     data_size="234MB",
     doc="Download 2 subjects from the SNAIL dataset with their bundles",
@@ -616,10 +620,10 @@ fetch_bundles_2_subjects = _make_fetcher(
 
 fetch_ivim = _make_fetcher(
     "fetch_ivim",
-    pjoin(dipy_home, "ivim"),
+    Path(dipy_home) / "ivim",
     "https://ndownloader.figshare.com/files/",
     ["5305243", "5305246", "5305249"],
-    ["ivim.nii.gz", "ivim.bval", "ivim.bvec"],
+    [Path("ivim.nii.gz"), Path("ivim.bval"), Path("ivim.bvec")],
     md5_list=[
         "cda596f89dc2676af7d9bf1cabccf600",
         "f03d89f84aa9a9397103a400e43af43a",
@@ -630,7 +634,7 @@ fetch_ivim = _make_fetcher(
 
 fetch_cfin_multib = _make_fetcher(
     "fetch_cfin_multib",
-    pjoin(dipy_home, "cfin_multib"),
+    Path(dipy_home) / "cfin_multib",
     UW_RW_URL + "/1773/38488/",
     [
         "T1.nii",
@@ -639,10 +643,10 @@ fetch_cfin_multib = _make_fetcher(
         "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bvec",
     ],
     [
-        "T1.nii",
-        "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii",
-        "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bval",
-        "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bvec",
+        Path("T1.nii"),
+        Path("__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii"),
+        Path("__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bval"),
+        Path("__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bvec"),
     ],
     md5_list=[
         "889883b5e7d93a6e372bc760ea887e7c",
@@ -660,7 +664,7 @@ fetch_cfin_multib = _make_fetcher(
 
 fetch_file_formats = _make_fetcher(
     "bundle_file_formats_example",
-    pjoin(dipy_home, "bundle_file_formats_example"),
+    Path(dipy_home) / "bundle_file_formats_example",
     "https://zenodo.org/record/3352379/files/",
     [
         "cc_m_sub.trk",
@@ -671,12 +675,12 @@ fetch_file_formats = _make_fetcher(
         "template0.nii.gz",
     ],
     [
-        "cc_m_sub.trk",
-        "laf_m_sub.tck",
-        "lpt_m_sub.fib",
-        "raf_m_sub.vtk",
-        "rpt_m_sub.dpy",
-        "template0.nii.gz",
+        Path("cc_m_sub.trk"),
+        Path("laf_m_sub.tck"),
+        Path("lpt_m_sub.fib"),
+        Path("raf_m_sub.vtk"),
+        Path("rpt_m_sub.dpy"),
+        Path("template0.nii.gz"),
     ],
     md5_list=[
         "78ed7bead3e129fb4b4edd6da1d7e2d2",
@@ -692,10 +696,10 @@ fetch_file_formats = _make_fetcher(
 
 fetch_bundle_atlas_hcp842 = _make_fetcher(
     "fetch_bundle_atlas_hcp842",
-    pjoin(dipy_home, "bundle_atlas_hcp842"),
+    Path(dipy_home) / "bundle_atlas_hcp842",
     "https://ndownloader.figshare.com/files/",
     ["13638644"],
-    ["Atlas_80_Bundles.zip"],
+    [Path("Atlas_80_Bundles.zip")],
     md5_list=["78331d527a10ec000d4f33bac472e099"],
     doc="Download atlas tractogram from the hcp842 dataset with 80 bundles",
     data_size="300MB",
@@ -704,10 +708,10 @@ fetch_bundle_atlas_hcp842 = _make_fetcher(
 
 fetch_30_bundle_atlas_hcp842 = _make_fetcher(
     "fetch_30_bundle_atlas_hcp842",
-    pjoin(dipy_home, "bundle_atlas_hcp842"),
+    Path(dipy_home) / "bundle_atlas_hcp842",
     "https://ndownloader.figshare.com/files/",
     ["26842853"],
-    ["Atlas_30_Bundles.zip"],
+    [Path("Atlas_30_Bundles.zip")],
     md5_list=["f3922cdbea4216823798fade128d6782"],
     doc="Download atlas tractogram from the hcp842 dataset with 30 bundles",
     data_size="207.09MB",
@@ -716,10 +720,10 @@ fetch_30_bundle_atlas_hcp842 = _make_fetcher(
 
 fetch_target_tractogram_hcp = _make_fetcher(
     "fetch_target_tractogram_hcp",
-    pjoin(dipy_home, "target_tractogram_hcp"),
+    Path(dipy_home) / "target_tractogram_hcp",
     "https://ndownloader.figshare.com/files/",
     ["12871127"],
-    ["hcp_tractogram.zip"],
+    [Path("hcp_tractogram.zip")],
     md5_list=["fa25ef19c9d3748929b6423397963b6a"],
     doc="Download tractogram of one of the hcp dataset subjects",
     data_size="541MB",
@@ -729,10 +733,10 @@ fetch_target_tractogram_hcp = _make_fetcher(
 
 fetch_bundle_fa_hcp = _make_fetcher(
     "fetch_bundle_fa_hcp",
-    pjoin(dipy_home, "bundle_fa_hcp"),
+    Path(dipy_home) / "bundle_fa_hcp",
     "https://ndownloader.figshare.com/files/",
     ["14035265"],
-    ["hcp_bundle_fa.nii.gz"],
+    [Path("hcp_bundle_fa.nii.gz")],
     md5_list=["2d5c0036b0575597378ddf39191028ea"],
     doc=("Download map of FA within two bundles in one of the hcp dataset subjects"),
     data_size="230kb",
@@ -741,7 +745,7 @@ fetch_bundle_fa_hcp = _make_fetcher(
 
 fetch_qtdMRI_test_retest_2subjects = _make_fetcher(
     "fetch_qtdMRI_test_retest_2subjects",
-    pjoin(dipy_home, "qtdMRI_test_retest_2subjects"),
+    Path(dipy_home) / "qtdMRI_test_retest_2subjects",
     "https://zenodo.org/record/996889/files/",
     [
         "subject1_dwis_test.nii.gz",
@@ -758,18 +762,18 @@ fetch_qtdMRI_test_retest_2subjects = _make_fetcher(
         "subject2_scheme_retest.txt",
     ],
     [
-        "subject1_dwis_test.nii.gz",
-        "subject2_dwis_test.nii.gz",
-        "subject1_dwis_retest.nii.gz",
-        "subject2_dwis_retest.nii.gz",
-        "subject1_ccmask_test.nii.gz",
-        "subject2_ccmask_test.nii.gz",
-        "subject1_ccmask_retest.nii.gz",
-        "subject2_ccmask_retest.nii.gz",
-        "subject1_scheme_test.txt",
-        "subject2_scheme_test.txt",
-        "subject1_scheme_retest.txt",
-        "subject2_scheme_retest.txt",
+        Path("subject1_dwis_test.nii.gz"),
+        Path("subject2_dwis_test.nii.gz"),
+        Path("subject1_dwis_retest.nii.gz"),
+        Path("subject2_dwis_retest.nii.gz"),
+        Path("subject1_ccmask_test.nii.gz"),
+        Path("subject2_ccmask_test.nii.gz"),
+        Path("subject1_ccmask_retest.nii.gz"),
+        Path("subject2_ccmask_retest.nii.gz"),
+        Path("subject1_scheme_test.txt"),
+        Path("subject2_scheme_test.txt"),
+        Path("subject1_scheme_retest.txt"),
+        Path("subject2_scheme_retest.txt"),
     ],
     md5_list=[
         "ebd7441f32c40e25c28b9e069bd81981",
@@ -792,7 +796,7 @@ fetch_qtdMRI_test_retest_2subjects = _make_fetcher(
 
 fetch_gold_standard_io = _make_fetcher(
     "fetch_gold_standard_io",
-    pjoin(dipy_home, "gold_standard_io"),
+    Path(dipy_home) / "gold_standard_io",
     "https://zenodo.org/record/14538513/files/",
     [
         "gs_streamlines.trk",
@@ -828,37 +832,37 @@ fetch_gold_standard_io = _make_fetcher(
         "streamlines_data.json",
     ],
     [
-        "gs_streamlines.trk",
-        "gs_streamlines.tck",
-        "gs_streamlines.trx",
-        "gs_streamlines.fib",
-        "gs_streamlines.vtk",
-        "gs_streamlines.dpy",
-        "gs_mesh_faces.txt",
-        "gs_mesh.gii",
-        "gs_mesh_lpsmm_corner.ply",
-        "gs_mesh_lpsmm_center.ply",
-        "gs_mesh_rasmm_center.ply",
-        "gs_mesh_rasmm_corner.ply",
-        "gs_mesh_vox_center.ply",
-        "gs_mesh_vox_corner.ply",
-        "gs_mesh_voxmm_center.ply",
-        "gs_mesh_voxmm_corner.ply",
-        "gs_volume.nii",
-        "gs_volume_3mm.nii",
-        "gs_streamlines_rasmm_space.txt",
-        "gs_streamlines_voxmm_space.txt",
-        "gs_streamlines_vox_space.txt",
-        "gs_mesh_rasmm_corner.txt",
-        "gs_mesh_rasmm_center.txt",
-        "gs_mesh_lpsmm_corner.txt",
-        "gs_mesh_lpsmm_center.txt",
-        "gs_mesh_voxmm_corner.txt",
-        "gs_mesh_voxmm_center.txt",
-        "gs_mesh_vox_corner.txt",
-        "gs_mesh_vox_center.txt",
-        "points_data.json",
-        "streamlines_data.json",
+        Path("gs_streamlines.trk"),
+        Path("gs_streamlines.tck"),
+        Path("gs_streamlines.trx"),
+        Path("gs_streamlines.fib"),
+        Path("gs_streamlines.vtk"),
+        Path("gs_streamlines.dpy"),
+        Path("gs_mesh_faces.txt"),
+        Path("gs_mesh.gii"),
+        Path("gs_mesh_lpsmm_corner.ply"),
+        Path("gs_mesh_lpsmm_center.ply"),
+        Path("gs_mesh_rasmm_center.ply"),
+        Path("gs_mesh_rasmm_corner.ply"),
+        Path("gs_mesh_vox_center.ply"),
+        Path("gs_mesh_vox_corner.ply"),
+        Path("gs_mesh_voxmm_center.ply"),
+        Path("gs_mesh_voxmm_corner.ply"),
+        Path("gs_volume.nii"),
+        Path("gs_volume_3mm.nii"),
+        Path("gs_streamlines_rasmm_space.txt"),
+        Path("gs_streamlines_voxmm_space.txt"),
+        Path("gs_streamlines_vox_space.txt"),
+        Path("gs_mesh_rasmm_corner.txt"),
+        Path("gs_mesh_rasmm_center.txt"),
+        Path("gs_mesh_lpsmm_corner.txt"),
+        Path("gs_mesh_lpsmm_center.txt"),
+        Path("gs_mesh_voxmm_corner.txt"),
+        Path("gs_mesh_voxmm_center.txt"),
+        Path("gs_mesh_vox_corner.txt"),
+        Path("gs_mesh_vox_center.txt"),
+        Path("points_data.json"),
+        Path("streamlines_data.json"),
     ],
     md5_list=[
         "3acf565779f4d5107f96b2ef90578d64",
@@ -900,7 +904,7 @@ fetch_gold_standard_io = _make_fetcher(
 
 fetch_real_data_io = _make_fetcher(
     "fetch_real_data_io",
-    pjoin(dipy_home, "real_data_io"),
+    Path(dipy_home) / "real_data_io",
     "https://zenodo.org/record/14537772/files/",
     [
         "anat.nii.gz",
@@ -926,27 +930,27 @@ fetch_real_data_io = _make_fetcher(
         "smoothwm.L.surf.gii.gz",
     ],
     [
-        "anat.nii.gz",
-        "baf_lh.orig",
-        "baf_lh.pial",
-        "baf_lh.smoothwm",
-        "baf_rh.orig",
-        "baf_rh.pial",
-        "baf_rh.smoothwm",
-        "baf_t1.nii.gz",
-        "naf_lh.pial",
-        "naf_mni_masked.nii.gz",
-        "pial.L.surf.gii",
-        "pial.L.surf.gii.gz",
-        "saf_lh.orig",
-        "saf_lh.pial",
-        "saf_lh.smoothwm",
-        "saf_rh.orig",
-        "saf_rh.pial",
-        "saf_rh.smoothwm",
-        "saf_t1.nii.gz",
-        "smoothwm.L.surf.gii",
-        "smoothwm.L.surf.gii.gz",
+        Path("anat.nii.gz"),
+        Path("baf_lh.orig"),
+        Path("baf_lh.pial"),
+        Path("baf_lh.smoothwm"),
+        Path("baf_rh.orig"),
+        Path("baf_rh.pial"),
+        Path("baf_rh.smoothwm"),
+        Path("baf_t1.nii.gz"),
+        Path("naf_lh.pial"),
+        Path("naf_mni_masked.nii.gz"),
+        Path("pial.L.surf.gii"),
+        Path("pial.L.surf.gii.gz"),
+        Path("saf_lh.orig"),
+        Path("saf_lh.pial"),
+        Path("saf_lh.smoothwm"),
+        Path("saf_rh.orig"),
+        Path("saf_rh.pial"),
+        Path("saf_rh.smoothwm"),
+        Path("saf_t1.nii.gz"),
+        Path("smoothwm.L.surf.gii"),
+        Path("smoothwm.L.surf.gii.gz"),
     ],
     md5_list=[
         "deb754c933076edf360be8a1842d651b",
@@ -978,10 +982,15 @@ fetch_real_data_io = _make_fetcher(
 
 fetch_qte_lte_pte = _make_fetcher(
     "fetch_qte_lte_pte",
-    pjoin(dipy_home, "qte_lte_pte"),
+    Path(dipy_home) / "qte_lte_pte",
     "https://zenodo.org/record/4624866/files/",
     ["lte-pte.nii.gz", "lte-pte.bval", "lte-pte.bvec", "mask.nii.gz"],
-    ["lte-pte.nii.gz", "lte-pte.bval", "lte-pte.bvec", "mask.nii.gz"],
+    [
+        Path("lte-pte.nii.gz"),
+        Path("lte-pte.bval"),
+        Path("lte-pte.bvec"),
+        Path("mask.nii.gz"),
+    ],
     md5_list=[
         "f378b2cd9f57625512002b9e4c0f1660",
         "5c25d24dd3df8590582ed690507a8769",
@@ -995,7 +1004,7 @@ fetch_qte_lte_pte = _make_fetcher(
 
 fetch_cti_rat1 = _make_fetcher(
     "fetch_cti_rat1",
-    pjoin(dipy_home, "cti_rat1"),
+    Path(dipy_home) / "cti_rat1",
     "https://zenodo.org/record/8276773/files/",
     [
         "Rat1_invivo_cti_data.nii",
@@ -1006,12 +1015,12 @@ fetch_cti_rat1 = _make_fetcher(
         "Rat1_mask.nii",
     ],
     [
-        "Rat1_invivo_cti_data.nii",
-        "bvals1.bval",
-        "bvec1.bvec",
-        "bvals2.bval",
-        "bvec2.bvec",
-        "Rat1_mask.nii",
+        Path("Rat1_invivo_cti_data.nii"),
+        Path("bvals1.bval"),
+        Path("bvec1.bvec"),
+        Path("bvals2.bval"),
+        Path("bvec2.bvec"),
+        Path("Rat1_mask.nii"),
     ],
     md5_list=[
         "2f855e7826f359d80cfd6f094d3a7008",
@@ -1033,10 +1042,10 @@ fetch_cti_rat1 = _make_fetcher(
 
 fetch_fury_surface = _make_fetcher(
     "fetch_fury_surface",
-    pjoin(dipy_home, "fury_surface"),
+    Path(dipy_home) / "fury_surface",
     "https://raw.githubusercontent.com/fury-gl/fury-data/master/surfaces/",
     ["100307_white_lh.vtk"],
-    ["100307_white_lh.vtk"],
+    [Path("100307_white_lh.vtk")],
     md5_list=["dbec91e29af15541a5cb36d80977b26b"],
     doc="Surface for testing and examples",
     data_size="11MB",
@@ -1044,7 +1053,7 @@ fetch_fury_surface = _make_fetcher(
 
 fetch_DiB_70_lte_pte_ste = _make_fetcher(
     "fetch_DiB_70_lte_pte_ste",
-    pjoin(dipy_home, "DiB_70_lte_pte_ste"),
+    Path(dipy_home) / "DiB_70_lte_pte_ste",
     "https://github.com/filip-szczepankiewicz/Szczepankiewicz_DIB_2019/"
     "raw/master/DATA/brain/NII_Boito_SubSamples/",
     [
@@ -1054,10 +1063,10 @@ fetch_DiB_70_lte_pte_ste = _make_fetcher(
         "DiB_mask.nii.gz",
     ],
     [
-        "DiB_70_lte_pte_ste.nii.gz",
-        "bval_DiB_70_lte_pte_ste.bval",
-        "bvec_DiB_70_lte_pte_ste.bvec",
-        "DiB_mask.nii.gz",
+        Path("DiB_70_lte_pte_ste.nii.gz"),
+        Path("bval_DiB_70_lte_pte_ste.bval"),
+        Path("bvec_DiB_70_lte_pte_ste.bvec"),
+        Path("DiB_mask.nii.gz"),
     ],
     doc="Download QTE data with linear, planar, "
     + "and spherical tensor encoding. If using this data please cite "
@@ -1077,7 +1086,7 @@ fetch_DiB_70_lte_pte_ste = _make_fetcher(
 
 fetch_DiB_217_lte_pte_ste = _make_fetcher(
     "fetch_DiB_217_lte_pte_ste",
-    pjoin(dipy_home, "DiB_217_lte_pte_ste"),
+    Path(dipy_home) / "DiB_217_lte_pte_ste",
     "https://github.com/filip-szczepankiewicz/Szczepankiewicz_DIB_2019/"
     "raw/master/DATA/brain/NII_Boito_SubSamples/",
     [
@@ -1088,11 +1097,11 @@ fetch_DiB_217_lte_pte_ste = _make_fetcher(
         "DiB_mask.nii.gz",
     ],
     [
-        "DiB_217_lte_pte_ste_1.nii.gz",
-        "DiB_217_lte_pte_ste_2.nii.gz",
-        "bval_DiB_217_lte_pte_ste.bval",
-        "bvec_DiB_217_lte_pte_ste.bvec",
-        "DiB_mask.nii.gz",
+        Path("DiB_217_lte_pte_ste_1.nii.gz"),
+        Path("DiB_217_lte_pte_ste_2.nii.gz"),
+        Path("bval_DiB_217_lte_pte_ste.bval"),
+        Path("bvec_DiB_217_lte_pte_ste.bvec"),
+        Path("DiB_mask.nii.gz"),
     ],
     doc="Download QTE data with linear, planar, "
     + "and spherical tensor encoding. If using this data please cite "
@@ -1114,10 +1123,10 @@ fetch_DiB_217_lte_pte_ste = _make_fetcher(
 
 fetch_ptt_minimal_dataset = _make_fetcher(
     "fetch_ptt_minimal_dataset",
-    pjoin(dipy_home, "ptt_dataset"),
+    Path(dipy_home) / "ptt_dataset",
     "https://raw.githubusercontent.com/dipy/dipy_datatest/main/",
     ["ptt_fod.nii", "ptt_seed_coords.txt", "ptt_seed_image.nii"],
-    ["ptt_fod.nii", "ptt_seed_coords.txt", "ptt_seed_image.nii"],
+    [Path("ptt_fod.nii"), Path("ptt_seed_coords.txt"), Path("ptt_seed_image.nii")],
     md5_list=[
         "6e454f8088b64e7b85218c71010d8dbe",
         "8c2d71fb95020e2bb1743623eb11c2a6",
@@ -1130,12 +1139,12 @@ fetch_ptt_minimal_dataset = _make_fetcher(
 
 fetch_bundle_warp_dataset = _make_fetcher(
     "fetch_bundle_warp_dataset",
-    pjoin(dipy_home, "bundle_warp"),
+    Path(dipy_home) / "bundle_warp",
     "https://ndownloader.figshare.com/files/",
     ["40026343", "40026346"],
     [
-        "m_UF_L.trk",
-        "s_UF_L.trk",
+        Path("m_UF_L.trk"),
+        Path("s_UF_L.trk"),
     ],
     md5_list=["4db38ca1e80c16d6e3a97f88f0611187", "c1499005baccfab865ce38368d7a4c7f"],
     doc="Download Bundle Warp dataset",
@@ -1144,7 +1153,7 @@ fetch_bundle_warp_dataset = _make_fetcher(
 
 fetch_disco1_dataset = _make_fetcher(
     "fetch_disco1_dataset",
-    pjoin(dipy_home, "disco", "disco_1"),
+    Path(dipy_home) / "disco" / "disco_1",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -1190,47 +1199,47 @@ fetch_disco1_dataset = _make_fetcher(
         "f8878550-061b-40e0-a0c7-5aac5a33e542/file_downloaded",
     ],
     [
-        "DiSCo_gradients.bvals",
-        "DiSCo_gradients_dipy.bvecs",
-        "DiSCo_gradients_fsl.bvecs",
-        "DiSCo_gradients_mrtrix.b",
-        "DiSCo_gradients.scheme",
-        "lowRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz",
-        "lowRes_DiSCo1_ROIs.nii.gz",
-        "lowRes_DiSCo1_mask.nii.gz",
-        "lowRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz",
-        "lowRes_DiSCo1_ROIs-mask.nii.gz",
-        "lowRes_DiSCo1_DWI_Intra.nii.gz",
-        "lowRes_DiSCo1_Strand_Bundle_Count.nii.gz",
-        "lowRes_DiSCo1_Strand_Count.nii.gz",
-        "lowRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz",
-        "lowRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz",
-        "lowRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz",
-        "lowRes_DiSCo1_DWI.nii.gz",
-        "lowRes_DiSCo1_Strand_ODFs.nii.gz",
-        "lowRes_DiSCo1_Strand_Average_Diameter.nii.gz",
-        "lowRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz",
-        "highRes_DiSCo1_Strand_ODFs.nii.gz",
-        "highRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz",
-        "highRes_DiSCo1_DWI.nii.gz",
-        "highRes_DiSCo1_ROIs.nii.gz",
-        "highRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz",
-        "highRes_DiSCo1_mask.nii.gz",
-        "highRes_DiSCo1_Strand_Bundle_Count.nii.gz",
-        "highRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz",
-        "highRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz",
-        "highRes_DiSCo1_Strand_Average_Diameter.nii.gz",
-        "highRes_DiSCo1_Strand_Streamline_Count.nii.gz",
-        "highRes_DiSCo1_DWI_Intra.nii.gz",
-        "highRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz",
-        "highRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz",
-        "highRes_DiSCo1_ROIs-mask.nii.gz",
-        "DiSCo1_Connectivity_Matrix_Strands_Count.txt",
-        "DiSCo1_Connectivity_Matrix_Cross-Sectional_Area.txt",
-        "DiSCo1_Strands_ROIs_Pairs.txt",
-        "DiSCo1_Strands_Diameters.txt",
-        "DiSCo1_Strands_Trajectories.tck",
-        "DiSCo1_Strands_Trajectories.trk",
+        Path("DiSCo_gradients.bvals"),
+        Path("DiSCo_gradients_dipy.bvecs"),
+        Path("DiSCo_gradients_fsl.bvecs"),
+        Path("DiSCo_gradients_mrtrix.b"),
+        Path("DiSCo_gradients.scheme"),
+        Path("lowRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz"),
+        Path("lowRes_DiSCo1_ROIs.nii.gz"),
+        Path("lowRes_DiSCo1_mask.nii.gz"),
+        Path("lowRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz"),
+        Path("lowRes_DiSCo1_ROIs-mask.nii.gz"),
+        Path("lowRes_DiSCo1_DWI_Intra.nii.gz"),
+        Path("lowRes_DiSCo1_Strand_Bundle_Count.nii.gz"),
+        Path("lowRes_DiSCo1_Strand_Count.nii.gz"),
+        Path("lowRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("lowRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz"),
+        Path("lowRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz"),
+        Path("lowRes_DiSCo1_DWI.nii.gz"),
+        Path("lowRes_DiSCo1_Strand_ODFs.nii.gz"),
+        Path("lowRes_DiSCo1_Strand_Average_Diameter.nii.gz"),
+        Path("lowRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz"),
+        Path("highRes_DiSCo1_Strand_ODFs.nii.gz"),
+        Path("highRes_DiSCo1_DWI_RicianNoise-snr50.nii.gz"),
+        Path("highRes_DiSCo1_DWI.nii.gz"),
+        Path("highRes_DiSCo1_ROIs.nii.gz"),
+        Path("highRes_DiSCo1_DWI_RicianNoise-snr40.nii.gz"),
+        Path("highRes_DiSCo1_mask.nii.gz"),
+        Path("highRes_DiSCo1_Strand_Bundle_Count.nii.gz"),
+        Path("highRes_DiSCo1_DWI_RicianNoise-snr20.nii.gz"),
+        Path("highRes_DiSCo1_DWI_RicianNoise-snr30.nii.gz"),
+        Path("highRes_DiSCo1_Strand_Average_Diameter.nii.gz"),
+        Path("highRes_DiSCo1_Strand_Streamline_Count.nii.gz"),
+        Path("highRes_DiSCo1_DWI_Intra.nii.gz"),
+        Path("highRes_DiSCo1_DWI_RicianNoise-snr10.nii.gz"),
+        Path("highRes_DiSCo1_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("highRes_DiSCo1_ROIs-mask.nii.gz"),
+        Path("DiSCo1_Connectivity_Matrix_Strands_Count.txt"),
+        Path("DiSCo1_Connectivity_Matrix_Cross-Sectional_Area.txt"),
+        Path("DiSCo1_Strands_ROIs_Pairs.txt"),
+        Path("DiSCo1_Strands_Diameters.txt"),
+        Path("DiSCo1_Strands_Trajectories.tck"),
+        Path("DiSCo1_Strands_Trajectories.trk"),
     ],
     md5_list=[
         "c03cfec8ee605a54866ef09c3c8ba31d",
@@ -1321,7 +1330,7 @@ fetch_disco1_dataset = _make_fetcher(
 
 fetch_disco2_dataset = _make_fetcher(
     "fetch_disco2_dataset",
-    pjoin(dipy_home, "disco", "disco_2"),
+    Path(dipy_home) / "disco" / "disco_2",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -1367,47 +1376,47 @@ fetch_disco2_dataset = _make_fetcher(
         "e49d38af-e262-46ef-ad44-c51c29ee2178/file_downloaded",
     ],
     [
-        "DiSCo_gradients.bvals",
-        "DiSCo_gradients_dipy.bvecs",
-        "DiSCo_gradients_fsl.bvecs",
-        "DiSCo_gradients_mrtrix.b",
-        "DiSCo_gradients.scheme",
-        "lowRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz",
-        "lowRes_DiSCo2_Strand_Average_Diameter.nii.gz",
-        "lowRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz",
-        "lowRes_DiSCo2_DWI.nii.gz",
-        "lowRes_DiSCo2_ROIs.nii.gz",
-        "lowRes_DiSCo2_mask.nii.gz",
-        "lowRes_DiSCo2_DWI_Intra.nii.gz",
-        "lowRes_DiSCo2_ROIs-mask.nii.gz",
-        "lowRes_DiSCo2_Strand_Count.nii.gz",
-        "lowRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz",
-        "lowRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz",
-        "lowRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz",
-        "lowRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz",
-        "lowRes_DiSCo2_Strand_ODFs.nii.gz",
-        "lowRes_DiSCo2_Strand_Bundle_Count.nii.gz",
-        "highRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz",
-        "highRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz",
-        "highRes_DiSCo2_ROIs-mask.nii.gz",
-        "highRes_DiSCo2_Strand_ODFs.nii.gz",
-        "highRes_DiSCo2_Strand_Count.nii.gz",
-        "highRes_DiSCo2_ROIs.nii.gz",
-        "highRes_DiSCo2_mask.nii.gz",
-        "highRes_DiSCo2_Strand_Average_Diameter.nii.gz",
-        "highRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz",
-        "highRes_DiSCo2_DWI_Intra.nii.gz",
-        "highRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz",
-        "highRes_DiSCo2_DWI.nii.gz",
-        "highRes_DiSCo2_Strand_Bundle_Count.nii.gz",
-        "highRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz",
-        "highRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz",
-        "DiSCo2_Strands_Diameters.txt",
-        "DiSCo2_Connectivity_Matrix_Strands_Count.txt",
-        "DiSCo2_Strands_Trajectories.trk",
-        "DiSCo2_Strands_ROIs_Pairs.txt",
-        "DiSCo2_Strands_Trajectories.tck",
-        "DiSCo2_Connectivity_Matrix_Cross-Sectional_Area.txt",
+        Path("DiSCo_gradients.bvals"),
+        Path("DiSCo_gradients_dipy.bvecs"),
+        Path("DiSCo_gradients_fsl.bvecs"),
+        Path("DiSCo_gradients_mrtrix.b"),
+        Path("DiSCo_gradients.scheme"),
+        Path("lowRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz"),
+        Path("lowRes_DiSCo2_Strand_Average_Diameter.nii.gz"),
+        Path("lowRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz"),
+        Path("lowRes_DiSCo2_DWI.nii.gz"),
+        Path("lowRes_DiSCo2_ROIs.nii.gz"),
+        Path("lowRes_DiSCo2_mask.nii.gz"),
+        Path("lowRes_DiSCo2_DWI_Intra.nii.gz"),
+        Path("lowRes_DiSCo2_ROIs-mask.nii.gz"),
+        Path("lowRes_DiSCo2_Strand_Count.nii.gz"),
+        Path("lowRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz"),
+        Path("lowRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz"),
+        Path("lowRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("lowRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz"),
+        Path("lowRes_DiSCo2_Strand_ODFs.nii.gz"),
+        Path("lowRes_DiSCo2_Strand_Bundle_Count.nii.gz"),
+        Path("highRes_DiSCo2_DWI_RicianNoise-snr40.nii.gz"),
+        Path("highRes_DiSCo2_DWI_RicianNoise-snr50.nii.gz"),
+        Path("highRes_DiSCo2_ROIs-mask.nii.gz"),
+        Path("highRes_DiSCo2_Strand_ODFs.nii.gz"),
+        Path("highRes_DiSCo2_Strand_Count.nii.gz"),
+        Path("highRes_DiSCo2_ROIs.nii.gz"),
+        Path("highRes_DiSCo2_mask.nii.gz"),
+        Path("highRes_DiSCo2_Strand_Average_Diameter.nii.gz"),
+        Path("highRes_DiSCo2_DWI_RicianNoise-snr30.nii.gz"),
+        Path("highRes_DiSCo2_DWI_Intra.nii.gz"),
+        Path("highRes_DiSCo2_DWI_RicianNoise-snr20.nii.gz"),
+        Path("highRes_DiSCo2_DWI.nii.gz"),
+        Path("highRes_DiSCo2_Strand_Bundle_Count.nii.gz"),
+        Path("highRes_DiSCo2_DWI_RicianNoise-snr10.nii.gz"),
+        Path("highRes_DiSCo2_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("DiSCo2_Strands_Diameters.txt"),
+        Path("DiSCo2_Connectivity_Matrix_Strands_Count.txt"),
+        Path("DiSCo2_Strands_Trajectories.trk"),
+        Path("DiSCo2_Strands_ROIs_Pairs.txt"),
+        Path("DiSCo2_Strands_Trajectories.tck"),
+        Path("DiSCo2_Connectivity_Matrix_Cross-Sectional_Area.txt"),
     ],
     md5_list=[
         "c03cfec8ee605a54866ef09c3c8ba31d",
@@ -1498,7 +1507,7 @@ fetch_disco2_dataset = _make_fetcher(
 
 fetch_disco3_dataset = _make_fetcher(
     "fetch_disco3_dataset",
-    pjoin(dipy_home, "disco", "disco_3"),
+    Path(dipy_home) / "disco" / "disco_3",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -1544,47 +1553,47 @@ fetch_disco3_dataset = _make_fetcher(
         "482bcf8f-52eb-4bf8-83b4-765ed935ad81/file_downloaded",
     ],
     [
-        "DiSCo_gradients.bvals",
-        "DiSCo_gradients_dipy.bvecs",
-        "DiSCo_gradients_fsl.bvecs",
-        "DiSCo_gradients_mrtrix.b",
-        "DiSCo_gradients.scheme",
-        "lowRes_DiSCo3_Strand_ODFs.nii.gz",
-        "lowRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz",
-        "lowRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz",
-        "lowRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz",
-        "lowRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz",
-        "lowRes_DiSCo3_Strand_Average_Diameter.nii.gz",
-        "lowRes_DiSCo3_DWI_Intra.nii.gz",
-        "lowRes_DiSCo3_Strand_Count.nii.gz",
-        "lowRes_DiSCo3_DWI.nii.gz",
-        "lowRes_DiSCo3_Strand_Bundle_Count.nii.gz",
-        "lowRes_DiSCo3_ROIs-mask.nii.gz",
-        "lowRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz",
-        "lowRes_DiSCo3_mask.nii.gz",
-        "lowRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz",
-        "lowRes_DiSCo3_ROIs.nii.gz",
-        "highRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz",
-        "highRes_DiSCo3_Strand_Average_Diameter.nii.gz",
-        "highRes_DiSCo3_Strand_Count.nii.gz",
-        "highRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz",
-        "highRes_DiSCo3_DWI.nii.gz",
-        "highRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz",
-        "highRes_DiSCo3_ROIs-mask.nii.gz",
-        "highRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz",
-        "highRes_DiSCo3_Strand_Bundle_Count.nii.gz",
-        "highRes_DiSCo3_DWI_Intra.nii.gz",
-        "highRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz",
-        "highRes_DiSCo3_Strand_ODFs.nii.gz",
-        "highRes_DiSCo3_mask.nii.gz",
-        "highRes_DiSCo3_ROIs.nii.gz",
-        "highRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz",
-        "DiSCo3_Connectivity_Matrix_Cross-Sectional_Area.txt",
-        "DiSCo3_Strands_Trajectories.tck",
-        "DiSCo3_Strands_Trajectories.trk",
-        "DiSCo3_Strands_ROIs_Pairs.txt",
-        "DiSCo3_Connectivity_Matrix_Strands_Count.txt",
-        "DiSCo3_Strands_Diameters.txt",
+        Path("DiSCo_gradients.bvals"),
+        Path("DiSCo_gradients_dipy.bvecs"),
+        Path("DiSCo_gradients_fsl.bvecs"),
+        Path("DiSCo_gradients_mrtrix.b"),
+        Path("DiSCo_gradients.scheme"),
+        Path("lowRes_DiSCo3_Strand_ODFs.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz"),
+        Path("lowRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz"),
+        Path("lowRes_DiSCo3_Strand_Average_Diameter.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_Intra.nii.gz"),
+        Path("lowRes_DiSCo3_Strand_Count.nii.gz"),
+        Path("lowRes_DiSCo3_DWI.nii.gz"),
+        Path("lowRes_DiSCo3_Strand_Bundle_Count.nii.gz"),
+        Path("lowRes_DiSCo3_ROIs-mask.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz"),
+        Path("lowRes_DiSCo3_mask.nii.gz"),
+        Path("lowRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz"),
+        Path("lowRes_DiSCo3_ROIs.nii.gz"),
+        Path("highRes_DiSCo3_DWI_RicianNoise-snr10.nii.gz"),
+        Path("highRes_DiSCo3_Strand_Average_Diameter.nii.gz"),
+        Path("highRes_DiSCo3_Strand_Count.nii.gz"),
+        Path("highRes_DiSCo3_DWI_RicianNoise-snr20.nii.gz"),
+        Path("highRes_DiSCo3_DWI.nii.gz"),
+        Path("highRes_DiSCo3_DWI_RicianNoise-snr30.nii.gz"),
+        Path("highRes_DiSCo3_ROIs-mask.nii.gz"),
+        Path("highRes_DiSCo3_Strand_Intra_Volume_Fraction.nii.gz"),
+        Path("highRes_DiSCo3_Strand_Bundle_Count.nii.gz"),
+        Path("highRes_DiSCo3_DWI_Intra.nii.gz"),
+        Path("highRes_DiSCo3_DWI_RicianNoise-snr50.nii.gz"),
+        Path("highRes_DiSCo3_Strand_ODFs.nii.gz"),
+        Path("highRes_DiSCo3_mask.nii.gz"),
+        Path("highRes_DiSCo3_ROIs.nii.gz"),
+        Path("highRes_DiSCo3_DWI_RicianNoise-snr40.nii.gz"),
+        Path("DiSCo3_Connectivity_Matrix_Cross-Sectional_Area.txt"),
+        Path("DiSCo3_Strands_Trajectories.tck"),
+        Path("DiSCo3_Strands_Trajectories.trk"),
+        Path("DiSCo3_Strands_ROIs_Pairs.txt"),
+        Path("DiSCo3_Connectivity_Matrix_Strands_Count.txt"),
+        Path("DiSCo3_Strands_Diameters.txt"),
     ],
     md5_list=[
         "c03cfec8ee605a54866ef09c3c8ba31d",
@@ -1686,9 +1695,9 @@ def fetch_disco_dataset(*, include_optional=False):
     files_3, folder_3 = fetch_disco3_dataset(include_optional=include_optional)
 
     all_path = (
-        [pjoin(folder_1, f) for f in files_1]
-        + [pjoin(folder_2, f) for f in files_2]
-        + [pjoin(folder_3, f) for f in files_3]
+        [Path(folder_1) / f for f in files_1]
+        + [Path(folder_2) / f for f in files_2]
+        + [Path(folder_3) / f for f in files_3]
     )
 
     return all_path
@@ -1741,131 +1750,133 @@ def get_fnames(*, name="small_64D", include_optional=False):
     True
 
     """
-    DATA_DIR = pjoin(op.dirname(__file__), "files")
+    DATA_DIR = Path(__file__).parent / "files"
     if name == "small_64D":
-        fbvals = pjoin(DATA_DIR, "small_64D.bval")
-        fbvecs = pjoin(DATA_DIR, "small_64D.bvec")
-        fimg = pjoin(DATA_DIR, "small_64D.nii")
+        fbvals = Path(DATA_DIR) / "small_64D.bval"
+        fbvecs = Path(DATA_DIR) / "small_64D.bvec"
+        fimg = Path(DATA_DIR) / "small_64D.nii"
         return fimg, fbvals, fbvecs
     if name == "55dir_grad":
-        fbvals = pjoin(DATA_DIR, "55dir_grad.bval")
-        fbvecs = pjoin(DATA_DIR, "55dir_grad.bvec")
+        fbvals = Path(DATA_DIR) / "55dir_grad.bval"
+        fbvecs = Path(DATA_DIR) / "55dir_grad.bvec"
         return fbvals, fbvecs
     if name == "small_101D":
-        fbvals = pjoin(DATA_DIR, "small_101D.bval")
-        fbvecs = pjoin(DATA_DIR, "small_101D.bvec")
-        fimg = pjoin(DATA_DIR, "small_101D.nii.gz")
+        fbvals = Path(DATA_DIR) / "small_101D.bval"
+        fbvecs = Path(DATA_DIR) / "small_101D.bvec"
+        fimg = Path(DATA_DIR) / "small_101D.nii.gz"
         return fimg, fbvals, fbvecs
     if name == "aniso_vox":
-        return pjoin(DATA_DIR, "aniso_vox.nii.gz")
+        return Path(DATA_DIR) / "aniso_vox.nii.gz"
     if name == "ascm_test":
-        return pjoin(DATA_DIR, "ascm_out_test.nii.gz")
+        return Path(DATA_DIR) / "ascm_out_test.nii.gz"
     if name == "fornix":
-        return pjoin(DATA_DIR, "tracks300.trk")
+        return Path(DATA_DIR) / "tracks300.trk"
     if name == "gqi_vectors":
-        return pjoin(DATA_DIR, "ScannerVectors_GQI101.txt")
+        return Path(DATA_DIR) / "ScannerVectors_GQI101.txt"
     if name == "dsi515btable":
-        return pjoin(DATA_DIR, "dsi515_b_table.txt")
+        return Path(DATA_DIR) / "dsi515_b_table.txt"
     if name == "dsi4169btable":
-        return pjoin(DATA_DIR, "dsi4169_b_table.txt")
+        return Path(DATA_DIR) / "dsi4169_b_table.txt"
     if name == "grad514":
-        return pjoin(DATA_DIR, "grad_514.txt")
+        return Path(DATA_DIR) / "grad_514.txt"
     if name == "small_25":
-        fbvals = pjoin(DATA_DIR, "small_25.bval")
-        fbvecs = pjoin(DATA_DIR, "small_25.bvec")
-        fimg = pjoin(DATA_DIR, "small_25.nii.gz")
+        fbvals = Path(DATA_DIR) / "small_25.bval"
+        fbvecs = Path(DATA_DIR) / "small_25.bvec"
+        fimg = Path(DATA_DIR) / "small_25.nii.gz"
         return fimg, fbvals, fbvecs
     if name == "small_25_streamlines":
-        fstreamlines = pjoin(DATA_DIR, "EuDX_small_25.trk")
+        fstreamlines = Path(DATA_DIR) / "EuDX_small_25.trk"
         return fstreamlines
     if name == "S0_10":
-        fimg = pjoin(DATA_DIR, "S0_10slices.nii.gz")
+        fimg = Path(DATA_DIR) / "S0_10slices.nii.gz"
         return fimg
     if name == "test_piesno":
-        fimg = pjoin(DATA_DIR, "test_piesno.nii.gz")
+        fimg = Path(DATA_DIR) / "test_piesno.nii.gz"
         return fimg
     if name == "reg_c":
-        return pjoin(DATA_DIR, "C.npy")
+        return Path(DATA_DIR) / "C.npy"
     if name == "reg_o":
-        return pjoin(DATA_DIR, "circle.npy")
+        return Path(DATA_DIR) / "circle.npy"
     if name == "cb_2":
-        return pjoin(DATA_DIR, "cb_2.npz")
+        return Path(DATA_DIR) / "cb_2.npz"
     if name == "minimal_bundles":
-        return pjoin(DATA_DIR, "minimal_bundles.zip")
+        return Path(DATA_DIR) / "minimal_bundles.zip"
     if name == "t1_coronal_slice":
-        return pjoin(DATA_DIR, "t1_coronal_slice.npy")
+        return Path(DATA_DIR) / "t1_coronal_slice.npy"
     if name == "t-design":
         N = 45
-        return pjoin(DATA_DIR, f"tdesign{N}.txt")
+        return Path(DATA_DIR) / f"tdesign{N}.txt"
     if name == "scil_b0":
         files, folder = fetch_scil_b0()
         files = files["datasets_multi-site_all_companies.zip"][2]
-        files = [pjoin(folder, f) for f in files]
-        return [f for f in files if op.isfile(f)]
+        files = [Path(folder) / f for f in files]
+        return [f for f in files if f.is_file()]
     if name == "stanford_hardi":
         files, folder = fetch_stanford_hardi()
-        fraw = pjoin(folder, "HARDI150.nii.gz")
-        fbval = pjoin(folder, "HARDI150.bval")
-        fbvec = pjoin(folder, "HARDI150.bvec")
+        fraw = Path(folder) / "HARDI150.nii.gz"
+        fbval = Path(folder) / "HARDI150.bval"
+        fbvec = Path(folder) / "HARDI150.bvec"
         return fraw, fbval, fbvec
     if name == "taiwan_ntu_dsi":
         files, folder = fetch_taiwan_ntu_dsi()
-        fraw = pjoin(folder, "DSI203.nii.gz")
-        fbval = pjoin(folder, "DSI203.bval")
-        fbvec = pjoin(folder, "DSI203.bvec")
+        fraw = Path(folder) / "DSI203.nii.gz"
+        fbval = Path(folder) / "DSI203.bval"
+        fbvec = Path(folder) / "DSI203.bvec"
         return fraw, fbval, fbvec
     if name == "sherbrooke_3shell":
         files, folder = fetch_sherbrooke_3shell()
-        fraw = pjoin(folder, "HARDI193.nii.gz")
-        fbval = pjoin(folder, "HARDI193.bval")
-        fbvec = pjoin(folder, "HARDI193.bvec")
+        fraw = Path(folder) / "HARDI193.nii.gz"
+        fbval = Path(folder) / "HARDI193.bval"
+        fbvec = Path(folder) / "HARDI193.bvec"
         return fraw, fbval, fbvec
     if name == "isbi2013_2shell":
         files, folder = fetch_isbi2013_2shell()
-        fraw = pjoin(folder, "phantom64.nii.gz")
-        fbval = pjoin(folder, "phantom64.bval")
-        fbvec = pjoin(folder, "phantom64.bvec")
+        fraw = Path(folder) / "phantom64.nii.gz"
+        fbval = Path(folder) / "phantom64.bval"
+        fbvec = Path(folder) / "phantom64.bvec"
         return fraw, fbval, fbvec
     if name == "stanford_labels":
         files, folder = fetch_stanford_labels()
-        return pjoin(folder, "aparc-reduced.nii.gz")
+        return Path(folder) / "aparc-reduced.nii.gz"
     if name == "syn_data":
         files, folder = fetch_syn_data()
-        t1_name = pjoin(folder, "t1.nii.gz")
-        b0_name = pjoin(folder, "b0.nii.gz")
+        t1_name = Path(folder) / "t1.nii.gz"
+        b0_name = Path(folder) / "b0.nii.gz"
         return t1_name, b0_name
     if name == "stanford_t1":
         files, folder = fetch_stanford_t1()
-        return pjoin(folder, "t1.nii.gz")
+        return Path(folder) / "t1.nii.gz"
     if name == "stanford_pve_maps":
         files, folder = fetch_stanford_pve_maps()
-        f_pve_csf = pjoin(folder, "pve_csf.nii.gz")
-        f_pve_gm = pjoin(folder, "pve_gm.nii.gz")
-        f_pve_wm = pjoin(folder, "pve_wm.nii.gz")
+        f_pve_csf = Path(folder) / "pve_csf.nii.gz"
+        f_pve_gm = Path(folder) / "pve_gm.nii.gz"
+        f_pve_wm = Path(folder) / "pve_wm.nii.gz"
         return f_pve_csf, f_pve_gm, f_pve_wm
     if name == "ivim":
         files, folder = fetch_ivim()
-        fraw = pjoin(folder, "ivim.nii.gz")
-        fbval = pjoin(folder, "ivim.bval")
-        fbvec = pjoin(folder, "ivim.bvec")
+        fraw = Path(folder) / "ivim.nii.gz"
+        fbval = Path(folder) / "ivim.bval"
+        fbvec = Path(folder) / "ivim.bvec"
         return fraw, fbval, fbvec
     if name == "tissue_data":
         files, folder = fetch_tissue_data()
-        t1_name = pjoin(folder, "t1_brain.nii.gz")
-        t1d_name = pjoin(folder, "t1_brain_denoised.nii.gz")
-        ap_name = pjoin(folder, "power_map.nii.gz")
+        t1_name = Path(folder) / "t1_brain.nii.gz"
+        t1d_name = Path(folder) / "t1_brain_denoised.nii.gz"
+        ap_name = Path(folder) / "power_map.nii.gz"
         return t1_name, t1d_name, ap_name
     if name == "cfin_multib":
         files, folder = fetch_cfin_multib()
-        t1_name = pjoin(folder, "T1.nii")
-        fraw = pjoin(folder, "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii")
-        fbval = pjoin(folder, "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bval")
-        fbvec = pjoin(folder, "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bvec")
+        t1_name = Path(folder) / "T1.nii"
+        fraw = Path(folder) / "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.nii"
+        fbval = Path(folder) / "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bval"
+        fbvec = Path(folder) / "__DTI_AX_ep2d_2_5_iso_33d_20141015095334_4.bvec"
         return fraw, fbval, fbvec, t1_name
     if name == "target_tractrogram_hcp":
         files, folder = fetch_target_tractogram_hcp()
-        return pjoin(
-            folder, "target_tractogram_hcp", "hcp_tractogram", "streamlines.trk"
+        return (
+            Path(folder) / "target_tractogram_hcp",
+            "hcp_tractogram",
+            "streamlines.trk",
         )
     if name == "bundle_atlas_hcp842":
         files, folder = fetch_bundle_atlas_hcp842()
@@ -1875,96 +1886,96 @@ def get_fnames(*, name="small_64D", include_optional=False):
         return get_bundle_atlas_hcp842(size=30)
     if name == "qte_lte_pte":
         _, folder = fetch_qte_lte_pte()
-        fdata = pjoin(folder, "lte-pte.nii.gz")
-        fbval = pjoin(folder, "lte-pte.bval")
-        fbvec = pjoin(folder, "lte-pte.bvec")
-        fmask = pjoin(folder, "mask.nii.gz")
+        fdata = Path(folder) / "lte-pte.nii.gz"
+        fbval = Path(folder) / "lte-pte.bval"
+        fbvec = Path(folder) / "lte-pte.bvec"
+        fmask = Path(folder) / "mask.nii.gz"
         return fdata, fbval, fbvec, fmask
     if name == "cti_rat1":
         _, folder = fetch_cti_rat1()
-        fdata = pjoin(folder, "Rat1_invivo_cti_data.nii")
-        fbval1 = pjoin(folder, "bvals1.bval")
-        fbvec1 = pjoin(folder, "bvec1.bvec")
-        fbval2 = pjoin(folder, "bvals2.bval")
-        fbvec2 = pjoin(folder, "bvec2.bvec")
-        fmask = pjoin(folder, "Rat1_mask.nii")
+        fdata = Path(folder) / "Rat1_invivo_cti_data.nii"
+        fbval1 = Path(folder) / "bvals1.bval"
+        fbvec1 = Path(folder) / "bvec1.bvec"
+        fbval2 = Path(folder) / "bvals2.bval"
+        fbvec2 = Path(folder) / "bvec2.bvec"
+        fmask = Path(folder) / "Rat1_mask.nii"
         return fdata, fbval1, fbvec1, fbval2, fbvec2, fmask
     if name == "fury_surface":
         files, folder = fetch_fury_surface()
-        surface_name = pjoin(folder, "100307_white_lh.vtk")
+        surface_name = Path(folder) / "100307_white_lh.vtk"
         return surface_name
     if name == "histo_resdnn_tf_weights":
         files, folder = fetch_resdnn_tf_weights()
-        wraw = pjoin(folder, "resdnn_weights_mri_2018.h5")
+        wraw = Path(folder) / "resdnn_weights_mri_2018.h5"
         return wraw
     if name == "histo_resdnn_torch_weights":
         files, folder = fetch_resdnn_torch_weights()
-        wraw = pjoin(folder, "histo_weights.pth")
+        wraw = Path(folder) / "histo_weights.pth"
         return wraw
     if name == "synb0_default_weights":
         _, folder = fetch_synb0_weights()
-        w1 = pjoin(folder, "synb0_default_weights1.h5")
-        w2 = pjoin(folder, "synb0_default_weights2.h5")
-        w3 = pjoin(folder, "synb0_default_weights3.h5")
-        w4 = pjoin(folder, "synb0_default_weights4.h5")
-        w5 = pjoin(folder, "synb0_default_weights5.h5")
+        w1 = Path(folder) / "synb0_default_weights1.h5"
+        w2 = Path(folder) / "synb0_default_weights2.h5"
+        w3 = Path(folder) / "synb0_default_weights3.h5"
+        w4 = Path(folder) / "synb0_default_weights4.h5"
+        w5 = Path(folder) / "synb0_default_weights5.h5"
         return w1, w2, w3, w4, w5
     if name == "synb0_test_data":
         files, folder = fetch_synb0_test()
-        input_array = pjoin(folder, "test_input_synb0.npz")
-        target_array = pjoin(folder, "test_output_synb0.npz")
+        input_array = Path(folder) / "test_input_synb0.npz"
+        target_array = Path(folder) / "test_output_synb0.npz"
         return input_array, target_array
     if name == "deepn4_default_tf_weights":
         _, folder = fetch_deepn4_tf_weights()
-        w1 = pjoin(folder, "model_weights.h5")
+        w1 = Path(folder) / "model_weights.h5"
         return w1
     if name == "deepn4_default_torch_weights":
         _, folder = fetch_deepn4_torch_weights()
-        w1 = pjoin(folder, "deepn4_torch_weights")
+        w1 = Path(folder) / "deepn4_torch_weights"
         return w1
     if name == "deepn4_test_data":
         files, folder = fetch_deepn4_test()
-        input_array = pjoin(folder, "test_input_deepn4.npz")
-        target_array = pjoin(folder, "new_test_output_deepn4.npz")
+        input_array = Path(folder) / "test_input_deepn4.npz"
+        target_array = Path(folder) / "new_test_output_deepn4.npz"
         return input_array, target_array
     if name == "evac_default_tf_weights":
         files, folder = fetch_evac_tf_weights()
-        weight = pjoin(folder, "evac_default_weights.h5")
+        weight = Path(folder) / "evac_default_weights.h5"
         return weight
     if name == "evac_default_torch_weights":
         files, folder = fetch_evac_torch_weights()
-        weight = pjoin(folder, "evac_weights.pth")
+        weight = Path(folder) / "evac_weights.pth"
         return weight
     if name == "evac_test_data":
         files, folder = fetch_evac_test()
-        test_data = pjoin(folder, "evac_test_data.npz")
+        test_data = Path(folder) / "evac_test_data.npz"
         return test_data
     if name == "DiB_70_lte_pte_ste":
         _, folder = fetch_DiB_70_lte_pte_ste()
-        fdata = pjoin(folder, "DiB_70_lte_pte_ste.nii.gz")
-        fbval = pjoin(folder, "bval_DiB_70_lte_pte_ste.bval")
-        fbvec = pjoin(folder, "bvec_DiB_70_lte_pte_ste.bvec")
-        fmask = pjoin(folder, "DiB_mask.nii.gz")
+        fdata = Path(folder) / "DiB_70_lte_pte_ste.nii.gz"
+        fbval = Path(folder) / "bval_DiB_70_lte_pte_ste.bval"
+        fbvec = Path(folder) / "bvec_DiB_70_lte_pte_ste.bvec"
+        fmask = Path(folder) / "DiB_mask.nii.gz"
         return fdata, fbval, fbvec, fmask
     if name == "DiB_217_lte_pte_ste":
         _, folder = fetch_DiB_217_lte_pte_ste()
-        fdata_1 = pjoin(folder, "DiB_217_lte_pte_ste_1.nii.gz")
-        fdata_2 = pjoin(folder, "DiB_217_lte_pte_ste_2.nii.gz")
-        fbval = pjoin(folder, "bval_DiB_217_lte_pte_ste.bval")
-        fbvec = pjoin(folder, "bvec_DiB_217_lte_pte_ste.bvec")
-        fmask = pjoin(folder, "DiB_mask.nii.gz")
+        fdata_1 = Path(folder) / "DiB_217_lte_pte_ste_1.nii.gz"
+        fdata_2 = Path(folder) / "DiB_217_lte_pte_ste_2.nii.gz"
+        fbval = Path(folder) / "bval_DiB_217_lte_pte_ste.bval"
+        fbvec = Path(folder) / "bvec_DiB_217_lte_pte_ste.bvec"
+        fmask = Path(folder) / "DiB_mask.nii.gz"
         return fdata_1, fdata_2, fbval, fbvec, fmask
     if name == "ptt_minimal_dataset":
         files, folder = fetch_ptt_minimal_dataset()
-        fod_name = pjoin(folder, "ptt_fod.nii")
-        seed_coords_name = pjoin(folder, "ptt_seed_coords.txt")
-        seed_image_name = pjoin(folder, "ptt_seed_image.nii")
+        fod_name = Path(folder) / "ptt_fod.nii"
+        seed_coords_name = Path(folder) / "ptt_seed_coords.txt"
+        seed_image_name = Path(folder) / "ptt_seed_image.nii"
         return fod_name, seed_coords_name, seed_image_name
     if name == "gold_standard_io":
         filepath_dix = {}
         files, folder = fetch_gold_standard_io()
         for filename in files:
-            filepath_dix[filename] = os.path.join(folder, filename)
+            filepath_dix[filename] = Path(folder) / filename
 
         with open(filepath_dix["points_data.json"]) as json_file:
             points_data = dict(json.load(json_file))
@@ -1983,7 +1994,7 @@ def get_fnames(*, name="small_64D", include_optional=False):
     if name in ["disco", "disco1", "disco2", "disco3"]:
         local_fetcher = globals().get(f"fetch_{name}_dataset")
         files, folder = local_fetcher(include_optional=include_optional)
-        return [pjoin(folder, f) for f in files]
+        return [Path(folder) / f for f in files]
 
 
 def read_qtdMRI_test_retest_2subjects():
@@ -2028,7 +2039,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_dwis_retest.nii.gz",
     ]
     for data_name in data_names:
-        data_loc = pjoin(dipy_home, "qtdMRI_test_retest_2subjects", data_name)
+        data_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects", data_name
         data.append(load_nifti_data(data_loc))
 
     cc_masks = []
@@ -2039,7 +2050,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_ccmask_retest.nii.gz",
     ]
     for mask_name in mask_names:
-        mask_loc = pjoin(dipy_home, "qtdMRI_test_retest_2subjects", mask_name)
+        mask_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects", mask_name
         cc_masks.append(load_nifti_data(mask_loc))
 
     gtabs = []
@@ -2050,7 +2061,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_scheme_retest.txt",
     ]
     for gtab_txt_name in gtab_txt_names:
-        txt_loc = pjoin(dipy_home, "qtdMRI_test_retest_2subjects", gtab_txt_name)
+        txt_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects", gtab_txt_name
         qtdmri_scheme = np.loadtxt(txt_loc, skiprows=1)
         bvecs = qtdmri_scheme[:, 1:4]
         G = qtdmri_scheme[:, 4] / 1e3  # because dipy takes T/mm not T/m
@@ -2211,7 +2222,7 @@ def fetch_tissue_data(*, include_optional=False):
     t1d = "https://ndownloader.figshare.com/files/6965981"
     ap = "https://ndownloader.figshare.com/files/6965984"
 
-    folder = pjoin(dipy_home, "tissue_data")
+    folder = Path(dipy_home) / "tissue_data"
 
     md5_list = [
         "99c4b77267a6855cbfd96716d5d65b70",  # t1
@@ -2222,15 +2233,15 @@ def fetch_tissue_data(*, include_optional=False):
     url_list = [t1, t1d, ap]
     fname_list = ["t1_brain.nii.gz", "t1_brain_denoised.nii.gz", "power_map.nii.gz"]
 
-    if not op.exists(folder):
+    if not folder.exists():
         logger.info(f"Creating new directory {folder}")
         os.makedirs(folder)
         msg = "Downloading 3 Nifti1 images (9.3MB)..."
         logger.info(msg)
 
         for i in range(len(md5_list)):
-            _get_file_data(pjoin(folder, fname_list[i]), url_list[i])
-            check_md5(pjoin(folder, fname_list[i]), md5_list[i])
+            _get_file_data(Path(folder) / fname_list[i], url_list[i])
+            check_md5(Path(folder) / fname_list[i], md5_list[i])
 
         logger.info("Done.")
         logger.info(f"Files copied in folder {folder}")
@@ -2255,10 +2266,10 @@ def read_tissue_data(*, contrast="T1"):
         Nifti1Image
 
     """
-    folder = pjoin(dipy_home, "tissue_data")
-    t1_name = pjoin(folder, "t1_brain.nii.gz")
-    t1d_name = pjoin(folder, "t1_brain_denoised.nii.gz")
-    ap_name = pjoin(folder, "power_map.nii.gz")
+    folder = Path(dipy_home) / "tissue_data"
+    t1_name = Path(folder) / "t1_brain.nii.gz"
+    t1d_name = Path(folder) / "t1_brain_denoised.nii.gz"
+    ap_name = Path(folder) / "power_map.nii.gz"
 
     md5_dict = {
         "t1": "99c4b77267a6855cbfd96716d5d65b70",
@@ -2338,13 +2349,13 @@ def read_mni_template(*, version="a", contrast="T2"):
     """
     files, folder = fetch_mni_template()
     file_dict_a = {
-        "T1": pjoin(folder, "mni_icbm152_t1_tal_nlin_asym_09a.nii"),
-        "T2": pjoin(folder, "mni_icbm152_t2_tal_nlin_asym_09a.nii"),
+        "T1": Path(folder) / "mni_icbm152_t1_tal_nlin_asym_09a.nii",
+        "T2": Path(folder) / "mni_icbm152_t2_tal_nlin_asym_09a.nii",
     }
 
     file_dict_c = {
-        "T1": pjoin(folder, "mni_icbm152_t1_tal_nlin_asym_09c.nii"),
-        "mask": pjoin(folder, "mni_icbm152_t1_tal_nlin_asym_09c_mask.nii"),
+        "T1": Path(folder) / "mni_icbm152_t1_tal_nlin_asym_09c.nii",
+        "mask": Path(folder) / "mni_icbm152_t1_tal_nlin_asym_09c_mask.nii",
     }
 
     if contrast == "T2" and version == "c":
@@ -2392,7 +2403,7 @@ def fetch_cenir_multib(*, with_raw=False, **kwargs):
         Whether to fetch the raw data. Per default, this is False, which means
         that only eddy-current/motion corrected data is fetched
     """
-    folder = pjoin(dipy_home, "cenir_multib")
+    folder = Path(dipy_home) / "cenir_multib"
 
     fname_list = [
         "4D_dwi_eddycor_B200.nii.gz",
@@ -2480,29 +2491,29 @@ def read_cenir_multib(*, bvals=None):
         bvals = [bvals]
     file_dict = {
         200: {
-            "DWI": pjoin(folder, "4D_dwi_eddycor_B200.nii.gz"),
-            "bvals": pjoin(folder, "dwi_bvals_B200"),
-            "bvecs": pjoin(folder, "dwi_bvecs_B200"),
+            "DWI": Path(folder) / "4D_dwi_eddycor_B200.nii.gz",
+            "bvals": Path(folder) / "dwi_bvals_B200",
+            "bvecs": Path(folder) / "dwi_bvecs_B200",
         },
         400: {
-            "DWI": pjoin(folder, "4D_dwieddycor_B400.nii.gz"),
-            "bvals": pjoin(folder, "bvals_B400"),
-            "bvecs": pjoin(folder, "bvecs_B400"),
+            "DWI": Path(folder) / "4D_dwieddycor_B400.nii.gz",
+            "bvals": Path(folder) / "bvals_B400",
+            "bvecs": Path(folder) / "bvecs_B400",
         },
         1000: {
-            "DWI": pjoin(folder, "4D_dwieddycor_B1000.nii.gz"),
-            "bvals": pjoin(folder, "bvals_B1000"),
-            "bvecs": pjoin(folder, "bvecs_B1000"),
+            "DWI": Path(folder) / "4D_dwieddycor_B1000.nii.gz",
+            "bvals": Path(folder) / "bvals_B1000",
+            "bvecs": Path(folder) / "bvecs_B1000",
         },
         2000: {
-            "DWI": pjoin(folder, "4D_dwieddycor_B2000.nii.gz"),
-            "bvals": pjoin(folder, "bvals_B2000"),
-            "bvecs": pjoin(folder, "bvecs_B2000"),
+            "DWI": Path(folder) / "4D_dwieddycor_B2000.nii.gz",
+            "bvals": Path(folder) / "bvals_B2000",
+            "bvecs": Path(folder) / "bvecs_B2000",
         },
         3000: {
-            "DWI": pjoin(folder, "4D_dwieddycor_B3000.nii.gz"),
-            "bvals": pjoin(folder, "bvals_B3000"),
-            "bvecs": pjoin(folder, "bvecs_B3000"),
+            "DWI": Path(folder) / "4D_dwieddycor_B3000.nii.gz",
+            "bvals": Path(folder) / "bvals_B3000",
+            "bvecs": Path(folder) / "bvecs_B3000",
         },
     }
     data = []
@@ -2568,7 +2579,7 @@ def read_bundles_2_subjects(
     .. footbibliography::
 
     """
-    dname = pjoin(dipy_home, "exp_bundles_and_maps", "bundles_2_subjects")
+    dname = Path(dipy_home) / "exp_bundles_and_maps", "bundles_2_subjects"
 
     from dipy.io.streamline import load_tractogram
     from dipy.tracking.streamline import Streamlines
@@ -2576,18 +2587,20 @@ def read_bundles_2_subjects(
     res = {}
 
     if "t1" in metrics:
-        data, affine = load_nifti(pjoin(dname, subj_id, "t1_warped.nii.gz"))
+        data, affine = load_nifti(Path(dname) / subj_id, "t1_warped.nii.gz")
         res["t1"] = data
 
     if "fa" in metrics:
-        fa, affine = load_nifti(pjoin(dname, subj_id, "fa_1x1x1.nii.gz"))
+        fa, affine = load_nifti(Path(dname) / subj_id, "fa_1x1x1.nii.gz")
         res["fa"] = fa
 
     res["affine"] = affine
 
     for bun in bundles:
         streams = load_tractogram(
-            pjoin(dname, subj_id, "bundles", f"bundles_{bun}.trk"),
+            Path(dname) / subj_id,
+            "bundles",
+            f"bundles_{bun}.trk",
             "same",
             bbox_valid_check=False,
         ).streamlines
@@ -2656,7 +2669,7 @@ def get_file_formats():
     bundles_list : all bundles (list)
     ref_anat : reference
     """
-    ref_anat = pjoin(dipy_home, "bundle_file_formats_example", "template0.nii.gz")
+    ref_anat = Path(dipy_home) / "bundle_file_formats_example", "template0.nii.gz"
     bundles_list = []
     for filename in [
         "cc_m_sub.trk",
@@ -2665,7 +2678,7 @@ def get_file_formats():
         "raf_m_sub.vtk",
         "rpt_m_sub.dpy",
     ]:
-        bundles_list.append(pjoin(dipy_home, "bundle_file_formats_example", filename))
+        bundles_list.append(Path(dipy_home) / "bundle_file_formats_example", filename)
 
     return bundles_list, ref_anat
 
@@ -2680,16 +2693,20 @@ def get_bundle_atlas_hcp842(*, size=80):
     """
     size = 80 if size not in [80, 30] else size
 
-    file1 = pjoin(
-        dipy_home,
-        "bundle_atlas_hcp842",
-        f"Atlas_{size}_Bundles",
-        "whole_brain",
-        "whole_brain_MNI.trk",
+    file1 = (
+        Path(dipy_home)
+        / "bundle_atlas_hcp842"
+        / f"Atlas_{size}_Bundles"
+        / "whole_brain"
+        / "whole_brain_MNI.trk",
     )
 
-    file2 = pjoin(
-        dipy_home, "bundle_atlas_hcp842", f"Atlas_{size}_Bundles", "bundles", "*.trk"
+    file2 = (
+        Path(dipy_home)
+        / "bundle_atlas_hcp842"
+        / f"Atlas_{size}_Bundles"
+        / "bundles"
+        / "*.trk"
     )
 
     return file1, file2
@@ -2702,12 +2719,18 @@ def get_two_hcp842_bundles():
     file1 : string
     file2 : string
     """
-    file1 = pjoin(
-        dipy_home, "bundle_atlas_hcp842", "Atlas_80_Bundles", "bundles", "AF_L.trk"
+    file1 = (
+        Path(dipy_home) / "bundle_atlas_hcp842",
+        "Atlas_80_Bundles",
+        "bundles",
+        "AF_L.trk",
     )
 
-    file2 = pjoin(
-        dipy_home, "bundle_atlas_hcp842", "Atlas_80_Bundles", "bundles", "CST_L.trk"
+    file2 = (
+        Path(dipy_home) / "bundle_atlas_hcp842",
+        "Atlas_80_Bundles",
+        "bundles",
+        "CST_L.trk",
     )
 
     return file1, file2
@@ -2719,8 +2742,10 @@ def get_target_tractogram_hcp():
     -------
     file1 : string
     """
-    file1 = pjoin(
-        dipy_home, "target_tractogram_hcp", "hcp_tractogram", "streamlines.trk"
+    file1 = (
+        Path(dipy_home) / "target_tractogram_hcp",
+        "hcp_tractogram",
+        "streamlines.trk",
     )
 
     return file1
@@ -2799,14 +2824,14 @@ def read_DiB_217_lte_pte_ste():
     """
     fdata_1, fdata_2, fbval, fbvec, fmask = get_fnames(name="DiB_217_lte_pte_ste")
     _, folder = fetch_DiB_217_lte_pte_ste()
-    if op.isfile(pjoin(folder, "DiB_217_lte_pte_ste.nii.gz")):
-        data_img = nib.load(pjoin(folder, "DiB_217_lte_pte_ste.nii.gz"))
+    if Path(Path(folder) / "DiB_217_lte_pte_ste.nii.gz").is_file():
+        data_img = nib.load(Path(folder) / "DiB_217_lte_pte_ste.nii.gz")
     else:
         data_1, affine = load_nifti(fdata_1)
         data_2, _ = load_nifti(fdata_2)
         data = np.concatenate((data_1, data_2), axis=3)
-        save_nifti(pjoin(folder, "DiB_217_lte_pte_ste.nii.gz"), data, affine)
-        data_img = nib.load(pjoin(folder, "DiB_217_lte_pte_ste.nii.gz"))
+        save_nifti(Path(folder) / "DiB_217_lte_pte_ste.nii.gz", data, affine)
+        data_img = nib.load(Path(folder) / "DiB_217_lte_pte_ste.nii.gz")
     mask_img = nib.load(fmask)
     bvals = np.loadtxt(fbval)
     bvecs = np.loadtxt(fbvec)
@@ -2863,7 +2888,7 @@ def read_five_af_bundles():
 
         bundles = []
         for sub in subjects:
-            fname = pjoin(temp_dir, sub, "AF_L.trk")
+            fname = Path(temp_dir) / sub / "AF_L.trk"
             bundle_obj = load_trk(fname, "same", bbox_valid_check=False)
             bundles.append(bundle_obj.streamlines)
 
@@ -2876,7 +2901,7 @@ def to_bids_description(
 ):
     """Dumps a dict into a bids description at the given location"""
     kwargs.update({"BIDSVersion": BIDSVersion})
-    desc_file = op.join(path, fname)
+    desc_file = Path(path) / fname
     with open(desc_file, "w") as outfile:
         json.dump(kwargs, outfile)
 
@@ -2966,15 +2991,15 @@ def fetch_hcp(
     bucket = s3.Bucket(hcp_bucket)
 
     if path is None:
-        if not op.exists(dipy_home):
+        if not Path(dipy_home).exists():
             os.mkdir(dipy_home)
         my_path = dipy_home
     else:
         my_path = path
 
-    base_dir = pjoin(my_path, study, "derivatives", "hcp_pipeline")
+    base_dir = Path(my_path) / study, "derivatives", "hcp_pipeline"
 
-    if not op.exists(base_dir):
+    if not Path(base_dir).exists():
         os.makedirs(base_dir, exist_ok=True)
 
     data_files = {}
@@ -2984,29 +3009,29 @@ def fetch_hcp(
         subjects = [subjects]
 
     for subject in subjects:
-        sub_dir = pjoin(base_dir, f"sub-{subject}")
-        if not op.exists(sub_dir):
-            os.makedirs(pjoin(sub_dir, "dwi"), exist_ok=True)
-            os.makedirs(pjoin(sub_dir, "anat"), exist_ok=True)
-        data_files[pjoin(sub_dir, "dwi", f"sub-{subject}_dwi.bval")] = (
+        sub_dir = Path(base_dir) / f"sub-{subject}"
+        if not Path(sub_dir).exists():
+            os.makedirs(Path(sub_dir) / "dwi", exist_ok=True)
+            os.makedirs(Path(sub_dir) / "anat", exist_ok=True)
+        data_files[Path(sub_dir) / "dwi", f"sub-{subject}_dwi.bval"] = (
             f"{study}/{subject}/T1w/Diffusion/bvals"
         )
-        data_files[pjoin(sub_dir, "dwi", f"sub-{subject}_dwi.bvec")] = (
+        data_files[Path(sub_dir) / "dwi", f"sub-{subject}_dwi.bvec"] = (
             f"{study}/{subject}/T1w/Diffusion/bvecs"
         )
-        data_files[pjoin(sub_dir, "dwi", f"sub-{subject}_dwi.nii.gz")] = (
+        data_files[Path(sub_dir) / "dwi", f"sub-{subject}_dwi.nii.gz"] = (
             f"{study}/{subject}/T1w/Diffusion/data.nii.gz"
         )
-        data_files[pjoin(sub_dir, "anat", f"sub-{subject}_T1w.nii.gz")] = (
+        data_files[Path(sub_dir) / "anat", f"sub-{subject}_T1w.nii.gz"] = (
             f"{study}/{subject}/T1w/T1w_acpc_dc.nii.gz"
         )
-        data_files[pjoin(sub_dir, "anat", f"sub-{subject}_aparc+aseg_seg.nii.gz")] = (
+        data_files[Path(sub_dir) / "anat", f"sub-{subject}_aparc+aseg_seg.nii.gz"] = (
             f"{study}/{subject}/T1w/aparc+aseg.nii.gz"
         )
 
     download_files = {}
     for k in data_files.keys():
-        if not op.exists(k):
+        if not Path(k).exists():
             download_files[k] = data_files[k]
     if len(download_files.keys()):
         with tqdm(total=len(download_files.keys())) as pbar:
@@ -3024,7 +3049,7 @@ def fetch_hcp(
         " Neuroscience at Washington University.",
     )
     to_bids_description(
-        pjoin(my_path, study),
+        Path(my_path) / study,
         **{
             "Name": study,
             "Acknowledgements": hcp_acknowledgements,
@@ -3042,13 +3067,13 @@ def fetch_hcp(
         },
     )
 
-    return data_files, pjoin(my_path, study)
+    return data_files, Path(my_path) / study
 
 
 def _hbn_downloader(my_path, derivative, subjects, client):
-    base_dir = op.join(my_path, "HBN", "derivatives", derivative)
+    base_dir = Path(my_path) / "HBN" / "derivatives" / derivative
 
-    if not os.path.exists(base_dir):
+    if not base_dir.exists():
         os.makedirs(base_dir, exist_ok=True)
 
     data_files = {}
@@ -3071,30 +3096,30 @@ def _hbn_downloader(my_path, derivative, subjects, client):
         if query_content is None:
             raise ValueError(f"Could not find derivatives data for subject {subject}")
         file_list = [kk["Key"] for kk in query["Contents"]]
-        sub_dir = op.join(base_dir, f"sub-{subject}")
-        ses_dir = op.join(sub_dir, ses)
+        sub_dir = base_dir / f"sub-{subject}"
+        ses_dir = sub_dir / ses
         if derivative == "qsiprep":
-            if not os.path.exists(sub_dir):
-                os.makedirs(os.path.join(sub_dir, "anat"), exist_ok=True)
-                os.makedirs(os.path.join(sub_dir, "figures"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "dwi"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "anat"), exist_ok=True)
+            if not sub_dir.exists():
+                os.makedirs(sub_dir / "anat", exist_ok=True)
+                os.makedirs(sub_dir / "figures", exist_ok=True)
+                os.makedirs(ses_dir / "dwi", exist_ok=True)
+                os.makedirs(ses_dir / "anat", exist_ok=True)
         if derivative == "afq":
-            if not os.path.exists(sub_dir):
-                os.makedirs(os.path.join(ses_dir, "bundles"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "clean_bundles"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "ROIs"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "tract_profile_plots"), exist_ok=True)
-                os.makedirs(os.path.join(ses_dir, "viz_bundles"), exist_ok=True)
+            if not sub_dir.exists():
+                os.makedirs(ses_dir / "bundles", exist_ok=True)
+                os.makedirs(ses_dir / "clean_bundles", exist_ok=True)
+                os.makedirs(ses_dir / "ROIs", exist_ok=True)
+                os.makedirs(ses_dir / "tract_profile_plots", exist_ok=True)
+                os.makedirs(ses_dir / "viz_bundles", exist_ok=True)
 
         for remote in file_list:
             full = remote.split("Projects")[-1][1:].replace("/BIDS_curated", "")
-            local = op.join(my_path, full)
+            local = Path(my_path) / full
             data_files[local] = remote
 
     download_files = {}
     for k in data_files.keys():
-        if not op.exists(k):
+        if not Path(k).exists():
             download_files[k] = data_files[k]
 
     if len(download_files.keys()):
@@ -3106,12 +3131,12 @@ def _hbn_downloader(my_path, derivative, subjects, client):
 
     # Create the BIDS dataset description file text
     to_bids_description(
-        op.join(my_path, "HBN"), **{"Name": "HBN", "Subjects": subjects}
+        str(Path(my_path) / "HBN"), **{"Name": "HBN", "Subjects": subjects}
     )
 
     # Create the BIDS derivatives description file text
     to_bids_description(
-        base_dir, **{"Name": "HBN", "PipelineDescription": {"Name": "qsiprep"}}
+        str(base_dir), **{"Name": "HBN", "PipelineDescription": {"Name": "qsiprep"}}
     )
 
     return data_files
@@ -3162,7 +3187,7 @@ def fetch_hbn(subjects, *, path=None, include_afq=False):
     client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
     if path is None:
-        if not op.exists(dipy_home):
+        if not Path(dipy_home).exists():
             os.mkdir(dipy_home)
         my_path = dipy_home
     else:
@@ -3178,4 +3203,4 @@ def fetch_hbn(subjects, *, path=None, include_afq=False):
     if include_afq:
         data_files.update(_hbn_downloader(my_path, "afq", subjects, client))
 
-    return data_files, pjoin(my_path, "HBN")
+    return data_files, Path(my_path) / "HBN"

--- a/dipy/denoise/patch2self.py
+++ b/dipy/denoise/patch2self.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import tempfile
 import time
 from warnings import warn
@@ -448,7 +449,7 @@ def _validate_inputs(data, out_dtype, patch_radius, version, tmp_dir):
     if isinstance(patch_radius, int):
         patch_radius = (patch_radius, patch_radius, patch_radius)
 
-    if version == 3 and tmp_dir is not None and not os.path.exists(tmp_dir):
+    if version == 3 and tmp_dir is not None and not Path(tmp_dir).exists():
         raise ValueError("The temporary directory does not exist.")
     if data.ndim != 4:
         raise ValueError("Patch2Self can only denoise on 4D arrays.", data.shape)

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -25,7 +25,7 @@ class Dpy:
 
         Parameters
         ----------
-        fname : str
+        fname : str or Path
             Full filename
         mode : str, optional
             Use 'r' to read, 'w' to write, and 'r+' to read and write (only if

--- a/dipy/io/gradients.py
+++ b/dipy/io/gradients.py
@@ -1,5 +1,5 @@
 import io
-from os.path import splitext
+from pathlib import Path
 import re
 import warnings
 
@@ -11,9 +11,9 @@ def read_bvals_bvecs(fbvals, fbvecs):
 
     Parameters
     ----------
-    fbvals : str
+    fbvals : str or Path
        Full path to file with b-values. None to not read bvals.
-    fbvecs : str
+    fbvecs : str or Path
        Full path of file with b-vectors. None to not read bvecs.
 
     Returns
@@ -37,10 +37,10 @@ def read_bvals_bvecs(fbvals, fbvecs):
             vals.append(None)
             continue
 
-        if not isinstance(this_fname, str):
+        if not isinstance(this_fname, (str, Path)):
             raise ValueError("String with full path to file is required")
 
-        base, ext = splitext(this_fname)
+        ext = Path(this_fname).suffix
         if ext in [
             ".bvals",
             ".bval",

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -11,7 +11,7 @@ def load_nifti_data(fname, *, as_ndarray=True):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Full path to the file.
     as_ndarray: bool, optional
         convert nibabel ArrayProxy to a numpy.ndarray.
@@ -44,7 +44,7 @@ def load_nifti(
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Full path to a nifti file.
 
     return_img : bool, optional
@@ -93,7 +93,7 @@ def save_nifti(fname, data, affine, *, hdr=None, dtype=None):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         The full path to the file to be saved.
 
     data : ndarray
@@ -144,7 +144,7 @@ def save_qa_metric(fname, xopt, fopt):
 
     Parameters
     ----------
-    fname: string
+    fname: string or Path
         File name to save the metric values.
     xopt: numpy array
         The metric containing the

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -58,7 +58,7 @@ def load_pam(fname, *, verbose=False):
 
     Parameters
     ----------
-    fname : string
+    fname : string or Path
         Filename of PAM5 file.
     verbose : bool, optional
         Print summary information about the loaded file.
@@ -69,7 +69,7 @@ def load_pam(fname, *, verbose=False):
         Object holding peaks information and metrics.
 
     """
-    if os.path.splitext(fname)[1].lower() != ".pam5":
+    if Path(fname).suffix.lower() != ".pam5":
         raise IOError("This function supports only PAM5 (HDF5) files")
 
     f = h5py.File(fname, "r")
@@ -174,7 +174,7 @@ def save_pam(fname, pam, *, affine=None, verbose=False):
         Print summary information about the saved file.
 
     """
-    if os.path.splitext(fname)[1] != ".pam5":
+    if Path(fname).suffix.lower() != ".pam5":
         raise IOError("This function saves only PAM5 (HDF5) files")
 
     if not (

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-import os
+from pathlib import Path
 import time
 
 import nibabel as nib
@@ -31,7 +31,7 @@ def save_tractogram(
     ----------
     sft : StatefulTractogram
         The stateful tractogram to save
-    filename : string
+    filename : string or Path
         Filename with valid extension
     bbox_valid_check : bool
         Verification for negative voxel coordinates or values above the
@@ -44,7 +44,8 @@ def save_tractogram(
             TRACKVIS standard (corner of the voxel)
     """
 
-    _, extension = os.path.splitext(filename)
+    filename = Path(filename)
+    extension = "".join(filename.suffixes)
     if extension not in [".trk", ".tck", ".trx", ".vtk", ".vtp", ".fib", ".dpy"]:
         raise TypeError("Output filename is not one of the supported format.")
 
@@ -77,7 +78,7 @@ def save_tractogram(
     sft.to_space(to_space)
     sft.to_origin(to_origin)
     if extension in [".trk", ".tck"]:
-        tractogram_type = detect_format(filename)
+        tractogram_type = detect_format(str(filename))
         header = create_tractogram_header(tractogram_type, *sft.space_attributes)
         new_tractogram = Tractogram(sft.streamlines, affine_to_rasmm=np.eye(4))
 
@@ -86,7 +87,7 @@ def save_tractogram(
             new_tractogram.data_per_streamline = sft.data_per_streamline
 
         fileobj = tractogram_type(new_tractogram, header=header)
-        nib.streamlines.save(fileobj, filename)
+        nib.streamlines.save(fileobj, str(filename))
 
     elif extension in [".vtk", ".vtp", ".fib"]:
         binary = extension in [".vtk", ".fib"]
@@ -101,7 +102,7 @@ def save_tractogram(
         dpy_obj.close()
     elif extension in [".trx"]:
         trx = tmm.TrxFile.from_sft(sft)
-        tmm.save(trx, filename)
+        tmm.save(trx, str(filename))
         trx.close()
 
     logger.debug(
@@ -131,7 +132,7 @@ def load_tractogram(
 
     Parameters
     ----------
-    filename : string
+    filename : string or Path
         Filename with valid extension
     reference : Nifti or Trk filename, Nifti1Image or TrkFile, Nifti1Header or
         trk.header (dict), or 'same' if the input is a trk file.
@@ -163,7 +164,7 @@ def load_tractogram(
     output : StatefulTractogram
         The tractogram to load (must have been saved properly)
     """
-    _, extension = os.path.splitext(filename)
+    extension = "".join(Path(filename).suffixes)
     if extension not in [".trk", ".tck", ".trx", ".vtk", ".vtp", ".fib", ".dpy"]:
         logger.error("Output filename is not one of the supported format.")
         return False
@@ -283,7 +284,7 @@ def load_generator(ttype):
         from_space=None,
         from_origin=None,
     ):
-        _, extension = os.path.splitext(filename)
+        extension = "".join(Path(filename).suffixes)
         if not extension == ttype:
             msg = f"This function can only load {ttype} files, "
             msg += "for a more general purpose, use load_tractogram instead."
@@ -323,7 +324,7 @@ def save_generator(ttype):
     """
 
     def f_gen(sft, filename, bbox_valid_check=True):
-        _, extension = os.path.splitext(filename)
+        extension = "".join(Path(filename).suffixes)
         if not extension == ttype:
             msg = f"This function can only save {ttype} file, "
             msg += "for more general cases, use save_tractogram instead."

--- a/dipy/io/surface.py
+++ b/dipy/io/surface.py
@@ -1,14 +1,14 @@
 from copy import deepcopy
 import gzip
 import logging
-import os
+from pathlib import Path
 import time
 
 import nibabel as nib
 import numpy as np
 
 from dipy.io.stateful_surface import StatefulSurface
-from dipy.io.utils import Origin, Space, get_reference_info, split_name_with_gz
+from dipy.io.utils import Origin, Space, get_reference_info
 from dipy.io.vtk import (
     get_polydata_triangles,
     get_polydata_vertices,
@@ -40,7 +40,7 @@ def load_surface(
 
     Parameters
     ----------
-    fname : string
+    filename : string or Path
         Filename with valid extension
     reference : Nifti or Trk filename, Nifti1Image or TrkFile, Nifti1Header or
         trk.header (dict), or 'same' if the input is a trk file.
@@ -77,9 +77,10 @@ def load_surface(
     """
     vtk_ext = [".vtk", ".vtp", ".obj", ".stl", ".ply"]
     freesurfer_ext = [".gii", ".gii.gz", ".pial", ".nofix", ".orig", ".smoothwm", ".T1"]
-    _, ext = split_name_with_gz(fname)
 
-    if ext not in (freesurfer_ext + vtk_ext):
+    ext = "".join(Path(fname).suffixes).lower()
+
+    if not any(ext.endswith(_ext) for _ext in freesurfer_ext + vtk_ext):
         logging.error("Input extension is not one of the supported format.")
         return False
 
@@ -92,7 +93,7 @@ def load_surface(
         return False
 
     if reference == "same":
-        if ext in [".gii", ".gii.gz"]:
+        if any(ext.endswith(_ext) for _ext in [".gii", ".gii.gz"]):
             reference = fname
         else:
             logging.error(
@@ -103,7 +104,7 @@ def load_surface(
     timer = time.time()
     metadata = None
     data_per_vertex = None
-    if ext == ".gii" or ext == ".gii.gz":
+    if any(ext.endswith(_ext) for _ext in [".gii", ".gii.gz"]):
         data = load_gifti(fname)
         if gifti_in_freesurfer:
             data = (apply_freesurfer_transform(data[0], reference, inv=True), data[1])
@@ -194,7 +195,7 @@ def save_surface(
     ----------
     sfs : StatefulSurface
         The surface to save (must have been loaded properly)
-    fname : str
+    fname : str or Path
         Absolute path of the file.
     to_space : Enum (dipy.io.stateful_surface.Space), optional
         Space to which the surface will be transformed before saving
@@ -207,10 +208,10 @@ def save_surface(
     bbox_valid_check : bool, optional
         Verification for negative voxel coordinates or values above the
         volume dimensions. Default is True, to enforce valid file.
-    ref_pial : str, optional
+    ref_pial : str or Path, optional
         Reference pial file to save the surface in pial format.
         If not provided, the metadata of the input surface is used (if available).
-    ref_gii : str, optional
+    ref_gii : str or Path, optional
         Reference gii file to save the surface in gii format.
         If not provided, the header of the input surface is used (if available).
     gifti_in_freesurfer : bool, optional
@@ -232,7 +233,7 @@ def save_surface(
             "bounding box of the surface."
         )
 
-    _, ext = split_name_with_gz(fname)
+    ext = "".join(Path(fname).suffixes).lower()
 
     if ext in [".vtk", ".vtp", ".obj", ".stl", ".ply"]:
         sfs.to_space(to_space)
@@ -270,7 +271,7 @@ def save_surface(
         save_polydata(
             polydata, fname, legacy_vtk_format=legacy_vtk_format, color_array_name="RGB"
         )
-    elif ext in [".gii", ".gii.gz"]:
+    elif any(ext.endswith(_ext) for _ext in [".gii", ".gii.gz"]):
         if not hasattr(sfs, "gii_header") and ref_gii is None:
             raise ValueError(
                 "Metadata is required to save a gii file.\n"
@@ -278,8 +279,8 @@ def save_surface(
             )
 
         if ref_gii is not None:
-            _, ref_ext = split_name_with_gz(ref_gii)
-            if ref_ext != ".gii" or ref_ext != ".gii.gz":
+            ext = "".join(Path(ref_gii).suffixes).lower()
+            if not any(ext.endswith(_ext) for _ext in [".gii", ".gii.gz"]):
                 raise ValueError("Reference gii file must have .gii extension.")
             _, metadata = load_gifti(ref_gii, return_header=True)[-1]
         else:
@@ -299,7 +300,7 @@ def save_surface(
             )
 
         if ref_pial is not None:
-            _, ext = os.path.splitext(ref_pial)
+            ext = Path(ref_pial).suffix
             if ext != ".pial":
                 raise ValueError("Reference pial file must have .pial extension.")
             metadata = load_pial(ref_pial, return_meta=True)[-1]
@@ -329,7 +330,7 @@ def load_pial(fname, *, return_meta=False):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Absolute path of the file.
     return_meta : bool, optional
         Whether to read the metadata of the file or not, by default False.
@@ -357,7 +358,7 @@ def save_pial(fname, vertices, faces, *, metadata=None):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Absolute path of the file.
     vertices : ndarray
         Vertices.
@@ -374,7 +375,7 @@ def load_gifti(fname, *, return_header=False):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Absolute path of the file.
 
     return_header : bool, optional
@@ -388,7 +389,8 @@ def load_gifti(fname, *, return_header=False):
     """
 
     def reader(fname):
-        if str(fname).endswith(".gii.gz"):
+        ext = "".join(Path(fname).suffixes).lower()
+        if ext.endswith(".gii.gz"):
             with gzip.GzipFile(fname) as gz:
                 img = nib.GiftiImage.from_bytes(gz.read())
         else:
@@ -408,12 +410,14 @@ def save_gifti(fname, vertices, faces, *, header=None):
 
     Parameters
     ----------
-    fname : str
+    fname : str or Path
         Absolute path of the file.
     vertices : ndarray
         Vertices.
     faces : ndarray
         Faces.
+    header : nib.filebasedimages.FileBasedHeader
+        Valid header for the gifti file, typically loaded from a reference GII
     """
     vert = nib.gifti.GiftiDataArray(
         vertices,
@@ -435,7 +439,7 @@ def apply_freesurfer_transform(vertices, reference, *, inv=False):
     ----------
     vertices : ndarray
         Vertices to transform.
-    reference : str
+    reference : str or Path
         Reference file to get the transform from.
     inv : bool, optional
         True if loading the surface, False if saving the surface.

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -9,7 +9,7 @@ from dipy.io.dpy import Dpy, Streamlines
 
 def test_dpy():
     with TemporaryDirectory() as tmpdir:
-        fname = pjoin(tmpdir, "test.bin")
+        fname = Path(tmpdir) / "test.bin"
         dpw = Dpy(fname, mode="w")
         A = np.ones((5, 3))
         B = 2 * A.copy()

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -1,5 +1,4 @@
-import os.path as osp
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -26,7 +25,7 @@ def test_read_bvals_bvecs():
     npt.assert_array_equal(bvals_none, gt.bvals)
 
     # Test for error raising with unknown file formats:
-    nan_fbvecs = osp.splitext(fbvecs)[0] + ".nan"  # Nonsense extension
+    nan_fbvecs = Path(fbvecs).stem + ".nan"  # Nonsense extension
     npt.assert_raises(ValueError, read_bvals_bvecs, fbvals, nan_fbvecs)
     npt.assert_raises(ValueError, read_bvals_bvecs, bvals, nan_fbvecs)
     npt.assert_raises(ValueError, read_bvals_bvecs, fbvals, bvecs)
@@ -38,7 +37,7 @@ def test_read_bvals_bvecs():
         new_bvecs1 = bvecs[:, :2]
         # Make a temporary file
         fname = "test_bv_file1.txt"
-        with open(pjoin(tmpdir, fname), "wt") as bv_file1:
+        with open(Path(tmpdir) / fname, "wt") as bv_file1:
             # And fill it with these 2-columned bvecs:
             for x in range(new_bvecs1.shape[0]):
                 bv_file1.write(f"{new_bvecs1[x][0]} {new_bvecs1[x][1]}\n")
@@ -47,14 +46,14 @@ def test_read_bvals_bvecs():
         # These bvecs are saved as one long array:
         fname = "test_bv_file2.npy"
         new_bvecs2 = np.ravel(bvecs)
-        with open(pjoin(tmpdir, fname), "w") as bv_file2:
+        with open(Path(tmpdir) / fname, "w") as bv_file2:
             np.save(bv_file2.name, new_bvecs2)
         npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
 
         # There are less bvecs than bvals:
         fname = "test_bv_file3.txt"
         new_bvecs3 = bvecs[:-1, :]
-        with open(pjoin(tmpdir, fname), "w") as bv_file3:
+        with open(Path(tmpdir) / fname, "w") as bv_file3:
             np.savetxt(bv_file3.name, new_bvecs3)
         npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
 
@@ -63,19 +62,19 @@ def test_read_bvals_bvecs():
 
         # All possible delimiters should work
         bv_file4 = "test_space.txt"
-        with open(pjoin(tmpdir, bv_file4), "w") as f:
+        with open(Path(tmpdir) / bv_file4, "w") as f:
             f.write("66 55 33")
-        bvals_1, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file4), "")
+        bvals_1, _ = read_bvals_bvecs(Path(tmpdir) / bv_file4, "")
 
         bv_file5 = "test_coma.txt"
-        with open(pjoin(tmpdir, bv_file5), "w") as f:
+        with open(Path(tmpdir) / bv_file5, "w") as f:
             f.write("66, 55, 33")
-        bvals_2, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file5), "")
+        bvals_2, _ = read_bvals_bvecs(Path(tmpdir) / bv_file5, "")
 
         bv_file6 = "test_tabs.txt"
-        with open(pjoin(tmpdir, bv_file6), "w") as f:
+        with open(Path(tmpdir) / bv_file6, "w") as f:
             f.write("66 \t 55 \t 33")
-        bvals_3, _ = read_bvals_bvecs(pjoin(tmpdir, bv_file6), "")
+        bvals_3, _ = read_bvals_bvecs(Path(tmpdir) / bv_file6, "")
 
         ans = np.array([66.0, 55.0, 33.0])
         npt.assert_array_equal(ans, bvals_1)
@@ -83,24 +82,24 @@ def test_read_bvals_bvecs():
         npt.assert_array_equal(ans, bvals_3)
 
         bv_file7 = "test_space_2.txt"
-        with open(pjoin(tmpdir, bv_file7), "w") as f:
+        with open(Path(tmpdir) / bv_file7, "w") as f:
             f.write("66 55 33\n45 34 21\n55 32 65\n")
-        _, bvecs_1 = read_bvals_bvecs("", pjoin(tmpdir, bv_file7))
+        _, bvecs_1 = read_bvals_bvecs("", Path(tmpdir) / bv_file7)
 
         bv_file8 = "test_coma_2.txt"
-        with open(pjoin(tmpdir, bv_file8), "w") as f:
+        with open(Path(tmpdir) / bv_file8, "w") as f:
             f.write("66, 55, 33\n45, 34, 21 \n 55, 32, 65\n")
-        _, bvecs_2 = read_bvals_bvecs("", pjoin(tmpdir, bv_file8))
+        _, bvecs_2 = read_bvals_bvecs("", Path(tmpdir) / bv_file8)
 
         bv_file9 = "test_tabs_2.txt"
-        with open(pjoin(tmpdir, bv_file9), "w") as f:
+        with open(Path(tmpdir) / bv_file9, "w") as f:
             f.write("66 \t 55 \t 33\n45 \t 34 \t 21\n55 \t 32 \t 65\n")
-        _, bvecs_3 = read_bvals_bvecs("", pjoin(tmpdir, bv_file9))
+        _, bvecs_3 = read_bvals_bvecs("", Path(tmpdir) / bv_file9)
 
         bv_file10 = "test_multiple_space.txt"
-        with open(pjoin(tmpdir, bv_file10), "w") as f:
+        with open(Path(tmpdir) / bv_file10, "w") as f:
             f.write("66   55   33\n45,   34,   21 \n 55,   32,     65\n")
-        _, bvecs_4 = read_bvals_bvecs("", pjoin(tmpdir, bv_file10))
+        _, bvecs_4 = read_bvals_bvecs("", Path(tmpdir) / bv_file10)
 
         ans = np.array([[66.0, 55.0, 33.0], [45.0, 34.0, 21.0], [55.0, 32.0, 65.0]])
         npt.assert_array_equal(ans, bvecs_1)
@@ -109,27 +108,27 @@ def test_read_bvals_bvecs():
         npt.assert_array_equal(ans, bvecs_4)
 
         bv_two_volume = "bv_two_volume.txt"
-        with open(pjoin(tmpdir, bv_two_volume), "w") as f:
+        with open(Path(tmpdir) / bv_two_volume, "w") as f:
             f.write("0 0 \n0 0 \n0 0")
         bval_two_volume = "bval_two_volume.txt"
-        with open(pjoin(tmpdir, bval_two_volume), "w") as f:
+        with open(Path(tmpdir) / bval_two_volume, "w") as f:
             f.write("0\n0\n")
         bval_5, bvecs_5 = read_bvals_bvecs(
-            pjoin(tmpdir, bval_two_volume), pjoin(tmpdir, bv_two_volume)
+            Path(tmpdir) / bval_two_volume, Path(tmpdir) / bv_two_volume
         )
         npt.assert_array_equal(bvecs_5, np.zeros((2, 3)))
         npt.assert_array_equal(bval_5, np.zeros(2))
 
         bv_single_volume = "test_single_volume.txt"
-        with open(pjoin(tmpdir, bv_single_volume), "w") as f:
+        with open(Path(tmpdir) / bv_single_volume, "w") as f:
             f.write("0 \n0 \n0 ")
         bval_single_volume = "test_single_volume_2.txt"
-        with open(pjoin(tmpdir, bval_single_volume), "w") as f:
+        with open(Path(tmpdir) / bval_single_volume, "w") as f:
             f.write("0\n")
 
         with warnings.catch_warnings(record=True) as w:
             bval_5, bvecs_5 = read_bvals_bvecs(
-                pjoin(tmpdir, bval_single_volume), pjoin(tmpdir, bv_single_volume)
+                Path(tmpdir) / bval_single_volume, Path(tmpdir) / bv_single_volume
             )
             npt.assert_array_equal(bvecs_5, np.zeros((1, 3)))
             npt.assert_array_equal(bval_5, np.zeros(1))

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -1,5 +1,4 @@
-import os
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -44,7 +43,7 @@ def generate_default_pam(rng):
 @set_random_number_generator()
 def test_io_peaks(rng):
     with TemporaryDirectory() as tmpdir:
-        fname = pjoin(tmpdir, "test.pam5")
+        fname = Path(tmpdir) / "test.pam5"
 
         pam = generate_default_pam(rng)
         save_pam(fname, pam)
@@ -53,7 +52,7 @@ def test_io_peaks(rng):
 
         pam2.affine = None
 
-        fname2 = pjoin(tmpdir, "test2.pam5")
+        fname2 = Path(tmpdir) / "test2.pam5"
         save_pam(fname2, pam2, affine=np.eye(4))
         pam2_res = load_pam(fname2, verbose=True)
         npt.assert_array_equal(pam.peak_dirs, pam2_res.peak_dirs)
@@ -76,23 +75,23 @@ def test_io_peaks(rng):
         npt.assert_equal(pam3.ang_thr, pam.ang_thr)
         npt.assert_array_almost_equal(pam3.sphere.vertices, pam.sphere.vertices)
 
-        fname3 = pjoin(tmpdir, "test3.pam5")
+        fname3 = Path(tmpdir) / "test3.pam5"
         pam4 = PeaksAndMetrics()
         npt.assert_raises((ValueError, AttributeError), save_pam, fname3, pam4)
 
-        fname4 = pjoin(tmpdir, "test4.pam5")
+        fname4 = Path(tmpdir) / "test4.pam5"
         del pam.affine
         save_pam(fname4, pam, affine=None)
 
-        fname5 = pjoin(tmpdir, "test5.pkm")
+        fname5 = Path(tmpdir) / "test5.pkm"
         npt.assert_raises(IOError, save_pam, fname5, pam)
 
         pam.affine = np.eye(4)
-        fname6 = pjoin(tmpdir, "test6.pam5")
+        fname6 = Path(tmpdir) / "test6.pam5"
         save_pam(fname6, pam, verbose=True)
 
         del pam.shm_coeff
-        save_pam(pjoin(tmpdir, fname6), pam, verbose=False)
+        save_pam(Path(tmpdir) / fname6, pam, verbose=False)
 
         pam.shm_coeff = np.zeros((10, 10, 10, 45))
         del pam.odf
@@ -100,20 +99,20 @@ def test_io_peaks(rng):
         pam_tmp = load_pam(fname6, verbose=True)
         npt.assert_equal(pam_tmp.odf, None)
 
-        fname7 = pjoin(tmpdir, "test7.paw")
+        fname7 = Path(tmpdir) / "test7.paw"
         npt.assert_raises(OSError, load_pam, fname7)
 
         del pam.shm_coeff
         save_pam(fname6, pam, verbose=True)
 
-        fname_shm = pjoin(tmpdir, "shm.nii.gz")
-        fname_dirs = pjoin(tmpdir, "peaks_dirs.nii.gz")
-        fname_values = pjoin(tmpdir, "peaks_values.nii.gz")
-        fname_indices = pjoin(tmpdir, "peaks_indices.nii.gz")
-        fname_gfa = pjoin(tmpdir, "gfa.nii.gz")
-        fname_sphere = pjoin(tmpdir, "sphere.txt")
-        fname_b = pjoin(tmpdir, "B.nii.gz")
-        fname_qa = pjoin(tmpdir, "qa.nii.gz")
+        fname_shm = Path(tmpdir) / "shm.nii.gz"
+        fname_dirs = Path(tmpdir) / "peaks_dirs.nii.gz"
+        fname_values = Path(tmpdir) / "peaks_values.nii.gz"
+        fname_indices = Path(tmpdir) / "peaks_indices.nii.gz"
+        fname_gfa = Path(tmpdir) / "gfa.nii.gz"
+        fname_sphere = Path(tmpdir) / "sphere.txt"
+        fname_b = Path(tmpdir) / "B.nii.gz"
+        fname_qa = Path(tmpdir) / "qa.nii.gz"
 
         pam.shm_coeff = np.ones((10, 10, 10, 45))
         pam_to_niftis(
@@ -138,8 +137,8 @@ def test_io_peaks(rng):
             "shm.nii.gz",
         ]:
             npt.assert_(
-                os.path.isfile(pjoin(tmpdir, name)),
-                f"{pjoin(tmpdir, name)} file does not exist",
+                Path(Path(tmpdir) / name).is_file(),
+                f"{Path(tmpdir) / name} file does not exist",
             )
 
 
@@ -150,9 +149,9 @@ def test_io_save_pam_error(rng):
 
         pam = PeaksAndMetrics()
 
-        npt.assert_raises(IOError, save_pam, pjoin(tmpdir, "test.pam"), pam)
+        npt.assert_raises(IOError, save_pam, Path(tmpdir) / "test.pam", pam)
         npt.assert_raises(
-            (ValueError, AttributeError), save_pam, pjoin(tmpdir, fname), pam
+            (ValueError, AttributeError), save_pam, Path(tmpdir) / fname, pam
         )
 
         pam.affine = np.eye(4)
@@ -184,11 +183,11 @@ def test_io_niftis_to_pam():
             odf=np.zeros((10, 10, 10, default_sphere.vertices.shape[0])),
             total_weight=0.5,
             ang_thr=60,
-            pam_file=pjoin(tmpdir, "test15.pam5"),
+            pam_file=Path(tmpdir) / "test15.pam5",
         )
 
         npt.assert_equal(pam.peak_dirs.shape, (10, 10, 10, 5, 3))
-        npt.assert_(os.path.isfile(pjoin(tmpdir, "test15.pam5")))
+        npt.assert_(Path(Path(tmpdir) / "test15.pam5").is_file())
 
 
 def test_tensor_to_pam():
@@ -209,11 +208,11 @@ def test_tensor_to_pam():
             affine=affine,
             sphere=sphere,
             odf=odf,
-            pam_file=pjoin(tmpdir, fname),
+            pam_file=Path(tmpdir) / fname,
         )
-        npt.assert_(os.path.isfile(pjoin(tmpdir, fname)))
-        save_pam(pjoin(tmpdir, "test_tt_2.pam5"), pam)
-        pam2 = load_pam(pjoin(tmpdir, "test_tt_2.pam5"))
+        npt.assert_(Path(Path(tmpdir) / fname).is_file())
+        save_pam(Path(tmpdir) / "test_tt_2.pam5", pam)
+        pam2 = load_pam(Path(tmpdir) / "test_tt_2.pam5")
 
         npt.assert_array_equal(pam.peak_values, pam2.peak_values)
         npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
@@ -226,7 +225,7 @@ def test_io_peaks_deprecated(rng):
     with TemporaryDirectory() as tmpdir:
         with warnings.catch_warnings(record=True) as cw:
             warnings.simplefilter("always", DeprecationWarning)
-            fname = pjoin(tmpdir, "test_tt.pam5")
+            fname = Path(tmpdir) / "test_tt.pam5"
             pam = generate_default_pam(rng)
             save_peaks(fname, pam)
             pam2 = load_peaks(fname, verbose=True)

--- a/dipy/io/tests/test_stateful_surface.py
+++ b/dipy/io/tests/test_stateful_surface.py
@@ -252,7 +252,7 @@ def test_space_origin_gold_standard(space, origin):
     )
 
     # Test in the space it was loaded from
-    vertices = np.loadtxt(fname.replace(".ply", ".txt"))
+    vertices = np.loadtxt(fname.with_suffix(".txt"))
     faces = np.loadtxt(FILEPATH_DIX["gs_mesh_faces.txt"])
     npt.assert_allclose(vertices, sfs.vertices, atol=1e-3, rtol=1e-6)
     npt.assert_allclose(faces, sfs.faces, atol=1e-3, rtol=1e-6)

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import itertools
-import os
-from os.path import join as pjoin
+from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
@@ -49,14 +48,14 @@ def teardown_module():
 def test_direct_trx_loading():
     trx = tmm.load(FILEPATH_DIX["gs_streamlines.trx"])
     tmp_dir = deepcopy(trx._uncompressed_folder_handle.name)
-    assert os.path.isdir(tmp_dir)
+    assert Path(tmp_dir).is_dir()
     sft = trx.to_sft()
 
     tmp_points_vox = np.loadtxt(FILEPATH_DIX["gs_streamlines_vox_space.txt"])
     tmp_points_rasmm = np.loadtxt(FILEPATH_DIX["gs_streamlines_rasmm_space.txt"])
 
     trx.close()
-    assert not os.path.isdir(tmp_dir)
+    assert not Path(tmp_dir).is_dir()
 
     npt.assert_allclose(sft.streamlines._data, tmp_points_rasmm, rtol=1e-04, atol=1e-06)
     sft.to_vox()
@@ -258,19 +257,19 @@ def test_iterative_saving_loading(ext):
         from_space=from_space,
     )
     with TemporaryDirectory() as tmp_dir:
-        save_tractogram(sft, pjoin(tmp_dir, f"gs_iter.{ext}"))
+        save_tractogram(sft, Path(tmp_dir) / f"gs_iter.{ext}")
         tmp_points_rasmm = np.loadtxt(FILEPATH_DIX["gs_streamlines_rasmm_space.txt"])
 
         for _ in range(100):
             sft_iter = load_tractogram(
-                pjoin(tmp_dir, f"gs_iter.{ext}"),
+                Path(tmp_dir) / f"gs_iter.{ext}",
                 FILEPATH_DIX["gs_volume.nii"],
                 to_space=Space.RASMM,
             )
             npt.assert_allclose(
                 tmp_points_rasmm, sft_iter.streamlines.get_data(), atol=1e-3, rtol=1e-6
             )
-            save_tractogram(sft_iter, pjoin(tmp_dir, f"gs_iter.{ext}"))
+            save_tractogram(sft_iter, Path(tmp_dir) / f"gs_iter.{ext}")
 
 
 def test_iterative_to_vox_transformation():
@@ -467,7 +466,7 @@ def test_random_point_color(rng):
     try:
         sft.data_per_point = coloring_dict
         with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, pjoin(tmp_dir, "random_points_color.trk"))
+            save_tractogram(sft, Path(tmp_dir) / "random_points_color.trk")
         npt.assert_(True)
     except (TypeError, ValueError):
         npt.assert_(False)
@@ -489,7 +488,7 @@ def test_random_point_gray(rng):
     try:
         sft.data_per_point = coloring_dict
         with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, pjoin(tmp_dir, "random_points_gray.trk"))
+            save_tractogram(sft, Path(tmp_dir) / "random_points_gray.trk")
         npt.assert_(True)
     except ValueError:
         npt.assert_(False)
@@ -517,7 +516,7 @@ def test_random_streamline_color(rng):
     try:
         sft.data_per_point = coloring_dict
         with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, pjoin(tmp_dir, "random_streamlines_color.trk"))
+            save_tractogram(sft, Path(tmp_dir) / "random_streamlines_color.trk")
         npt.assert_(True)
     except (TypeError, ValueError):
         npt.assert_(False)

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -1,5 +1,5 @@
 import itertools
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
@@ -176,7 +176,7 @@ def teardown_module():
 def io_tractogram(extension):
     with TemporaryDirectory() as tmp_dir:
         fname = f"test.{extension}"
-        fpath = pjoin(tmp_dir, fname)
+        fpath = Path(tmp_dir) / fname
 
         in_affine = np.eye(4)
         in_dimensions = np.array([50, 50, 50])
@@ -216,9 +216,9 @@ def test_vtk_matching_space(space, origin):
     ref_coords = sfs.streamlines._data.copy()
 
     with TemporaryDirectory() as tmpdir:
-        save_tractogram(sfs, pjoin(tmpdir, "tmp.vtk"), to_space=space, to_origin=origin)
+        save_tractogram(sfs, Path(tmpdir) / "tmp.vtk", to_space=space, to_origin=origin)
         sfs = load_tractogram(
-            pjoin(tmpdir, "tmp.vtk"),
+            Path(tmpdir) / "tmp.vtk",
             FILEPATH_DIX["gs_volume.nii"],
             from_space=space,
             from_origin=origin,
@@ -244,7 +244,7 @@ def test_io_vtk(ext):
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
 def test_low_io_vtk():
     with TemporaryDirectory() as tmp_dir:
-        fname = pjoin(tmp_dir, "test.fib")
+        fname = Path(tmp_dir) / "test.fib"
 
         # Test save
         save_vtk_streamlines(STREAMLINES, fname, binary=True)
@@ -256,7 +256,7 @@ def test_low_io_vtk():
 def trk_loader(filename):
     try:
         with TemporaryDirectory() as tmp_dir:
-            load_trk(pjoin(tmp_dir, filename), FILEPATH_DIX["gs_volume.nii"])
+            load_trk(Path(tmp_dir) / filename, FILEPATH_DIX["gs_volume.nii"])
         return True
     except ValueError:
         return False
@@ -269,7 +269,7 @@ def trk_saver(filename):
 
     try:
         with TemporaryDirectory() as tmp_dir:
-            save_trk(sft, pjoin(tmp_dir, filename))
+            save_trk(sft, Path(tmp_dir) / filename)
         return True
     except ValueError:
         return False

--- a/dipy/io/tests/test_surface.py
+++ b/dipy/io/tests/test_surface.py
@@ -1,5 +1,5 @@
 import itertools
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
@@ -51,9 +51,9 @@ def test_pial_load_save():
 
     with TemporaryDirectory() as tmpdir:
         save_surface(
-            sfs, pjoin(tmpdir, "lh.pial"), ref_pial=FILEPATH_DIX["naf_lh.pial"]
+            sfs, Path(tmpdir) / "lh.pial", ref_pial=FILEPATH_DIX["naf_lh.pial"]
         )
-        data_save = nib.freesurfer.read_geometry(pjoin(tmpdir, "lh.pial"))
+        data_save = nib.freesurfer.read_geometry(Path(tmpdir) / "lh.pial")
     npt.assert_almost_equal(data_raw[0], data_save[0], decimal=5)
 
 
@@ -68,9 +68,9 @@ def test_vtk_matching_space(space, origin):
     ref_vertices = sfs.vertices.copy()
 
     with TemporaryDirectory() as tmpdir:
-        save_surface(sfs, pjoin(tmpdir, "tmp.vtk"), to_space=space, to_origin=origin)
+        save_surface(sfs, Path(tmpdir) / "tmp.vtk", to_space=space, to_origin=origin)
         sfs = load_surface(
-            pjoin(tmpdir, "tmp.vtk"),
+            Path(tmpdir) / "tmp.vtk",
             FILEPATH_DIX["naf_mni_masked.nii.gz"],
             from_space=space,
             from_origin=origin,
@@ -96,9 +96,9 @@ def test_gifti_matching_space(type, fname, space, origin):
     ref_vertices = sfs.vertices.copy()
 
     with TemporaryDirectory() as tmpdir:
-        save_surface(sfs, pjoin(tmpdir, "tmp.gii"), to_space=space, to_origin=origin)
+        save_surface(sfs, Path(tmpdir) / "tmp.gii", to_space=space, to_origin=origin)
         sfs = load_surface(
-            pjoin(tmpdir, "tmp.gii"),
+            Path(tmpdir) / "tmp.gii",
             FILEPATH_DIX["anat.nii.gz"],
             from_space=space,
             from_origin=origin,
@@ -134,7 +134,7 @@ def test_freesurfer_density_operation(dataset, hemisphere, type):
     with TemporaryDirectory() as tmpdir:
         nib.save(
             nib.Nifti1Image(data, sfs.affine),
-            pjoin(tmpdir, f"{hemisphere}_{type}.nii.gz"),
+            Path(tmpdir) / f"{hemisphere}_{type}.nii.gz",
         )
 
     # Compute the barycenter of the density map and compare it to the

--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -33,14 +33,14 @@ def load_polydata(file_name):
 
     Parameters
     ----------
-    file_name : string
+    file_name : string or Path
 
     Returns
     -------
     output : vtkPolyData
 
     """
-    return fury.io.load_polydata(file_name)
+    return fury.io.load_polydata(str(file_name))
 
 
 @warning_for_keywords()
@@ -56,7 +56,7 @@ def save_polydata(
     Parameters
     ----------
     polydata : vtkPolyData
-    file_name : string
+    file_name : string or Path
     """
     # use kwargs for backward compatibility with fury < 2.0
     kwargs = {}
@@ -65,7 +65,7 @@ def save_polydata(
 
     fury.io.save_polydata(
         polydata=polydata,
-        file_name=file_name,
+        file_name=str(file_name),
         binary=binary,
         color_array_name=color_array_name,
         **kwargs,
@@ -82,7 +82,7 @@ def save_vtk_streamlines(streamlines, filename, *, to_lps=True, binary=False):
     ----------
     streamlines : list
         list of 2D arrays or ArraySequence
-    filename : string
+    filename : string or Path
         output filename (.obj, .vtk, .fib, .ply, .stl and .xml)
     to_lps : bool
         Default to True, will follow the vtk file convention for streamlines
@@ -110,7 +110,7 @@ def load_vtk_streamlines(filename, *, to_lps=True):
 
     Parameters
     ----------
-    filename : string
+    filename : string or Path
         input filename (.vtk or .fib)
     to_lps : bool
         Default to True, will follow the vtk file convention for streamlines

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 from scipy.ndimage import map_coordinates
@@ -104,7 +104,7 @@ def anatomical_measures(
 
     file_name = f"{bname}_{pname}"
 
-    save_buan_profiles_hdf5(os.path.join(dir_name, file_name), dt)
+    save_buan_profiles_hdf5(Path(dir_name) / file_name, dt)
 
 
 def assignment_map(target_bundle, model_bundle, no_disks):

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -2,14 +2,14 @@
 
 from functools import partial
 import operator
-from os.path import abspath, dirname, join as pjoin
+from pathlib import Path
 import warnings
 
 import numpy.testing as npt
 from numpy.testing import assert_array_equal
 
 # set path to example data
-IO_DATA_PATH = abspath(pjoin(dirname(__file__), "..", "io", "tests", "data"))
+IO_DATA_PATH = Path(__file__).resolve().parent / ".." / "io" / "tests" / "data"
 
 
 def assert_operator(value1, value2, msg="", op=operator.eq):

--- a/dipy/utils/tests/test_optpkg.py
+++ b/dipy/utils/tests/test_optpkg.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -27,8 +28,8 @@ def test_optional_package():
     assert_true(have_pkg)
 
     with TemporaryDirectory() as tmpdir:
-        os.makedirs(os.path.join(tmpdir, "fake_package"))
-        open(os.path.join(tmpdir, "fake_package", "__init__.py"), "a").close()
+        os.makedirs(Path(tmpdir) / "fake_package")
+        open(Path(tmpdir) / "fake_package" / "__init__.py", "a").close()
         current_dir = os.getcwd()
         os.chdir(tmpdir)
         pkg, have_pkg, setup_module = optional_package(

--- a/dipy/utils/tractogram.py
+++ b/dipy/utils/tractogram.py
@@ -1,6 +1,7 @@
 """This module is dedicated to the handling of tractograms."""
 
 import os
+from pathlib import Path
 
 import numpy as np
 import trx.trx_file_memmap as tmm
@@ -167,10 +168,11 @@ def concatenate_tractogram(
         # When memory is allocated on the spot, groups and data_per_group can
         # be concatenated together
         for group_key in all_groups_len.keys():
-            if not os.path.isdir(os.path.join(tmp_dir, "groups/")):
-                os.mkdir(os.path.join(tmp_dir, "groups/"))
+            group_dirname = Path(tmp_dir) / "groups"
+            if not group_dirname.is_dir():
+                os.mkdir(group_dirname)
             dtype = all_groups_dtype[group_key]
-            group_filename = os.path.join(tmp_dir, f"groups/{group_key}.{dtype.name}")
+            group_filename = group_dirname / f"{group_key}.{dtype.name}"
             group_len = all_groups_len[group_key]
             new_trx.groups[group_key] = tmm._create_memmap(
                 group_filename, mode="w+", shape=(group_len,), dtype=dtype

--- a/dipy/viz/horizon/visualizer/peak.py
+++ b/dipy/viz/horizon/visualizer/peak.py
@@ -1,4 +1,3 @@
-from os.path import join as pjoin
 from pathlib import Path
 import warnings
 
@@ -172,11 +171,11 @@ class PeakActor(Actor):
             uniform vec3 lowRanges;
             uniform vec3 highRanges;
             """
-        orient_to_rgb = import_fury_shader(pjoin("utils", "orient_to_rgb.glsl"))
+        orient_to_rgb = import_fury_shader(Path("utils") / "orient_to_rgb.glsl")
         visible_cross_section = import_fury_shader(
-            pjoin("interaction", "visible_cross_section.glsl")
+            Path("interaction") / "visible_cross_section.glsl"
         )
-        visible_range = import_fury_shader(pjoin("interaction", "visible_range.glsl"))
+        visible_range = import_fury_shader(Path("interaction") / "visible_range.glsl")
 
         vs_dec = compose_shader([vs_var_dec, orient_to_rgb])
         fs_dec = compose_shader([fs_var_dec, visible_cross_section, visible_range])

--- a/dipy/viz/streamline.py
+++ b/dipy/viz/streamline.py
@@ -41,7 +41,7 @@ def show_bundles(
        Colors to be used for each bundle. If None default colors are used.
     linewidth : float, optional
         Width of each rendered streamline. Default is 0.3.
-    save_as : str, optional
+    save_as : str or Path, optional
         If not None rendered scene is stored in a png file with that name.
         Default is None.
 
@@ -96,7 +96,7 @@ def viz_two_bundles(b1, b2, fname, *, c1=(1, 0, 0), c2=(0, 1, 0), interactive=Fa
         Bundle one to be rendered.
     b2 : Streamlines
         Bundle two to be rendered.
-    fname: str
+    fname: str or Path
         Rendered scene is stored in a png file with that name.
     C1 : tuple, optional
         Color to be used for first bundle. Default red.

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -1,5 +1,4 @@
-import os
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -67,7 +66,7 @@ def test_horizon_events(rng):
     # select all centroids and expand and click everything else
     # do not press the key shortcuts as vtk generates warning that
     # blocks recording
-    fname = os.path.join(DATA_DIR, "record_horizon.log.gz")
+    fname = Path(DATA_DIR) / "record_horizon.log.gz"
 
     with TemporaryDirectory() as out_dir:
         horizon(
@@ -84,8 +83,8 @@ def test_horizon_events(rng):
             clusters_lt=np.inf,
             world_coords=True,
             interactive=True,
-            out_png=pjoin(out_dir, "horizon-event.png"),
-            recorded_events=fname,
+            out_png=str(Path(out_dir) / "horizon-event.png"),
+            recorded_events=str(fname),
         )
 
 
@@ -143,7 +142,7 @@ def test_horizon(rng):
             clusters_gt=0,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "only-tractograms.png"),
+            out_png=Path(out_dir) / "only-tractograms.png",
         )
 
         images = [(data, affine, "/test/filename.nii.gz")]
@@ -161,7 +160,7 @@ def test_horizon(rng):
                 clusters_gt=0,
                 world_coords=False,
                 interactive=False,
-                out_png=pjoin(out_dir, "native-tractograms.png"),
+                out_png=Path(out_dir) / "native-tractograms.png",
             )
 
         msg = "Currently native coordinates are not supported for streamlines."
@@ -181,7 +180,7 @@ def test_horizon(rng):
             clusters_gt=0,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "only-images.png"),
+            out_png=Path(out_dir) / "only-images.png",
         )
 
         # no clustering tractograms and images
@@ -197,7 +196,7 @@ def test_horizon(rng):
             clusters_gt=0,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "no-clusting-tractograms-and-images.png"),
+            out_png=Path(out_dir) / "no-clusting-tractograms-and-images.png",
         )
 
 
@@ -218,10 +217,12 @@ def test_horizon_wrong_dtype_images():
         horizon(
             images=images,
             interactive=False,
-            out_png=pjoin(out_dir, "wrong-dtype.png"),
+            out_png=str(Path(out_dir) / "wrong-dtype.png"),
         )
         # Asserting the image will not get added and the image will be black.
-        assert len(np.unique(io.load_image(pjoin(out_dir, "wrong-dtype.png")))) == 1
+        assert (
+            len(np.unique(io.load_image(str(Path(out_dir) / "wrong-dtype.png")))) == 1
+        )
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -101,13 +101,13 @@ def test_contour_from_roi():
         sc2 = window.Scene()
         sc.add(streamlines_actor)
         arr3 = window.snapshot(
-            sc, fname=pjoin(out_dir, "test_surface3.png"), offscreen=True
+            sc, fname=Path(out_dir) / "test_surface3.png", offscreen=True
         )
         report3 = window.analyze_snapshot(arr3, find_objects=True)
         sc2.add(streamlines_actor)
         sc2.add(seedroi_actor)
         arr4 = window.snapshot(
-            sc2, fname=pjoin(out_dir, "test_surface4.png"), offscreen=True
+            sc2, fname=Path(out_dir) / "test_surface4.png", offscreen=True
         )
         report4 = window.analyze_snapshot(arr4, find_objects=True)
 

--- a/dipy/viz/tests/test_streamline.py
+++ b/dipy/viz/tests/test_streamline.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import tempfile
 import warnings
 
@@ -52,30 +52,30 @@ def test_output_created():
             )
 
             view = "sagital"  # codespell:ignore sagital
-            fname = os.path.join(temp_dir, f"test_{view}.png")
+            fname = Path(temp_dir) / f"test_{view}.png"
             show_bundles(bundles, interactive=False, view=view, save_as=fname)
-            assert_equal(os.path.exists(fname), True)
+            assert_equal(fname.exists(), True)
 
         views = ["axial", "sagittal", "coronal"]
 
         for view in views:
-            fname = os.path.join(temp_dir, f"test_{view}.png")
+            fname = Path(temp_dir) / f"test_{view}.png"
             show_bundles(bundles, interactive=False, view=view, save_as=fname)
-            assert_equal(os.path.exists(fname), True)
+            assert_equal(fname.exists(), True)
 
-        fname = os.path.join(temp_dir, "test_colors.png")
+        fname = Path(temp_dir) / "test_colors.png"
         show_bundles(bundles, interactive=False, colors=colors, save_as=fname)
-        assert_equal(os.path.exists(fname), True)
+        assert_equal(fname.exists(), True)
 
         # Check rendered image is not empty
-        report = window.analyze_snapshot(fname, find_objects=True)
+        report = window.analyze_snapshot(str(fname), find_objects=True)
         assert_equal(report.objects > 0, True)
 
         cb1, cb2 = two_cingulum_bundles()
 
-        fname = os.path.join(temp_dir, "test_two_bundles.png")
+        fname = Path(temp_dir) / "test_two_bundles.png"
         viz_two_bundles(cb1, cb2, fname=fname)
-        assert_equal(os.path.exists(fname), True)
+        assert_equal(fname.exists(), True)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -106,10 +106,10 @@ def test_bundlewarp_viz():
         )
         points_aligned, _ = unlist_streamlines(affine_bundle)
 
-        fname = os.path.join(temp_dir, "test_vector_field.png")
+        fname = Path(temp_dir) / "test_vector_field.png"
         viz_vector_field(points_aligned, directions, colors, offsets, fname)
-        assert_equal(os.path.exists(fname), True)
+        assert_equal(fname.exists(), True)
 
-        fname = os.path.join(temp_dir, "test_mag_viz.png")
+        fname = Path(temp_dir) / "test_mag_viz.png"
         viz_displacement_mag(affine_bundle, offsets, fname)
-        assert_equal(os.path.exists(fname), True)
+        assert_equal(fname.exists(), True)

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from warnings import warn
 
 import nibabel as nib
@@ -71,7 +71,7 @@ class ResliceFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         new_vox_size : variable float
@@ -150,9 +150,9 @@ class SlrWithQbxFlow(Workflow):
 
         Parameters
         ----------
-        static_files : string
+        static_files : string or Path
             List of reference/fixed bundle tractograms.
-        moving_files : string
+        moving_files : string or Path
             List of target bundle tractograms that will be moved/registered to
             match the static bundles.
         x0 : string, optional
@@ -239,7 +239,9 @@ class SlrWithQbxFlow(Workflow):
             new_tractogram = nib.streamlines.Tractogram(
                 moved, affine_to_rasmm=np.eye(4)
             )
-            nib.streamlines.save(new_tractogram, out_moved_file, header=moving_header)
+            nib.streamlines.save(
+                new_tractogram, str(out_moved_file), header=moving_header
+            )
 
             logger.info(f"Saving output file {out_affine_file}")
             np.savetxt(out_affine_file, affine)
@@ -249,7 +251,7 @@ class SlrWithQbxFlow(Workflow):
                 centroids_static, affine_to_rasmm=np.eye(4)
             )
             nib.streamlines.save(
-                new_tractogram, static_centroids_file, header=static_header
+                new_tractogram, str(static_centroids_file), header=static_header
             )
 
             logger.info(f"Saving output file {moving_centroids_file}")
@@ -257,7 +259,7 @@ class SlrWithQbxFlow(Workflow):
                 centroids_moving, affine_to_rasmm=np.eye(4)
             )
             nib.streamlines.save(
-                new_tractogram, moving_centroids_file, header=moving_header
+                new_tractogram, str(moving_centroids_file), header=moving_header
             )
 
             centroids_moved = transform_streamlines(centroids_moving, affine)
@@ -268,7 +270,7 @@ class SlrWithQbxFlow(Workflow):
                 centroids_moved, affine_to_rasmm=np.eye(4)
             )
             nib.streamlines.save(
-                new_tractogram, moved_centroids_file, header=moving_header
+                new_tractogram, str(moved_centroids_file), header=moving_header
             )
 
 
@@ -975,7 +977,7 @@ class BundleWarpFlow(Workflow):
             affine_bundle, affine_to_rasmm=np.eye(4)
         )
         nib.streamlines.save(
-            new_tractogram, pjoin(out_dir, out_linear_moved), header=moving_header
+            new_tractogram, str(Path(out_dir) / out_linear_moved), header=moving_header
         )
 
         logger.info(f"Saving output file {out_nonlinear_moved}")
@@ -983,17 +985,19 @@ class BundleWarpFlow(Workflow):
             deformed_bundle, affine_to_rasmm=np.eye(4)
         )
         nib.streamlines.save(
-            new_tractogram, pjoin(out_dir, out_nonlinear_moved), header=moving_header
+            new_tractogram,
+            str(Path(out_dir) / out_nonlinear_moved),
+            header=moving_header,
         )
 
         logger.info(f"Saving output file {out_warp_transform}")
-        np.save(pjoin(out_dir, out_warp_transform), np.array(warp["transforms"]))
+        np.save(Path(out_dir) / out_warp_transform, np.array(warp["transforms"]))
 
         logger.info(f"Saving output file {out_warp_kernel}")
-        np.save(pjoin(out_dir, out_warp_kernel), np.array(warp["gaussian_kernel"]))
+        np.save(Path(out_dir) / out_warp_kernel, np.array(warp["gaussian_kernel"]))
 
         logger.info(f"Saving output file {out_dist}")
-        np.save(pjoin(out_dir, out_dist), dist)
+        np.save(Path(out_dir) / out_dist, dist)
 
         logger.info(f"Saving output file {out_matched_pairs}")
-        np.save(pjoin(out_dir, out_matched_pairs), mp)
+        np.save(Path(out_dir) / out_matched_pairs, mp)

--- a/dipy/workflows/cli.py
+++ b/dipy/workflows/cli.py
@@ -1,5 +1,5 @@
 #!python
-import os
+from pathlib import Path
 import sys
 
 from dipy.utils.logging import logger
@@ -67,7 +67,7 @@ cli_flows = {
 
 def run():
     """Run scripts located in pyproject.toml."""
-    script_name = os.path.basename(sys.argv[0])
+    script_name = Path(sys.argv[0]).name
     mod_name, flow_name = cli_flows.get(script_name, (None, None))
     if mod_name is None:
         logger.info(f"Flow: {script_name} not Found in DIPY")

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -1,5 +1,5 @@
 from ast import literal_eval
-import os.path
+from pathlib import Path
 from warnings import warn
 
 import nibabel as nib
@@ -259,7 +259,7 @@ class ReconstMAPMRIFlow(Workflow):
                     r = func()
                     save_nifti(fname, r.astype(np.float32), affine)
 
-            logger.info(f"MAPMRI saved in {os.path.abspath(out_dir)}")
+            logger.info(f"MAPMRI saved in {Path(out_dir).resolve()}")
 
             sphere = default_sphere
             if sphere_name:
@@ -573,7 +573,7 @@ class ReconstDtiFlow(Workflow):
                     )
 
             if save_metrics:
-                msg = f"DTI metrics saved to {os.path.abspath(out_dir)}"
+                msg = f"DTI metrics saved to {Path(out_dir).resolve()}"
                 logger.info(msg)
                 for metric in save_metrics:
                     logger.info(self.last_generated_outputs[f"out_{metric}"])
@@ -817,7 +817,7 @@ class ReconstDsiFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            logger.info(f"DSI metrics saved to {os.path.abspath(out_dir)}")
+            logger.info(f"DSI metrics saved to {Path(out_dir).resolve()}")
 
 
 class ReconstCSDFlow(Workflow):
@@ -1051,7 +1051,7 @@ class ReconstCSDFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             if dname_ == "":
                 logger.info("Pam5 file saved in current directory")
             else:
@@ -1275,7 +1275,7 @@ class ReconstQBallBaseFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             if dname_ == "":
                 logger.info("Pam5 file saved in current directory")
             else:
@@ -1530,7 +1530,7 @@ class ReconstDkiFlow(Workflow):
             if "rk" in save_metrics:
                 save_nifti(ork, dkfit.rk().astype(np.float32), affine)
 
-            logger.info(f"DKI metrics saved in {os.path.dirname(oevals)}")
+            logger.info(f"DKI metrics saved in {Path(oevals).parent}")
 
             pam = tensor_to_pam(
                 dkfit.evals.astype(np.float32),
@@ -1696,7 +1696,7 @@ class ReconstIvimFlow(Workflow):
             if "D" in save_metrics:
                 save_nifti(oD, ivimfit.D.astype(np.float32), affine)
 
-            logger.info(f"IVIM metrics saved in {os.path.dirname(oD)}")
+            logger.info(f"IVIM metrics saved in {Path(oD).parent}")
 
     @warning_for_keywords()
     def get_fitted_ivim(self, data, mask, bval, bvec, *, b0_threshold=50):
@@ -1972,7 +1972,7 @@ class ReconstRUMBAFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             if dname_ == "":
                 logger.info("Pam5 file saved in current directory")
             else:
@@ -2199,7 +2199,7 @@ class ReconstSDTFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             if dname_ == "":
                 logger.info("Pam5 file saved in current directory")
             else:
@@ -2413,7 +2413,7 @@ class ReconstSFMFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             msg = (
                 "Pam5 file saved in current directory"
                 if dname_ == ""
@@ -2616,7 +2616,7 @@ class ReconstGQIFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             msg = (
                 "Pam5 file saved in current directory"
                 if dname_ == ""
@@ -2829,7 +2829,7 @@ class ReconstForecastFlow(Workflow):
                     reshape_dirs=True,
                 )
 
-            dname_ = os.path.dirname(opam)
+            dname_ = Path(opam).parent
             msg = (
                 "Pam5 file saved in current directory"
                 if dname_ == ""

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sys
 from time import time
 
@@ -502,7 +502,7 @@ class ClassifyTissueFlow(Workflow):
                 save_nifti(opve, PVE, affine)
 
             elif method.lower() == "dam":
-                if bvals_file is None or not os.path.isfile(bvals_file):
+                if bvals_file is None or not Path(bvals_file).is_file():
                     logger.error("'--bvals filename' is required for 'dam' method")
                     sys.exit(1)
 

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -1,5 +1,4 @@
-import os.path
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import nibabel as nib
@@ -36,7 +35,7 @@ def test_reslice():
         volume = load_nifti_data(data_path)
 
         reslice_flow = ResliceFlow()
-        reslice_flow.run(data_path, [1.5, 1.5, 1.5], out_dir=out_dir)
+        reslice_flow.run(str(data_path), [1.5, 1.5, 1.5], out_dir=out_dir)
 
         out_path = reslice_flow.last_generated_outputs["out_resliced"]
         resliced = load_nifti_data(out_path)
@@ -56,23 +55,23 @@ def test_slr_flow():
         f = Streamlines(fornix)
         f1 = f.copy()
 
-        f1_path = pjoin(out_dir, "f1.trk")
+        f1_path = Path(out_dir) / "f1.trk"
         sft = StatefulTractogram(f1, data_path, Space.RASMM)
         save_tractogram(sft, f1_path, bbox_valid_check=False)
 
         f2 = f1.copy()
         f2._data += np.array([50, 0, 0])
 
-        f2_path = pjoin(out_dir, "f2.trk")
+        f2_path = Path(out_dir) / "f2.trk"
         sft = StatefulTractogram(f2, data_path, Space.RASMM)
         save_tractogram(sft, f2_path, bbox_valid_check=False)
 
         slr_flow = SlrWithQbxFlow(force=True)
-        slr_flow.run(f1_path, f2_path, out_dir=out_dir)
+        slr_flow.run(str(f1_path), str(f2_path), out_dir=out_dir)
 
         out_path = slr_flow.last_generated_outputs["out_moved"]
 
-        npt.assert_equal(os.path.isfile(out_path), True)
+        npt.assert_equal(Path(out_path).is_file(), True)
 
 
 @set_random_number_generator(1234)
@@ -84,53 +83,53 @@ def test_image_registration(rng):
             )
         )
 
-        save_nifti(pjoin(temp_out_dir, "b0.nii.gz"), data=static, affine=static_g2w)
-        save_nifti(pjoin(temp_out_dir, "t1.nii.gz"), data=moving, affine=moving_g2w)
+        save_nifti(Path(temp_out_dir) / "b0.nii.gz", data=static, affine=static_g2w)
+        save_nifti(Path(temp_out_dir) / "t1.nii.gz", data=moving, affine=moving_g2w)
         # simulate three direction DWI by repeating b0 three times
         save_nifti(
-            pjoin(temp_out_dir, "dwi.nii.gz"),
+            Path(temp_out_dir) / "dwi.nii.gz",
             data=np.repeat(static[..., None], 3, axis=-1),
             affine=static_g2w,
         )
 
-        static_image_file = pjoin(temp_out_dir, "b0.nii.gz")
-        moving_image_file = pjoin(temp_out_dir, "t1.nii.gz")
-        dwi_image_file = pjoin(temp_out_dir, "dwi.nii.gz")
+        static_image_file = Path(temp_out_dir) / "b0.nii.gz"
+        moving_image_file = Path(temp_out_dir) / "t1.nii.gz"
+        dwi_image_file = Path(temp_out_dir) / "dwi.nii.gz"
 
         image_registration_flow = ImageRegistrationFlow()
         apply_trans = ApplyTransformFlow()
 
         def read_distance(qual_fname):
-            with open(pjoin(temp_out_dir, qual_fname), "r") as f:
+            with open(Path(temp_out_dir) / qual_fname, "r") as f:
                 return float(f.readlines()[-1])
 
         def test_com():
-            out_moved = pjoin(temp_out_dir, "com_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "com_affine.txt")
+            out_moved = Path(temp_out_dir) / "com_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "com_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="com",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
             )
             check_existence(out_moved, out_affine)
 
         def test_translation():
-            out_moved = pjoin(temp_out_dir, "trans_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "trans_affine.txt")
+            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "trans_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="trans",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="trans_q.txt",
@@ -141,17 +140,17 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
         def test_rigid():
-            out_moved = pjoin(temp_out_dir, "rigid_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "rigid_affine.txt")
+            out_moved = Path(temp_out_dir) / "rigid_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "rigid_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="rigid",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_q.txt",
@@ -162,17 +161,17 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
         def test_rigid_isoscaling():
-            out_moved = pjoin(temp_out_dir, "rigid_isoscaling_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "rigid_isoscaling_affine.txt")
+            out_moved = Path(temp_out_dir) / "rigid_isoscaling_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "rigid_isoscaling_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="rigid_isoscaling",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_isoscaling_q.txt",
@@ -183,17 +182,17 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
         def test_rigid_scaling():
-            out_moved = pjoin(temp_out_dir, "rigid_scaling_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "rigid_scaling_affine.txt")
+            out_moved = Path(temp_out_dir) / "rigid_scaling_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "rigid_scaling_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="rigid_scaling",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_scaling_q.txt",
@@ -204,17 +203,17 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
         def test_affine():
-            out_moved = pjoin(temp_out_dir, "affine_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "affine_affine.txt")
+            out_moved = Path(temp_out_dir) / "affine_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "affine_affine.txt"
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="affine",
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="affine_q.txt",
@@ -230,8 +229,8 @@ def test_image_registration(rng):
             npt.assert_raises(
                 ValueError,
                 image_registration_flow.run,
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform="notransform",
             )
 
@@ -239,28 +238,28 @@ def test_image_registration(rng):
             npt.assert_raises(
                 ValueError,
                 image_registration_flow.run,
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 metric="wrong_metric",
             )
 
         def check_existence(movedfile, affine_mat_file):
-            assert os.path.exists(movedfile)
-            assert os.path.exists(affine_mat_file)
+            assert Path(movedfile).exists()
+            assert Path(affine_mat_file).exists()
             return True
 
         def test_4D_static():
-            out_moved = pjoin(temp_out_dir, "trans_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "trans_affine.txt")
+            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "trans_affine.txt"
 
             image_registration_flow._force_overwrite = True
             kwargs = {
-                "static_image_files": dwi_image_file,
-                "moving_image_files": moving_image_file,
+                "static_image_files": str(dwi_image_file),
+                "moving_image_files": str(moving_image_file),
                 "transform": "trans",
                 "out_dir": temp_out_dir,
-                "out_moved": out_moved,
-                "out_affine": out_affine,
+                "out_moved": str(out_moved),
+                "out_affine": str(out_affine),
                 "save_metric": True,
                 "level_iters": [100, 10, 1],
                 "out_quality": "trans_q.txt",
@@ -275,29 +274,29 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
             apply_trans.run(
-                static_image_files=dwi_image_file,
-                moving_image_files=moving_image_file,
+                static_image_files=str(dwi_image_file),
+                moving_image_files=str(moving_image_file),
                 out_dir=temp_out_dir,
-                transform_map_file=out_affine,
+                transform_map_file=str(out_affine),
             )
 
             # Checking for the transformed volume shape
-            volume = load_nifti_data(pjoin(temp_out_dir, "transformed.nii.gz"))
+            volume = load_nifti_data(Path(temp_out_dir) / "transformed.nii.gz")
             assert volume.ndim == 3
 
         def test_4D_moving():
-            out_moved = pjoin(temp_out_dir, "trans_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, "trans_affine.txt")
+            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
+            out_affine = Path(temp_out_dir) / "trans_affine.txt"
 
             image_registration_flow._force_overwrite = True
 
             kwargs = {
-                "static_image_files": static_image_file,
-                "moving_image_files": dwi_image_file,
+                "static_image_files": str(static_image_file),
+                "moving_image_files": str(dwi_image_file),
                 "transform": "trans",
                 "out_dir": temp_out_dir,
-                "out_moved": out_moved,
-                "out_affine": out_affine,
+                "out_moved": str(out_moved),
+                "out_affine": str(out_affine),
                 "save_metric": True,
                 "level_iters": [100, 10, 1],
                 "out_quality": "trans_q.txt",
@@ -312,15 +311,15 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
             apply_trans.run(
-                static_image_files=static_image_file,
-                moving_image_files=dwi_image_file,
+                static_image_files=str(static_image_file),
+                moving_image_files=str(dwi_image_file),
                 out_dir=temp_out_dir,
-                transform_map_file=out_affine,
+                transform_map_file=str(out_affine),
                 out_file="transformed2.nii.gz",
             )
 
             # Checking for the transformed volume shape
-            volume = load_nifti_data(pjoin(temp_out_dir, "transformed2.nii.gz"))
+            volume = load_nifti_data(Path(temp_out_dir) / "transformed2.nii.gz")
             assert volume.ndim == 4
 
         test_com()
@@ -396,15 +395,15 @@ def test_apply_affine_transform():
             stat_file = str(i[0]) + "_static.nii.gz"
             mov_file = str(i[0]) + "_moving.nii.gz"
 
-            save_nifti(pjoin(temp_out_dir, stat_file), data=static, affine=static_g2w)
+            save_nifti(Path(temp_out_dir) / stat_file, data=static, affine=static_g2w)
 
-            save_nifti(pjoin(temp_out_dir, mov_file), data=moving, affine=moving_g2w)
+            save_nifti(Path(temp_out_dir) / mov_file, data=moving, affine=moving_g2w)
 
-            static_image_file = pjoin(temp_out_dir, str(i[0]) + "_static.nii.gz")
-            moving_image_file = pjoin(temp_out_dir, str(i[0]) + "_moving.nii.gz")
+            static_image_file = Path(temp_out_dir) / str(i[0] + "_static.nii.gz")
+            moving_image_file = Path(temp_out_dir) / str(i[0] + "_moving.nii.gz")
 
-            out_moved = pjoin(temp_out_dir, str(i[0]) + "_moved.nii.gz")
-            out_affine = pjoin(temp_out_dir, str(i[0]) + "_affine.txt")
+            out_moved = Path(temp_out_dir) / str(i[0] + "_moved.nii.gz")
+            out_affine = Path(temp_out_dir) / str(i[0] + "_affine.txt")
 
             if str(i[0]) == "TRANSLATION":
                 transform_type = "trans"
@@ -416,30 +415,30 @@ def test_apply_affine_transform():
                 transform_type = str(i[0]).lower()
 
             image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
+                str(static_image_file),
+                str(moving_image_file),
                 transform=transform_type,
                 out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
+                out_moved=str(out_moved),
+                out_affine=str(out_affine),
                 level_iters=[1, 1, 1],
                 save_metric=False,
             )
 
             # Checking for the created moved file.
-            assert os.path.exists(out_moved)
-            assert os.path.exists(out_affine)
+            assert Path(out_moved).exists()
+            assert Path(out_affine).exists()
 
-        images = pjoin(temp_out_dir, "*moving*")
+        images = Path(temp_out_dir) / "*moving*"
         apply_trans.run(
-            static_image_file,
-            images,
+            str(static_image_file),
+            str(images),
             out_dir=temp_out_dir,
-            transform_map_file=out_affine,
+            transform_map_file=str(out_affine),
         )
 
         # Checking for the transformed file.
-        assert os.path.exists(pjoin(temp_out_dir, "transformed.nii.gz"))
+        assert Path(Path(temp_out_dir) / "transformed.nii.gz").exists()
 
 
 def test_motion_correction():
@@ -449,22 +448,20 @@ def test_motion_correction():
         # Use an abbreviated data-set:
         img = nib.load(data_path)
         data = img.get_fdata()[..., :10]
-        nib.save(
-            nib.Nifti1Image(data, img.affine), os.path.join(out_dir, "data.nii.gz")
-        )
+        nib.save(nib.Nifti1Image(data, img.affine), Path(out_dir) / "data.nii.gz")
         # Save a subset:
         bvals = np.loadtxt(fbvals_path)
         bvecs = np.loadtxt(fbvecs_path)
-        np.savetxt(os.path.join(out_dir, "bvals.txt"), bvals[:10])
-        np.savetxt(os.path.join(out_dir, "bvecs.txt"), bvecs[:10])
+        np.savetxt(Path(out_dir) / "bvals.txt", bvals[:10])
+        np.savetxt(Path(out_dir) / "bvecs.txt", bvecs[:10])
 
         motion_correction_flow = MotionCorrectionFlow()
 
         motion_correction_flow._force_overwrite = True
         motion_correction_flow.run(
-            os.path.join(out_dir, "data.nii.gz"),
-            os.path.join(out_dir, "bvals.txt"),
-            os.path.join(out_dir, "bvecs.txt"),
+            str(Path(out_dir) / "data.nii.gz"),
+            str(Path(out_dir) / "bvals.txt"),
+            str(Path(out_dir) / "bvecs.txt"),
             out_dir=out_dir,
         )
         out_path = motion_correction_flow.last_generated_outputs["out_moved"]
@@ -486,14 +483,14 @@ def test_syn_registration_flow():
 
     with TemporaryDirectory() as out_dir:
         static_img = nib.Nifti1Image(static_data.astype(float), np.eye(4))
-        fname_static = pjoin(out_dir, "tmp_static.nii.gz")
+        fname_static = Path(out_dir) / "tmp_static.nii.gz"
         nib.save(static_img, fname_static)
 
         moving_img = nib.Nifti1Image(moving_data.astype(float), np.eye(4))
-        fname_moving = pjoin(out_dir, "tmp_moving.nii.gz")
+        fname_moving = Path(out_dir) / "tmp_moving.nii.gz"
         nib.save(moving_img, fname_moving)
 
-        positional_args = [fname_static, fname_moving]
+        positional_args = [str(fname_static), str(fname_moving)]
 
         # Test the cc metric
         metric_optional_args = {
@@ -514,9 +511,9 @@ def test_syn_registration_flow():
         syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
 
         warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(os.path.isfile(warped_path), True)
+        npt.assert_equal(Path(warped_path).is_file(), True)
         warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(os.path.isfile(warped_map_path), True)
+        npt.assert_equal(Path(warped_map_path).is_file(), True)
 
         # Test the ssd metric
         metric_optional_args = {
@@ -538,9 +535,9 @@ def test_syn_registration_flow():
         syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
 
         warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(os.path.isfile(warped_path), True)
+        npt.assert_equal(Path(warped_path).is_file(), True)
         warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(os.path.isfile(warped_map_path), True)
+        npt.assert_equal(Path(warped_map_path).is_file(), True)
 
         # Test the em metric
         metric_optional_args = {
@@ -562,9 +559,9 @@ def test_syn_registration_flow():
         syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
 
         warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(os.path.isfile(warped_path), True)
+        npt.assert_equal(Path(warped_path).is_file(), True)
         warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(os.path.isfile(warped_map_path), True)
+        npt.assert_equal(Path(warped_map_path).is_file(), True)
 
 
 @pytest.mark.skipif(not have_pd, reason="Requires pandas")
@@ -577,22 +574,22 @@ def test_bundlewarp_flow():
         f = Streamlines(fornix)
         f1 = f.copy()
 
-        f1_path = pjoin(out_dir, "f1.trk")
+        f1_path = Path(out_dir) / "f1.trk"
         sft = StatefulTractogram(f1, data_path, Space.RASMM)
         save_tractogram(sft, f1_path, bbox_valid_check=False)
 
         f2 = f1.copy()
         f2._data += np.array([50, 0, 0])
 
-        f2_path = pjoin(out_dir, "f2.trk")
+        f2_path = Path(out_dir) / "f2.trk"
         sft = StatefulTractogram(f2, data_path, Space.RASMM)
         save_tractogram(sft, f2_path, bbox_valid_check=False)
 
         bw_flow = BundleWarpFlow(force=True)
-        bw_flow.run(f1_path, f2_path, out_dir=out_dir)
+        bw_flow.run(str(f1_path), str(f2_path), out_dir=out_dir)
 
-        out_linearly_moved = pjoin(out_dir, "linearly_moved.trk")
-        out_nonlinearly_moved = pjoin(out_dir, "nonlinearly_moved.trk")
+        out_linearly_moved = Path(out_dir) / "linearly_moved.trk"
+        out_nonlinearly_moved = Path(out_dir) / "nonlinearly_moved.trk"
 
-        assert os.path.exists(out_linearly_moved)
-        assert os.path.exists(out_nonlinearly_moved)
+        assert out_linearly_moved.exists()
+        assert out_nonlinearly_moved.exists()

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -31,13 +31,13 @@ def test_nlmeans_flow():
 
         nlmeans_flow = NLMeansFlow()
 
-        nlmeans_flow.run(data_path, out_dir=out_dir)
-        assert_true(os.path.isfile(nlmeans_flow.last_generated_outputs["out_denoised"]))
+        nlmeans_flow.run(str(data_path), out_dir=out_dir)
+        assert_true(Path(nlmeans_flow.last_generated_outputs["out_denoised"]).is_file())
 
         nlmeans_flow._force_overwrite = True
-        nlmeans_flow.run(data_path, sigma=4, out_dir=out_dir)
+        nlmeans_flow.run(str(data_path), sigma=4, out_dir=out_dir)
         denoised_path = nlmeans_flow.last_generated_outputs["out_denoised"]
-        assert_true(os.path.isfile(denoised_path))
+        assert_true(Path(denoised_path).is_file())
         denoised_data, denoised_affine = load_nifti(denoised_path)
         npt.assert_equal(denoised_data.shape, volume.shape)
         npt.assert_array_almost_equal(denoised_affine, affine)
@@ -50,17 +50,17 @@ def test_patch2self_flow():
 
         patch2self_flow = Patch2SelfFlow()
         patch2self_flow.run(
-            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=1
+            str(data_path), str(fbvals), patch_radius=(0, 0, 0), out_dir=out_dir, ver=1
         )
         assert_true(
-            os.path.isfile(patch2self_flow.last_generated_outputs["out_denoised"])
+            Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
         )
         patch2self_flow = Patch2SelfFlow()
         patch2self_flow.run(
-            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=3
+            str(data_path), str(fbvals), patch_radius=(0, 0, 0), out_dir=out_dir, ver=3
         )
         assert_true(
-            os.path.isfile(patch2self_flow.last_generated_outputs["out_denoised"])
+            Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
         )
 
 
@@ -69,26 +69,28 @@ def test_lpca_flow():
         data_path, fbvals, fbvecs = get_fnames()
 
     lpca_flow = LPCAFlow()
-    lpca_flow.run(data_path, fbvals, fbvecs, out_dir=out_dir)
-    assert_true(os.path.isfile(lpca_flow.last_generated_outputs["out_denoised"]))
+    lpca_flow.run(str(data_path), str(fbvals), str(fbvecs), out_dir=out_dir)
+    assert_true(Path(lpca_flow.last_generated_outputs["out_denoised"]).is_file())
 
 
 @set_random_number_generator()
 def test_mppca_flow(rng):
     with TemporaryDirectory() as out_dir:
         S0 = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
-        data_path = os.path.join(out_dir, "random_noise.nii.gz")
+        data_path = Path(out_dir) / "random_noise.nii.gz"
         save_nifti(data_path, S0, np.eye(4))
 
         mppca_flow = MPPCAFlow()
-        mppca_flow.run(data_path, out_dir=out_dir)
-        assert_true(os.path.isfile(mppca_flow.last_generated_outputs["out_denoised"]))
-        assert_false(os.path.isfile(mppca_flow.last_generated_outputs["out_sigma"]))
+        mppca_flow.run(str(data_path), out_dir=out_dir)
+        assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
+        assert_false(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
         mppca_flow._force_overwrite = True
-        mppca_flow.run(data_path, return_sigma=True, pca_method="svd", out_dir=out_dir)
-        assert_true(os.path.isfile(mppca_flow.last_generated_outputs["out_denoised"]))
-        assert_true(os.path.isfile(mppca_flow.last_generated_outputs["out_sigma"]))
+        mppca_flow.run(
+            str(data_path), return_sigma=True, pca_method="svd", out_dir=out_dir
+        )
+        assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
+        assert_true(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
         denoised_path = mppca_flow.last_generated_outputs["out_denoised"]
         denoised_data = load_nifti_data(denoised_path)
@@ -121,9 +123,9 @@ def test_gibbs_flow():
         image4d[:, :, 1, 0] = generate_slice()
         image4d[:, :, 0, 1] = generate_slice()
         image4d[:, :, 1, 1] = generate_slice()
-        data_path = os.path.join(out_dir, "random_noise.nii.gz")
+        data_path = Path(out_dir) / "random_noise.nii.gz"
         save_nifti(data_path, image4d, np.eye(4))
 
         gibbs_flow = GibbsRingingFlow()
-        gibbs_flow.run(data_path, out_dir=out_dir)
-        assert_true(os.path.isfile(gibbs_flow.last_generated_outputs["out_unring"]))
+        gibbs_flow.run(str(data_path), out_dir=out_dir)
+        assert_true(Path(gibbs_flow.last_generated_outputs["out_unring"]).is_file())

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
 
@@ -55,15 +55,15 @@ def test_none_or_dtype():
 
 def test_variable_type():
     with TemporaryDirectory() as out_dir:
-        open(pjoin(out_dir, "test"), "w").close()
-        open(pjoin(out_dir, "test1"), "w").close()
-        open(pjoin(out_dir, "test2"), "w").close()
+        open(Path(out_dir) / "test", "w").close()
+        open(Path(out_dir) / "test1", "w").close()
+        open(Path(out_dir) / "test2", "w").close()
 
         sys.argv = [sys.argv[0]]
         pos_results = [
-            pjoin(out_dir, "test"),
-            pjoin(out_dir, "test1"),
-            pjoin(out_dir, "test2"),
+            Path(out_dir) / "test",
+            Path(out_dir) / "test1",
+            Path(out_dir) / "test2",
             12,
         ]
         inputs = inputs_from_results(pos_results)
@@ -73,7 +73,7 @@ def test_variable_type():
         npt.assert_equal(positional_res2, 12)
 
         for k, v in zip(positional_res, pos_results[:-1]):
-            npt.assert_equal(k, v)
+            npt.assert_equal(Path(k), v)
 
         dcwf = DummyVariableTypeErrorWorkflow()
         npt.assert_raises(ValueError, run_flow, dcwf)

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -1,8 +1,7 @@
 import importlib
 from inspect import getmembers, isfunction
 import logging
-import os
-from os.path import join as pjoin
+from pathlib import Path
 import shutil
 import sys
 from tempfile import TemporaryDirectory, mkstemp
@@ -58,29 +57,35 @@ is_big_endian = "big" in sys.byteorder.lower()
 def test_io_info():
     fimg, fbvals, fbvecs = get_fnames(name="small_101D")
     io_info_flow = IoInfoFlow()
-    io_info_flow.run([fimg, fbvals, fbvecs])
+    io_info_flow.run([str(fimg), str(fbvals), str(fbvecs)])
 
     fimg, fbvals, fbvecs = get_fnames(name="small_25")
     io_info_flow = IoInfoFlow()
-    io_info_flow.run([fimg, fbvals, fbvecs])
-
-    io_info_flow = IoInfoFlow()
-    io_info_flow.run([fimg, fbvals, fbvecs], b0_threshold=20, bvecs_tol=0.001)
+    io_info_flow.run([str(fimg), str(fbvals), str(fbvecs)])
+    io_info_flow.run(
+        [str(fimg), str(fbvals), str(fbvecs)], b0_threshold=20, bvecs_tol=0.001
+    )
 
     filepath_dix, _, _ = get_fnames(name="gold_standard_io")
     if not is_big_endian:
         io_info_flow = IoInfoFlow()
-        io_info_flow.run(filepath_dix["gs_streamlines.trx"])
+        io_info_flow.run(str(filepath_dix["gs_streamlines.trx"]))
 
     io_info_flow = IoInfoFlow()
-    io_info_flow.run(filepath_dix["gs_streamlines.trk"])
+    io_info_flow.run(str(filepath_dix["gs_streamlines.trk"]))
 
     io_info_flow = IoInfoFlow()
-    npt.assert_raises(SystemExit, io_info_flow.run, filepath_dix["gs_streamlines.tck"])
+    npt.assert_raises(
+        SystemExit, io_info_flow.run, str(filepath_dix["gs_streamlines.tck"])
+    )
+
+    io_info_flow = IoInfoFlow()
+    npt.assert_raises(OSError, io_info_flow.run, "fake.vtk")
 
     io_info_flow = IoInfoFlow()
     io_info_flow.run(
-        filepath_dix["gs_streamlines.tck"], reference=filepath_dix["gs_volume.nii"]
+        str(filepath_dix["gs_streamlines.tck"]),
+        reference=str(filepath_dix["gs_volume.nii"]),
     )
 
     with open(fname_log, "r") as file:
@@ -95,10 +100,10 @@ def test_io_fetch():
     fetch_flow = FetchFlow()
     with TemporaryDirectory() as out_dir:
         fetch_flow.run(["bundle_fa_hcp"])
-        npt.assert_equal(os.path.isdir(os.path.join(dipy_home, "bundle_fa_hcp")), True)
+        npt.assert_equal(Path(Path(dipy_home) / "bundle_fa_hcp").is_dir(), True)
 
         fetch_flow.run(["bundle_fa_hcp"], out_dir=out_dir)
-        npt.assert_equal(os.path.isdir(os.path.join(out_dir, "bundle_fa_hcp")), True)
+        npt.assert_equal(Path(Path(dipy_home) / "bundle_fa_hcp").is_dir(), True)
 
 
 def test_io_fetch_fetcher_datanames():
@@ -130,12 +135,12 @@ def test_split_flow():
         split_flow = SplitFlow()
         data_path, _, _ = get_fnames()
         volume, affine = load_nifti(data_path)
-        split_flow.run(data_path, out_dir=out_dir)
-        assert_true(os.path.isfile(split_flow.last_generated_outputs["out_split"]))
+        split_flow.run(str(data_path), out_dir=out_dir)
+        assert_true(Path(split_flow.last_generated_outputs["out_split"]).is_file())
         split_flow._force_overwrite = True
-        split_flow.run(data_path, vol_idx=0, out_dir=out_dir)
+        split_flow.run(str(data_path), vol_idx=0, out_dir=out_dir)
         split_path = split_flow.last_generated_outputs["out_split"]
-        assert_true(os.path.isfile(split_path))
+        assert_true(Path(split_path).is_file())
         split_data, split_affine = load_nifti(split_path)
         npt.assert_equal(split_data.shape, volume[..., 0].shape)
         npt.assert_array_almost_equal(split_affine, affine)
@@ -146,7 +151,7 @@ def test_concatenate_flow():
         concatenate_flow = ConcatenateTractogramFlow()
         data_path, _, _ = get_fnames(name="gold_standard_io")
         input_files = [
-            v
+            str(v)
             for k, v in data_path.items()
             if k
             in [
@@ -161,9 +166,9 @@ def test_concatenate_flow():
             concatenate_flow.last_generated_outputs["out_extension"].endswith("trx")
         )
         assert_true(
-            os.path.isfile(
+            Path(
                 concatenate_flow.last_generated_outputs["out_tractogram"] + ".trx"
-            )
+            ).is_file()
         )
 
         trk = load_tractogram(
@@ -174,9 +179,9 @@ def test_concatenate_flow():
 
 def test_convert_sh_flow():
     with TemporaryDirectory() as out_dir:
-        filepath_in = os.path.join(out_dir, "sh_coeff_img.nii.gz")
+        filepath_in = Path(out_dir) / "sh_coeff_img.nii.gz"
         filename_out = "sh_coeff_img_converted.nii.gz"
-        filepath_out = os.path.join(out_dir, filename_out)
+        filepath_out = Path(out_dir) / filename_out
 
         # Create an input image
         dim0, dim1, dim2 = 2, 3, 3  # spatial dimensions of array
@@ -192,9 +197,9 @@ def test_convert_sh_flow():
         # Run the workflow and load the output
         workflow = ConvertSHFlow()
         workflow.run(
-            filepath_in,
+            str(filepath_in),
             out_dir=out_dir,
-            out_file=filename_out,
+            out_file=str(filename_out),
         )
         img_out, _ = load_nifti(filepath_out)
 
@@ -205,11 +210,18 @@ def test_convert_sh_flow():
 def test_convert_tractogram_flow():
     with TemporaryDirectory() as out_dir:
         data_path, _, _ = get_fnames(name="gold_standard_io")
-        input_files = [v for k, v in data_path.items() if k in ["gs_streamlines.tck"]]
+        input_files = [
+            str(v)
+            for k, v in data_path.items()
+            if k
+            in [
+                "gs_streamlines.tck",
+            ]
+        ]
 
         convert_tractogram_flow = ConvertTractogramFlow(mix_names=True)
         convert_tractogram_flow.run(
-            input_files, reference=data_path["gs_volume.nii"], out_dir=out_dir
+            input_files, reference=str(data_path["gs_volume.nii"]), out_dir=out_dir
         )
 
         convert_tractogram_flow._force_overwrite = True
@@ -221,7 +233,7 @@ def test_convert_tractogram_flow():
             npt.assert_warns(
                 UserWarning,
                 convert_tractogram_flow.run,
-                data_path["gs_streamlines.trx"],
+                str(data_path["gs_streamlines.trx"]),
                 out_dir=out_dir,
                 out_tractogram="gs_converted.trx",
             )
@@ -229,9 +241,9 @@ def test_convert_tractogram_flow():
 
 def test_convert_tensors_flow():
     with TemporaryDirectory() as out_dir:
-        filepath_in = os.path.join(out_dir, "tensors_img.nii.gz")
+        filepath_in = Path(out_dir) / "tensors_img.nii.gz"
         filename_out = "tensors_converted.nii.gz"
-        filepath_out = os.path.join(out_dir, filename_out)
+        filepath_out = Path(out_dir) / filename_out
 
         # Create an input image
         fdata, fbval, fbvec = get_fnames(name="small_25")
@@ -253,11 +265,11 @@ def test_convert_tensors_flow():
         # Run the workflow and load the output
         workflow = ConvertTensorsFlow()
         workflow.run(
-            filepath_in,
+            str(filepath_in),
             from_format="dipy",
             to_format="mrtrix",
             out_dir=out_dir,
-            out_tensor=filename_out,
+            out_tensor=str(filename_out),
         )
 
         img_out, _ = load_nifti(filepath_out)
@@ -284,10 +296,10 @@ def generate_random_pam():
 def test_niftis_to_pam_flow():
     pam = generate_random_pam()
     with TemporaryDirectory() as out_dir:
-        fname = pjoin(out_dir, "test.pam5")
+        fname = Path(out_dir) / "test.pam5"
         save_pam(fname, pam)
 
-        args = [fname, out_dir]
+        args = [str(fname), str(out_dir)]
         flow = PamToNiftisFlow()
         flow.run(*args)
 
@@ -300,7 +312,7 @@ def test_niftis_to_pam_flow():
         flow2 = NiftisToPamFlow()
         flow2.run(*args, out_dir=out_dir)
         pam_file = flow2.last_generated_outputs["out_pam"]
-        assert_true(os.path.isfile(pam_file))
+        assert_true(Path(pam_file).is_file())
 
         res_pam = load_pam(pam_file)
         npt.assert_array_equal(pam.affine, res_pam.affine)
@@ -319,17 +331,17 @@ def test_tensor_to_pam_flow():
 
     with TemporaryDirectory() as out_dir:
         f_mevals, f_mevecs = (
-            pjoin(out_dir, "evals.nii.gz"),
-            pjoin(out_dir, "evecs.nii.gz"),
+            Path(out_dir) / "evals.nii.gz",
+            Path(out_dir) / "evecs.nii.gz",
         )
         save_nifti(f_mevals, df.evals, affine)
         save_nifti(f_mevecs, df.evecs, affine)
 
-        args = [f_mevals, f_mevecs]
+        args = [str(f_mevals), str(f_mevecs)]
         flow = TensorToPamFlow()
         flow.run(*args, out_dir=out_dir)
         pam_file = flow.last_generated_outputs["out_pam"]
-        assert_true(os.path.isfile(pam_file))
+        assert_true(Path(pam_file).is_file())
 
         pam = load_pam(pam_file)
         npt.assert_array_equal(pam.affine, affine)
@@ -341,25 +353,25 @@ def test_pam_to_niftis_flow():
     pam = generate_random_pam()
 
     with TemporaryDirectory() as out_dir:
-        fname = pjoin(out_dir, "test.pam5")
+        fname = Path(out_dir) / "test.pam5"
         save_pam(fname, pam)
 
-        args = [fname, out_dir]
+        args = [str(fname), str(out_dir)]
         flow = PamToNiftisFlow()
         flow.run(*args)
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_peaks_dir"]))
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_peaks_values"]))
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_peaks_indices"]))
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_shm"]))
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_gfa"]))
-        assert_true(os.path.isfile(flow.last_generated_outputs["out_sphere"]))
+        assert_true(Path(flow.last_generated_outputs["out_peaks_dir"]).is_file())
+        assert_true(Path(flow.last_generated_outputs["out_peaks_values"]).is_file())
+        assert_true(Path(flow.last_generated_outputs["out_peaks_indices"]).is_file())
+        assert_true(Path(flow.last_generated_outputs["out_shm"]).is_file())
+        assert_true(Path(flow.last_generated_outputs["out_gfa"]).is_file())
+        assert_true(Path(flow.last_generated_outputs["out_sphere"]).is_file())
 
 
 def test_math():
     with TemporaryDirectory() as out_dir:
         data_path, _, _ = get_fnames(name="small_101D")
-        data_path_a = pjoin(out_dir, "data_a.nii.gz")
-        data_path_b = pjoin(out_dir, "data_b.nii.gz")
+        data_path_a = Path(out_dir) / "data_a.nii.gz"
+        data_path_b = Path(out_dir) / "data_b.nii.gz"
         shutil.copy(data_path, data_path_a)
         shutil.copy(data_path, data_path_b)
 
@@ -371,9 +383,12 @@ def test_math():
             for op, kwarg in zip(operations, kwargs):
                 math_flow = MathFlow()
                 math_flow.run(
-                    op, [data_path_a, data_path_b, data_path], out_dir=out_dir, **kwarg
+                    op,
+                    [str(data_path_a), str(data_path_b), str(data_path)],
+                    out_dir=out_dir,
+                    **kwarg,
                 )
-                out_path = pjoin(out_dir, "math_out.nii.gz")
+                out_path = Path(out_dir) / "math_out.nii.gz"
                 out_data, _ = load_nifti(out_path)
                 npt.assert_array_equal(out_data, data * 3)
                 if kwarg:
@@ -381,12 +396,12 @@ def test_math():
 
             # Test broadcasting 3D/4D
             data_3d = np.ones(data.shape[:-1]) * 15
-            data_3d_path = pjoin(out_dir, "data_3d.nii.gz")
+            data_3d_path = Path(out_dir) / "data_3d.nii.gz"
             save_nifti(data_3d_path, data_3d, np.eye(4))
             math_flow = MathFlow()
             math_flow.run(
                 "vol1*vol2",
-                [data_path_a, data_3d_path],
+                [str(data_path_a), str(data_3d_path)],
                 disable_check=True,
                 out_dir=out_dir,
             )
@@ -394,26 +409,28 @@ def test_math():
             # Test boolean data type
             data_bool = np.ones(data.shape, dtype=np.uint8)
             data_bool_2 = np.zeros(data.shape, dtype=np.uint8)
-            data_bool_path = pjoin(out_dir, "data_bool.nii.gz")
-            data_bool_2_path = pjoin(out_dir, "data_bool_2.nii.gz")
+            data_bool_path = Path(out_dir) / "data_bool.nii.gz"
+            data_bool_2_path = Path(out_dir) / "data_bool_2.nii.gz"
             save_nifti(data_bool_path, data_bool, np.eye(4))
             save_nifti(data_bool_2_path, data_bool_2, np.eye(4))
             math_flow = MathFlow()
             math_flow.run(
                 "vol1*vol2",
-                [data_bool_path, data_bool_2_path],
+                [str(data_bool_path), str(data_bool_2_path)],
                 disable_check=True,
                 dtype="bool",
                 out_dir=out_dir,
             )
-            out_path = pjoin(out_dir, "math_out.nii.gz")
+            out_path = Path(out_dir) / "math_out.nii.gz"
             out_data, _ = load_nifti(out_path)
             npt.assert_array_equal(out_data, data_bool * data_bool_2)
             npt.assert_equal(out_data.dtype, np.uint8)
 
         else:
             math_flow = MathFlow()
-            npt.assert_raises(TripWireError, math_flow.run, "vol1*3", [data_path_a])
+            npt.assert_raises(
+                TripWireError, math_flow.run, "vol1*3", [str(data_path_a)]
+            )
 
 
 @pytest.mark.skipif(not have_ne, reason="numexpr not installed")
@@ -421,38 +438,38 @@ def test_math_error():
     with TemporaryDirectory() as out_dir:
         data_path, _, _ = get_fnames(name="small_101D")
         data_path_2, _, _ = get_fnames(name="small_64D")
-        data_path_a = pjoin(out_dir, "data_a.nii.gz")
-        data_path_b = pjoin(out_dir, "data_b.gz")
-        data_path_c = pjoin(out_dir, "data_c.nii")
+        data_path_a = Path(out_dir) / "data_a.nii.gz"
+        data_path_b = Path(out_dir) / "data_b.gz"
+        data_path_c = Path(out_dir) / "data_c.nii"
         shutil.copy(data_path, data_path_a)
         shutil.copy(data_path, data_path_b)
 
         math_flow = MathFlow()
         npt.assert_raises(
-            SyntaxError, math_flow.run, "vol1*", [data_path_a], out_dir=out_dir
+            SyntaxError, math_flow.run, "vol1*", [str(data_path_a)], out_dir=out_dir
         )
         npt.assert_raises(
             SystemExit,
             math_flow.run,
             "vol1*2",
-            [data_path_a],
+            [str(data_path_a)],
             dtype="k",
             out_dir=out_dir,
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [data_path_b], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*2", [str(data_path_b)], out_dir=out_dir
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [data_path_c], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*2", [str(data_path_c)], out_dir=out_dir
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*vol3", [data_path_a], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*vol3", [str(data_path_a)], out_dir=out_dir
         )
         npt.assert_raises(
             SystemExit,
             math_flow.run,
             "vol1*vol2",
-            [data_path, data_path_2],
+            [str(data_path), str(data_path_2)],
             out_dir=out_dir,
         )
 
@@ -462,14 +479,14 @@ def test_extract_b0_flow():
         fdata, fbval, fbvec = get_fnames(name="small_25")
         data, affine = load_nifti(fdata)
         b0_data = data[..., 0]
-        b0_path = pjoin(out_dir, "b0_expected.nii.gz")
+        b0_path = Path(out_dir) / "b0_expected.nii.gz"
         save_nifti(b0_path, b0_data, affine)
 
         extract_b0_flow = ExtractB0Flow()
-        extract_b0_flow.run(fdata, fbval, out_dir=out_dir, strategy="first")
+        extract_b0_flow.run(str(fdata), str(fbval), out_dir=out_dir, strategy="first")
         npt.assert_equal(
-            extract_b0_flow.last_generated_outputs["out_b0"],
-            pjoin(out_dir, "b0.nii.gz"),
+            Path(extract_b0_flow.last_generated_outputs["out_b0"]),
+            Path(out_dir) / "b0.nii.gz",
         )
         res, _ = load_nifti(extract_b0_flow.last_generated_outputs["out_b0"])
         npt.assert_array_equal(res, b0_data)
@@ -482,24 +499,24 @@ def test_extract_shell_flow():
 
         extract_shell_flow = ExtractShellFlow()
         extract_shell_flow.run(
-            fdata, fbval, fbvec, bvals_to_extract="2000", out_dir=out_dir
+            str(fdata), str(fbval), str(fbvec), bvals_to_extract="2000", out_dir=out_dir
         )
-        res, _ = load_nifti(pjoin(out_dir, "shell_2000.nii.gz"))
+        res, _ = load_nifti(Path(out_dir) / "shell_2000.nii.gz")
         npt.assert_array_equal(res, data[..., 1:])
 
         extract_shell_flow._force_overwrite = True
         extract_shell_flow.run(
-            fdata,
-            fbval,
-            fbvec,
+            str(fdata),
+            str(fbval),
+            str(fbvec),
             bvals_to_extract="0, 2000",
             group_shells=False,
             out_dir=out_dir,
         )
-        npt.assert_equal(os.path.isfile(pjoin(out_dir, "shell_0.nii.gz")), True)
-        npt.assert_equal(os.path.isfile(pjoin(out_dir, "shell_2000.nii.gz")), True)
-        res0, _ = load_nifti(pjoin(out_dir, "shell_0.nii.gz"))
-        res2000, _ = load_nifti(pjoin(out_dir, "shell_2000.nii.gz"))
+        npt.assert_equal(Path(Path(out_dir) / "shell_0.nii.gz").is_file(), True)
+        npt.assert_equal(Path(Path(out_dir) / "shell_2000.nii.gz").is_file(), True)
+        res0, _ = load_nifti(Path(out_dir) / "shell_0.nii.gz")
+        res2000, _ = load_nifti(Path(out_dir) / "shell_2000.nii.gz")
         npt.assert_array_equal(np.squeeze(res0), data[..., 0])
         npt.assert_array_equal(res2000[..., 9], data[..., 10])
 
@@ -510,15 +527,17 @@ def test_extract_volume_flow():
         data, affine = load_nifti(fdata)
 
         extract_volume_flow = ExtractVolumeFlow()
-        extract_volume_flow.run(fdata, vol_idx="0-3,5", out_dir=out_dir)
+        extract_volume_flow.run(str(fdata), vol_idx="0-3,5", out_dir=out_dir)
         res, _ = load_nifti(extract_volume_flow.last_generated_outputs["out_vol"])
         npt.assert_equal(res.shape[-1], 5)
 
         extract_volume_flow._force_overwrite = True
-        extract_volume_flow.run(fdata, vol_idx="0-3,5", grouped=False, out_dir=out_dir)
-        npt.assert_equal(os.path.isfile(pjoin(out_dir, "volume_2.nii.gz")), True)
-        npt.assert_equal(os.path.isfile(pjoin(out_dir, "volume_5.nii.gz")), True)
-        res2, _ = load_nifti(pjoin(out_dir, "volume_2.nii.gz"))
-        res5, _ = load_nifti(pjoin(out_dir, "volume_5.nii.gz"))
+        extract_volume_flow.run(
+            str(fdata), vol_idx="0-3,5", grouped=False, out_dir=out_dir
+        )
+        npt.assert_equal(Path(Path(out_dir) / "volume_2.nii.gz").is_file(), True)
+        npt.assert_equal(Path(Path(out_dir) / "volume_5.nii.gz").is_file(), True)
+        res2, _ = load_nifti(Path(out_dir) / "volume_2.nii.gz")
+        res5, _ = load_nifti(Path(out_dir) / "volume_5.nii.gz")
         npt.assert_array_equal(res2, data[..., 2])
         npt.assert_array_equal(res5, data[..., 5])

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -15,10 +15,10 @@ def test_mask():
 
         mask_flow = MaskFlow()
 
-        mask_flow.run(data_path, 10, out_dir=out_dir, ub=9)
+        mask_flow.run(str(data_path), 10, out_dir=out_dir, ub=9)
         assert_false(mask_flow.last_generated_outputs)
 
-        mask_flow.run(data_path, 10, out_dir=out_dir)
+        mask_flow.run(str(data_path), 10, out_dir=out_dir)
         mask_path = mask_flow.last_generated_outputs["out_mask"]
         mask_data, mask_affine = load_nifti(mask_path)
         npt.assert_equal(mask_data.shape, volume.shape)

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -23,12 +23,12 @@ def test_evac_plus_flow():
 
         volume = np.load(file_path)["input"][0]
         temp_affine = np.eye(4)
-        temp_path = pjoin(out_dir, "temp.nii.gz")
+        temp_path = Path(out_dir) / "temp.nii.gz"
         save_nifti(temp_path, volume, temp_affine)
         save_masked = True
 
         evac_flow = EVACPlusFlow()
-        evac_flow.run(temp_path, out_dir=out_dir, save_masked=save_masked)
+        evac_flow.run(str(temp_path), out_dir=out_dir, save_masked=save_masked)
 
         mask_name = evac_flow.last_generated_outputs["out_mask"]
         masked_name = evac_flow.last_generated_outputs["out_masked"]
@@ -37,10 +37,10 @@ def test_evac_plus_flow():
         mask = evac.predict(volume, temp_affine)
         masked = volume * mask
 
-        result_mask_data = load_nifti_data(pjoin(out_dir, mask_name))
+        result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
         npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
 
-        result_masked_data = load_nifti_data(pjoin(out_dir, masked_name))
+        result_masked_data = load_nifti_data(Path(out_dir) / masked_name)
 
         npt.assert_array_equal(result_masked_data, masked)
 
@@ -54,15 +54,15 @@ def test_correct_biasfield_flow():
 
             volume = np.load(file_path[0])["img"]
             temp_affine = np.load(file_path[0])["affine"]
-            temp_path = pjoin(out_dir, "temp.nii.gz")
+            temp_path = Path(out_dir) / "temp.nii.gz"
             save_nifti(temp_path, volume, temp_affine)
 
             bias_flow = BiasFieldCorrectionFlow()
-            bias_flow.run(temp_path, out_dir=out_dir)
+            bias_flow.run(str(temp_path), out_dir=out_dir)
 
             corrected_name = bias_flow.last_generated_outputs["out_corrected"]
 
-            corrected_data = load_nifti_data(pjoin(out_dir, corrected_name))
+            corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
             npt.assert_almost_equal(
                 corrected_data.mean(), 119.03902876428222, decimal=4
             )
@@ -71,9 +71,9 @@ def test_correct_biasfield_flow():
     with TemporaryDirectory() as out_dir:
         fdata, fbval, fbvec = get_fnames(name="small_25")
         args = {
-            "input_files": fdata,
-            "bval": fbval,
-            "bvec": fbvec,
+            "input_files": str(fdata),
+            "bval": str(fbval),
+            "bvec": str(fbvec),
             "method": "b0",
             "out_dir": out_dir,
         }
@@ -82,13 +82,13 @@ def test_correct_biasfield_flow():
 
         corrected_name = bias_flow.last_generated_outputs["out_corrected"]
 
-        corrected_data = load_nifti_data(pjoin(out_dir, corrected_name))
+        corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
         npt.assert_almost_equal(corrected_data.mean(), 0.0384615384615, decimal=5)
 
     args = {
-        "input_files": fdata,
-        "bval": fbval,
-        "bvec": fbvec,
+        "input_files": str(fdata),
+        "bval": str(fbval),
+        "bvec": str(fbvec),
         "method": "random",
         "out_dir": out_dir,
     }

--- a/dipy/workflows/tests/test_reconst.py
+++ b/dipy/workflows/tests/test_reconst.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -99,21 +99,21 @@ def reconst_flow_core(flow, *, use_multishell_data=None, **kwargs):
             bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
             bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
             gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
-            bval_path = pjoin(out_dir, os.path.basename(bval_path))
-            bvec_path = pjoin(out_dir, os.path.basename(bvec_path))
+            bval_path = Path(out_dir) / os.path.basename(bval_path)
+            bvec_path = Path(out_dir) / os.path.basename(bvec_path)
             np.savetxt(bval_path, bvals_2s)
             np.savetxt(bvec_path, bvecs_2s)
 
             volume = simulate_multitensor_data(gtab_2s)
-            data_path = pjoin(out_dir, "dwi.nii.gz")
+            data_path = Path(out_dir) / "dwi.nii.gz"
             mask = np.ones_like(volume[..., 0], dtype=bool)
-            mask_path = pjoin(out_dir, "mask.nii.gz")
+            mask_path = Path(out_dir) / "mask.nii.gz"
             save_nifti(mask_path, mask.astype(np.int32), np.eye(4))
             save_nifti(data_path, volume, np.eye(4))
         else:
             volume, affine = load_nifti(data_path)
             mask = np.ones_like(volume[:, :, :, 0])
-            mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
+            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
             save_nifti(mask_path, mask.astype(np.uint8), affine)
 
         reconst_flow = flow()
@@ -121,10 +121,10 @@ def reconst_flow_core(flow, *, use_multishell_data=None, **kwargs):
             8,
         ]:
             reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
+                str(data_path),
+                str(bval_path),
+                str(bvec_path),
+                str(mask_path),
                 sh_order_max=sh_order_max,
                 out_dir=out_dir,
                 extract_pam_values=True,

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -1,5 +1,5 @@
 import logging
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -72,16 +72,16 @@ def reconst_flow_core(flow, **kwargs):
         data_path, bval_path, bvec_path = get_fnames(name="small_64D")
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
+        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask.astype(np.uint8), affine)
 
         reconst_flow = flow()
         for sh_order in [4, 6, 8]:
             reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
+                str(data_path),
+                str(bval_path),
+                str(bvec_path),
+                str(mask_path),
                 sh_order_max=sh_order,
                 out_dir=out_dir,
                 extract_pam_values=True,
@@ -129,8 +129,8 @@ def reconst_flow_core(flow, **kwargs):
             bvals[0] = 5.0
             bvecs = generate_bvecs(len(bvals))
 
-            tmp_bval_path = pjoin(out_dir, "tmp.bval")
-            tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+            tmp_bval_path = Path(out_dir) / "tmp.bval"
+            tmp_bvec_path = Path(out_dir) / "tmp.bvec"
             np.savetxt(tmp_bval_path, bvals)
             np.savetxt(tmp_bvec_path, bvecs.T)
             reconst_flow._force_overwrite = True
@@ -139,10 +139,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
+                    str(data_path),
+                    str(bval_path),
+                    str(bvec_path),
+                    str(mask_path),
                     out_dir=out_dir,
                     frf=[15, 5, 5],
                     **kwargs,
@@ -150,10 +150,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
+                    str(data_path),
+                    str(bval_path),
+                    str(bvec_path),
+                    str(mask_path),
                     out_dir=out_dir,
                     frf="15, 5, 5",
                     **kwargs,
@@ -161,10 +161,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
+                    str(data_path),
+                    str(bval_path),
+                    str(bvec_path),
+                    str(mask_path),
                     out_dir=out_dir,
                     frf=None,
                     **kwargs,
@@ -172,10 +172,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow2 = flow()
                 reconst_flow2._force_overwrite = True
                 reconst_flow2.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
+                    str(data_path),
+                    str(bval_path),
+                    str(bvec_path),
+                    str(mask_path),
                     out_dir=out_dir,
                     frf=None,
                     roi_center=[5, 5, 5],
@@ -186,10 +186,10 @@ def reconst_flow_core(flow, **kwargs):
                     npt.assert_warns(
                         UserWarning,
                         reconst_flow.run,
-                        data_path,
-                        tmp_bval_path,
-                        tmp_bvec_path,
-                        mask_path,
+                        str(data_path),
+                        str(tmp_bval_path),
+                        str(tmp_bvec_path),
+                        str(mask_path),
                         out_dir=out_dir,
                         extract_pam_values=True,
                         **kwargs,
@@ -201,10 +201,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
+                    str(data_path),
+                    str(bval_path),
+                    str(bvec_path),
+                    str(mask_path),
                     out_dir=out_dir,
                     parallel=True,
                     num_processes=2,

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -19,12 +19,12 @@ def test_reconst_dki():
         data_path, bval_path, bvec_path = get_fnames(name="small_101D")
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
+        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask.astype(np.uint8), affine)
 
         dki_flow = ReconstDkiFlow()
 
-        args = [data_path, bval_path, bvec_path, mask_path]
+        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
 
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -119,8 +119,8 @@ def test_reconst_dki():
         bvals[0] = 5.0
         bvecs = generate_bvecs(len(bvals))
 
-        tmp_bval_path = pjoin(out_dir, "tmp.bval")
-        tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+        tmp_bval_path = Path(out_dir) / "tmp.bval"
+        tmp_bvec_path = Path(out_dir) / "tmp.bvec"
         np.savetxt(tmp_bval_path, bvals)
         np.savetxt(tmp_bvec_path, bvecs.T)
         dki_flow._force_overwrite = True
@@ -131,10 +131,10 @@ def test_reconst_dki():
                 category=PendingDeprecationWarning,
             )
             dki_flow.run(
-                data_path,
-                tmp_bval_path,
-                tmp_bvec_path,
-                mask_path,
+                str(data_path),
+                str(tmp_bval_path),
+                str(tmp_bvec_path),
+                str(mask_path),
                 out_dir=out_dir,
                 b0_threshold=0,
             )

--- a/dipy/workflows/tests/test_reconst_dsi.py
+++ b/dipy/workflows/tests/test_reconst_dsi.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -36,7 +36,7 @@ def reconst_flow_core(flow, **kwargs):
         data_path, bval_path, bvec_path = get_fnames(name="small_64D")
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
+        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask.astype(np.uint8), affine)
 
         dsi_flow = ReconstDsiFlow()
@@ -47,10 +47,10 @@ def reconst_flow_core(flow, **kwargs):
                 category=PendingDeprecationWarning,
             )
             dsi_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
+                str(data_path),
+                str(bval_path),
+                str(bvec_path),
+                str(mask_path),
                 out_dir=out_dir,
                 extract_pam_values=True,
                 **kwargs,

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -57,7 +57,7 @@ def reconst_flow_core(flow, extra_args=None, extra_kwargs=None):
 
         dti_flow = flow()
 
-        args = [data_path, bval_path, bvec_path, mask_path]
+        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
         args.extend(extra_args)
         kwargs = {"out_dir": out_dir, "extract_pam_values": True}
         kwargs.update(extra_kwargs)

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -40,9 +40,9 @@ def test_reconst_ivim():
         )
         N = len(bvals)
         bvecs = generate_bvecs(N)
-        temp_bval_path = pjoin(out_dir, "temp.bval")
+        temp_bval_path = Path(out_dir) / "temp.bval"
         np.savetxt(temp_bval_path, bvals)
-        temp_bvec_path = pjoin(out_dir, "temp.bvec")
+        temp_bvec_path = Path(out_dir) / "temp.bvec"
         np.savetxt(temp_bvec_path, bvecs)
 
         gtab = gradient_table(bvals, bvecs=bvecs)
@@ -62,16 +62,21 @@ def test_reconst_ivim():
         data_multi[0, 0, 0] = data_multi[0, 1, 0] = data_multi[1, 0, 0] = data_multi[
             1, 1, 0
         ] = data_single
-        data_path = pjoin(out_dir, "tmp_data.nii.gz")
+        data_path = Path(out_dir) / "tmp_data.nii.gz"
         save_nifti(data_path, data_multi, temp_affine, dtype=data_multi.dtype)
 
         mask = np.ones_like(data_multi[..., 0], dtype=np.uint8)
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
+        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask, temp_affine)
 
         ivim_flow = ReconstIvimFlow()
 
-        args = [data_path, temp_bval_path, temp_bvec_path, mask_path]
+        args = [
+            str(data_path),
+            str(temp_bval_path),
+            str(temp_bvec_path),
+            str(mask_path),
+        ]
 
         msg = "Bounds for this fit have been set from experiments and * "
         with warnings.catch_warnings():

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -43,9 +43,9 @@ def reconst_mmri_core(flow, lap, pos):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=msg, category=UserWarning)
             mmri_flow.run(
-                data_files=data_path,
-                bvals_files=bval_path,
-                bvecs_files=bvec_path,
+                data_files=str(data_path),
+                bvals_files=str(bval_path),
+                bvecs_files=str(bvec_path),
                 small_delta=0.0129,
                 big_delta=0.0218,
                 laplacian=lap,
@@ -71,8 +71,8 @@ def reconst_mmri_core(flow, lap, pos):
         bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
         bvals[0] = 5.0
         bvecs = generate_bvecs(len(bvals))
-        tmp_bval_path = pjoin(out_dir, "tmp.bval")
-        tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+        tmp_bval_path = Path(out_dir) / "tmp.bval"
+        tmp_bvec_path = Path(out_dir) / "tmp.bvec"
         np.savetxt(tmp_bval_path, bvals)
         np.savetxt(tmp_bvec_path, bvecs.T)
         mmri_flow._force_overwrite = True
@@ -80,9 +80,9 @@ def reconst_mmri_core(flow, lap, pos):
             npt.assert_warns(
                 UserWarning,
                 mmri_flow.run,
-                data_path,
-                tmp_bval_path,
-                tmp_bvec_path,
+                str(data_path),
+                str(tmp_bval_path),
+                str(tmp_bvec_path),
                 small_delta=0.0129,
                 big_delta=0.0218,
                 laplacian=lap,

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-from os.path import join
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -35,37 +35,37 @@ def test_stats():
         data_path, bval_path, bvec_path = get_fnames(name="small_101D")
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = join(out_dir, "tmp_mask.nii.gz")
+        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask, affine)
 
         snr_flow = SNRinCCFlow(force=True)
-        args = [data_path, bval_path, bvec_path, mask_path]
+        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
         snr_flow.run(*args, out_dir=out_dir)
 
-        assert_true(os.path.exists(os.path.join(out_dir, "product.json")))
-        assert_true(os.stat(os.path.join(out_dir, "product.json")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "cc.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "cc.nii.gz")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "mask_noise.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "mask_noise.nii.gz")).st_size != 0)
+        assert_true(Path(Path(out_dir) / "product.json").exists())
+        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
+        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
+        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
 
         snr_flow._force_overwrite = True
         snr_flow.run(*args, out_dir=out_dir)
-        assert_true(os.path.exists(os.path.join(out_dir, "product.json")))
-        assert_true(os.stat(os.path.join(out_dir, "product.json")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "cc.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "cc.nii.gz")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "mask_noise.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "mask_noise.nii.gz")).st_size != 0)
+        assert_true(Path(Path(out_dir) / "product.json").exists())
+        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
+        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
+        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
 
         snr_flow._force_overwrite = True
         snr_flow.run(*args, bbox_threshold=(0.5, 1, 0, 0.15, 0, 0.2), out_dir=out_dir)
-        assert_true(os.path.exists(os.path.join(out_dir, "product.json")))
-        assert_true(os.stat(os.path.join(out_dir, "product.json")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "cc.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "cc.nii.gz")).st_size != 0)
-        assert_true(os.path.exists(os.path.join(out_dir, "mask_noise.nii.gz")))
-        assert_true(os.stat(os.path.join(out_dir, "mask_noise.nii.gz")).st_size != 0)
+        assert_true(Path(Path(out_dir) / "product.json").exists())
+        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
+        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
+        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
+        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
 
 
 @pytest.mark.skipif(
@@ -80,40 +80,47 @@ def test_buan_bundle_profiles(rng):
 
         f = Streamlines(fornix)
 
-        mb = os.path.join(dirpath, "model_bundles")
+        mb = Path(dirpath) / "model_bundles"
 
         os.mkdir(mb)
 
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, os.path.join(mb, "temp.trk"), bbox_valid_check=False)
+        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
 
-        rb = os.path.join(dirpath, "rec_bundles")
+        rb = Path(dirpath) / "rec_bundles"
         os.mkdir(rb)
 
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, os.path.join(rb, "temp.trk"), bbox_valid_check=False)
+        save_tractogram(sft, Path(rb) / "temp.trk", bbox_valid_check=False)
 
-        ob = os.path.join(dirpath, "org_bundles")
+        ob = Path(dirpath) / "org_bundles"
         os.mkdir(ob)
 
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, os.path.join(ob, "temp.trk"), bbox_valid_check=False)
+        save_tractogram(sft, Path(ob) / "temp.trk", bbox_valid_check=False)
 
-        dt = os.path.join(dirpath, "anatomical_measures")
+        dt = Path(dirpath) / "anatomical_measures"
         os.mkdir(dt)
 
         fa = rng.random((255, 255, 255))
 
-        save_nifti(os.path.join(dt, "fa.nii.gz"), fa, affine=np.eye(4))
+        save_nifti(Path(dt) / "fa.nii.gz", fa, affine=np.eye(4))
 
-        out_dir = os.path.join(dirpath, "output")
+        out_dir = Path(dirpath) / "output"
         os.mkdir(out_dir)
 
         buan_bundle_profiles(
-            mb, rb, ob, dt, group_id=1, subject="10001", no_disks=100, out_dir=out_dir
+            str(mb),
+            str(rb),
+            str(ob),
+            str(dt),
+            group_id=1,
+            subject="10001",
+            no_disks=100,
+            out_dir=str(out_dir),
         )
 
-        assert_true(os.path.exists(os.path.join(out_dir, "temp_fa.h5")))
+        assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
 
 
 @pytest.mark.skipif(
@@ -128,62 +135,62 @@ def test_bundle_analysis_tractometry_flow(rng):
 
         f = Streamlines(fornix)
 
-        mb = os.path.join(dirpath, "model_bundles")
-        sub = os.path.join(dirpath, "subjects")
+        mb = Path(dirpath) / "model_bundles"
+        sub = Path(dirpath) / "subjects"
 
         os.mkdir(mb)
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, os.path.join(mb, "temp.trk"), bbox_valid_check=False)
+        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
 
         os.mkdir(sub)
 
-        os.mkdir(os.path.join(sub, "patient"))
+        os.mkdir(Path(sub) / "patient")
 
-        os.mkdir(os.path.join(sub, "control"))
+        os.mkdir(Path(sub) / "control")
 
-        p = os.path.join(sub, "patient", "10001")
+        p = sub / "patient" / "10001"
         os.mkdir(p)
 
-        c = os.path.join(sub, "control", "20002")
+        c = sub / "control" / "20002"
         os.mkdir(c)
 
         for pre in [p, c]:
-            os.mkdir(os.path.join(pre, "rec_bundles"))
+            os.mkdir(Path(pre) / "rec_bundles")
 
             sft = StatefulTractogram(f, data_path, Space.RASMM)
             save_tractogram(
                 sft,
-                os.path.join(pre, "rec_bundles", "temp.trk"),
+                Path(pre) / "rec_bundles" / "temp.trk",
                 bbox_valid_check=False,
             )
-            os.mkdir(os.path.join(pre, "org_bundles"))
+            os.mkdir(Path(pre) / "org_bundles")
 
             sft = StatefulTractogram(f, data_path, Space.RASMM)
             save_tractogram(
                 sft,
-                os.path.join(pre, "org_bundles", "temp.trk"),
+                Path(pre) / "org_bundles" / "temp.trk",
                 bbox_valid_check=False,
             )
-            os.mkdir(os.path.join(pre, "anatomical_measures"))
+            os.mkdir(Path(pre) / "anatomical_measures")
 
             fa = rng.random((255, 255, 255))
 
             save_nifti(
-                os.path.join(pre, "anatomical_measures", "fa.nii.gz"),
+                Path(pre) / "anatomical_measures" / "fa.nii.gz",
                 fa,
                 affine=np.eye(4),
             )
 
-        out_dir = os.path.join(dirpath, "output")
+        out_dir = Path(dirpath) / "output"
         os.mkdir(out_dir)
 
         ba_flow = BundleAnalysisTractometryFlow()
 
-        ba_flow.run(mb, sub, out_dir=out_dir)
+        ba_flow.run(str(mb), str(sub), out_dir=str(out_dir))
 
-        assert_true(os.path.exists(os.path.join(out_dir, "temp_fa.h5")))
+        assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
 
-        dft = pd.read_hdf(os.path.join(out_dir, "temp_fa.h5"))
+        dft = pd.read_hdf(Path(out_dir) / "temp_fa.h5")
 
         # assert_true(dft.bundle.unique() == "temp")
 
@@ -196,7 +203,7 @@ def test_bundle_analysis_tractometry_flow(rng):
 )
 def test_linear_mixed_models_flow():
     with TemporaryDirectory() as dirpath:
-        out_dir = os.path.join(dirpath, "output")
+        out_dir = Path(dirpath) / "output"
         os.mkdir(out_dir)
 
         d = {
@@ -219,21 +226,21 @@ def test_linear_mixed_models_flow():
         }
 
         df = pd.DataFrame(data=d)
-        store = pd.HDFStore(os.path.join(out_dir, "temp_fa.h5"))
+        store = pd.HDFStore(Path(out_dir) / "temp_fa.h5")
         store.append("fa", df, data_columns=True)
         store.close()
 
         lmm_flow = LinearMixedModelsFlow()
 
-        out_dir2 = os.path.join(dirpath, "output2")
+        out_dir2 = Path(dirpath) / "output2"
         os.mkdir(out_dir2)
 
-        input_path = os.path.join(out_dir, "*")
+        input_path = Path(out_dir) / "*"
 
-        lmm_flow.run(input_path, no_disks=5, out_dir=out_dir2)
+        lmm_flow.run(str(input_path), no_disks=5, out_dir=str(out_dir2))
 
-        assert_true(os.path.exists(os.path.join(out_dir2, "temp_fa_pvalues.npy")))
-        assert_true(os.path.exists(os.path.join(out_dir2, "temp_fa.png")))
+        assert_true(Path(Path(out_dir2) / "temp_fa_pvalues.npy").exists())
+        assert_true(Path(Path(out_dir2) / "temp_fa.png").exists())
 
         # test error
         d2 = {
@@ -257,26 +264,26 @@ def test_linear_mixed_models_flow():
 
         df = pd.DataFrame(data=d2)
 
-        out_dir3 = os.path.join(dirpath, "output3")
+        out_dir3 = Path(dirpath) / "output3"
         os.mkdir(out_dir3)
 
-        store = pd.HDFStore(os.path.join(out_dir3, "temp_fa.h5"))
+        store = pd.HDFStore(Path(out_dir3) / "temp_fa.h5")
         store.append("fa", df, data_columns=True)
         store.close()
 
-        out_dir4 = os.path.join(dirpath, "output4")
+        out_dir4 = Path(dirpath) / "output4"
         os.mkdir(out_dir4)
 
-        input_path = os.path.join(out_dir3, "f*")
+        input_path = Path(out_dir3) / "f*"
         # OS error raised if path is wrong or file does not exist
         npt.assert_raises(
-            OSError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
+            OSError, lmm_flow.run, str(input_path), no_disks=5, out_dir=out_dir4
         )
 
-        input_path = os.path.join(out_dir3, "*")
+        input_path = Path(out_dir3) / "*"
         # value error raised if length of data frame is less than 100
         npt.assert_raises(
-            ValueError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
+            ValueError, lmm_flow.run, str(input_path), no_disks=5, out_dir=str(out_dir4)
         )
 
 
@@ -292,57 +299,57 @@ def test_bundle_shape_analysis_flow(rng):
 
         f = Streamlines(fornix)
 
-        mb = os.path.join(dirpath, "model_bundles")
-        sub = os.path.join(dirpath, "subjects")
+        mb = Path(dirpath) / "model_bundles"
+        sub = Path(dirpath) / "subjects"
 
         os.mkdir(mb)
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, os.path.join(mb, "temp.trk"), bbox_valid_check=False)
+        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
 
         os.mkdir(sub)
 
-        os.mkdir(os.path.join(sub, "patient"))
+        os.mkdir(sub / "patient")
 
-        os.mkdir(os.path.join(sub, "control"))
+        os.mkdir(sub / "control")
 
-        p = os.path.join(sub, "patient", "10001")
+        p = sub / "patient" / "10001"
         os.mkdir(p)
 
-        c = os.path.join(sub, "control", "20002")
+        c = sub / "control" / "20002"
         os.mkdir(c)
 
         for pre in [p, c]:
-            os.mkdir(os.path.join(pre, "rec_bundles"))
+            os.mkdir(Path(pre) / "rec_bundles")
 
             sft = StatefulTractogram(f, data_path, Space.RASMM)
             save_tractogram(
                 sft,
-                os.path.join(pre, "rec_bundles", "temp.trk"),
+                Path(pre) / "rec_bundles" / "temp.trk",
                 bbox_valid_check=False,
             )
-            os.mkdir(os.path.join(pre, "org_bundles"))
+            os.mkdir(Path(pre) / "org_bundles")
 
             sft = StatefulTractogram(f, data_path, Space.RASMM)
             save_tractogram(
                 sft,
-                os.path.join(pre, "org_bundles", "temp.trk"),
+                Path(pre) / "org_bundles" / "temp.trk",
                 bbox_valid_check=False,
             )
-            os.mkdir(os.path.join(pre, "anatomical_measures"))
+            os.mkdir(Path(pre) / "anatomical_measures")
 
             fa = rng.random((255, 255, 255))
 
             save_nifti(
-                os.path.join(pre, "anatomical_measures", "fa.nii.gz"),
+                Path(pre) / "anatomical_measures" / "fa.nii.gz",
                 fa,
                 affine=np.eye(4),
             )
 
-        out_dir = os.path.join(dirpath, "output")
+        out_dir = Path(dirpath) / "output"
         os.mkdir(out_dir)
 
         sm_flow = BundleShapeAnalysis()
 
-        sm_flow.run(sub, out_dir=out_dir)
+        sm_flow.run(str(sub), out_dir=str(out_dir))
 
-        assert_true(os.path.exists(os.path.join(out_dir, "temp.npy")))
+        assert_true(Path(Path(out_dir) / "temp.npy").exists())

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -103,10 +103,10 @@ def test_particle_filtering_tracking_workflows():
                 category=PendingDeprecationWarning,
             )
             reconst_csd_flow.run(
-                dwi_path,
-                bval_path,
-                bvec_path,
-                mask_path,
+                str(dwi_path),
+                str(bval_path),
+                str(bvec_path),
+                str(mask_path),
                 out_dir=out_dir,
                 extract_pam_values=True,
             )
@@ -144,11 +144,11 @@ def test_particle_filtering_tracking_workflows():
                 category=PendingDeprecationWarning,
             )
             pf_track_pam.run(
-                pam_path,
-                wm_path,
-                gm_path,
-                csf_path,
-                seeds_path,
+                str(pam_path),
+                str(wm_path),
+                str(gm_path),
+                str(csf_path),
+                str(seeds_path),
                 save_seeds=True,
                 out_dir=out_dir,
             )
@@ -173,10 +173,10 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             reconst_csd_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
+                str(data_path),
+                str(bval_path),
+                str(bvec_path),
+                str(mask_path),
                 out_dir=out_dir,
                 extract_pam_values=True,
             )
@@ -242,9 +242,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
+                str(pam_path),
+                str(gfa_path),
+                str(seeds_path),
                 tracking_method="deterministic",
                 out_dir=out_dir,
             )
@@ -261,9 +261,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
+                str(pam_path),
+                str(gfa_path),
+                str(seeds_path),
                 tracking_method="probabilistic",
                 out_dir=out_dir,
             )
@@ -280,9 +280,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
+                str(pam_path),
+                str(gfa_path),
+                str(seeds_path),
                 tracking_method="closestpeaks",
                 out_dir=out_dir,
             )
@@ -299,9 +299,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
+                str(pam_path),
+                str(gfa_path),
+                str(seeds_path),
                 tracking_method="deterministic",
                 save_seeds=True,
                 out_dir=out_dir,

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -1,5 +1,4 @@
-import os
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -75,7 +74,7 @@ def test_horizon_flow(rng):
             clusters_gt=0,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "horizon-flow.png"),
+            out_png=str(Path(out_dir) / "horizon-flow.png"),
         )
 
         buan_colors = np.ones(streamlines.get_data().shape)
@@ -86,7 +85,7 @@ def test_horizon_flow(rng):
             buan_colors=buan_colors,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "buan.png"),
+            out_png=str(Path(out_dir) / "buan.png"),
         )
 
         data = 255 * rng.random((197, 233, 189))
@@ -105,12 +104,12 @@ def test_horizon_flow(rng):
             clusters_gt=0,
             world_coords=True,
             interactive=False,
-            out_png=pjoin(out_dir, "horizon-flow-nii-images.png"),
+            out_png=str(Path(out_dir) / "horizon-flow-nii-images.png"),
         )
 
-        fimg = os.path.join(out_dir, "test.nii.gz")
-        ftrk = os.path.join(out_dir, "test.trk")
-        fnpy = os.path.join(out_dir, "test.npy")
+        fimg = Path(out_dir) / "test.nii.gz"
+        ftrk = Path(out_dir) / "test.trk"
+        fnpy = Path(out_dir) / "test.npy"
 
         save_nifti(fimg, data, affine)
         dimensions = data.shape
@@ -121,7 +120,7 @@ def test_horizon_flow(rng):
         pvalues = rng.uniform(low=0, high=1, size=(10,))
         np.save(fnpy, pvalues)
 
-        input_files = [ftrk, fimg]
+        input_files = [str(ftrk), str(fimg)]
 
         npt.assert_equal(len(input_files), 2)
 
@@ -134,7 +133,7 @@ def test_horizon_flow(rng):
             out_stealth_png="tmp_x.png",
         )
 
-        npt.assert_equal(os.path.exists(os.path.join(out_dir, "tmp_x.png")), True)
+        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
         npt.assert_raises(
             ValueError, hz_flow.run, input_files=input_files, bg_color=(0.2, 0.2)
         )
@@ -148,9 +147,9 @@ def test_horizon_flow(rng):
             out_dir=out_dir,
             out_stealth_png="tmp_x.png",
         )
-        npt.assert_equal(os.path.exists(os.path.join(out_dir, "tmp_x.png")), True)
+        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
 
-        input_files = [ftrk, fnpy]
+        input_files = [str(ftrk), str(fnpy)]
 
         npt.assert_equal(len(input_files), 2)
 
@@ -166,7 +165,7 @@ def test_horizon_flow(rng):
             out_dir=out_dir,
             out_stealth_png="tmp_x.png",
         )
-        npt.assert_equal(os.path.exists(os.path.join(out_dir, "tmp_x.png")), True)
+        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
 
         npt.assert_raises(
             ValueError, hz_flow.run, input_files=input_files, roi_colors=(0.2, 0.2)
@@ -181,4 +180,4 @@ def test_horizon_flow(rng):
             out_dir=out_dir,
             out_stealth_png="tmp_x.png",
         )
-        npt.assert_equal(os.path.exists(os.path.join(out_dir, "tmp_x.png")), True)
+        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -1,5 +1,5 @@
 import os
-from os.path import join as pjoin
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import time
 
@@ -18,12 +18,12 @@ def test_force_overwrite():
 
         # Generate the first results
         with npt.assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+            mo_flow.run(str(data_path), out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         first_time = os.path.getmtime(mask_file)
 
         # re-run with no force overwrite, modified time should not change
-        mo_flow.run(data_path, out_dir=out_dir)
+        mo_flow.run(str(data_path), out_dir=out_dir)
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         second_time = os.path.getmtime(mask_file)
         assert first_time == second_time
@@ -34,7 +34,7 @@ def test_force_overwrite():
         # different (sometimes measured in whole seconds)
         time.sleep(1)
         with npt.assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+            mo_flow.run(str(data_path), out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         third_time = os.path.getmtime(mask_file)
         assert third_time != second_time
@@ -70,4 +70,4 @@ def test_missing_file():
 
     dummyflow = TestMissingFile()
     with TemporaryDirectory() as tempdir:
-        npt.assert_raises(OSError, dummyflow.run, pjoin(tempdir, "dummy_file.txt"))
+        npt.assert_raises(OSError, dummyflow.run, str(Path(tempdir) / "dummy_file.txt"))

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -1,4 +1,4 @@
-from os.path import join as pjoin
+from pathlib import Path
 from warnings import warn
 
 import numpy as np
@@ -286,5 +286,5 @@ class HorizonFlow(Workflow):
             buan_colors=bundle_colors,
             roi_images=roi_images,
             roi_colors=roi_colors,
-            out_png=pjoin(out_dir, out_stealth_png),
+            out_png=Path(out_dir) / out_stealth_png,
         )

--- a/dipy/workflows/workflow.py
+++ b/dipy/workflows/workflow.py
@@ -1,5 +1,5 @@
 import inspect
-import os
+from pathlib import Path
 
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.logging import logger
@@ -98,7 +98,7 @@ class Workflow:
         """
         duplicates = []
         for output in self.flat_outputs:
-            if os.path.isfile(output):
+            if Path(output).is_file():
                 duplicates.append(output)
 
         if len(duplicates) > 0:

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -14,7 +14,7 @@ the ``dipy.align`` module. The second part will use a simplified functional
 interface.
 """
 
-from os.path import join as pjoin
+from pathlib import Path
 
 import numpy as np
 
@@ -41,7 +41,7 @@ from dipy.viz import regtools
 
 files, folder = fetch_stanford_hardi()
 static_data, static_affine, static_img = load_nifti(
-    pjoin(folder, "HARDI150.nii.gz"), return_img=True
+    Path(folder) / "HARDI150.nii.gz", return_img=True
 )
 static = np.squeeze(static_data)[..., 0]
 static_grid2world = static_affine
@@ -51,7 +51,7 @@ static_grid2world = static_affine
 
 files, folder2 = fetch_syn_data()
 moving_data, moving_affine, moving_img = load_nifti(
-    pjoin(folder2, "b0.nii.gz"), return_img=True
+    Path(folder2) / "b0.nii.gz", return_img=True
 )
 moving = moving_data
 moving_grid2world = moving_affine
@@ -458,7 +458,7 @@ regtools.overlay_slices(
 
 xformed_dwi, reg_affine = register_dwi_to_template(
     dwi=static_img,
-    gtab=(pjoin(folder, "HARDI150.bval"), pjoin(folder, "HARDI150.bvec")),
+    gtab=(Path(folder) / "HARDI150.bval", Path(folder) / "HARDI150.bvec"),
     template=moving_img,
     reg_method="aff",
     nbins=32,

--- a/doc/examples/affine_registration_masks.py
+++ b/doc/examples/affine_registration_masks.py
@@ -18,7 +18,7 @@ with respect to the heart.
 
 """
 
-from os.path import join as pjoin
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -35,7 +35,7 @@ from dipy.viz import regtools
 
 files, folder = fetch_stanford_hardi()
 static_data, static_affine, static_img = load_nifti(
-    pjoin(folder, "HARDI150.nii.gz"), return_img=True
+    Path(folder) / "HARDI150.nii.gz", return_img=True
 )
 static = np.squeeze(static_data)[..., 0]
 

--- a/doc/examples/afq_tract_profiles.py
+++ b/doc/examples/afq_tract_profiles.py
@@ -16,8 +16,6 @@ mean trajectory of the bundle at that location.
 
 """
 
-import os.path as op
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -42,7 +40,7 @@ session = "HBNsiteRU"
 
 fdict, path = fetch_hbn([subject], include_afq=True)
 
-afq_path = op.join(path, "derivatives", "afq", f"sub-{subject}", f"ses-{session}")
+afq_path = path / "derivatives" / "afq" / f"sub-{subject}" / f"ses-{session}"
 
 ###############################################################################
 # We can use the `dipy.io` API to read in the bundles from file.
@@ -50,17 +48,17 @@ afq_path = op.join(path, "derivatives", "afq", f"sub-{subject}", f"ses-{session}
 # the `streamlines` attribute will give us access to the sequence of arrays
 # that contain the streamline coordinates.
 
-cst_l_file = op.join(
-    afq_path,
-    "clean_bundles",
-    f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
+cst_l_file = (
+    afq_path
+    / "clean_bundles"
+    / f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
     "-RASMM_model-CSD_desc-prob-afq-CST_L_tractography.trk",
 )
 
-arc_l_file = op.join(
-    afq_path,
-    "clean_bundles",
-    f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
+arc_l_file = (
+    afq_path
+    / "clean_bundles"
+    / f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
     "-RASMM_model-CSD_desc-prob-afq-ARC_L_tractography.trk",
 )
 
@@ -123,11 +121,8 @@ oriented_arc_l = dts.orient_by_streamline(arc_l, standard_af_l)
 # this subject with the diffusion tensor imaging (DTI) model.
 
 fa, fa_affine = load_nifti(
-    op.join(
-        afq_path,
-        f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc"
-        "-preproc_dwi_model-DTI_FA.nii.gz",
-    )
+    afq_path / f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc"
+    "-preproc_dwi_model-DTI_FA.nii.gz",
 )
 
 ###############################################################################

--- a/doc/examples/bundlewarp_registration.py
+++ b/doc/examples/bundlewarp_registration.py
@@ -13,7 +13,7 @@ registration of white matter tracts :footcite:p:`Chandio2023`.
 
 """
 
-from os.path import join as pjoin
+from pathlib import Path
 from time import time
 
 from dipy.align.streamwarp import (
@@ -37,8 +37,8 @@ from dipy.viz.streamline import viz_displacement_mag, viz_two_bundles, viz_vecto
 # https://figshare.com/articles/dataset/Test_Bundles_for_DIPY/22557733
 
 bundle_warp_files = fetch_bundle_warp_dataset()
-s_UF_L_path = pjoin(bundle_warp_files[1], "s_UF_L.trk")
-m_UF_L_path = pjoin(bundle_warp_files[1], "m_UF_L.trk")
+s_UF_L_path = Path(bundle_warp_files[1]) / "s_UF_L.trk"
+m_UF_L_path = Path(bundle_warp_files[1]) / "m_UF_L.trk"
 
 uf_subj1 = load_trk(s_UF_L_path, reference="same", bbox_valid_check=False).streamlines
 uf_subj2 = load_trk(m_UF_L_path, reference="same", bbox_valid_check=False).streamlines

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -21,7 +21,7 @@ variables that were created in that example:
 
 """
 
-from os.path import join as pjoin
+from pathlib import Path
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -56,7 +56,7 @@ cc_slice = labels == 2
 # Read the candidates from file in voxel space:
 
 streamlines_files = fetch_stanford_tracks()
-lr_superiorfrontal_path = pjoin(streamlines_files[1], "hardi-lr-superiorfrontal.trk")
+lr_superiorfrontal_path = Path(streamlines_files[1]) / "hardi-lr-superiorfrontal.trk"
 
 candidate_sl_sft = load_trk(lr_superiorfrontal_path, "same")
 candidate_sl_sft.to_vox()

--- a/doc/examples/quick_start.py
+++ b/doc/examples/quick_start.py
@@ -14,7 +14,7 @@ their own datasets.
 Let's start with some necessary imports.
 """
 
-from os.path import expanduser, join
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 
@@ -32,25 +32,25 @@ fetch_sherbrooke_3shell()
 # By default these datasets will go in the ``.dipy`` folder inside your home
 # directory. Here is how you can access them.
 
-home = expanduser("~")
+home = Path("~").expanduser()
 
 ###############################################################################
 # ``dname`` holds the directory name where the 3 files are in.
 
-dname = join(home, ".dipy", "sherbrooke_3shell")
+dname = home / ".dipy" / "sherbrooke_3shell"
 
 ###############################################################################
 # Here, we show the complete filenames of the 3 files
 
-fdwi = join(dname, "HARDI193.nii.gz")
+fdwi = dname / "HARDI193.nii.gz"
 
 print(fdwi)
 
-fbval = join(dname, "HARDI193.bval")
+fbval = dname / "HARDI193.bval"
 
 print(fbval)
 
-fbvec = join(dname, "HARDI193.bvec")
+fbvec = dname / "HARDI193.bvec"
 
 print(fbvec)
 

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -11,8 +11,6 @@ axially symmetric tensor and the fODF using the FORECAST model from
 First import the necessary modules:
 """
 
-import os.path as op
-
 import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
@@ -30,35 +28,29 @@ from dipy.viz import actor, window
 # HBN-POD2 dataset :footcite:p:`RichieHalford2022`.
 
 data_path = fetch_hbn(["NDARAA948VFH"])[1]
-dwi_path = op.join(
-    data_path, "derivatives", "qsiprep", "sub-NDARAA948VFH", "ses-HBNsiteRU", "dwi"
+dwi_path = (
+    data_path / "derivatives" / "qsiprep" / "sub-NDARAA948VFH" / "ses-HBNsiteRU" / "dwi"
 )
 
 img = nib.load(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz",
-    )
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz",
 )
 
 gtab = gradient_table(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bval",
-    ),
-    bvecs=op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec",
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bval",
+    bvecs=(
+        dwi_path
+        / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec"
     ),
 )
 
 data = np.asarray(img.dataobj)
 
 mask_img = nib.load(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-brain_mask.nii.gz",
-    )
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-brain_mask.nii.gz"
 )
 
 brain_mask = mask_img.get_fdata()

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -41,8 +41,6 @@ algorithm.
 Let's start by importing the relevant modules:
 """
 
-import os.path as op
-
 import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
@@ -58,25 +56,21 @@ import dipy.reconst.fwdti as fwdti
 # here we download a dataset that was acquired with multiple b-values.
 
 data_path = fetch_hbn(["NDARAA948VFH"])[1]
-dwi_path = op.join(
-    data_path, "derivatives", "qsiprep", "sub-NDARAA948VFH", "ses-HBNsiteRU", "dwi"
+dwi_path = (
+    data_path / "derivatives" / "qsiprep" / "sub-NDARAA948VFH" / "ses-HBNsiteRU" / "dwi"
 )
 
 img = nib.load(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz",
-    )
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz",
 )
 
 gtab = gradient_table(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bval",
-    ),
-    bvecs=op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec",
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bval",
+    bvecs=(
+        dwi_path
+        / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec",
     ),
 )
 
@@ -88,10 +82,8 @@ data = np.asarray(img.dataobj)
 # remove the background of the image and avoid unnecessary calculations.
 
 mask_img = nib.load(
-    op.join(
-        dwi_path,
-        "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-brain_mask.nii.gz",
-    )
+    dwi_path
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-brain_mask.nii.gz",
 )
 
 ###############################################################################

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -20,8 +20,6 @@ example.
 
 """
 
-from os.path import join as pjoin
-
 import numpy as np
 
 from dipy.align import affine_registration, syn_registration
@@ -181,7 +179,7 @@ regtools.overlay_slices(
 # We read the streamlines from file in voxel space:
 
 streamlines_files = fetch_stanford_tracks()
-lr_superiorfrontal_path = pjoin(streamlines_files[1], "hardi-lr-superiorfrontal.trk")
+lr_superiorfrontal_path = streamlines_files[1] / "hardi-lr-superiorfrontal.trk"
 
 sft = load_tractogram(lr_superiorfrontal_path, "same")
 

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -8,7 +8,7 @@ Here we present an example for visualizing slices from 3D images.
 Let's start by importing the relevant modules.
 """
 
-import os
+from pathlib import Path
 
 from dipy.data import fetch_bundles_2_subjects
 from dipy.io.image import load_nifti, load_nifti_data
@@ -19,13 +19,13 @@ from dipy.viz import actor, ui, window
 
 fetch_bundles_2_subjects()
 
-fname_t1 = os.path.join(
-    os.path.expanduser("~"),
-    ".dipy",
-    "exp_bundles_and_maps",
-    "bundles_2_subjects",
-    "subj_1",
-    "t1_warped.nii.gz",
+fname_t1 = (
+    Path("~").expanduser()
+    / ".dipy"
+    / "exp_bundles_and_maps"
+    / "bundles_2_subjects"
+    / "subj_1"
+    / "t1_warped.nii.gz"
 )
 
 data, affine = load_nifti(fname_t1)
@@ -99,12 +99,12 @@ window.record(scene=scene, out_path="slices.png", size=(600, 600), reset_camera=
 # loading an FA image and showing it in a non-standard way using an HSV
 # colormap.
 
-fname_fa = os.path.join(
-    os.path.expanduser("~"),
-    ".dipy",
-    "exp_bundles_and_maps",
-    "bundles_2_subjects",
-    "subj_1",
+fname_fa = (
+    Path("~").expanduser()
+    / ".dipy"
+    / "exp_bundles_and_maps"
+    / "bundles_2_subjects"
+    / "subj_1"
     "fa_1x1x1.nii.gz",
 )
 

--- a/doc/sphinxext/prepare_gallery.py
+++ b/doc/sphinxext/prepare_gallery.py
@@ -197,8 +197,7 @@ def preprocess_include_directive(input_rst, output_rst):
 
 
 def prepare_gallery(app=None):
-    srcdir = app.srcdir if app else os.path.abspath(pjoin(
-        os.path.dirname(__file__), '..'))
+    srcdir = app.srcdir if app else os.path.abspath(Path(os.path.dirname(__file__)) / '..')
     examples_dir = os.path.join(srcdir, 'examples')
     examples_revamp_dir = os.path.join(srcdir, 'examples_revamped')
     os.makedirs(examples_revamp_dir, exist_ok=True)


### PR DESCRIPTION
Adopt `pathlib` for path manipulation:
- Use `pathlib` for path manipulation in all internal operations, except workflows.
- All I/O functions except workflows now accept `Path` instances for paths besides `str` instances.
- Simplifies the code and eases the manipulation of paths.
- The local files returned by the fetcher are now `Path` instances.

The modules dealing with the `workflow` class I/O argument iteration, namely `workflows/io.py` and `workflows/multi_io.py` are not changed in this patch set. Thus, atlhough workflow tests have been transitioned to create `Path` instances for the I/O arguments, they are casted into `str` instances.