### PR TITLE
RF: Address cvxpy 1.7.0 warnings.

### DIFF
--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -549,7 +549,10 @@ class PositiveDefiniteLeastSquares:
                     return np.asarray(self._h.value).squeeze()
 
             # Solve constrained problem
-            self.problem.solve(**kwargs)
+            with warnings.catch_warnings():
+                if self._y.value.shape[0] < 1000:
+                    warnings.filterwarnings("ignore", message="Converting A to a CSC")
+                self.problem.solve(**kwargs)
 
             # Show warning if solution is not optimal
             status = self.problem.status

--- a/dipy/reconst/qti.py
+++ b/dipy/reconst/qti.py
@@ -686,28 +686,37 @@ def _sdpdc_fit(data, mask, X, cvxpy_solver):
     prob = cp.Problem(objective, constraints)
     unconstrained = cp.Problem(objective)
 
+    import warnings
+
     for i in range(0, size, 1):
         vox_data = data_masked[i : i + 1, :].T
         vox_log_data = log_data[i : i + 1, :].T
         vox_log_data[np.isinf(vox_log_data)] = 0
         y.value = vox_data * vox_log_data
-        A.value = vox_data * X
+        A_val = vox_data * X
 
-        try:
-            prob.solve(solver=cvxpy_solver, verbose=False)
-            m = x.value
-        except Exception:
-            msg = "Constrained optimization failed, attempting unconstrained"
-            msg += " optimization."
-            warn(msg, stacklevel=2)
+        A.value = A_val
+
+        # Suppress SCS CSC warning only for small matrices
+        with warnings.catch_warnings():
+            if A_val.shape[0] < 1000:
+                warnings.filterwarnings("ignore", message="Converting A to a CSC")
+
             try:
-                unconstrained.solve(solver=cvxpy_solver)
+                prob.solve(solver=cvxpy_solver, verbose=False)
                 m = x.value
             except Exception:
-                msg = "Unconstrained optimization failed,"
-                msg += " returning zero array."
+                msg = "Constrained optimization failed, attempting unconstrained"
+                msg += " optimization."
                 warn(msg, stacklevel=2)
-                m = np.zeros(x.shape)
+                try:
+                    unconstrained.solve(solver=cvxpy_solver)
+                    m = x.value
+                except Exception:
+                    msg = "Unconstrained optimization failed,"
+                    msg += " returning zero array."
+                    warn(msg, stacklevel=2)
+                    m = np.zeros(x.shape)
 
         params_masked[i : i + 1, :] = m.T
 


### PR DESCRIPTION
Currently, our CI's are failing due to the new `cvxpy`release.  Here is a quick fix, but I am not the problem is in our level, we shoudl check with `cvxpy` and introspect deeper.

```
reconst/tests/test_mapmri.py::test_plus_constraint
reconst/tests/test_qti.py::test_ls_sdp_fits
reconst/tests/test_qti.py::test_qti_fit
  /Users/runner/work/dipy/dipy/venv/lib/python3.10/site-packages/scs/__init__.py:83: UserWarning: Converting A to a CSC (compressed sparse column) matrix; may take a while.
    warn(
```