### PR TITLE
TEST: Restore removed test case in io workflows

### DIFF
--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -79,6 +79,9 @@ def test_io_info():
     npt.assert_raises(SystemExit, io_info_flow.run, filepath_dix["gs_streamlines.tck"])
 
     io_info_flow = IoInfoFlow()
+    npt.assert_raises(OSError, io_info_flow.run, "fake.vtk")
+
+    io_info_flow = IoInfoFlow()
     io_info_flow.run(
         filepath_dix["gs_streamlines.tck"], reference=filepath_dix["gs_volume.nii"]
     )


### PR DESCRIPTION
Restore removed test case in io workflows. The test case was added in commit 5478aad and removed without any proper reason when PR https://github.com/dipy/dipy/pull/3429 was merged.

That PR started from a `master` branch that was more than 1400 commits behind (commit 75b490b from Dec 29 2023) the current DIPY `master` branch, and the commit where that test case was added was dated Jun 3, 2025, and thus way more recent. The line was removed in commit 9bcd2b3, across the many conflict fix and `master` merge commits that were done in https://github.com/dipy/dipy/pull/3429.