### PR TITLE
MNT: Fix miscellaneous labeler regexes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -112,11 +112,11 @@ area:utils:
 
 area:viz:
   files:
-    - "src/viz/*"
+    - "dipy/viz/*"
 
 area:workflows:
   files:
-    - "src/workflows/*"
+    - "dipy/workflows/*"
 
 type:cython:
   files:


### PR DESCRIPTION
Fix miscellaneous labeler regexes: fix the paths for `area:viz` and `area:workflows`.