### PR TITLE
DOC: Fix workflows test utils parameter name in docstring

### DIFF
--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -166,7 +166,7 @@ class DummyVariableTypeWorkflow(Workflow):
         ----------
         positional_variable_str : variable string
             fake input string param
-        positional_variable_int : int
+        positional_int : int
             fake positional param
         out_dir : string
             fake output directory


### PR DESCRIPTION
Fix workflows test utils parameter name in docstring.

Fixes:
```
Missing parameter positional_int in docstring
```

and
```
Function 'run' does not have a parameter 'positional_variable_int'
```

raised by the IDE.