### PR TITLE
ENH: Adopt `pathlib` for workflows

### DIFF
--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -336,9 +336,9 @@ class ImageRegistrationFlow(Workflow):
         """
         Parameters
         ----------
-        static_image_files : string
+        static_image_files : string or Path
             Path to the static image file.
-        moving_image_files : string
+        moving_image_files : string or Path
             Path to the moving image file.
         transform : string, optional
             ``'com'``: center of mass; ``'trans'``: translation; ``'rigid'``:
@@ -377,7 +377,7 @@ class ImageRegistrationFlow(Workflow):
             `moving` input volume. From the command line use something like
             `3 4 5 6`. From script use something like `[3, 4, 5, 6]`. This
             input is required for 4D volumes.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Directory to save the transformed image and the affine matrix
         out_moved : string, optional
             Name for the saved transformed image.
@@ -503,12 +503,12 @@ class ApplyTransformFlow(Workflow):
         """
         Parameters
         ----------
-        static_image_files : string
+        static_image_files : string or Path
             Path of the static image file.
-        moving_image_files : string
+        moving_image_files : string or Path
             Path of the moving image(s). It can be a single image or a
             folder containing multiple images.
-        transform_map_file : string
+        transform_map_file : string or Path
             For the affine case, it should be a text(``*.txt``) file containing
             the affine matrix. For the diffeomorphic case,
             it should be a nifti file containing the mapping displacement
@@ -516,7 +516,7 @@ class ApplyTransformFlow(Workflow):
         transform_type : string, optional
             Select the transformation type to apply between 'affine' or
             'diffeomorphic'.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Directory to save the transformed files.
         out_file : string, optional
             Name of the transformed file.
@@ -624,11 +624,11 @@ class SynRegistrationFlow(Workflow):
         """
         Parameters
         ----------
-        static_image_files : string
+        static_image_files : string or Path
             Path of the static image file.
-        moving_image_files : string
+        moving_image_files : string or Path
             Path to the moving image file.
-        prealign_file : string, optional
+        prealign_file : string or Path, optional
             The text file containing pre alignment information via an affine matrix.
         inv_static : boolean, optional
             Apply the inverse mapping to the static image.
@@ -690,7 +690,7 @@ class SynRegistrationFlow(Workflow):
         inv_tol : float, optional
             the displacement field inversion algorithm will stop iterating
             when the inversion error falls below this threshold.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Directory to save the transformed files.
         out_warped : string, optional
             Name of the warped file.
@@ -845,13 +845,13 @@ class MotionCorrectionFlow(Workflow):
         """
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvectors files at once.
         b0_threshold : float, optional
@@ -859,7 +859,7 @@ class MotionCorrectionFlow(Workflow):
         bvecs_tol : float, optional
             Threshold used to check that norm(bvec) = 1 +/- bvecs_tol
             b-vectors are unit vectors
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Directory to save the transformed image and the affine matrix.
         out_moved : string, optional
             Name for the saved transformed image.
@@ -933,9 +933,9 @@ class BundleWarpFlow(Workflow):
 
         Parameters
         ----------
-        static_file : string
+        static_file : string or Path
             Path to the static (reference) .trx file.
-        moving_file : string
+        moving_file : string or Path
             Path to the moving (target to be registered) .trx file.
         dist : string, optional
             Path to the precalculated distance matrix file.
@@ -957,7 +957,7 @@ class BundleWarpFlow(Workflow):
         bbox_valid_check : boolean, optional
             Verification for negative voxel coordinates or values above the volume
             dimensions.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_linear_moved : string, optional
             Filename of linearly moved bundle.

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -47,10 +47,10 @@ class Patch2SelfFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bval_files : string
+        bval_files : string or Path
             bval file associated with the diffusion data.
         model : string, or initialized linear model object, optional
             This will determine the algorithm used to solve the set of linear
@@ -79,7 +79,7 @@ class Patch2SelfFlow(Workflow):
             non-negative values if set to True.
         ver : int, optional
             Version of the Patch2Self algorithm to use between  1 or 3.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume
@@ -144,7 +144,7 @@ class NLMeansFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         sigma : float, optional
@@ -156,7 +156,7 @@ class NLMeansFlow(Workflow):
         rician : bool, optional
             If True the noise is estimated as Rician, otherwise Gaussian noise
             is assumed.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
@@ -217,10 +217,10 @@ class LPCAFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
         bvectors_files : string
@@ -257,7 +257,7 @@ class LPCAFlow(Workflow):
             noise standard deviation and the threshold $\tau$. If
             $\tau_{factor}$ is set to None, it will be automatically calculated
             using the Marcenko-Pastur distribution :footcite:p`Veraart2016b`.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
@@ -316,7 +316,7 @@ class MPPCAFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         patch_radius : variable int, optional
@@ -332,7 +332,7 @@ class MPPCAFlow(Workflow):
         return_sigma : bool, optional
             If true, a noise standard deviation estimate based on the
             Marcenko-Pastur distribution is returned :footcite:p:`Veraart2016b`.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_denoised : string, optional
             Name of the resulting denoised volume.
@@ -387,7 +387,7 @@ class GibbsRingingFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         slice_axis : int, optional
@@ -401,7 +401,7 @@ class GibbsRingingFlow(Workflow):
             applies to 3D or 4D `data` arrays. Default is 1. If < 0 the maximal
             number of cores minus ``num_processes + 1`` is used (enter -1 to
             use as many cores as possible). 0 raises an error.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_unring : string, optional
             Name of the resulting denoised volume.

--- a/dipy/workflows/mask.py
+++ b/dipy/workflows/mask.py
@@ -17,13 +17,13 @@ class MaskFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
            Path to image to be masked.
         lb : float
             Lower bound value.
         ub : float, optional
             Upper bound value.
-        out_dir : string, optional
+        out_dir : string or Path, optional
            Output directory.
         out_mask : string, optional
            Name of the masked file.

--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import sys
 
 import numpy as np
@@ -30,12 +31,12 @@ class EVACPlusFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         save_masked : bool, optional
             Save mask.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_mask : string, optional
             Name of the mask volume to be saved.
@@ -99,12 +100,12 @@ class BiasFieldCorrectionFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bval : string, optional
+        bval : string or Path, optional
             Path to the b-value file.
-        bvec : string, optional
+        bvec : string or Path, optional
             Path to the b-vector file.
         method : string, optional
             Bias field correction method. Choose from:
@@ -120,7 +121,7 @@ class BiasFieldCorrectionFlow(Workflow):
             Use CUDA for DeepN4 bias field correction.
         verbose : bool, optional
             Print verbose output.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_corrected : string, optional
             Name of the corrected volume to be saved.
@@ -138,10 +139,10 @@ class BiasFieldCorrectionFlow(Workflow):
 
         prefix = "t1" if method.lower() == "n4" else "dwi"
         for i, name in enumerate(self.flat_outputs):
-            if name.endswith("biasfield_corrected.nii.gz"):
-                self.flat_outputs[i] = name.replace(
-                    "biasfield_corrected.nii.gz", f"{prefix}_biasfield_corrected.nii.gz"
-                )
+            if str(name).endswith("biasfield_corrected.nii.gz"):
+                self.flat_outputs[i] = Path(name).parent / Path(
+                    "biasfield_corrected.nii.gz"
+                ).with_name(f"{prefix}_biasfield_corrected.nii.gz")
 
         self.update_flat_outputs(self.flat_outputs, io_it)
         for fpath, corrected_out_path in io_it:

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -96,11 +96,11 @@ class ReconstMAPMRIFlow(Workflow):
 
         Parameters
         ----------
-        data_files : string
+        data_files : string or Path
             Path to the input volume.
-        bvals_files : string
+        bvals_files : string or Path
             Path to the bval files.
-        bvecs_files : string
+        bvecs_files : string or Path
             Path to the bvec files.
         small_delta : float
             Small delta value used in generation of gradient table of provided
@@ -143,7 +143,7 @@ class ReconstMAPMRIFlow(Workflow):
             If true, all peak values are calculated relative to `max(odf)`.
         extract_pam_values : bool, optional
             Save or not to save pam volumes as single nifti files.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_rtop : string, optional
             Name of the rtop to be saved.
@@ -355,16 +355,16 @@ class ReconstDtiFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvectors files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once.
         fit_method : string, optional
@@ -397,7 +397,7 @@ class ReconstDtiFlow(Workflow):
             Dxx, Dxy, Dxz, Dyy, Dyz, Dzz on the last dimension.
         extract_pam_values : bool, optional
             Save or not to save pam volumes as single nifti files.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_tensor : string, optional
             Name of the tensors volume to be saved.
@@ -667,16 +667,16 @@ class ReconstDsiFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvectors files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once.
         qgrid_size : int, optional
@@ -717,7 +717,7 @@ class ReconstDsiFlow(Workflow):
             (default multiprocessing.cpu_count()). If < 0 the maximal number
             of cores minus ``num_processes + 1`` is used (enter -1 to use as
             many cores as possible). 0 raises an error.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -1103,16 +1103,16 @@ class ReconstQBallBaseFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvectors files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once. (default: No mask used)
         method : string, optional
@@ -1154,7 +1154,7 @@ class ReconstQBallBaseFlow(Workflow):
             (default multiprocessing.cpu_count()). If < 0 the maximal number
             of cores minus ``num_processes + 1`` is used (enter -1 to use as
             many cores as possible). 0 raises an error.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -1331,16 +1331,16 @@ class ReconstDkiFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once. (default: No mask used)
         fit_method : string, optional
@@ -1361,7 +1361,7 @@ class ReconstDkiFlow(Workflow):
             Save or not to save pam volumes as single nifti files.
         npeaks : int, optional
             Number of peaks to fit in each voxel.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_dt_tensor : string, optional
             Name of the tensors volume to be saved.
@@ -1613,16 +1613,16 @@ class ReconstIvimFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once. (default: No mask used)
         split_b_D : int, optional
@@ -1636,7 +1636,7 @@ class ReconstIvimFlow(Workflow):
         save_metrics : variable string, optional
             List of metrics to save.
             Possible values: S0_predicted, perfusion_fraction, D_star, D
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_S0_predicted : string, optional
             Name of the S0 signal estimated to be saved.
@@ -1774,16 +1774,16 @@ class ReconstRUMBAFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvectors files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once.
         b0_threshold : float, optional
@@ -1849,7 +1849,7 @@ class ReconstRUMBAFlow(Workflow):
         min_separation_angle : float, optional
             The minimum distance between directions. If two peaks are too close
             only the larger of the two is returned.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -2025,16 +2025,16 @@ class ReconstSDTFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once. (default: No mask used)
         ratio : float, optional
@@ -2071,7 +2071,7 @@ class ReconstSDTFlow(Workflow):
             Save or not to save pam volumes as single nifti files.
         num_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -2251,14 +2251,14 @@ class ReconstSFMFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
         sphere_name : string, optional
             Sphere name on which to reconstruct the fODFs.
@@ -2295,7 +2295,7 @@ class ReconstSFMFlow(Workflow):
             Save or not to save pam volumes as single nifti files.
         num_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -2465,13 +2465,13 @@ class ReconstGQIFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
         mask_files : string
@@ -2502,7 +2502,7 @@ class ReconstGQIFlow(Workflow):
             Save or not to save pam volumes as single nifti files.
         num_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.
@@ -2673,16 +2673,16 @@ class ReconstForecastFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvalues_files : string
+        bvalues_files : string or Path
             Path to the bvalues files. This path may contain wildcards to use
             multiple bvalues files at once.
-        bvectors_files : string
+        bvectors_files : string or Path
             Path to the bvectors files. This path may contain wildcards to use
             multiple bvalues files at once.
-        mask_files : string
+        mask_files : string or Path
             Path to the input masks. This path may contain wildcards to use
             multiple masks at once. (default: No mask used)
         lambda_lb : float, optional
@@ -2713,7 +2713,7 @@ class ReconstForecastFlow(Workflow):
             Save or not to save pam volumes as single nifti files.
         num_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_pam : string, optional
             Name of the peaks volume to be saved.

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -46,7 +46,7 @@ class MedianOtsuFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
         save_masked : bool, optional
@@ -72,7 +72,7 @@ class MedianOtsuFlow(Workflow):
         finalize_mask : bool, optional
             Whether to remove potential holes or islands.
             Useful for solving minor errors.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_mask : string, optional
             Name of the mask volume to be saved.
@@ -144,9 +144,9 @@ class RecoBundlesFlow(Workflow):
 
         Parameters
         ----------
-        streamline_files : string
+        streamline_files : string or Path
             The path of streamline files where you want to recognize bundles.
-        model_bundle_files : string
+        model_bundle_files : string or Path
             The path of model bundle files.
         greater_than : int, optional
             Keep streamlines that have length greater than
@@ -184,7 +184,7 @@ class RecoBundlesFlow(Workflow):
         no_r_slr : bool, optional
             Don't enable Refine local Streamline-based Linear
             Registration.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_recognized_transf : string, optional
             Recognized bundle in the space of the model bundle.
@@ -344,11 +344,11 @@ class LabelsBundlesFlow(Workflow):
 
         Parameters
         ----------
-        streamline_files : string
+        streamline_files : string or Path
             The path of streamline files where you want to recognize bundles.
-        labels_files : string
+        labels_files : string or Path
             The path of model bundle files.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_bundle : string, optional
             Recognized bundle in the space of the model bundle.
@@ -404,10 +404,10 @@ class ClassifyTissueFlow(Workflow):
 
         Parameters
         ----------
-        input_files : string
+        input_files : string or Path
             Path to the input volumes. This path may contain wildcards to
             process multiple inputs at once.
-        bvals_file : string, optional
+        bvals_file : string or Path, optional
             Path to the b-values file. Required for 'dam' method.
         method : string, optional
             Method to use for tissue extraction. Options are:
@@ -445,7 +445,7 @@ class ClassifyTissueFlow(Workflow):
             and the algorithm will run for the specified number of
             iterations unless another stopping criterion is met.
             Used only for 'hmrf' method.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
         out_tissue : string, optional
             Name of the tissue volume to be saved.
@@ -468,15 +468,14 @@ class ClassifyTissueFlow(Workflow):
 
         prefix = "t1" if method.lower() == "hmrf" else "dwi"
         for i, name in enumerate(self.flat_outputs):
-            if name.endswith("tissue_classified.nii.gz"):
-                self.flat_outputs[i] = name.replace(
-                    "tissue_classified.nii.gz", f"{prefix}_tissue_classified.nii.gz"
-                )
-            if name.endswith("tissue_classified_pve.nii.gz"):
-                self.flat_outputs[i] = name.replace(
-                    "tissue_classified_pve.nii.gz",
-                    f"{prefix}_tissue_classified_pve.nii.gz",
-                )
+            if str(name).endswith("tissue_classified.nii.gz"):
+                self.flat_outputs[i] = Path(name).parent / Path(
+                    "tissue_classified.nii.gz"
+                ).with_name(f"{prefix}_tissue_classified.nii.gz")
+            if str(name).endswith("tissue_classified_pve.nii.gz"):
+                self.flat_outputs[i] = Path(name).parent / Path(
+                    "tissue_classified_pve.nii.gz"
+                ).with_name(f"{prefix}_tissue_classified_pve.nii.gz")
 
         self.update_flat_outputs(self.flat_outputs, io_it)
 

--- a/dipy/workflows/stats.py
+++ b/dipy/workflows/stats.py
@@ -49,19 +49,19 @@ class SNRinCCFlow(Workflow):
 
         Parameters
         ----------
-        data_files : string
+        data_files : string or Path
             Path to the dwi.nii.gz file. This path may contain wildcards to
             process multiple inputs at once.
-        bvals_files : string
+        bvals_files : string or Path
             Path of bvals.
-        bvecs_files : string
+        bvecs_files : string or Path
             Path of bvecs.
-        mask_file : string
+        mask_file : string or Path
             Path of a brain mask file.
         bbox_threshold : variable float, optional
             Threshold for bounding box, values separated with commas for ex.
             [0.6,1,0,0.1,0,0.1].
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Where the resulting file will be saved.
         out_file : string, optional
             Name of the result file to be saved.
@@ -339,7 +339,7 @@ class BundleAnalysisTractometryFlow(Workflow):
             wildcards to process multiple inputs at once.
         no_disks : integer, optional
             Number of disks used for dividing bundle into disks.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
 
         References
@@ -492,12 +492,12 @@ class LinearMixedModelsFlow(Workflow):
 
         Parameters
         ----------
-        h5_files : string
+        h5_files : string or Path
             Path to the input metric files. This path may
             contain wildcards to process multiple inputs at once.
         no_disks : integer, optional
             Number of disks used for dividing bundle into disks.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
 
         """
@@ -566,7 +566,7 @@ class BundleShapeAnalysis(Workflow):
             list of bundle clustering thresholds used in QuickBundlesX.
         threshold : float, optional
             Bundle shape similarity threshold.
-        out_dir : string, optional
+        out_dir : string or Path, optional
             Output directory.
 
         References

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -35,7 +35,7 @@ def test_reslice():
         volume = load_nifti_data(data_path)
 
         reslice_flow = ResliceFlow()
-        reslice_flow.run(str(data_path), [1.5, 1.5, 1.5], out_dir=out_dir)
+        reslice_flow.run(data_path, [1.5, 1.5, 1.5], out_dir=out_dir)
 
         out_path = reslice_flow.last_generated_outputs["out_resliced"]
         resliced = load_nifti_data(out_path)
@@ -56,9 +56,7 @@ def test_slr_flow():
         save_tractogram(sft, moved_path, bbox_valid_check=False)
 
         slr_flow = SlrWithQbxFlow(force=True)
-        slr_flow.run(
-            str(data_path), str(moved_path), out_dir=out_dir, bbox_valid_check=False
-        )
+        slr_flow.run(data_path, moved_path, out_dir=out_dir, bbox_valid_check=False)
 
         out_path = slr_flow.last_generated_outputs["out_moved"]
 
@@ -100,12 +98,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="com",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
             )
             check_existence(out_moved, out_affine)
 
@@ -115,12 +113,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="trans",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="trans_q.txt",
@@ -136,12 +134,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="rigid",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_q.txt",
@@ -157,12 +155,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="rigid_isoscaling",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_isoscaling_q.txt",
@@ -178,12 +176,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="rigid_scaling",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="rigid_scaling_q.txt",
@@ -199,12 +197,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="affine",
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 save_metric=True,
                 level_iters=[100, 10, 1],
                 out_quality="affine_q.txt",
@@ -220,8 +218,8 @@ def test_image_registration(rng):
             npt.assert_raises(
                 ValueError,
                 image_registration_flow.run,
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform="notransform",
             )
 
@@ -229,8 +227,8 @@ def test_image_registration(rng):
             npt.assert_raises(
                 ValueError,
                 image_registration_flow.run,
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 metric="wrong_metric",
             )
 
@@ -245,12 +243,12 @@ def test_image_registration(rng):
 
             image_registration_flow._force_overwrite = True
             kwargs = {
-                "static_image_files": str(dwi_image_file),
-                "moving_image_files": str(moving_image_file),
+                "static_image_files": dwi_image_file,
+                "moving_image_files": moving_image_file,
                 "transform": "trans",
                 "out_dir": temp_out_dir,
-                "out_moved": str(out_moved),
-                "out_affine": str(out_affine),
+                "out_moved": out_moved,
+                "out_affine": out_affine,
                 "save_metric": True,
                 "level_iters": [100, 10, 1],
                 "out_quality": "trans_q.txt",
@@ -265,10 +263,10 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
             apply_trans.run(
-                static_image_files=str(dwi_image_file),
-                moving_image_files=str(moving_image_file),
+                static_image_files=dwi_image_file,
+                moving_image_files=moving_image_file,
                 out_dir=temp_out_dir,
-                transform_map_file=str(out_affine),
+                transform_map_file=out_affine,
             )
 
             # Checking for the transformed volume shape
@@ -282,12 +280,12 @@ def test_image_registration(rng):
             image_registration_flow._force_overwrite = True
 
             kwargs = {
-                "static_image_files": str(static_image_file),
-                "moving_image_files": str(dwi_image_file),
+                "static_image_files": static_image_file,
+                "moving_image_files": dwi_image_file,
                 "transform": "trans",
                 "out_dir": temp_out_dir,
-                "out_moved": str(out_moved),
-                "out_affine": str(out_affine),
+                "out_moved": out_moved,
+                "out_affine": out_affine,
                 "save_metric": True,
                 "level_iters": [100, 10, 1],
                 "out_quality": "trans_q.txt",
@@ -302,10 +300,10 @@ def test_image_registration(rng):
             check_existence(out_moved, out_affine)
 
             apply_trans.run(
-                static_image_files=str(static_image_file),
-                moving_image_files=str(dwi_image_file),
+                static_image_files=static_image_file,
+                moving_image_files=dwi_image_file,
                 out_dir=temp_out_dir,
-                transform_map_file=str(out_affine),
+                transform_map_file=out_affine,
                 out_file="transformed2.nii.gz",
             )
 
@@ -406,12 +404,12 @@ def test_apply_affine_transform():
                 transform_type = str(i[0]).lower()
 
             image_registration_flow.run(
-                str(static_image_file),
-                str(moving_image_file),
+                static_image_file,
+                moving_image_file,
                 transform=transform_type,
                 out_dir=temp_out_dir,
-                out_moved=str(out_moved),
-                out_affine=str(out_affine),
+                out_moved=out_moved,
+                out_affine=out_affine,
                 level_iters=[1, 1, 1],
                 save_metric=False,
             )
@@ -422,10 +420,10 @@ def test_apply_affine_transform():
 
         images = Path(temp_out_dir) / "*moving*"
         apply_trans.run(
-            str(static_image_file),
-            str(images),
+            static_image_file,
+            images,
             out_dir=temp_out_dir,
-            transform_map_file=str(out_affine),
+            transform_map_file=out_affine,
         )
 
         # Checking for the transformed file.
@@ -481,7 +479,7 @@ def test_syn_registration_flow():
         fname_moving = Path(out_dir) / "tmp_moving.nii.gz"
         nib.save(moving_img, fname_moving)
 
-        positional_args = [str(fname_static), str(fname_moving)]
+        positional_args = [fname_static, fname_moving]
 
         # Test the cc metric
         metric_optional_args = {
@@ -577,7 +575,7 @@ def test_bundlewarp_flow():
         save_tractogram(sft, f2_path, bbox_valid_check=False)
 
         bw_flow = BundleWarpFlow(force=True)
-        bw_flow.run(str(f1_path), str(f2_path), out_dir=out_dir, bbox_valid_check=False)
+        bw_flow.run(f1_path, f2_path, out_dir=out_dir, bbox_valid_check=False)
 
         out_linearly_moved = Path(out_dir) / "linearly_moved.trx"
         out_nonlinearly_moved = Path(out_dir) / "nonlinearly_moved.trx"

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -31,11 +31,11 @@ def test_nlmeans_flow():
 
         nlmeans_flow = NLMeansFlow()
 
-        nlmeans_flow.run(str(data_path), out_dir=out_dir)
+        nlmeans_flow.run(data_path, out_dir=out_dir)
         assert_true(Path(nlmeans_flow.last_generated_outputs["out_denoised"]).is_file())
 
         nlmeans_flow._force_overwrite = True
-        nlmeans_flow.run(str(data_path), sigma=4, out_dir=out_dir)
+        nlmeans_flow.run(data_path, sigma=4, out_dir=out_dir)
         denoised_path = nlmeans_flow.last_generated_outputs["out_denoised"]
         assert_true(Path(denoised_path).is_file())
         denoised_data, denoised_affine = load_nifti(denoised_path)
@@ -50,14 +50,14 @@ def test_patch2self_flow():
 
         patch2self_flow = Patch2SelfFlow()
         patch2self_flow.run(
-            str(data_path), str(fbvals), patch_radius=(0, 0, 0), out_dir=out_dir, ver=1
+            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=1
         )
         assert_true(
             Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
         )
         patch2self_flow = Patch2SelfFlow()
         patch2self_flow.run(
-            str(data_path), str(fbvals), patch_radius=(0, 0, 0), out_dir=out_dir, ver=3
+            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=3
         )
         assert_true(
             Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
@@ -69,7 +69,7 @@ def test_lpca_flow():
         data_path, fbvals, fbvecs = get_fnames()
 
     lpca_flow = LPCAFlow()
-    lpca_flow.run(str(data_path), str(fbvals), str(fbvecs), out_dir=out_dir)
+    lpca_flow.run(data_path, fbvals, fbvecs, out_dir=out_dir)
     assert_true(Path(lpca_flow.last_generated_outputs["out_denoised"]).is_file())
 
 
@@ -81,14 +81,12 @@ def test_mppca_flow(rng):
         save_nifti(data_path, S0, np.eye(4))
 
         mppca_flow = MPPCAFlow()
-        mppca_flow.run(str(data_path), out_dir=out_dir)
+        mppca_flow.run(data_path, out_dir=out_dir)
         assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
         assert_false(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
         mppca_flow._force_overwrite = True
-        mppca_flow.run(
-            str(data_path), return_sigma=True, pca_method="svd", out_dir=out_dir
-        )
+        mppca_flow.run(data_path, return_sigma=True, pca_method="svd", out_dir=out_dir)
         assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
         assert_true(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
@@ -127,5 +125,5 @@ def test_gibbs_flow():
         save_nifti(data_path, image4d, np.eye(4))
 
         gibbs_flow = GibbsRingingFlow()
-        gibbs_flow.run(str(data_path), out_dir=out_dir)
+        gibbs_flow.run(data_path, out_dir=out_dir)
         assert_true(Path(gibbs_flow.last_generated_outputs["out_unring"]).is_file())

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -57,14 +57,12 @@ is_big_endian = "big" in sys.byteorder.lower()
 def test_io_info():
     fimg, fbvals, fbvecs = get_fnames(name="small_101D")
     io_info_flow = IoInfoFlow()
-    io_info_flow.run([str(fimg), str(fbvals), str(fbvecs)])
+    io_info_flow.run([fimg, fbvals, fbvecs])
 
     fimg, fbvals, fbvecs = get_fnames(name="small_25")
     io_info_flow = IoInfoFlow()
-    io_info_flow.run([str(fimg), str(fbvals), str(fbvecs)])
-    io_info_flow.run(
-        [str(fimg), str(fbvals), str(fbvecs)], b0_threshold=20, bvecs_tol=0.001
-    )
+    io_info_flow.run([fimg, fbvals, fbvecs])
+    io_info_flow.run([fimg, fbvals, fbvecs], b0_threshold=20, bvecs_tol=0.001)
 
     filepath_dix, _, _ = get_fnames(name="gold_standard_io")
     if not is_big_endian:
@@ -138,10 +136,10 @@ def test_split_flow():
         split_flow = SplitFlow()
         data_path, _, _ = get_fnames()
         volume, affine = load_nifti(data_path)
-        split_flow.run(str(data_path), out_dir=out_dir)
+        split_flow.run(data_path, out_dir=out_dir)
         assert_true(Path(split_flow.last_generated_outputs["out_split"]).is_file())
         split_flow._force_overwrite = True
-        split_flow.run(str(data_path), vol_idx=0, out_dir=out_dir)
+        split_flow.run(data_path, vol_idx=0, out_dir=out_dir)
         split_path = split_flow.last_generated_outputs["out_split"]
         assert_true(Path(split_path).is_file())
         split_data, split_affine = load_nifti(split_path)
@@ -154,7 +152,7 @@ def test_concatenate_flow():
         concatenate_flow = ConcatenateTractogramFlow()
         data_path, _, _ = get_fnames(name="gold_standard_io")
         input_files = [
-            str(v)
+            v
             for k, v in data_path.items()
             if k
             in [
@@ -166,17 +164,15 @@ def test_concatenate_flow():
         ]
         concatenate_flow.run(*input_files, out_dir=out_dir)
         assert_true(
-            concatenate_flow.last_generated_outputs["out_extension"].endswith("trx")
+            str(concatenate_flow.last_generated_outputs["out_extension"]).endswith(
+                "trx"
+            )
         )
-        assert_true(
-            Path(
-                concatenate_flow.last_generated_outputs["out_tractogram"] + ".trx"
-            ).is_file()
-        )
+        _fname = concatenate_flow.last_generated_outputs["out_tractogram"]
+        _fname = Path(_fname).with_suffix(Path(_fname).suffix + ".trx")
+        assert_true(_fname.is_file())
 
-        trk = load_tractogram(
-            concatenate_flow.last_generated_outputs["out_tractogram"] + ".trx", "same"
-        )
+        trk = load_tractogram(_fname, "same")
         npt.assert_equal(len(trk), 13)
 
 
@@ -200,9 +196,9 @@ def test_convert_sh_flow():
         # Run the workflow and load the output
         workflow = ConvertSHFlow()
         workflow.run(
-            str(filepath_in),
+            filepath_in,
             out_dir=out_dir,
-            out_file=str(filename_out),
+            out_file=filename_out,
         )
         img_out, _ = load_nifti(filepath_out)
 
@@ -214,7 +210,7 @@ def test_convert_tractogram_flow():
     with TemporaryDirectory() as out_dir:
         data_path, _, _ = get_fnames(name="gold_standard_io")
         input_files = [
-            str(v)
+            v
             for k, v in data_path.items()
             if k
             in [
@@ -268,11 +264,11 @@ def test_convert_tensors_flow():
         # Run the workflow and load the output
         workflow = ConvertTensorsFlow()
         workflow.run(
-            str(filepath_in),
+            filepath_in,
             from_format="dipy",
             to_format="mrtrix",
             out_dir=out_dir,
-            out_tensor=str(filename_out),
+            out_tensor=filename_out,
         )
 
         img_out, _ = load_nifti(filepath_out)
@@ -302,7 +298,7 @@ def test_niftis_to_pam_flow():
         fname = Path(out_dir) / "test.pam5"
         save_pam(fname, pam)
 
-        args = [str(fname), str(out_dir)]
+        args = [fname, out_dir]
         flow = PamToNiftisFlow()
         flow.run(*args)
 
@@ -340,7 +336,7 @@ def test_tensor_to_pam_flow():
         save_nifti(f_mevals, df.evals, affine)
         save_nifti(f_mevecs, df.evecs, affine)
 
-        args = [str(f_mevals), str(f_mevecs)]
+        args = [f_mevals, f_mevecs]
         flow = TensorToPamFlow()
         flow.run(*args, out_dir=out_dir)
         pam_file = flow.last_generated_outputs["out_pam"]
@@ -359,7 +355,7 @@ def test_pam_to_niftis_flow():
         fname = Path(out_dir) / "test.pam5"
         save_pam(fname, pam)
 
-        args = [str(fname), str(out_dir)]
+        args = [fname, out_dir]
         flow = PamToNiftisFlow()
         flow.run(*args)
         assert_true(Path(flow.last_generated_outputs["out_peaks_dir"]).is_file())
@@ -387,7 +383,7 @@ def test_math():
                 math_flow = MathFlow()
                 math_flow.run(
                     op,
-                    [str(data_path_a), str(data_path_b), str(data_path)],
+                    [data_path_a, data_path_b, data_path],
                     out_dir=out_dir,
                     **kwarg,
                 )
@@ -404,7 +400,7 @@ def test_math():
             math_flow = MathFlow()
             math_flow.run(
                 "vol1*vol2",
-                [str(data_path_a), str(data_3d_path)],
+                [data_path_a, data_3d_path],
                 disable_check=True,
                 out_dir=out_dir,
             )
@@ -419,7 +415,7 @@ def test_math():
             math_flow = MathFlow()
             math_flow.run(
                 "vol1*vol2",
-                [str(data_bool_path), str(data_bool_2_path)],
+                [data_bool_path, data_bool_2_path],
                 disable_check=True,
                 dtype="bool",
                 out_dir=out_dir,
@@ -431,9 +427,7 @@ def test_math():
 
         else:
             math_flow = MathFlow()
-            npt.assert_raises(
-                TripWireError, math_flow.run, "vol1*3", [str(data_path_a)]
-            )
+            npt.assert_raises(TripWireError, math_flow.run, "vol1*3", [data_path_a])
 
 
 @pytest.mark.skipif(not have_ne, reason="numexpr not installed")
@@ -449,30 +443,30 @@ def test_math_error():
 
         math_flow = MathFlow()
         npt.assert_raises(
-            SyntaxError, math_flow.run, "vol1*", [str(data_path_a)], out_dir=out_dir
+            SyntaxError, math_flow.run, "vol1*", [data_path_a], out_dir=out_dir
         )
         npt.assert_raises(
             SystemExit,
             math_flow.run,
             "vol1*2",
-            [str(data_path_a)],
+            [data_path_a],
             dtype="k",
             out_dir=out_dir,
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [str(data_path_b)], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*2", [data_path_b], out_dir=out_dir
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [str(data_path_c)], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*2", [data_path_c], out_dir=out_dir
         )
         npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*vol3", [str(data_path_a)], out_dir=out_dir
+            SystemExit, math_flow.run, "vol1*vol3", [data_path_a], out_dir=out_dir
         )
         npt.assert_raises(
             SystemExit,
             math_flow.run,
             "vol1*vol2",
-            [str(data_path), str(data_path_2)],
+            [data_path, data_path_2],
             out_dir=out_dir,
         )
 
@@ -486,7 +480,7 @@ def test_extract_b0_flow():
         save_nifti(b0_path, b0_data, affine)
 
         extract_b0_flow = ExtractB0Flow()
-        extract_b0_flow.run(str(fdata), str(fbval), out_dir=out_dir, strategy="first")
+        extract_b0_flow.run(fdata, fbval, out_dir=out_dir, strategy="first")
         npt.assert_equal(
             Path(extract_b0_flow.last_generated_outputs["out_b0"]),
             Path(out_dir) / "b0.nii.gz",
@@ -502,16 +496,16 @@ def test_extract_shell_flow():
 
         extract_shell_flow = ExtractShellFlow()
         extract_shell_flow.run(
-            str(fdata), str(fbval), str(fbvec), bvals_to_extract="2000", out_dir=out_dir
+            fdata, fbval, fbvec, bvals_to_extract="2000", out_dir=out_dir
         )
         res, _ = load_nifti(Path(out_dir) / "shell_2000.nii.gz")
         npt.assert_array_equal(res, data[..., 1:])
 
         extract_shell_flow._force_overwrite = True
         extract_shell_flow.run(
-            str(fdata),
-            str(fbval),
-            str(fbvec),
+            fdata,
+            fbval,
+            fbvec,
             bvals_to_extract="0, 2000",
             group_shells=False,
             out_dir=out_dir,
@@ -530,14 +524,12 @@ def test_extract_volume_flow():
         data, affine = load_nifti(fdata)
 
         extract_volume_flow = ExtractVolumeFlow()
-        extract_volume_flow.run(str(fdata), vol_idx="0-3,5", out_dir=out_dir)
+        extract_volume_flow.run(fdata, vol_idx="0-3,5", out_dir=out_dir)
         res, _ = load_nifti(extract_volume_flow.last_generated_outputs["out_vol"])
         npt.assert_equal(res.shape[-1], 5)
 
         extract_volume_flow._force_overwrite = True
-        extract_volume_flow.run(
-            str(fdata), vol_idx="0-3,5", grouped=False, out_dir=out_dir
-        )
+        extract_volume_flow.run(fdata, vol_idx="0-3,5", grouped=False, out_dir=out_dir)
         npt.assert_equal(Path(Path(out_dir) / "volume_2.nii.gz").is_file(), True)
         npt.assert_equal(Path(Path(out_dir) / "volume_5.nii.gz").is_file(), True)
         res2, _ = load_nifti(Path(out_dir) / "volume_2.nii.gz")

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -15,10 +15,10 @@ def test_mask():
 
         mask_flow = MaskFlow()
 
-        mask_flow.run(str(data_path), 10, out_dir=out_dir, ub=9)
+        mask_flow.run(data_path, 10, out_dir=out_dir, ub=9)
         assert_false(mask_flow.last_generated_outputs)
 
-        mask_flow.run(str(data_path), 10, out_dir=out_dir)
+        mask_flow.run(data_path, 10, out_dir=out_dir)
         mask_path = mask_flow.last_generated_outputs["out_mask"]
         mask_data, mask_affine = load_nifti(mask_path)
         npt.assert_equal(mask_data.shape, volume.shape)

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -28,7 +28,7 @@ def test_evac_plus_flow():
         save_masked = True
 
         evac_flow = EVACPlusFlow()
-        evac_flow.run(str(temp_path), out_dir=out_dir, save_masked=save_masked)
+        evac_flow.run(temp_path, out_dir=out_dir, save_masked=save_masked)
 
         mask_name = evac_flow.last_generated_outputs["out_mask"]
         masked_name = evac_flow.last_generated_outputs["out_masked"]
@@ -58,7 +58,7 @@ def test_correct_biasfield_flow():
             save_nifti(temp_path, volume, temp_affine)
 
             bias_flow = BiasFieldCorrectionFlow()
-            bias_flow.run(str(temp_path), out_dir=out_dir)
+            bias_flow.run(temp_path, out_dir=out_dir)
 
             corrected_name = bias_flow.last_generated_outputs["out_corrected"]
 
@@ -71,9 +71,9 @@ def test_correct_biasfield_flow():
     with TemporaryDirectory() as out_dir:
         fdata, fbval, fbvec = get_fnames(name="small_25")
         args = {
-            "input_files": str(fdata),
-            "bval": str(fbval),
-            "bvec": str(fbvec),
+            "input_files": fdata,
+            "bval": fbval,
+            "bvec": fbvec,
             "method": "b0",
             "out_dir": out_dir,
         }
@@ -86,9 +86,9 @@ def test_correct_biasfield_flow():
         npt.assert_almost_equal(corrected_data.mean(), 0.0384615384615, decimal=5)
 
     args = {
-        "input_files": str(fdata),
-        "bval": str(fbval),
-        "bvec": str(fbvec),
+        "input_files": fdata,
+        "bval": fbval,
+        "bvec": fbvec,
         "method": "random",
         "out_dir": out_dir,
     }

--- a/dipy/workflows/tests/test_reconst.py
+++ b/dipy/workflows/tests/test_reconst.py
@@ -121,10 +121,10 @@ def reconst_flow_core(flow, *, use_multishell_data=None, **kwargs):
             8,
         ]:
             reconst_flow.run(
-                str(data_path),
-                str(bval_path),
-                str(bvec_path),
-                str(mask_path),
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
                 sh_order_max=sh_order_max,
                 out_dir=out_dir,
                 extract_pam_values=True,

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -78,10 +78,10 @@ def reconst_flow_core(flow, **kwargs):
         reconst_flow = flow()
         for sh_order in [4, 6, 8]:
             reconst_flow.run(
-                str(data_path),
-                str(bval_path),
-                str(bvec_path),
-                str(mask_path),
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
                 sh_order_max=sh_order,
                 out_dir=out_dir,
                 extract_pam_values=True,
@@ -139,10 +139,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    str(data_path),
-                    str(bval_path),
-                    str(bvec_path),
-                    str(mask_path),
+                    data_path,
+                    bval_path,
+                    bvec_path,
+                    mask_path,
                     out_dir=out_dir,
                     frf=[15, 5, 5],
                     **kwargs,
@@ -150,10 +150,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    str(data_path),
-                    str(bval_path),
-                    str(bvec_path),
-                    str(mask_path),
+                    data_path,
+                    bval_path,
+                    bvec_path,
+                    mask_path,
                     out_dir=out_dir,
                     frf="15, 5, 5",
                     **kwargs,
@@ -161,10 +161,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    str(data_path),
-                    str(bval_path),
-                    str(bvec_path),
-                    str(mask_path),
+                    data_path,
+                    bval_path,
+                    bvec_path,
+                    mask_path,
                     out_dir=out_dir,
                     frf=None,
                     **kwargs,
@@ -172,10 +172,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow2 = flow()
                 reconst_flow2._force_overwrite = True
                 reconst_flow2.run(
-                    str(data_path),
-                    str(bval_path),
-                    str(bvec_path),
-                    str(mask_path),
+                    data_path,
+                    bval_path,
+                    bvec_path,
+                    mask_path,
                     out_dir=out_dir,
                     frf=None,
                     roi_center=[5, 5, 5],
@@ -186,10 +186,10 @@ def reconst_flow_core(flow, **kwargs):
                     npt.assert_warns(
                         UserWarning,
                         reconst_flow.run,
-                        str(data_path),
-                        str(tmp_bval_path),
-                        str(tmp_bvec_path),
-                        str(mask_path),
+                        data_path,
+                        tmp_bval_path,
+                        tmp_bvec_path,
+                        mask_path,
                         out_dir=out_dir,
                         extract_pam_values=True,
                         **kwargs,
@@ -201,10 +201,10 @@ def reconst_flow_core(flow, **kwargs):
                 reconst_flow = flow()
                 reconst_flow._force_overwrite = True
                 reconst_flow.run(
-                    str(data_path),
-                    str(bval_path),
-                    str(bvec_path),
-                    str(mask_path),
+                    data_path,
+                    bval_path,
+                    bvec_path,
+                    mask_path,
                     out_dir=out_dir,
                     parallel=True,
                     num_processes=2,

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -24,7 +24,7 @@ def test_reconst_dki():
 
         dki_flow = ReconstDkiFlow()
 
-        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
+        args = [data_path, bval_path, bvec_path, mask_path]
 
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -131,10 +131,10 @@ def test_reconst_dki():
                 category=PendingDeprecationWarning,
             )
             dki_flow.run(
-                str(data_path),
-                str(tmp_bval_path),
-                str(tmp_bvec_path),
-                str(mask_path),
+                data_path,
+                tmp_bval_path,
+                tmp_bvec_path,
+                mask_path,
                 out_dir=out_dir,
                 b0_threshold=0,
             )

--- a/dipy/workflows/tests/test_reconst_dsi.py
+++ b/dipy/workflows/tests/test_reconst_dsi.py
@@ -47,10 +47,10 @@ def reconst_flow_core(flow, **kwargs):
                 category=PendingDeprecationWarning,
             )
             dsi_flow.run(
-                str(data_path),
-                str(bval_path),
-                str(bvec_path),
-                str(mask_path),
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
                 out_dir=out_dir,
                 extract_pam_values=True,
                 **kwargs,

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -57,7 +57,7 @@ def reconst_flow_core(flow, extra_args=None, extra_kwargs=None):
 
         dti_flow = flow()
 
-        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
+        args = [data_path, bval_path, bvec_path, mask_path]
         args.extend(extra_args)
         kwargs = {"out_dir": out_dir, "extract_pam_values": True}
         kwargs.update(extra_kwargs)

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -72,10 +72,10 @@ def test_reconst_ivim():
         ivim_flow = ReconstIvimFlow()
 
         args = [
-            str(data_path),
-            str(temp_bval_path),
-            str(temp_bvec_path),
-            str(mask_path),
+            data_path,
+            temp_bval_path,
+            temp_bvec_path,
+            mask_path,
         ]
 
         msg = "Bounds for this fit have been set from experiments and * "

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -43,9 +43,9 @@ def reconst_mmri_core(flow, lap, pos):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=msg, category=UserWarning)
             mmri_flow.run(
-                data_files=str(data_path),
-                bvals_files=str(bval_path),
-                bvecs_files=str(bvec_path),
+                data_files=data_path,
+                bvals_files=bval_path,
+                bvecs_files=bvec_path,
                 small_delta=0.0129,
                 big_delta=0.0218,
                 laplacian=lap,
@@ -80,9 +80,9 @@ def reconst_mmri_core(flow, lap, pos):
             npt.assert_warns(
                 UserWarning,
                 mmri_flow.run,
-                str(data_path),
-                str(tmp_bval_path),
-                str(tmp_bvec_path),
+                data_path,
+                tmp_bval_path,
+                tmp_bvec_path,
                 small_delta=0.0129,
                 big_delta=0.0218,
                 laplacian=lap,

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -39,7 +39,7 @@ def test_median_otsu_flow():
         mo_flow = MedianOtsuFlow()
         with npt.assert_warns(ArgsDeprecationWarning):
             mo_flow.run(
-                str(data_path),
+                data_path,
                 out_dir=out_dir,
                 save_masked=save_masked,
                 median_radius=median_radius,
@@ -96,8 +96,8 @@ def test_recobundles_flow():
 
         rb_flow = RecoBundlesFlow(force=True)
         rb_flow.run(
-            str(f1_path),
-            str(f2_path),
+            f1_path,
+            f2_path,
             greater_than=0,
             clust_thr=10,
             model_clust_thr=5.0,
@@ -114,7 +114,7 @@ def test_recobundles_flow():
         npt.assert_equal(len(rec_bundle) == len(f2), True)
 
         label_flow = LabelsBundlesFlow(force=True)
-        label_flow.run(str(f1_path), labels, out_dir=out_dir)
+        label_flow.run(f1_path, labels, out_dir=out_dir)
 
         recog_bundle = label_flow.last_generated_outputs["out_bundle"]
         rec_bundle_org = load_tractogram(
@@ -140,7 +140,7 @@ def test_classify_tissue_flow():
         nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
 
         args = {
-            "input_files": str(data_path),
+            "input_files": data_path,
             "method": "hmrf",
             "nclass": 4,
             "beta": 0.1,
@@ -164,10 +164,10 @@ def test_classify_tissue_flow():
         npt.assert_equal(pve_data.shape, (data.shape) + (4,))
         npt.assert_equal(pve_data.max(), 1)
 
-        npt.assert_raises(SystemExit, flow.run, str(data_path))
-        npt.assert_raises(SystemExit, flow.run, str(data_path), method="random")
-        npt.assert_raises(SystemExit, flow.run, str(data_path), method="dam")
-        npt.assert_raises(SystemExit, flow.run, str(data_path), method="hmrf")
+        npt.assert_raises(SystemExit, flow.run, data_path)
+        npt.assert_raises(SystemExit, flow.run, data_path, method="random")
+        npt.assert_raises(SystemExit, flow.run, data_path, method="dam")
+        npt.assert_raises(SystemExit, flow.run, data_path, method="hmrf")
 
     if has_sklearn:
         with TemporaryDirectory() as out_dir:
@@ -179,8 +179,8 @@ def test_classify_tissue_flow():
             nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
 
             args = {
-                "input_files": str(data_path),
-                "bvals_file": str(bvals_path),
+                "input_files": data_path,
+                "bvals_file": bvals_path,
                 "method": "dam",
                 "wm_threshold": 0.5,
                 "out_dir": out_dir,

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -39,7 +39,7 @@ def test_stats():
         save_nifti(mask_path, mask, affine)
 
         snr_flow = SNRinCCFlow(force=True)
-        args = [str(data_path), str(bval_path), str(bvec_path), str(mask_path)]
+        args = [data_path, bval_path, bvec_path, mask_path]
         snr_flow.run(*args, out_dir=out_dir)
 
         assert_true(Path(Path(out_dir) / "product.json").exists())
@@ -110,14 +110,14 @@ def test_buan_bundle_profiles(rng):
         os.mkdir(out_dir)
 
         buan_bundle_profiles(
-            str(mb),
-            str(rb),
-            str(ob),
-            str(dt),
+            mb,
+            rb,
+            ob,
+            dt,
             group_id=1,
             subject="10001",
             no_disks=100,
-            out_dir=str(out_dir),
+            out_dir=out_dir,
         )
 
         assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
@@ -186,7 +186,7 @@ def test_bundle_analysis_tractometry_flow(rng):
 
         ba_flow = BundleAnalysisTractometryFlow()
 
-        ba_flow.run(str(mb), str(sub), out_dir=str(out_dir))
+        ba_flow.run(mb, sub, out_dir=out_dir)
 
         assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
 
@@ -237,7 +237,7 @@ def test_linear_mixed_models_flow():
 
         input_path = Path(out_dir) / "*"
 
-        lmm_flow.run(str(input_path), no_disks=5, out_dir=str(out_dir2))
+        lmm_flow.run(input_path, no_disks=5, out_dir=out_dir2)
 
         assert_true(Path(Path(out_dir2) / "temp_fa_pvalues.npy").exists())
         assert_true(Path(Path(out_dir2) / "temp_fa.png").exists())
@@ -277,13 +277,13 @@ def test_linear_mixed_models_flow():
         input_path = Path(out_dir3) / "f*"
         # OS error raised if path is wrong or file does not exist
         npt.assert_raises(
-            OSError, lmm_flow.run, str(input_path), no_disks=5, out_dir=out_dir4
+            OSError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
         )
 
         input_path = Path(out_dir3) / "*"
         # value error raised if length of data frame is less than 100
         npt.assert_raises(
-            ValueError, lmm_flow.run, str(input_path), no_disks=5, out_dir=str(out_dir4)
+            ValueError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
         )
 
 
@@ -350,6 +350,6 @@ def test_bundle_shape_analysis_flow(rng):
 
         sm_flow = BundleShapeAnalysis()
 
-        sm_flow.run(str(sub), out_dir=str(out_dir))
+        sm_flow.run(sub, out_dir=out_dir)
 
         assert_true(Path(Path(out_dir) / "temp.npy").exists())

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -102,10 +102,10 @@ def test_particle_filtering_tracking_workflows():
                 category=PendingDeprecationWarning,
             )
             reconst_csd_flow.run(
-                str(dwi_path),
-                str(bval_path),
-                str(bvec_path),
-                str(mask_path),
+                dwi_path,
+                bval_path,
+                bvec_path,
+                mask_path,
                 out_dir=out_dir,
                 extract_pam_values=True,
             )
@@ -143,11 +143,11 @@ def test_particle_filtering_tracking_workflows():
                 category=PendingDeprecationWarning,
             )
             pf_track_pam.run(
-                str(pam_path),
-                str(wm_path),
-                str(gm_path),
-                str(csf_path),
-                str(seeds_path),
+                pam_path,
+                wm_path,
+                gm_path,
+                csf_path,
+                seeds_path,
                 save_seeds=True,
                 out_dir=out_dir,
             )
@@ -172,10 +172,10 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             reconst_csd_flow.run(
-                str(data_path),
-                str(bval_path),
-                str(bvec_path),
-                str(mask_path),
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
                 out_dir=out_dir,
                 extract_pam_values=True,
             )
@@ -241,9 +241,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                str(pam_path),
-                str(gfa_path),
-                str(seeds_path),
+                pam_path,
+                gfa_path,
+                seeds_path,
                 tracking_method="deterministic",
                 out_dir=out_dir,
             )
@@ -260,9 +260,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                str(pam_path),
-                str(gfa_path),
-                str(seeds_path),
+                pam_path,
+                gfa_path,
+                seeds_path,
                 tracking_method="probabilistic",
                 out_dir=out_dir,
             )
@@ -279,9 +279,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                str(pam_path),
-                str(gfa_path),
-                str(seeds_path),
+                pam_path,
+                gfa_path,
+                seeds_path,
                 tracking_method="closestpeaks",
                 out_dir=out_dir,
             )
@@ -298,9 +298,9 @@ def test_local_fiber_tracking_workflow():
                 category=PendingDeprecationWarning,
             )
             lf_track_pam.run(
-                str(pam_path),
-                str(gfa_path),
-                str(seeds_path),
+                pam_path,
+                gfa_path,
+                seeds_path,
                 tracking_method="deterministic",
                 save_seeds=True,
                 out_dir=out_dir,

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -120,7 +120,7 @@ def test_horizon_flow(rng):
         pvalues = rng.uniform(low=0, high=1, size=(10,))
         np.save(fnpy, pvalues)
 
-        input_files = [str(ftrk), str(fimg)]
+        input_files = [ftrk, fimg]
 
         npt.assert_equal(len(input_files), 2)
 
@@ -149,7 +149,7 @@ def test_horizon_flow(rng):
         )
         npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
 
-        input_files = [str(ftrk), str(fnpy)]
+        input_files = [ftrk, fnpy]
 
         npt.assert_equal(len(input_files), 2)
 

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -18,12 +18,12 @@ def test_force_overwrite():
 
         # Generate the first results
         with npt.assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(str(data_path), out_dir=out_dir, vol_idx=[0])
+            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         first_time = os.path.getmtime(mask_file)
 
         # re-run with no force overwrite, modified time should not change
-        mo_flow.run(str(data_path), out_dir=out_dir)
+        mo_flow.run(data_path, out_dir=out_dir)
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         second_time = os.path.getmtime(mask_file)
         assert first_time == second_time
@@ -34,7 +34,7 @@ def test_force_overwrite():
         # different (sometimes measured in whole seconds)
         time.sleep(1)
         with npt.assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(str(data_path), out_dir=out_dir, vol_idx=[0])
+            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         third_time = os.path.getmtime(mask_file)
         assert third_time != second_time
@@ -61,9 +61,9 @@ def test_missing_file():
             Parameters
             ----------
 
-            filename : string
+            filename : string or Path
                 path of the first input file.
-            out_dir: string, optional
+            out_dir: string or Path, optional
                 folder path to save the results.
             """
             _ = self.get_io_iterator()

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -12,11 +12,11 @@ class DummyWorkflow1(Workflow):
 
         Parameters
         ----------
-        inputs : string
+        inputs : string or Path
             fake input string param
         param1 : int
             fake positional param
-        out_dir : string
+        out_dir : string or Path
             fake output directory
         output_1 : string
             fake out file
@@ -38,11 +38,11 @@ class DummyWorkflow2(Workflow):
 
         Parameters
         ----------
-        inputs : string
+        inputs : string or Path
             fake input string param
         param2 : int
             fake positional param
-        out_dir : string
+        out_dir : string or Path
             fake output directory
         output_1 : string
             fake out file
@@ -61,11 +61,11 @@ class DummyCombinedWorkflow(CombinedWorkflow):
 
         Parameters
         ----------
-        inputs : string
+        inputs : string or Path
             fake input string param
         param_combined : int
             fake positional param
-        out_dir : string
+        out_dir : string or Path
             fake output directory
         out_combined : string
             fake out file
@@ -99,7 +99,7 @@ class DummyFlow(Workflow):
 
         Parameters
         ----------
-        positional_str : string
+        positional_str : string or Path
             positional string argument
         positional_bool : bool
             positional bool argument
@@ -121,7 +121,7 @@ class DummyFlow(Workflow):
             optional int argument #2
         optional_float_3 : float, optional
             optional float argument #3
-        out_dir : string
+        out_dir : string or Path
             output directory
         """
         return (
@@ -164,11 +164,11 @@ class DummyVariableTypeWorkflow(Workflow):
 
         Parameters
         ----------
-        positional_variable_str : variable string
+        positional_variable_str : variable string or Path
             fake input string param
         positional_int : int
             fake positional param
-        out_dir : string
+        out_dir : string or Path
             fake output directory
         """
         result = []
@@ -189,11 +189,11 @@ class DummyVariableTypeErrorWorkflow(Workflow):
 
         Parameters
         ----------
-        positional_variable_str : variable string
+        positional_variable_str : variable string or Path
             fake input string param
         positional_variable_int : variable int
             fake positional param
-        out_dir : string
+        out_dir : string or Path
             fake output directory
         """
         result = []

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -60,12 +60,12 @@ class LocalFiberTrackingPAMFlow(Workflow):
 
         Parameters
         ----------
-        pam_files : string
+        pam_files : string or Path
            Path to the peaks and metrics files. This path may contain
             wildcards to use multiple masks at once.
-        stopping_files : string
+        stopping_files : string or Path
             Path to images (e.g. FA) used for stopping criterion for tracking.
-        seeding_files : string
+        seeding_files : string or Path
             A binary image showing where we need to seed for tracking.
         use_binary_mask : bool, optional
             If True, uses a binary stopping criterion. If the provided
@@ -118,7 +118,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
             Fraction of the seed buffer to use. A value of 1.0 will use the entire seed
             buffer. A value of 0.5 will use half of the seed buffer then the other half.
             a way to reduce memory usage.
-        out_dir : string, optional
+        out_dir : string or Path, optional
            Output directory.
         out_tractogram : string, optional
            Name of the tractogram file to be saved.
@@ -302,17 +302,17 @@ class PFTrackingPAMFlow(Workflow):
 
         Parameters
         ----------
-        pam_files : string
+        pam_files : string or Path
            Path to the peaks and metrics files. This path may contain
             wildcards to use multiple masks at once.
-        wm_files : string
+        wm_files : string or Path
             Path to white matter partial volume estimate for tracking (CMC).
-        gm_files : string
+        gm_files : string or Path
             Path to grey matter partial volume estimate for tracking (CMC).
-        csf_files : string
+        csf_files : string or Path
             Path to cerebrospinal fluid partial volume estimate for tracking
             (CMC).
-        seeding_files : string
+        seeding_files : string or Path
             A binary image showing where we need to seed for tracking.
         step_size : float, optional
             Step size (in mm) used for tracking.
@@ -363,7 +363,7 @@ class PFTrackingPAMFlow(Workflow):
             Fraction of the seed buffer to use. A value of 1.0 will use the entire seed
             buffer. A value of 0.5 will use half of the seed buffer then the other half.
             a way to reduce memory usage.
-        out_dir : string, optional
+        out_dir : string or Path, optional
            Output directory.
         out_tractogram : string, optional
            Name of the tractogram file to be saved.

--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -61,7 +61,7 @@ class HorizonFlow(Workflow):
 
         Parameters
         ----------
-        input_files : variable string
+        input_files : variable string or Path
             Filenames.
         cluster : bool, optional
             Enable QuickBundlesX clustering.
@@ -118,7 +118,7 @@ class HorizonFlow(Workflow):
             Define the color for the roi images. Colors can be defined
             with 1 or 3 values and should be between [0-1]. For example, a
             value of (1, 0, 0) would mean the red color.
-        out_dir : str, optional
+        out_dir : str or Path, optional
             Output directory.
         out_stealth_png : str, optional
             Filename of saved picture.
@@ -180,28 +180,27 @@ class HorizonFlow(Workflow):
             if verbose:
                 logger.info(f"Loading file ... \n {fname}\n")
 
-            fl = fname.lower()
-            ends = fl.endswith
+            ext = "".join(Path(fname).suffixes).lower()
 
-            if ends(".trk") or ends(".trx"):
+            if ext in [".trk", ".trx"]:
                 sft = load_tractogram(fname, "same", bbox_valid_check=False)
                 tractograms.append(sft)
 
-            if ends((".dpy", ".tck", ".vtk", ".vtp", ".fib")):
+            if ext in [".dpy", ".tck", ".vtk", ".vtp", ".fib"]:
                 sft = load_tractogram(fname, emergency_ref)
                 tractograms.append(sft)
 
-            if ends(".nii.gz") or ends(".nii"):
+            if ext in [".nii.gz", ".nii"]:
                 data, affine = load_nifti(fname)
                 images.append((data, affine, fname))
 
-            if ends(".pial"):
+            if ext == ".pial":
                 surface = load_pial(fname)
                 if surface:
                     vertices, faces = surface
                     surfaces.append((vertices, faces, fname))
 
-            if ends(".gii.gz") or ends(".gii"):
+            if any(ext.endswith(_ext) for _ext in [".gii", ".gii.gz"]):
                 surface = load_gifti(fname)
                 vertices, faces = surface
                 if len(vertices) and len(faces):
@@ -210,11 +209,11 @@ class HorizonFlow(Workflow):
                 else:
                     warn(f"{fname} does not have any surface geometry.", stacklevel=2)
 
-            if ends(".pam5"):
+            if ext == ".pam5":
                 pam = load_pam(fname)
                 pams.append((pam, fname))
 
-            if ends(".npy"):
+            if ext == ".npy":
                 data = np.load(fname)
                 numpy_files.append(data)
 


### PR DESCRIPTION
Adopt `pathlib` for workflows.

Used `Path` instances across tests for path-like objects.