### PR TITLE
RF: Parallel `quantize_evecs`

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -20,6 +20,7 @@ from dipy.reconst.weights_method import (
     weights_method_wls_m_est,
 )
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils.parallel import paramap
 
 MIN_POSITIVE_SIGNAL = 0.0001
 
@@ -2484,30 +2485,61 @@ def design_matrix(gtab, *, dtype=None):
 
 
 @warning_for_keywords()
-def quantize_evecs(evecs, *, odf_vertices=None):
+def quantize_evecs(evecs, *, odf_vertices=None, idx=0, n_jobs=-1, engine="serial"):
     """Find the closest orientation of an evenly distributed sphere
 
     Parameters
     ----------
     evecs : ndarray
-        Eigenvectors.
+        Eigenvectors of shape (..., 3, n_evecs)
     odf_vertices : ndarray, optional
         If None, then set vertices from symmetric362 sphere.  Otherwise use
         passed ndarray as vertices
+    idx : int, optional
+        Use idx-th eigenvector as the primary eigenvector for fiber tracking.
+        If 0, uses the largest eigenvalue.
+    n_jobs : int, optional
+        Number of parallel jobs.
+    engine : str, optional
+        Parallel engine to use.  Choose from {"serial", "ray", "dask", "joblib"}.
+        "ray" is recommended but requires the ray library to be installed.
 
     Returns
     -------
-    IN : ndarray
-
+    ndarray
+        Indices of the closest vertices in the odf_vertices for each
+        principal eigenvector.
     """
-    max_evecs = evecs[..., :, 0]
+    if idx < 0 or idx > evecs.shape[-1] - 1:
+        raise ValueError(f"idx must be in range [0, {evecs.shape[-1] - 1}]")
+
+    if evecs.ndim < 2 or evecs.shape[-2] != 3:
+        raise ValueError(
+            "evecs must be at least 2D with second-to-last dimension of size 3"
+        )
+
+    def _find_closest_vertex(eigenvector):
+        """Helper function to find closest vertex for a single eigenvector."""
+        return np.argmax(np.dot(odf_vertices, eigenvector))
+
+    principal_eigenvectors = evecs[..., :, idx]
     if odf_vertices is None:
         odf_vertices = get_sphere(name="symmetric362").vertices
-    tup = max_evecs.shape[:-1]
-    mec = max_evecs.reshape(np.prod(np.array(tup)), 3)
-    IN = np.array([np.argmin(np.dot(odf_vertices, m)) for m in mec])
-    IN = IN.reshape(tup)
-    return IN
+
+    if evecs.ndim == 2:
+        return _find_closest_vertex(principal_eigenvectors)
+
+    original_shape = principal_eigenvectors.shape[:-1]
+    flattened_eigenvectors = principal_eigenvectors.reshape(
+        np.prod(np.array(original_shape)), 3
+    )
+
+    vertex_indices = paramap(
+        _find_closest_vertex, flattened_eigenvectors, n_jobs=n_jobs, engine=engine
+    )
+
+    vertex_indices = np.array(vertex_indices).reshape(original_shape)
+    return vertex_indices
 
 
 @warning_for_keywords()

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -1,5 +1,7 @@
 """Testing DTI."""
 
+import random
+
 import numpy as np
 import numpy.testing as npt
 
@@ -37,6 +39,11 @@ from dipy.reconst.weights_method import (
 )
 from dipy.sims.voxel import single_tensor
 from dipy.testing.decorators import set_random_number_generator
+from dipy.utils.optpkg import optional_package
+
+ray, has_ray, _ = optional_package("ray")
+joblib, has_joblib, _ = optional_package("joblib")
+dask, has_dask, _ = optional_package("dask")
 
 
 def test_roll_evals():
@@ -1118,3 +1125,101 @@ def test_extra_return():
 
             tensor_est = tensor_model.fit(this_y)
             npt.assert_equal(tensor_est.model.extra["robust"].shape, Y.shape)
+
+
+def test_quantize_evecs():
+    """Test quantize_evecs function with different inputs and parameters."""
+    # Test with 3D eigenvector data (3x3x3x3 where last two dims are eigenvectors)
+    # Shape: (x, y, z, 3, 3) where evecs[..., :, j] is the j-th eigenvector
+    evecs = np.random.rand(3, 3, 3, 3)
+
+    result = dti.quantize_evecs(evecs)
+
+    expected_shape = evecs.shape[:-2]
+    npt.assert_equal(result.shape, expected_shape)
+
+    npt.assert_(np.all(result >= 0))  # Check that all values are valid indices
+    npt.assert_(np.all(result < 362))  # symmetric362 sphere has 362 vertices
+
+    # Test with custom sphere vertices
+    custom_vertices = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0]])
+    result_custom = dti.quantize_evecs(evecs, odf_vertices=custom_vertices)
+    npt.assert_equal(result_custom.shape, expected_shape)
+    npt.assert_(np.all(result_custom >= 0))
+    npt.assert_(np.all(result_custom < 4))  # Should be indices 0-3
+
+    # Test with single voxel (just 3x3 eigenvector matrix)
+    single_evec = np.random.rand(3, 3)
+    result_single = dti.quantize_evecs(single_evec)
+    npt.assert_equal(result_single.shape, ())  # Should be scalar
+
+    # Test with 2D array of eigenvectors
+    evecs_2d = np.random.rand(5, 5, 3, 3)
+    result_2d = dti.quantize_evecs(evecs_2d)
+    expected_shape_2d = (5, 5)
+    npt.assert_equal(result_2d.shape, expected_shape_2d)
+
+    # Test error handling with invalid input
+    evecs = np.random.rand(2, 2, 3, 3)
+    npt.assert_raises(ValueError, dti.quantize_evecs, evecs, idx=3)
+    npt.assert_raises(ValueError, dti.quantize_evecs, evecs, idx=-1)
+
+    bad_evecs = np.random.rand(3)
+    npt.assert_raises(ValueError, dti.quantize_evecs, bad_evecs)
+
+    bad_evecs2 = np.random.rand(2, 2, 4, 3)
+    npt.assert_raises(ValueError, dti.quantize_evecs, bad_evecs2)
+
+
+def test_quantize_evecs_known_vectors():
+    """Test quantize_evecs with known eigenvectors to verify correctness."""
+    sphere = get_sphere(name="symmetric362")
+    vertices = sphere.vertices
+
+    # Create test eigenvectors in the correct format [x, y, 3, 3]
+    # where evecs[..., :, j] is the j-th eigenvector (columnar format)
+    test_evecs = np.zeros((2, 2, 3, 3))
+
+    # Set the first eigenvector (principal eigenvector) at each position
+    test_evecs[0, 0, :, 0] = vertices[0]  # First vertex
+    test_evecs[0, 1, :, 0] = vertices[10]  # 11th vertex
+    test_evecs[1, 0, :, 0] = vertices[50]  # 51st vertex
+    test_evecs[1, 1, :, 0] = vertices[100]  # 101st vertex
+
+    # Fill other eigenvectors with random data
+    test_evecs[:, :, :, 1:] = np.random.rand(2, 2, 3, 2)
+
+    result = dti.quantize_evecs(test_evecs)
+
+    # Check that we get the expected indices
+    npt.assert_equal(result[0, 0], 0)
+    npt.assert_equal(result[0, 1], 10)
+    npt.assert_equal(result[1, 0], 50)
+    npt.assert_equal(result[1, 1], 100)
+
+
+def test_quantize_evecs_parallel_engines():
+    """Test that different parallel engines give the same results."""
+    evecs = np.random.rand(3, 3, 3, 3)
+
+    result_serial = dti.quantize_evecs(evecs, engine="serial")
+    engines_to_test = ["serial"]
+    if has_ray:
+        engines_to_test.append("ray")
+    if has_joblib:
+        engines_to_test.append("joblib")
+    if has_dask:
+        engines_to_test.append("dask")
+
+    for engine in engines_to_test[1:]:
+        try:
+            n_jobs = random.randint(1, 2)
+            result_engine = dti.quantize_evecs(evecs, n_jobs=n_jobs, engine=engine)
+            npt.assert_array_equal(
+                result_serial,
+                result_engine,
+                err_msg=f"Results differ between serial and {engine}",
+            )
+        except Exception as e:
+            # If an engine fails, that's okay - just skip it
+            print(f"Warning: Could not test engine {engine}: {e}")


### PR DESCRIPTION
This PR supersedes #1164 and #1097

- Added a multiprocessing option by using `paramap`. Parallel engine can be choosen between Ray, Dask, Joblib, etc..
- Added the ability to choose which eigenvector to use as primary vector.
- This function was not tested so many tests added. Actually, this function had a bug which has been fixed.
- Some variable renaming to clarify the function

