### PR TITLE
[MTN] Release 1.12.0 preparation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -158,6 +158,7 @@ Jong Sung Park <pjsjongsung@gmail.com> pjsjongsung <pjsjongsung@gmail.com>
 Jong Sung Park <pjsjongsung@gmail.com> Jong Sung Park <jp109@antelope.luddy.indiana.edu>
 Jong Sung Park <pjsjongsung@gmail.com> Jong Sung Park <jp109@dl.luddy.indiana.edu>
 Jong Sung Park <pjsjongsung@gmail.com> Jong Sung Park <jp109@iu.edu>
+Jong Sung Park <pjsjongsung@gmail.com> Jong Sung Park <jp109@kj.luddy.indiana.edu>
 Rahul Ubale <raubale@iu.edu> RahulUbale <raubale@iu.edu>
 Rahul Ubale <raubale@iu.edu> Rahul19 <68568128+RahulUbale@users.noreply.github.com>
 Baran Aydogan <baran.aydogan@gmail.com> baranaydogan <baran.aydogan@gmail.com>
@@ -174,6 +175,7 @@ John Kruper <jk6.28@outlook.com> 36000 <jk6.28@outlook.com>
 John Kruper <jk6.28@outlook.com> John Kruper <jk23@att.net>
 John Kruper <jk6.28@outlook.com> John K <jk23@att.net>
 John Kruper <jk6.28@outlook.com> John Kruper <jk23@att.net>
+John Kruper <jk6.28@outlook.com> John Kruper <36000@users.noreply.github.com>
 Atharva Shah <athshah@iu.edu> Atharva Shah <118627741+Atharva-Shah-2298@users.noreply.github.com>
 Theodore Ni <3806110+tjni@users.noreply.github.com>
 Nicolas Delinte <nicolas.delinte@uclouvain.be> Nicolas Delinte <70629561+DelinteNicolas@users.noreply.github.com>
@@ -193,3 +195,6 @@ Kaibo Tang <ktang@unc.edu> kaibo <ktang@unc.edu>
 Sandro Turriate <devel@penguinpee.nl> Sandro <devel@penguinpee.nl>
 Florent Wijanto <f.wijanto@hopital-foch.com> FWijanto <f.wijanto@hopital-foch.com>
 Vara Lakshmi Bayanagari <> lb-97 <42465606+lb-97@users.noreply.github.com>
+Maharshi Gor <gor.maharshi@gmail.com> maharshi-gor <gor.maharshi@gmail.com>
+satyam kumar <satyamkr6460@gmail.com> satyambitm <satyamkr6460@gmail.com>
+satyam kumar <satyamkr6460@gmail.com> Satyam kumar <satyamkr6460@gmail.com>

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,9 +1,13 @@
 """Additional Command-line interface for spin."""
 
+import datetime
 import os
+import re
 import shutil
+import subprocess
 
 import click
+from packaging.version import Version
 from spin import util
 from spin.cmds import meson
 
@@ -192,6 +196,50 @@ def bench(ctx, tests, compare, verbose, quick, commits):
 
 
 @click.command()
+@click.argument("tutorials", nargs=-1, metavar="[TUTORIAL]...")
+@click.option(
+    "--clean",
+    is_flag=True,
+    default=False,
+    help="Run `make clean` before building.",
+)
+@click.option(
+    "--plot/--no-plot",
+    "plot",
+    default=True,
+    help="Execute examples (default: yes). --no-plot skips example execution.",
+)
+def docs(*, tutorials, clean, plot):
+    """📖 Build Sphinx documentation.
+
+    Optionally restrict the build to one or more named tutorials.
+
+    \b
+    Examples:
+
+    \b
+    $ spin docs                          # full build with examples
+    $ spin docs --no-plot                # skip example execution (fast)
+    $ spin docs --clean                  # clean before building
+    $ spin docs reconst_csa              # build only reconst_csa tutorial
+    $ spin docs reconst_csa reconst_dti  # build only those two tutorials
+    $ spin docs reconst_csa --no-plot    # build tutorial RST without running it
+    """
+    if clean:
+        _run_shell("make -C doc clean", check=False)
+
+    sphinx_opts = ["-j auto"]
+    if not plot:
+        sphinx_opts.append("-D plot_gallery=0")
+    if tutorials:
+        pattern = "|".join(tutorials)
+        sphinx_opts.append(f'-D sphinx_gallery_conf.filename_pattern="{pattern}"')
+
+    opts_str = " ".join(sphinx_opts)
+    _run_shell(f'make -C doc html SPHINXOPTS="{opts_str}"')
+
+
+@click.command()
 def clean():
     """🧹 Remove build and install folder."""
     build_dir = "build"
@@ -202,3 +250,625 @@ def clean():
     print(f"Removing `{install_dir}`")
     if os.path.isdir(install_dir):
         shutil.rmtree(install_dir)
+
+
+# ---------------------------------------------------------------------------
+# Release preparation helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_shell(cmd, *, check=True):
+    """Run a shell command, echo it, and print its exit status.
+
+    Parameters
+    ----------
+    cmd : str
+        Shell command to run.
+    check : bool
+        Whether to raise on non-zero exit code.
+    """
+    click.secho(f"$ {cmd}", fg="cyan")
+    result = subprocess.run(cmd, shell=True, check=check)
+    rc = result.returncode
+    color = "green" if rc == 0 else "red"
+    click.secho(f"--- exit code: {rc} ---", fg=color)
+
+
+def _get_latest_tag():
+    """Fetch and return the latest DIPY release tag.
+
+    Returns
+    -------
+    str or None
+        The latest semver tag, or None if none found.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "https://github.com/dipy/dipy.git", "--tags"],
+            check=True,
+            capture_output=True,
+        )
+        tags = subprocess.check_output(["git", "tag"]).decode().splitlines()
+        pattern = r"^\d+\.\d+\.\d+([a-zA-Z0-9]+)?$"
+        release_tags = [t for t in tags if re.match(pattern, t)]
+        if not release_tags:
+            return None
+        release_tags.sort(key=lambda v: Version(v))
+        return release_tags[-1]
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _update_mailmap(*, last_tag, mailmap_path=".mailmap"):
+    """Detect duplicate authors since last_tag and propose .mailmap entries.
+
+    Scans ``git log`` for (name, email) pairs and identifies:
+
+    * Same email with different display names (clear duplicates).
+    * Same normalised name (lowercase, no punctuation) with different emails
+      (likely the same person using multiple addresses).
+
+    Already-mapped entries are skipped. New proposals are shown to the user
+    who can accept or reject each one before they are appended to
+    ``.mailmap``.  A full ``git shortlog -nse`` is shown afterwards for a
+    final manual review.
+
+    Parameters
+    ----------
+    last_tag : str
+        The previous release tag used to scope the shortlog display.
+    mailmap_path : str
+        Path to the ``.mailmap`` file.
+    """
+    click.secho("--- Scanning git log for duplicate authors ---", bold=True)
+
+    # 1. Collect all (canonical_name, canonical_email) pairs ever seen
+    raw = (
+        subprocess.check_output(["git", "log", "--format=%aN|%aE"])
+        .decode()
+        .splitlines()
+    )
+
+    # map email → set of names, name → set of emails
+    email_to_names: dict[str, set[str]] = {}
+    name_to_emails: dict[str, set[str]] = {}
+    for line in raw:
+        if "|" not in line:
+            continue
+        name, email = line.split("|", 1)
+        name, email = name.strip(), email.strip().lower()
+        email_to_names.setdefault(email, set()).add(name)
+        # normalise: lowercase, keep only alphanum + spaces
+        norm = re.sub(r"[^a-z0-9 ]", "", name.lower())
+        name_to_emails.setdefault(norm, set()).add(email)
+
+    # 2. Read existing .mailmap so we skip already-handled entries
+    existing_lines: list[str] = []
+    if os.path.isfile(mailmap_path):
+        with open(mailmap_path) as f:
+            existing_lines = f.readlines()
+    existing_text = "".join(existing_lines)
+
+    # 3. Build proposals
+    proposals: list[str] = []
+
+    # Same email → multiple names: pick the longest/most complete name as canonical
+    for email, names in email_to_names.items():
+        if len(names) <= 1:
+            continue
+        canonical = max(names, key=len)
+        for alias in names:
+            if alias == canonical:
+                continue
+            entry = f"{canonical} <{email}> {alias} <{email}>\n"
+            if alias not in existing_text and entry not in existing_text:
+                proposals.append(entry)
+
+    # Same normalised name → multiple emails: flag for user to pick canonical
+    for norm, emails in name_to_emails.items():
+        if len(emails) <= 1:
+            continue
+        # gather actual display names for this norm
+        display_names: set[str] = set()
+        for line in raw:
+            if "|" not in line:
+                continue
+            n, e = line.split("|", 1)
+            n, e = n.strip(), e.strip().lower()
+            if re.sub(r"[^a-z0-9 ]", "", n.lower()) == norm and e in emails:
+                display_names.add(n)
+        canonical_name = max(display_names, key=len)
+        canonical_email = min(emails)  # placeholder; user should confirm
+        for email in emails:
+            if email == canonical_email:
+                continue
+            alias_name = canonical_name  # best guess
+            entry = f"{canonical_name} <{canonical_email}> {alias_name} <{email}>\n"
+            if email not in existing_text and entry not in existing_text:
+                proposals.append(entry)
+
+    # 4. Present proposals to the user
+    if not proposals:
+        click.secho("No new duplicate authors detected.", fg="green")
+    else:
+        click.secho(
+            f"\nFound {len(proposals)} potential duplicate(s) not yet in "
+            f"{mailmap_path}:",
+            fg="yellow",
+        )
+        accepted: list[str] = []
+        for proposal in proposals:
+            click.echo(f"\n  {proposal.rstrip()}")
+            answer = (
+                click.prompt(
+                    "  Add this entry? [yes/no/edit]",
+                    default="yes",
+                )
+                .strip()
+                .lower()
+            )
+            if answer in ("yes", "y"):
+                accepted.append(proposal)
+            elif answer in ("edit", "e"):
+                edited = click.prompt("  Enter corrected entry").strip()
+                if edited:
+                    accepted.append(edited + "\n")
+            # "no" → skip
+
+        if accepted:
+            with open(mailmap_path, "a", newline="\n") as f:
+                f.writelines(accepted)
+            click.secho(f"Added {len(accepted)} entries to {mailmap_path}.", fg="green")
+            _run_shell(f"git diff {mailmap_path}", check=False)
+
+    # 5. Show full shortlog for final manual review
+    click.secho(
+        f"\n--- Full contributor list since {last_tag} (manual review) ---",
+        bold=True,
+    )
+    _run_shell(f"git shortlog -nse {last_tag}..HEAD", check=False)
+    input(
+        "\nReview the list above. Make any remaining manual edits to .mailmap, "
+        "then press Enter to continue..."
+    )
+
+
+def _update_author(*, file_path="AUTHOR"):
+    """Regenerate the AUTHOR file from the full git log.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the AUTHOR file.
+    """
+    click.secho(f"--- Updating {file_path} ---", bold=True)
+    git = subprocess.Popen(["git", "log", "--format=%aN"], stdout=subprocess.PIPE)
+    raw = git.stdout.read().decode().split("\n")
+    authors = sorted({a for a in raw if a and a != "dependabot[bot]"})
+    with open(file_path, "w", newline="\n") as f:
+        f.write("\n".join(authors) + "\n")
+    _run_shell(f"git diff {file_path}", check=False)
+
+
+def _check_copyright_year():
+    """Update copyright year in LICENSE and doc/conf.py if needed."""
+    current_year = datetime.datetime.now().year
+
+    # LICENSE
+    click.secho("--- Checking LICENSE copyright year ---", bold=True)
+    with open("LICENSE", "r") as f:
+        content = f.read()
+    pattern = r"(Copyright \(c\) \d{4}-)(\d{4})"
+    match = re.search(pattern, content)
+    if match:
+        if int(match.group(2)) != current_year:
+            click.echo(f"Updating LICENSE year to {current_year}")
+            updated = re.sub(pattern, rf"\g<1>{current_year}", content)
+            with open("LICENSE", "w", newline="\n") as f:
+                f.write(updated)
+            _run_shell("git diff LICENSE", check=False)
+        else:
+            click.echo("LICENSE year is up to date.")
+    else:
+        click.secho(
+            "Could not parse copyright year in LICENSE – update manually.", fg="yellow"
+        )
+
+    # doc/conf.py
+    click.secho("--- Checking doc/conf.py copyright year ---", bold=True)
+    conf_path = "doc/conf.py"
+    with open(conf_path, "r") as f:
+        content = f.read()
+    pattern = r"(Copyright \d{4}-)(\d{4})(,DIPY)"
+    match = re.search(pattern, content)
+    if match:
+        if int(match.group(2)) != current_year:
+            click.echo(f"Updating doc/conf.py year to {current_year}")
+            updated = re.sub(pattern, rf"\g<1>{current_year}\g<3>", content)
+            with open(conf_path, "w", newline="\n") as f:
+                f.write(updated)
+            _run_shell(f"git diff {conf_path}", check=False)
+        else:
+            click.echo("doc/conf.py copyright year is up to date.")
+    else:
+        click.secho(
+            "Could not parse copyright year in doc/conf.py – update manually.",
+            fg="yellow",
+        )
+
+
+def _generate_release_notes(*, last_tag, new_version):
+    """Generate release notes via tools/github_stats.py.
+
+    Parameters
+    ----------
+    last_tag : str
+        The previous release tag (e.g. ``"1.11.0"``).
+    new_version : str
+        The new version string (e.g. ``"1.12.0"``).
+    """
+    notes_path = f"doc/release_notes/release{new_version}.rst"
+    click.secho(f"--- Generating release notes → {notes_path} ---", bold=True)
+    _run_shell(f"python3 tools/github_stats.py {last_tag} > {notes_path}", check=False)
+    click.secho(
+        f"\nPlease open {notes_path} and add a header / highlights section "
+        "above the auto-generated stats.",
+        fg="yellow",
+    )
+    input("Press Enter when done editing the release notes...")
+
+
+def _update_changelog(*, new_version, file_path="Changelog"):
+    """Prepend a new entry for new_version in the Changelog.
+
+    Parameters
+    ----------
+    new_version : str
+        The new version string.
+    file_path : str
+        Path to the Changelog file.
+    """
+    click.secho(f"--- Updating {file_path} ---", bold=True)
+    today = datetime.date.today().strftime("%A, %B %d, %Y")
+    entry = f"\n* {new_version} ({today})\n\n- TODO: add highlights here.\n"
+    with open(file_path, "r") as f:
+        content = f.read()
+    marker = "Releases\n~~~~~~~~"
+    idx = content.find(marker)
+    if idx == -1:
+        click.secho(
+            f"Could not find 'Releases' section in {file_path} – skipping.", fg="yellow"
+        )
+        return
+    insert_at = idx + len(marker)
+    updated = content[:insert_at] + entry + content[insert_at:]
+    with open(file_path, "w", newline="\n") as f:
+        f.write(updated)
+    _run_shell(f"git diff {file_path}", check=False)
+    click.secho(f"Please open {file_path} and fill in the highlights.", fg="yellow")
+    input("Press Enter when done...")
+
+
+def _update_index_announcements(*, new_version, index_path="doc/index.rst"):
+    """Prepend a release announcement line in doc/index.rst.
+
+    Parameters
+    ----------
+    new_version : str
+        The new version string (e.g. ``"1.12.0"``).
+    index_path : str
+        Path to the doc/index.rst file.
+    """
+    click.secho(f"--- Updating Announcements in {index_path} ---", bold=True)
+    release_date = datetime.date.today().strftime("%B %d, %Y")
+    major_minor = ".".join(new_version.split(".")[:2])
+    note_file = f"release{major_minor}"
+    entry = (
+        f"- :doc:`DIPY {new_version} <release_notes/{note_file}>` "
+        f"released {release_date}.\n"
+    )
+    with open(index_path, "r") as f:
+        lines = f.readlines()
+    insert_after = None
+    for i, line in enumerate(lines):
+        if line.strip() == "Announcements":
+            for j in range(i, min(i + 5, len(lines))):
+                stripped = lines[j].strip()
+                if stripped and all(c == "*" for c in stripped):
+                    insert_after = j + 1
+                    break
+            break
+    if insert_after is None:
+        click.secho(
+            f"Could not find Announcements section in {index_path} – skipping.",
+            fg="yellow",
+        )
+        return
+    lines.insert(insert_after, entry)
+    with open(index_path, "w", newline="\n") as f:
+        f.writelines(lines)
+    _run_shell(f"git diff {index_path}", check=False)
+
+
+def _update_pyproject_version(*, new_version, file_path="pyproject.toml"):
+    """Set the version field in pyproject.toml.
+
+    Parameters
+    ----------
+    new_version : str
+        The new version string.
+    file_path : str
+        Path to pyproject.toml.
+    """
+    click.secho(f"--- Updating {file_path} version → {new_version} ---", bold=True)
+    with open(file_path, "r") as f:
+        content = f.read()
+    updated = re.sub(
+        r'^version = ".*?"',
+        f'version = "{new_version}"',
+        content,
+        flags=re.MULTILINE,
+    )
+    if updated == content:
+        click.secho(
+            "Could not find version field in pyproject.toml – update manually.",
+            fg="yellow",
+        )
+        return
+    with open(file_path, "w", newline="\n") as f:
+        f.write(updated)
+    _run_shell(f"git diff {file_path}", check=False)
+
+
+def _confirm(prompt):
+    """Loop until the user answers yes.
+
+    Parameters
+    ----------
+    prompt : str
+        Question to display.
+    """
+    while True:
+        answer = input(f"{prompt} [yes/no]: ").strip().lower()
+        if answer in ("yes", "y"):
+            return
+        if answer in ("no", "n"):
+            click.echo("Please complete that step before proceeding.")
+        else:
+            click.echo("Please answer 'yes' or 'no'.")
+
+
+# ---------------------------------------------------------------------------
+# Release preparation spin command
+# ---------------------------------------------------------------------------
+
+RELEASE_STEPS = [
+    "fetch-tag",
+    "mailmap",
+    "version",
+    "author",
+    "copyright",
+    "release-notes",
+    "changelog",
+    "index",
+    "pyproject",
+    "deprecations",
+    "doctest",
+    "tests",
+    "docs",
+]
+
+STEP_HELP = "\n".join(f"  {i + 1:>2}. {s}" for i, s in enumerate(RELEASE_STEPS))
+
+
+@click.command(name="prepare-release")
+@click.option(
+    "--from-step",
+    default=1,
+    metavar="N",
+    help=("Resume from step N (1-based). Steps:\n" + STEP_HELP),
+    type=click.IntRange(1, len(RELEASE_STEPS)),
+)
+@click.option(
+    "--last-tag", default=None, metavar="TAG", help="Override auto-detected last tag."
+)
+@click.option(
+    "--new-version", default=None, metavar="VER", help="Skip version prompt, use VER."
+)
+def prepare_release(*, from_step, last_tag, new_version):
+    (
+        """🚀 Prepare a DIPY release (interactive checklist).
+
+    Runs each preparation step in order. Use --from-step N to resume
+    after an interruption.
+
+    \b
+    Steps:
+    """
+        + STEP_HELP
+    )  # noqa: E501
+    if not os.path.isdir("dipy") or not os.path.isfile("pyproject.toml"):
+        raise click.ClickException("Run this command from the root 'dipy' directory.")
+
+    # State shared across steps
+    ctx = {"last_tag": last_tag, "new_version": new_version}
+
+    def skip(step_n):
+        return step_n < from_step
+
+    # ── Step 1: Fetch latest tag ──────────────────────────────────────────
+    step = 1
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Fetch latest tag",
+            bold=True,
+            fg="green",
+        )
+        if ctx["last_tag"] is None:
+            ctx["last_tag"] = _get_latest_tag()
+        if ctx["last_tag"] is None:
+            ctx["last_tag"] = click.prompt(
+                "Could not detect last tag. Enter it manually (e.g., 1.11.0)"
+            )
+        click.echo(f"Last release tag: {ctx['last_tag']}")
+    elif ctx["last_tag"] is None:
+        ctx["last_tag"] = click.prompt(
+            "Enter the last release tag (required, e.g., 1.11.0)"
+        )
+
+    # ── Step 2: Update .mailmap / contributors ────────────────────────────
+    step = 2
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Update .mailmap and contributors",
+            bold=True,
+            fg="green",
+        )
+        _update_mailmap(last_tag=ctx["last_tag"])
+
+    # ── Step 3: Determine new version ────────────────────────────────────
+    step = 3
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Determine new version",
+            bold=True,
+            fg="green",
+        )
+        if ctx["new_version"] is None:
+            last_ver = Version(ctx["last_tag"])
+            major, minor, patch = last_ver.release
+            proposed = f"{major}.{minor + 1}.0"
+            while True:
+                entered = click.prompt("Enter new version", default=proposed)
+                if re.match(r"^\d+\.\d+\.\d+([a-zA-Z0-9]+)?$", entered):
+                    ctx["new_version"] = entered
+                    break
+                click.echo("Version must follow semver (e.g., 1.12.0 or 1.12.0rc1).")
+        click.echo(f"New version: {ctx['new_version']}")
+    elif ctx["new_version"] is None:
+        ctx["new_version"] = click.prompt(
+            "Enter the new version (required, e.g., 1.12.0)"
+        )
+
+    # ── Step 4: Update AUTHOR file ────────────────────────────────────────
+    step = 4
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Update AUTHOR file",
+            bold=True,
+            fg="green",
+        )
+        _update_author()
+
+    # ── Step 5: Check copyright years ─────────────────────────────────────
+    step = 5
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Check copyright years",
+            bold=True,
+            fg="green",
+        )
+        _check_copyright_year()
+
+    # ── Step 6: Generate release notes ────────────────────────────────────
+    step = 6
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Generate release notes",
+            bold=True,
+            fg="green",
+        )
+        _generate_release_notes(
+            last_tag=ctx["last_tag"], new_version=ctx["new_version"]
+        )
+
+    # ── Step 7: Update Changelog ──────────────────────────────────────────
+    step = 7
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Update Changelog",
+            bold=True,
+            fg="green",
+        )
+        _update_changelog(new_version=ctx["new_version"])
+
+    # ── Step 8: Update doc/index.rst announcements ────────────────────────
+    step = 8
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Update doc/index.rst announcements",
+            bold=True,
+            fg="green",
+        )
+        _update_index_announcements(new_version=ctx["new_version"])
+
+    # ── Step 9: Update pyproject.toml version ─────────────────────────────
+    step = 9
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Update pyproject.toml version",
+            bold=True,
+            fg="green",
+        )
+        _update_pyproject_version(new_version=ctx["new_version"])
+
+    # ── Step 10: Check deprecations ───────────────────────────────────────
+    step = 10
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Check deprecations",
+            bold=True,
+            fg="green",
+        )
+        _confirm(
+            "Have you checked deprecated functions/modules and removed"
+            " those past their cycle?"
+        )
+
+    # ── Step 11: Run Cython/extension doctests ────────────────────────────
+    step = 11
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Run extension module doctests",
+            bold=True,
+            fg="green",
+        )
+        _run_shell("./tools/doctest_extmods.py dipy", check=False)
+        _confirm("Did the extension module doctests pass?")
+
+    # ── Step 12: Run test suite ───────────────────────────────────────────
+    step = 12
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Run test suite",
+            bold=True,
+            fg="green",
+        )
+        _run_shell("pytest -svv --doctest-modules dipy", check=False)
+        _confirm("Did the test suite pass?")
+
+    # ── Step 13: Build documentation ─────────────────────────────────────
+    step = 13
+    if not skip(step):
+        click.secho(
+            f"\n[Step {step}/{len(RELEASE_STEPS)}] Build documentation",
+            bold=True,
+            fg="green",
+        )
+        _run_shell("cd doc && make clean && make html && cd ..", check=False)
+        _confirm("Have you reviewed the generated docs (tutorials, figures, API)?")
+
+    v = ctx["new_version"]
+    click.secho("\n✅ Release preparation complete!", bold=True, fg="bright_green")
+    click.echo(
+        f"\nNext steps:\n"
+        f"  1. Stage and commit: git commit -m 'REL: set version to {v}'\n"
+        f"  2. Open a Pull Request and get it merged.\n"
+        f"  3. After merge, tag:  git tag -am 'Public release {v}' {v}\n"
+        f"  4. Build source dist: git clean -dfx && python -m build\n"
+        f"  5. Upload to PyPI:    twine upload dist/*\n"
+        f"  6. Push tag:          git push upstream {v}\n"
+        f"  7. Create maint branch: git checkout -b maint/{v}\n"
+        f"  8. Bump master version to {v.rsplit('.', 1)[0]}.dev0 in pyproject.toml.\n"
+        f"  9. Announce on mailing lists.\n"
+    )

--- a/AUTHOR
+++ b/AUTHOR
@@ -1,152 +1,186 @@
-Eleftherios Garyfallidis
-Ariel Rokem
-Serge Koudoro
-Matthew Brett
-Rafael Neto Henriques
-Bago Amirbekian
-Gabriel Girard
-Omar Ocegueda
-Bramsh Qamar
-Jon Haitz Legarreta Gorroño
-Francois Rheault
-Samuel St-Jean
-Shreyas Fadnavis
-Marc-Alexandre Côté
-Philippe Karan
-Javier Guaje
-Rutger Fick
-Shahnawaz Ahmed
-Ian Nimmo-Smith
-Mauro Zucchelli
-Matthieu Dumont
-Kesshi Jordan
-Stefan van der Walt
-Ranveer Aggarwal
-Maxime Descoteaux
-Kenji Marshall
-Jong Sung Park
-Riddhish Bhalodia
-Shilpi Prasad
-Tom Dela Haije
-Parichit Sharma
-Bishakh Ghosh
-Christopher Nguyen
-Ricci Woo
-Maharshi Gor
-Stephan Meesters
-Leevi Kerkela
-Eric Peterson
-David Romero-Bascones
-Etienne St-Onge
-Julio Villalon
-Jean-Christophe Houde
-Manu Tej Sharma
-Sourav Singh
-Nasim Anousheh
-Charles Poirier
-Dimitri Papadopoulos
-Paul Camacho
-Kumar Ashutosh
-David Reagan
-Guillaume Theaud
-Shubham Shaswat
-Aman Arya
-Deneb Boito
-Dimitris Rozakis
-Fabio Nery
-Rahul Ubale
-kunal mehta
-Gregory R. Lee
-Areesha Tariq
-Saber Sheybani
-Sam Coveney
-Chantal Tax
-Gregory Lee
-Nil Goyette
-Eric Larson
-Rohan Prinja
-Yaroslav Halchenko
-Antonio Ossa
-Jaewon Chung
-Vara Lakshmi Bayanagari
-Demian Wassermann
-John Kruper
-Michael Paquette
-Shrishti Hore
-Tingyi Wanyan
-Jiri Borovec
-Siddharth Kapoor
-Leon Weninger
-Malinda Dilhara
-Conor Corbin
-Dan Bullock
-Derek Pisner
-Martijn Nagtegaal
-ArjitJ
-Enes Albay
-Kimberly Chan
-Erik Ziegler
-Jacob Roberts
-Takis Panagopoulos
-Antoine Theberge
-Baran Aydogan
-Ross Lawrence
-Scott Trinkle
-David Qixiang Chen
-Kevin Sitek
-Pradeep Reddy Raamana
 Adam Richie-Halford
-Alexandre Gauvin
-Basile Pinsard
-David Hunt
-Emanuele Olivetti
-Emmanuelle Renauld
-Nicolas Delinte
-Sarath Chandra
-Clint Greene
-Giulia Bertò
-Lucas Da Costa
-Matthias Ekman
-Mitesh Gulecha
-Yash Sherry
-dependabot[bot]
-endolith
-Andrew Lawrence
-Bennet Fauber
-Emmanuel Caruyer
-Felix Liu
-Matt Cieslak
-Oscar Esteban
-Tashrif Billah
-Tom Wright
-svabhishek29
-ujjwal-shekhar
 Adam Rybinski
+Alberto Di Biase
+Alex Rockhill
+Alexandre Gauvin
+Aman Arya
+Aman Srivastava
+Andrew Lawrence
+Ankur Sinha (Ankur Sinha Gmail)
+Antoine Theberge
+Antonio Ossa
+Areesha Tariq
+Ariel Rokem
+ArjitJ
 Aryansh Omray
+Asa Gilmore
+Atharva Shah
+Bago Amirbekian
+Baran Aydogan
+Basile Pinsard
+Bennet Fauber
+Bishakh Ghosh
+Bramsh Qamar
 Chandan Gangwar
+Chantal Tax
+Charles Poirier
+Chris Filo Gorgolewski
+Christopher Nguyen
+Clint Greene
 Clément Zotti
+Conor Corbin
+Copilot
+Dan Bullock
+Daniel Enrico Cahall
+Daniel McCloy
+David Hunt
+David Qixiang Chen
+David Reagan
+David Romero-Bascones
+Demian Wassermann
+Deneb Boito
+Derek Pisner
+Dimitri Papadopoulos
+Dimitris Rozakis
+Ebrahim Ebrahim
+Eleftherios Garyfallidis
+Emanuele Olivetti
+Emmanuel Caruyer
+Emmanuelle Renauld
+Enes Albay
+Eric Larson
+Eric Peterson
+Erik Ziegler
+Etienne St-Onge
+Fabio Nery
+Felix Liu
+Florent Wijanto
+Francis Jerome
+Francois Rheault
+Gabriel Girard
+Giulia Bertò
+Gnaneswar Lopinti
 Gonzalo Sanguinetti
+Gregory Lee
+Gregory R. Lee
+Guillaume Theaud
+Himanshu Mishra
+Ian Nimmo-Smith
+Inigo Tellaetxe
+Jacob Roberts
+Jaewon Chung
+Jakob Wasserthal
+Javier Guaje
+Jean-Christophe Houde
+Jirka Borovec
+John Kruper
+John Shen
+Jon Haitz Legarreta Gorroño
+Jon Mendoza
+Jong Sung Park
 Joshua Newton
+Julio Villalon
+Kaibo Tang
+Karan
+Katrin Leinweber
+Kaustav Deka
+Kenji Marshall
+Kesshi Jordan
+Kevin Sitek
+Kimberly Chan
+Kumar Ashutosh
+Leevi Kerkela
+Leon Weninger
+Liberty
+Lucas Da Costa
+Maharshi Gor
+Malinda Dilhara
+Manu Tej Sharma
+Marc-Alexandre Côté
+Maria Luisa Mandelli
+Martijn Nagtegaal
+Martin Kozár
+Martino Pilia
+Matt Cieslak
+Matthew Brett
+Matthew Feickert
+Matthias Ekman
+Matthieu Dumont
+Mauro Zucchelli
+Maxime Descoteaux
+Michael Paquette
+Michael R. Crusoe
+Mitesh Gulecha
+Mohamed Abouagour
+Mrinal Chaturvedi
+Nasim Anousheh
 Naveen Kumarmarri
+Nicolas Delinte
+Nil Goyette
+Nishant Singh
+Omar Ocegueda
+Oscar Esteban
+Parichit Sharma
+Paul Camacho
+Philippe Karan
+Pradeep Reddy Raamana
+Praitayini Kanakaraj
+Prajwal Reddy
+Qiyuan Tian
+Rafael Neto Henriques
+Rahul Ubale
+Ranveer Aggarwal
+Ricci Woo
+Riddhish Bhalodia
+Rohan Prinja
+Ross Lawrence
+Rutger Fick
+Saber Sheybani
+Sagun Pai
+Sam Coveney
+Samuel St-Jean
+Sandro Turriate
+Santiago Vila
+Sarath Chandra
+Scott Trinkle
+Serge Koudoro
+Shahnawaz Ahmed
+Shilpi Prasad
+Shreyas Fadnavis
+Shrishti Hore
+Shubham Shaswat
+Siddharth Kapoor
+Siddhesh Thakur
+Sourav Singh
+Sreekar Chigurupati
+Stefan van der Walt
+Stephan Meesters
+Sven Dorkenwald
 Sylvain Merlet
+Takis Panagopoulos
+Tashrif Billah
+Theodore Ni
+Tingyi Wanyan
+Tom Dela Haije
+Tom Wright
+Umesh Gupta
+Vara Lakshmi Bayanagari
 Vatsala Swaroop
 Vibhatha Abeykoon
-Étienne Mollier
-Atharva Shah
-Chris Filo Gorgolewski
-Daniel Enrico Cahall
-Dogu Baran Aydogan
-Francis Jerome
-Himanshu Mishra
-Jakob Wasserthal
-Jirka Borovec
-Jon Mendoza
-Katrin Leinweber
-Maria Luisa Mandelli
-Martino Pilia
-Michael R. Crusoe
-Qiyuan Tian
-Sagun Pai
-Sven Dorkenwald
-Theodore Ni
+Yaroslav Halchenko
+Yash Sherry
 Yijun Liu
+aziza
+endolith
+kunal mehta
+lb-97
+prathameshfuke
+pre-commit-ci[bot]
+rishav
+root
+samarmaharaj
+satyam kumar
+shadow1409
+svabhishek29
+ujjwal-shekhar
+Étienne Mollier

--- a/Changelog
+++ b/Changelog
@@ -18,6 +18,33 @@ The full VCS changelog is available here:
 
 Releases
 ~~~~~~~~
+* 1.12.0 (Friday, March 13, 2026)
+
+- NF: FORCE recon model - new signal matching reconstruction model added.
+- NF: Parallel EuDX tractography added.
+- NF: MSMT-CSD CLI (dipy_fit_msmtcsd) added.
+- NF: New CLIs added: dipy_cluster_streamlines, dipy_brain_mask, dipy_fit_powermap.
+- NF: Free-Water DTI (FWDTI) Workflow added.
+- NF: Intermediate displacement map for symmetric diffeomorphic registration added.
+- NF: StatefulSurface class to handle surfaces added.
+- NF: SynthSeg PyTorch model integration added.
+- NF: BUAN Bundle Profiles Lite Version added.
+- NF: Streamline clipping utility function added.
+- NF: Broadcasting support in dipy_math CLI added.
+- RF: Adopt pathlib for path handling in workflows.
+- RF: Unified logger across the codebase.
+- RF: TRX set as the default file format for tractography.
+- RF: NLMeans refactored to support classic and blockwise variants.
+- RF: autocrop deprecated in median_otsu.
+- RF: Replace old LocalTracking by the new tracking interface.
+- ENH: Kurtosis metrics (AK, RK, KFA) Cythonized for performance.
+- ENH: Parallel quantize_evecs.
+- ENH: aarch64 native builds and Python 3.14 nightly wheels added.
+- BF: Multiple bug fixes (empty tractograms, CVXPY, FWDTI, Bingham, rumba, surfaces, stopping criterion reproducibility).
+- CI: Multiple CI improvements (caching, least-privilege permissions, dependabot pip tracking, cron schedule fixes).
+- Documentation: Extensive documentation improvements across modules and tutorials.
+- Closed 324 issues and merged 173 pull requests.
+
 
 Dipy
 ++++

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Unless otherwise specified by LICENSE.txt files in individual
 directories, or within individual files or functions, all code is:
 
-Copyright (c) 2008-2025, dipy developers
+Copyright (c) 2008-2026, dipy developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -8,251 +8,183 @@ A guide for developers who are doing a DIPY release
 
 .. _release-checklist:
 
-Release checklist
-=================
+Automated release preparation
+==============================
 
-* Review the open list of `dipy issues`_.  Check whether there are
-  outstanding issues that can be closed, and whether there are any issues that
-  should delay the release.  Label them !
+Most of the manual steps below are automated by the ``spin prepare-release``
+command.  Run it from the root of the DIPY repository::
 
-* Check whether there are no build failing on `DIPY Github Actions`_. Indeed, ``PRE`` build is
-  allowed to fail and does not block a PR merge but it should block release !
-  So make sure that ``PRE`` build is not failing.
+    spin prepare-release
 
-* Generate, Review and update the release notes. Run the following command from
-  the root directory of DIPY::
+The command walks you through each step interactively.  If it is interrupted
+you can resume from any step with ``--from-step N``::
 
-    python3 tools/github_stats.py 1.7.0 > doc/release_notes/release1.8.rst
+    spin prepare-release --from-step 6
 
-  where ``1.7.0`` was the last release tag name.
+You can also override the auto-detected previous tag or skip the version
+prompt::
 
-* Review and update the :file:`Changelog` file.  Get a partial list of
-  contributors with something like::
+    spin prepare-release --last-tag 1.11.0 --new-version 1.12.0
 
-      git shortlog -ns 0.1.7.0..
+Available steps (``--from-step`` values):
 
-  where ``1.7.0`` was the last release tag name.
+.. code-block:: text
 
-  Then manually go over ``git shortlog 0.7.0..`` to make sure the release notes
-  are as complete as possible and that every contributor was recognized.
+     1. fetch-tag       – detect the previous release tag
+     2. mailmap         – auto-detect duplicate authors, propose .mailmap entries, then show full shortlog for manual review
+     3. version         – choose the new version number
+     4. author          – regenerate the AUTHOR file
+     5. copyright       – update copyright years in LICENSE and doc/conf.py
+     6. release-notes   – generate doc/release_notes/releaseX.Y.Z.rst
+     7. changelog       – prepend entry in Changelog
+     8. index           – add announcement line to doc/index.rst
+     9. pyproject       – set version in pyproject.toml
+    10. deprecations    – confirm deprecated code has been removed
+    11. doctest         – run Cython / extension module doctests (exit code shown; no output means all passed)
+    12. tests           – run the full test suite
+    13. docs            – build HTML documentation
 
-* Use the opportunity to update the ``.mailmap`` file if there are any duplicate
-  authors listed from ``git shortlog -nse``.
+Before running the script, make sure to:
 
-* Add any new authors to the ``AUTHORS`` file.
+* Review the open list of `dipy issues`_.  Close or label outstanding issues,
+  and check whether any should delay the release.
 
-* Check the copyright years in ``doc/conf.py`` and ``LICENSE``
+* Verify that no builds are failing on `DIPY Github Actions`_.  The ``PRE``
+  build is allowed to fail for PR merges but **must not** fail at release time.
 
-* Check the examples - we really need an automated check here.
+* Check the ``README`` in the root directory and verify all links are still valid.
 
-* Check the ``pyx`` file doctests with::
+Notes on individual steps
+--------------------------
+
+**Step 2 – mailmap**
+  The script parses ``git log`` to detect duplicate authors automatically
+  (same email / different name, or same normalised name / different email).
+  Each new candidate entry is shown and you are asked ``yes / no / edit``.
+  Accepted entries are appended to ``.mailmap`` and a diff is shown.
+  A full ``git shortlog -nse <last_tag>..HEAD`` is printed afterwards for a
+  final manual review before you continue.
+
+**Step 6 – release-notes**
+  Release notes are generated with ``tools/github_stats.py``::
+
+      python3 tools/github_stats.py <last_tag> > doc/release_notes/release<version>.rst
+
+  You will be paused to add a header and highlights section above the
+  auto-generated contributor/PR/issue lists before continuing.
+
+**Step 7 – changelog**
+  A skeleton entry is prepended to ``Changelog``.  You are paused to fill in
+  the highlights (derived from the release notes) before continuing.
+
+**Step 11 – doctest**
+  Runs ``./tools/doctest_extmods.py dipy``.  No output means all doctests
+  passed; the exit code is always printed so you can tell the command
+  actually ran.  Requires the package to be built in-place
+  (``spin build`` or ``pip install --no-build-isolation -e .``).
+
+**Step 12 – tests**
+  Runs ``pytest -svv --doctest-modules dipy`` from the repo root.
+
+**Step 13 – docs**
+  Runs ``make clean && make html`` inside ``doc/``.  Review the generated
+  output for broken tutorials, figures, or API pages before confirming.
+
+Release checklist (manual reference)
+=====================================
+
+The steps below are the manual equivalent of what ``spin prepare-release``
+does, kept here for reference.
+
+* Detect the previous tag::
+
+    git tag | sort -V | tail -1
+
+* Review contributors and update ``.mailmap``::
+
+    git shortlog -nse <last_tag>..HEAD
+
+* Generate release notes::
+
+    python3 tools/github_stats.py <last_tag> > doc/release_notes/release<version>.rst
+
+  Edit the file to add a header and highlights section.
+
+* Prepend an entry to ``Changelog`` with the new version and highlights.
+
+* Add the new announcement line to ``doc/index.rst``.
+
+* Regenerate the ``AUTHOR`` file from git history::
+
+    git log --format=’%aN’ | sort -u > AUTHOR
+
+* Check copyright years in ``LICENSE`` and ``doc/conf.py``.
+
+* Set the version in ``pyproject.toml``.
+
+* Confirm all deprecated functions past their removal cycle have been removed.
+
+* Run Cython / extension module doctests::
 
     ./tools/doctest_extmods.py dipy
 
-  We really need an automated run of these using the buildbots, but we haven't
-  done it yet.
+* Run the full test suite::
 
-* Check the ``README`` in the root directory. Check all the links are still valid.
+    pytest -svv --doctest-modules dipy
 
-* Check all the DIPY builds are green on the nipy `DIPY Github Actions`_
+* Build the HTML documentation::
 
-* If you have `DIPY Github Actions`_ building set up you might want to push the code in its
-  current state to a branch that will build, e.g.::
+    cd doc && make clean && make html && cd ..
 
-    git branch -D pre-release-test # in case branch already exists
-    git co -b pre-release-test
-
-* Clean and compile::
-
-    make distclean
-    git clean -fxd
-    python3 -m build  or  pip install --no-build-isolation  -e .
-
-* Make sure all tests pass on your local machine (from the ``<dipy root>`` directory)::
-
-    cd ..
-    pytest -svv --with-doctest --pyargs dipy
-    cd dipy # back to the root directory
-
-* Check the documentation doctests::
-
-    cd doc
-    make doctest
-    cd ..
-
-  At the moment this generates lots of errors from the autodoc documentation
-  running the doctests in the code, where the doctests pass when run in pytest -
-  we should find out why this is at some point, but leave it for now.
-
-* Build and test the DIPY wheels.  See the `wheel builder README
-  <https://github.com/MacPython/dipy-wheels>`_ for instructions.  In summary,
-  clone the wheel-building repo, edit the ``.github/workflows/wheel.yml``
-  text files (if present) with the branch or commit for the release, commit
-  and then push back up to github.  This will trigger a wheel build and test
-  on macOS, Linux and Windows. Check the build has passed on the Github Actions
-  interface at https://github.com/MacPython/dipy-wheels/actions.  You'll need
-  commit privileges to the ``dipy-wheels`` repo; ask Matthew Brett or on the
-  mailing list if you do not have them.
-
-* The release should now be ready.
+* Build and test the DIPY wheels via `DIPY Github Actions`_.  Wheels are
+  built automatically on CI when a release tag is pushed.
 
 Doing the release
 =================
 
-Doing the release! This has two steps:
+Once ``spin prepare-release`` completes successfully:
 
-* build and upload the DIPY wheels;
-* make and upload the DIPY source release.
+1. Stage and commit all changes::
 
-The trick here is to get all the testing, pushing to upstream done *before* you
-do the final release commit.  There should be only one commit with the release
-version number, so you might want to make the release commit on your local
-machine, push to `dipy pypi`_, review, fix, rebase, until all is good.  Then and only
-then do you push to upstream on github.
+    git commit -m "REL: set version to <version>"
 
-* Make the release commit.  Edit :file:`pyproject.toml` and to get the correct version
-  number and commit it with a message like REL: set version to <version-number>.
-  Don’t push this commit to the DIPY_ repo yet.;
+2. Open a Pull Request, get it reviewed and merged.
 
-* Finally tag the release locally with git tag <v1.x.y>. Continue with building
-  release artifacts (next section). Only push the release commit to the DIPY_
-  repo once you have built the sdists and docs successfully.
-  Then continue with building wheels. Only push the release tag to the repo once
-  all wheels have been built successfully on `DIPY Github Actions`_.
+3. After the merge, create an annotated tag on the merge commit::
 
-* For the wheel build / upload, follow the `wheel builder README`_
-  instructions again.  Edit the ``.github/workflows/wheel.yml`` files (if
-  present) to give the release tag to build.  Check the build has passed on
-  the Github Interface interface at https://github.com/MacPython/dipy-wheels/actions.
-  Now follow the instructions in the page above to download the built wheels to a
-  local machine and upload to PyPI.
+    git tag -am ‘Public release <version>’ <version>
 
-* Now it's time for the source release. Build the release files::
+4. Build the source distribution::
 
-    make distclean
-    git clean -fxd
-    make source-release
+    git clean -dfx
+    python -m build
 
-* Once everything looks good, upload the source release to PyPi::
+5. Upload to PyPI::
 
     pip install twine
     twine upload dist/*
 
-* Check how everything looks on pypi - the description, the packages.  If
-  necessary delete the release and try again if it doesn't look right.
+6. Push the tag to trigger wheel builds on CI::
 
-* Make an annotated tag for the release with tag of form ``1.8.0``::
+    git push upstream <version>
 
-    git tag -am 'Public release 1.8.0' 1.8.0
+7. Create a maintenance branch and bump the development version::
 
-* Set up maintenance / development branches
+    git checkout -b maint/<version>
+    # set version to <major>.<minor+1>.0.dev0 in pyproject.toml on master
+    git checkout master
+    git merge -s ours maint/<version>
 
-  If this is a full release you need to set up two branches, one for
-  further substantial development (often called 'trunk') and another for
-  maintenance releases.
-
-  * Branch to maintenance::
-
-      git co -b maint/1.8.x
-
-    Set ``_version_extra`` back to ``.dev`` and bump ``_version_micro`` by 1.
-    Thus the maintenance series will have version numbers like - say - '1.8.1.dev'
-    until the next maintenance release - say '1.8.1'.  Commit.
-
-    Push with something like ``git push upstream-rw maint/1.8.x --set-upstream``
-
-  * Start next development series::
-
-      git co main-master
-
-    then restore ``.dev`` to ``_version_extra``, and bump ``_version_minor`` by 1.
-    Thus the development series ('trunk') will have a version number here of
-    '0.7.0.dev' and the next full release will be '0.7.0'.
-
-    Next merge the maintenance branch with the "ours" strategy.  This just labels
-    the maintenance branch `info.py` edits as seen but discarded, so we can
-    merge from maintenance in future without getting spurious merge conflicts::
-
-       git merge -s ours maint/1.8.x
-
-    Push with something like ``git push upstream-rw main-master:master``
-
-  If this is just a maintenance release from ``maint/1.8.x`` or similar, just
-  tag and set the version number to - say - ``1.8.2.dev``.
-
-* Push the tag with ``git push upstream-rw 1.8.0``
-
-Uploading binary builds for the release
-=======================================
-
-By far the easiest way to do this is via the buildbots.
-
-In order to do this, you need first to push the release commit and the release
-tag to github, so the buildbots can find the released code and build it.
-
-* In order to trigger the binary builds for the release commit, you need to go
-  to the web interface for the binary builder, go to the "Force build" section,
-  enter your username and password for the buildbot web service and enter the
-  commit tag name in the *revision* field.  For example, if the tag was
-  ``1.8.0`` then you would enter ``1.8.0`` in the revision field of the form.
-  This builds the exact commit labeled by the tag, which is what we want.
-
-* Trigger binary builds for Windows from the ``https://github.com/MacPython/dipy-wheels``
-
-  Download the builds and upload to pypi.
-
-  You can upload the exe files with the *files* interface for the new DIPY release.
-  Obviously you'll need to log in to do this, and you'll need to be an admin for
-  the DIPY pypi project.
-
-  For reference, if you need to do binary exe builds by hand, use something
-  like::
-
-    make distclean
-    git clean -fxd
-
-* Trigger binary builds for macOS from the buildbots ``https://github.com/MacPython/dipy-wheels``.
-  Download the eggs and upload to pypi.
-
-  Upload the dmg files with the *files* interface for the new DIPY release.
-
-* Building macOS dmgs from the mpkg builds.
-
-  The buildbot binary builders build ``mpkg`` directories, which are installers
-  for macOS.
-
-  These need their permissions to be fixed because the installers should install
-  the files as the root user, group ``admin``.  The all need to be converted to
-  macOS disk images.  Use the ``./tools/build_dmgs.py``, with something like
-  this command line::
-
-    ./tools/build_dmgs "dipy-dist/dipy-1.8.0-py*.mpkg"
-
-  For this to work you'll need several things:
-
-    * An account on a macOS box with sudo (Admin user) on which to run the
-      script.
-    * ssh access to the buildbot server https://nipy.bic.berkeley.edu (ask
-      Matthew or Eleftherios).
-    * a development version of ``bdist_mpkg`` installed from
-      https://github.com/matthew-brett/bdist_mpkg.  You need this second for the
-      script ``reown_mpkg`` that fixes the permissions.
-
-  Upload the dmg files with the *files* interface for the new DIPY release.
+8. Announce to the mailing lists.
 
 Other stuff that needs doing for the release
 ============================================
 
-* Checkout the tagged release, build the html docs and upload them to
-  the github pages website::
+* Build and upload the HTML docs to the GitHub Pages website::
 
     make upload
 
-  You need to checkout the tagged version in order to get the version number
-  correct for the doc build.  The version number gets picked up from the
-  ``info.py`` version.
-
-* Announce to the mailing lists.  With fear and trembling.
+* Announce to the mailing lists.
 
 
 .. include:: ../links_names.inc

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -108,9 +108,10 @@ See :ref:`Older Highlights <old_highlights>`.
 *************
 Announcements
 *************
+- :doc:`DIPY 1.12.0 <release_notes/release1.12>` released March 13, 2026.
+- :doc:`DIPY 1.12.0 <release_notes/release1.12>` released August 22, 2025.
 - :doc:`DIPY 1.11.0 <release_notes/release1.11>` released March 15, 2025.
 - :doc:`DIPY 1.10.0 <release_notes/release1.10>` released December 12, 2024.
-- :doc:`DIPY 1.9.0 <release_notes/release1.9>` released March 8, 2024.
 
 
 

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -4,6 +4,18 @@
 Older Highlights
 ****************
 
+**DIPY 1.11.0** is now available. New features include:
+
+- NF: Refactoring of the tracking API.
+- Deprecation of Tensorflow backend in favor of PyTorch.
+- Performance improvements of multiple functionalities.
+- DIPY Horizon improvements and minor features added.
+- Added support for Python 3.13.
+- Drop support for Python 3.9.
+- Multiple Workflows updated and added (15 workflows).
+- Documentation update.
+- Closed 73 issues and merged 47 pull requests.
+
 **DIPY 1.10.0** is now available. New features include:
 
 - NF: Patch2Self3 - Large improvements of self-supervised denoising method added.

--- a/doc/old_news.rst
+++ b/doc/old_news.rst
@@ -5,6 +5,7 @@
 Past Announcements
 **********************
 
+- :doc:`DIPY 1.9.0 <release_notes/release1.9>` released March 8, 2024.
 - :doc:`DIPY 1.8.0 <release_notes/release1.8>` released December 13, 2023.
 - :doc:`DIPY 1.7.0 <release_notes/release1.7>` released April 23, 2023.
 - :doc:`DIPY 1.6.0 <release_notes/release1.6>` released January 16, 2023.

--- a/doc/release_notes/release1.12.rst
+++ b/doc/release_notes/release1.12.rst
@@ -1,0 +1,707 @@
+.. _release1.12:
+
+=====================================
+ Release notes for DIPY version 1.12
+=====================================
+
+GitHub stats for 2025/03/16 - 2026/03/13 (tag: 1.11.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 187 authors contributed 15284 commits.
+
+* Adam Richie-Halford
+* Adam Rybinski
+* Alberto Di Biase
+* Alex Rockhill
+* Alexandre Gauvin
+* Aman Arya
+* Aman Srivastava
+* Andrew Lawrence
+* Ankur Sinha (Ankur Sinha Gmail)
+* Antoine Theberge
+* Antonio Ossa
+* Areesha Tariq
+* Ariel Rokem
+* ArjitJ
+* Aryansh Omray
+* Asa Gilmore
+* Atharva Shah
+* Bago Amirbekian
+* Baran Aydogan
+* Basile Pinsard
+* Bennet Fauber
+* Bishakh Ghosh
+* Bramsh Qamar
+* Chandan Gangwar
+* Chantal Tax
+* Charles Poirier
+* Chris Filo Gorgolewski
+* Christopher Nguyen
+* Clint Greene
+* Clément Zotti
+* Conor Corbin
+* Copilot
+* Dan Bullock
+* Daniel Enrico Cahall
+* Daniel McCloy
+* David Hunt
+* David Qixiang Chen
+* David Reagan
+* David Romero-Bascones
+* Demian Wassermann
+* Deneb Boito
+* Derek Pisner
+* Dimitri Papadopoulos
+* Dimitris Rozakis
+* Ebrahim Ebrahim
+* Eleftherios Garyfallidis
+* Emanuele Olivetti
+* Emmanuel Caruyer
+* Emmanuelle Renauld
+* Enes Albay
+* Eric Larson
+* Eric Peterson
+* Erik Ziegler
+* Etienne St-Onge
+* Fabio Nery
+* Felix Liu
+* Florent Wijanto
+* Francis Jerome
+* Francois Rheault
+* Gabriel Girard
+* Giulia Bertò
+* Gnaneswar Lopinti
+* Gonzalo Sanguinetti
+* Gregory Lee
+* Gregory R. Lee
+* Guillaume Theaud
+* Himanshu Mishra
+* Ian Nimmo-Smith
+* Inigo Tellaetxe
+* Jacob Roberts
+* Jaewon Chung
+* Jakob Wasserthal
+* Javier Guaje
+* Jean-Christophe Houde
+* Jirka Borovec
+* John Kruper
+* John Shen
+* Jon Haitz Legarreta Gorroño
+* Jon Mendoza
+* Jong Sung Park
+* Joshua Newton
+* Julio Villalon
+* Kaibo Tang
+* Karan
+* Katrin Leinweber
+* Kaustav Deka
+* Kenji Marshall
+* Kesshi Jordan
+* Kevin Sitek
+* Kimberly Chan
+* Kumar Ashutosh
+* Leevi Kerkela
+* Leon Weninger
+* Liberty
+* Lucas Da Costa
+* Maharshi Gor
+* Malinda Dilhara
+* Manu Tej Sharma
+* Marc-Alexandre Côté
+* Maria Luisa Mandelli
+* Martijn Nagtegaal
+* Martin Kozár
+* Martino Pilia
+* Matt Cieslak
+* Matthew Brett
+* Matthew Feickert
+* Matthias Ekman
+* Matthieu Dumont
+* Mauro Zucchelli
+* Maxime Descoteaux
+* Michael Paquette
+* Michael R. Crusoe
+* Mitesh Gulecha
+* Mohamed Abouagour
+* Mrinal Chaturvedi
+* Nasim Anousheh
+* Naveen Kumarmarri
+* Nicolas Delinte
+* Nil Goyette
+* Nishant Singh
+* Omar Ocegueda
+* Oscar Esteban
+* Parichit Sharma
+* Paul Camacho
+* Philippe Karan
+* Pradeep Reddy Raamana
+* Praitayini Kanakaraj
+* Prajwal Reddy
+* Qiyuan Tian
+* Rafael Neto Henriques
+* Rahul Ubale
+* Ranveer Aggarwal
+* Ricci Woo
+* Riddhish Bhalodia
+* Rohan Prinja
+* Ross Lawrence
+* Rutger Fick
+* Saber Sheybani
+* Sagun Pai
+* Sam Coveney
+* Samuel St-Jean
+* Sandro Turriate
+* Santiago Vila
+* Sarath Chandra
+* Scott Trinkle
+* Serge Koudoro
+* Shahnawaz Ahmed
+* Shilpi Prasad
+* Shreyas Fadnavis
+* Shrishti Hore
+* Shubham Shaswat
+* Siddharth Kapoor
+* Siddhesh Thakur
+* Sourav Singh
+* Sreekar Chigurupati
+* Stefan van der Walt
+* Stephan Meesters
+* Sven Dorkenwald
+* Sylvain Merlet
+* Takis Panagopoulos
+* Tashrif Billah
+* Theodore Ni
+* Tingyi Wanyan
+* Tom Dela Haije
+* Tom Wright
+* Umesh Gupta
+* Vara Lakshmi Bayanagari
+* Vatsala Swaroop
+* Vibhatha Abeykoon
+* Yaroslav Halchenko
+* Yash Sherry
+* Yijun Liu
+* aziza
+* dependabot[bot]
+* endolith
+* kunal mehta
+* lb-97
+* prathameshfuke
+* pre-commit-ci[bot]
+* rishav
+* root
+* samarmaharaj
+* satyam kumar
+* shadow1409
+* svabhishek29
+* ujjwal-shekhar
+* Étienne Mollier
+
+
+We closed a total of 497 issues, 173 pull requests and 324 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (173):
+
+* :ghpull:`3844`: NF: FORCE recon model
+* :ghpull:`3617`: NF: add dipy_fit_msmtcsd cli with its tests
+* :ghpull:`3687`: BUAN Bundle Profiles Lite Version
+* :ghpull:`3850`: DOC: Fix broken and outdated links in gitwash documentation
+* :ghpull:`3679`: Build aarch64 natively
+* :ghpull:`3847`: BF: Updated sherbrooke-3shell.
+* :ghpull:`3845`: BF: improve output file management of BiasField correction CLI
+* :ghpull:`3841`: DOC: Complete missing parameters in save_polydata docstring
+* :ghpull:`3689`: NF: Parallel Eudx
+* :ghpull:`3836`: DOC: Documentation fix
+* :ghpull:`3808`: RF: improve trx support for recobundles CLI
+* :ghpull:`3825`: DOC: Modernize and complete benchmarks/README.rst - closes #3824
+* :ghpull:`3813`: Fix #3811: reset warning filters in test_io_peaks_deprecated
+* :ghpull:`3833`: DOC: Improve docstrings for SimilarityMetric in align.metrics
+* :ghpull:`3795`: Added docs for nn and io
+* :ghpull:`3812`: Fix #3810: use warnings.warn() for empty tractogram
+* :ghpull:`3700`: RF: Simplify non-negative code in anisotropic_power
+* :ghpull:`3783`: Fix figure canvas not cleared in simulation tutorials
+* :ghpull:`3699`: Qti robust
+* :ghpull:`3834`: Bump docker/setup-qemu-action from 3 to 4 in the actions group
+* :ghpull:`3831`: DOC: Fix docstring errors in dipy/io/pickles.py
+* :ghpull:`3820`: BF: improve rumba performance
+* :ghpull:`3818`: BF: fix future errors/warnings from the future Numpy 2.5
+* :ghpull:`3816`: RF: relax precision for affine_registration / motion_correction
+* :ghpull:`3823`: DOC: Fix lowercase 'returns' section header in _make_fetcher docstring
+* :ghpull:`3805`: Bump the actions group with 2 updates
+* :ghpull:`3791`: NF: update biasfield correction method.
+* :ghpull:`3793`: DOC: Add documentation for the PAM5 file format
+* :ghpull:`3752`: CI: Update secrets management
+* :ghpull:`3796`: updated the docstring for ls_fit_dki and cls_fit_dki
+* :ghpull:`3790`: ENH: Cythonize AK, RK, and KFA kurtosis computations
+* :ghpull:`3789`: BF: handle `force` option when using symlink and hardlink
+* :ghpull:`3784`: Fix typo in test_template.yml input description (closes #3774)
+* :ghpull:`3765`: NF: add cli dipy_cluster_streamlines
+* :ghpull:`3766`: RF: improve CLI help formatting
+* :ghpull:`3767`: RF: Fix multiple cli
+* :ghpull:`3780`: Fix `numpydoc` validation issues in `fetcher.py`
+* :ghpull:`3781`: Fix epsilon docstring mismatch
+* :ghpull:`3771`: docs: Add a pull request template to standardize PR submissions.
+* :ghpull:`3762`: NF: add new CLI dipy_brain_mask with its associated test
+* :ghpull:`3761`:  [DOC] Fix grammatical errors and typos across documentation and codebase
+* :ghpull:`3754`: DOC: Typo in gitwash development_workflow guide
+* :ghpull:`3758`: DOC: Fix missing space in `load_peaks` deprecation message
+* :ghpull:`3756`: DOC: Remove Gitter link
+* :ghpull:`3704`: Fix get simplified backward transform
+* :ghpull:`3746`: TST: Replace legacy nose-style `yield assert_raises` with `pytest.raises`
+* :ghpull:`3750`: Update setuptools requirement from ~=69.5 to >=69.5,<83.0 in the python-dependencies group
+* :ghpull:`3739`: CI: Add top-level permissions for least-privilege security
+* :ghpull:`3733`: CI: Add pip ecosystem tracking to Dependabot configuration
+* :ghpull:`3729`: CI: Fix threading env vars not persisting across steps in benchmark.yml
+* :ghpull:`3722`: CI: Pin actions/first-interaction by commit SHA in first_interaction.yml
+* :ghpull:`3721`: CI: Pin srvaroa/labeler action by commit SHA in label-pr.yml
+* :ghpull:`3719`:  DOC: Update outdated Travis CI reference to GitHub Actions in CONTRIBUTING.md
+* :ghpull:`3716`: CI: Fix invalid cron schedule in test.yml
+* :ghpull:`3715`: CI: Add missing timeout-minutes to workflow jobs
+* :ghpull:`3749`: RF: Updated the list provide a table of dataset names.
+* :ghpull:`3740`: Bump srvaroa/labeler from 1.13.0 to 1.14.0 in the actions group
+* :ghpull:`3737`:  DOC: Migrate remaining `http://` URLs to `https://`
+* :ghpull:`3711`: CI: Fix incorrect Cython file glob patterns in labeler.yml
+* :ghpull:`3709`: STYLE: Fix spelling mistakes in docstrings and comments
+* :ghpull:`3713`: CI: Remove duplicate .mailmap entry in labeler.yml
+* :ghpull:`3706`: RF: Add alternative to symlink for some  CLI
+* :ghpull:`3696`: BF: Handle empty tractograms gracefully in horizon
+* :ghpull:`3694`: DOC: Fix numpydoc PR03 parameter order in path_length
+* :ghpull:`3692`: DOC: Fixed DOC CI Issue
+* :ghpull:`3675`: Adding synthseg pytorch model
+* :ghpull:`3686`: BF: Handle empty streamlines in slr_with_qbx after length filtering
+* :ghpull:`3684`: RF: address some edge cases in multiple workflows
+* :ghpull:`3681`: Examples for IRLS (robust fitting)
+* :ghpull:`3685`: DOC: fix some missing `:footcite:p` in documentation
+* :ghpull:`3671`: Increased speed and lisibility of connectivity matrix, added weights
+* :ghpull:`3680`: RF: Added max_version option to optional_package api.
+* :ghpull:`3677`: DOC: Fix file path in many tutorials.
+* :ghpull:`3676`: RF: Allow reslice to automatically determines isotropic resolution
+* :ghpull:`3678`: Build 3.14 nightly wheels
+* :ghpull:`3664`: DOC: Improve Horizon class docstring for clarity
+* :ghpull:`3665`: FIX: Correct path construction logic in fetcher data loader, Resolve path construction errors in read_bundles_2_subjects
+* :ghpull:`3673`: RF: Allow bvals file for medianOtsu workflow
+* :ghpull:`3674`: Bump scientific-python/upload-nightly-action from 0.6.2 to 0.6.3 in the actions group
+* :ghpull:`3542`: RF: Editing tranform_img in dipy.nn.utils
+* :ghpull:`3670`: Test: Add regression test for median_otsu autocrop deprecation
+* :ghpull:`3668`: MNT: Replace deprecated autocrop in brain_extraction_dwi.py, reconst_csa.py, reconst_csa_parallel.py, reconst_dti.py tutorial examples
+* :ghpull:`3672`: Bump the actions group with 3 updates
+* :ghpull:`3669`: DOC: Prefer BibTeX reference in GQSI example documentation
+* :ghpull:`3657`: Document pre-commit setup for developers
+* :ghpull:`3667`: MNT: Replace deprecated autocrop in reconst_dti.py
+* :ghpull:`3659`: NF: Intermediate map for symmetric diffeomorphic registration
+* :ghpull:`3660`: DOC: Programmatic DIPY Horizon usage (non-CLI)
+* :ghpull:`3623`: RF: refactoring of ``nlmeans`` to allow the selection our classic version and the blockwise version
+* :ghpull:`3661`: CI: simplify cache, too many data was cached
+* :ghpull:`3662`: Bump actions/checkout from 5 to 6 in the actions group
+* :ghpull:`3552`: BF: Discards streamlines by size
+* :ghpull:`3652`: NF:  Reduce default iteration counts and make level_iters configurable in motion correction
+* :ghpull:`3618`: BF: manage empty file in dipy_slr cli to avoid enigmatic crash
+* :ghpull:`3655`: CI: remove fetch-data job
+* :ghpull:`3658`: Added interpolation parameter to dipy_apply_transform
+* :ghpull:`3648`: Revert split extension (for SFT and SFS)
+* :ghpull:`3654`: RF: fix warnings introduced by the future Numpy version 2.4
+* :ghpull:`3651`: RF: handle bingham tests warnings
+* :ghpull:`3650`: BF: update first interaction Github action parameters
+* :ghpull:`3649`: Bump the actions group with 2 updates
+* :ghpull:`3635`: BF: Fix CVXPY warning
+* :ghpull:`3646`: [BF] Fix fwdti
+* :ghpull:`3639`: fix: BUG: fix UnboundLocalError in _single_sf_to_bingham when no valid peaks found
+* :ghpull:`3610`: NF: add dipy_fit_powermap workflows with its associated tests
+* :ghpull:`3634`: BF: expand requirements during its generation
+* :ghpull:`3425`: NF: add FWDTI Workflow
+* :ghpull:`3631`: RF: Fixed weird volumes instead of denoised volumes in Patch2Self 3
+* :ghpull:`3629`: Bump actions/setup-python from 5 to 6 in the actions group
+* :ghpull:`3625`: docs: remove NeuroFedora
+* :ghpull:`3424`: NF: Automate requirement files
+* :ghpull:`3624`: Bump the actions group with 3 updates
+* :ghpull:`3605`: RF: Parallel `quantize_evecs`
+* :ghpull:`3613`: BF: Allow `length` to work with float16 streamlines
+* :ghpull:`3612`: BF: fix lower triangular bug introduced in #3563
+* :ghpull:`1617`: NF: added streamline clipping function to utils
+* :ghpull:`3606`: RF: Address cvxpy 1.7.0 warnings.
+* :ghpull:`3609`: Bump actions/first-interaction from 1 to 2 in the actions group
+* :ghpull:`3560`: Doc: explicit ``finalize_mask`` information in CLI tutorial
+* :ghpull:`3602`: ENH: Adopt `pathlib` for workflows
+* :ghpull:`3604`: RF: replace old LocalTracking by our new tracking interface
+* :ghpull:`3587`: RF: from TRK to TRX as default file format for tracks
+* :ghpull:`3603`: DOC: Fix workflows test utils parameter name in docstring
+* :ghpull:`3601`: DOC: Record API changes after `pathlib` adoption
+* :ghpull:`3593`: STYLE: Adopt `pathlib` for path manipulation
+* :ghpull:`3599`: TEST: Restore removed test case in io workflows
+* :ghpull:`3600`: MNT: Fix miscellaneous labeler regexes
+* :ghpull:`3597`: STYLE: Miscellaneous style fixes
+* :ghpull:`3598`: BF: Miscellaneous fixes to surfaces
+* :ghpull:`3592`: STYLE: Adopt a unified logger across the code base
+* :ghpull:`3429`: StatefulSurface - Class to handle surfaces
+* :ghpull:`3595`: DOC: Remove default arguments from docstrings
+* :ghpull:`3594`: STYLE: Miscellaneous style fixes
+* :ghpull:`3591`: STYLE: Apply `ruff` manually to all files
+* :ghpull:`3582`: NF: Add PR labeler workflow
+* :ghpull:`3586`: MNT: Change issue template file extensions
+* :ghpull:`3584`: MNT: Add GitHub issue templates
+* :ghpull:`3583`: DOC: Change unused commit prefixes to some other more useful ones
+* :ghpull:`3581`: SciPy deprecation of "disp" in optimizer
+* :ghpull:`3556`: RF: allow the saving of S0 estimate for dti workflow
+* :ghpull:`3563`: RF: Address some Zero division warnings
+* :ghpull:`3565`: RF: use multi_voxel_fit for rumba
+* :ghpull:`3541`: RF: Deprecate autocrop in median_otsu
+* :ghpull:`3580`: TEST: uncomment and update test_cross
+* :ghpull:`3515`: RF: Improve `dipy_info` printed output
+* :ghpull:`3562`: DOC: Add missing opening backtick to reference syntax.
+* :ghpull:`3561`: STYLE: Make affine variable naming consistent
+* :ghpull:`3557`: DOC: fix streamline-tools tutorial by avoiding the use of identity affine
+* :ghpull:`3559`: [RF]: Patch2self in denoising CLI tutorial
+* :ghpull:`3555`: ENH: improve dipy_info message when no reference for some streamline files.
+* :ghpull:`3554`: Doc: Fix typo in multiple tutorial
+* :ghpull:`3546`: BF: Make `StoppingCriterion` reproducible for multi-thread execution
+* :ghpull:`3548`: RF: fix typo in hcp fetcher function argument name
+* :ghpull:`3549`: BF: Improves Cython enum management.
+* :ghpull:`3520`: ENH: Opacity slider turned off on hide
+* :ghpull:`3493`: NF: allow broadcasting in dipy_math
+* :ghpull:`3488`: RF - changed min/max len from nbr pts to mm
+* :ghpull:`3538`: RF: Fixed the latex
+* :ghpull:`3519`: ENH: Horizon peaks fname support
+* :ghpull:`3455`: Fix Bugs in #3453: Ensure Correct Weight Reshaping & Consistent Extra Output in iter_fit_tensor
+* :ghpull:`3535`: CI: Ignore fork() warnings.
+* :ghpull:`3528`: DOC: Changed documentation errors in dipy.sims.voxel
+* :ghpull:`3533`: CI: introduce cached Data.
+* :ghpull:`3531`: CI: Ignore specific cvxpy warnings to avoid CI failure.
+* :ghpull:`3527`: BF: Search bar should come bigger in the center.
+* :ghpull:`3530`: STYLE: Add additional emojis to first interaction message
+* :ghpull:`3526`: Bump scientific-python/upload-nightly-action from 0.6.1 to 0.6.2 in the actions group
+* :ghpull:`3522`: FIX: Avoid division by zero on single-CPU systems (issue #3521)
+* :ghpull:`3510`: [RF]: Saving the figure in the example.
+* :ghpull:`3512`: STYLE: Call `warning` instead of the deprecated `warn` function
+* :ghpull:`3514`: DOC: Miscellaneous doc improvements
+* :ghpull:`3495`: BF: Fixing minor issue in dipy_classify_tissue dam option
+* :ghpull:`3481`: UPCOMING:  Release 1.11.0
+
+Issues (324):
+
+* :ghissue:`3844`: NF: FORCE recon model
+* :ghissue:`3503`: Create new interface for MTMS CSD and standard CSD that use Ray properly
+* :ghissue:`3617`: NF: add dipy_fit_msmtcsd cli with its tests
+* :ghissue:`3687`: BUAN Bundle Profiles Lite Version
+* :ghissue:`3849`: DOC: Fix broken and outdated links in gitwash documentation
+* :ghissue:`3850`: DOC: Fix broken and outdated links in gitwash documentation
+* :ghissue:`2766`: WIP Issue 2738 click cli refactor
+* :ghissue:`2738`: Replace our custom Argparse CLI api by Click ?
+* :ghissue:`2547`: [WIP][FIX] option to disable multithreading while multiprocessing
+* :ghissue:`3143`: [WIP][NF] Add `dipy_gtable` cli
+* :ghissue:`3679`: Build aarch64 natively
+* :ghissue:`3847`: BF: Updated sherbrooke-3shell.
+* :ghissue:`3845`: BF: improve output file management of BiasField correction CLI
+* :ghissue:`3628`: iter_fit_tensor returns {} instead of None causing KeyError in nlls_fit_tensor when return_leverages=False
+* :ghissue:`3840`: DOC: Complete missing parameters in save_polydata docstring
+* :ghissue:`3841`: DOC: Complete missing parameters in save_polydata docstring
+* :ghissue:`3689`: NF: Parallel Eudx
+* :ghissue:`3836`: DOC: Documentation fix
+* :ghissue:`3808`: RF: improve trx support for recobundles CLI
+* :ghissue:`3693`: QTI issues - lack of MIN_POSITIVE_SIGNAL and issue with constrained solver and WLS is wrong anyway
+* :ghissue:`3824`: DOC: Modernize and complete benchmarks/README.rst (and developer docs)
+* :ghissue:`3825`: DOC: Modernize and complete benchmarks/README.rst - closes #3824
+* :ghissue:`3835`: ENH: add ASV continuous benchmarking workflow
+* :ghissue:`3811`: test_io_peaks_deprecated fails - ACTUAL: 82 warnings, DESIRED: 2
+* :ghissue:`3813`: Fix #3811: reset warning filters in test_io_peaks_deprecated
+* :ghissue:`3833`: DOC: Improve docstrings for SimilarityMetric in align.metrics
+* :ghissue:`3795`: Added docs for nn and io
+* :ghissue:`3827`: Enh asv continuous benchmarks
+* :ghissue:`3814`: ENH: Ray-aware CSD and MSMT-CSD workflows (#3503, #3617)
+* :ghissue:`3807`: Fix #3502: Add ODF and Tensor visualization to dipy_horizon
+* :ghissue:`3810`: test_horizon_empty_tractogram fails - logger.warning() not caught by warnings.catch_warnings()
+* :ghissue:`3812`: Fix #3810: use warnings.warn() for empty tractogram
+* :ghissue:`3700`: RF: Simplify non-negative code in anisotropic_power
+* :ghissue:`3656`: Some tutorials do not clear the figure canvas
+* :ghissue:`3783`: Fix figure canvas not cleared in simulation tutorials
+* :ghissue:`3645`: Powermap contains negative intensities
+* :ghissue:`3699`: Qti robust
+* :ghissue:`3834`: Bump docker/setup-qemu-action from 3 to 4 in the actions group
+* :ghissue:`3830`: DOC: Fix docstring errors in dipy/io/pickles.py
+* :ghissue:`3831`: DOC: Fix docstring errors in dipy/io/pickles.py
+* :ghissue:`3820`: BF: improve rumba performance
+* :ghissue:`3818`: BF: fix future errors/warnings from the future Numpy 2.5
+* :ghissue:`3816`: RF: relax precision for affine_registration / motion_correction
+* :ghissue:`3822`: DOC: Fix lowercase 'returns' section header in _make_fetcher docstring
+* :ghissue:`3823`: DOC: Fix lowercase 'returns' section header in _make_fetcher docstring
+* :ghissue:`3805`: Bump the actions group with 2 updates
+* :ghissue:`3647`: Biasfield Correction b0 method not working correctly
+* :ghissue:`3791`: NF: update biasfield correction method.
+* :ghissue:`2427`: Document the PAM file format
+* :ghissue:`3793`: DOC: Add documentation for the PAM5 file format
+* :ghissue:`3752`: CI: Update secrets management
+* :ghissue:`3785`: Weights parameter documented twice
+* :ghissue:`3796`: updated the docstring for ls_fit_dki and cls_fit_dki
+* :ghissue:`3790`: ENH: Cythonize AK, RK, and KFA kurtosis computations
+* :ghissue:`3799`: DOC: Add tutorial for saving and loading QuickBundles clustering results
+* :ghissue:`3789`: BF: handle `force` option when using symlink and hardlink
+* :ghissue:`3774`: CI: Fix typo in test_template.yml workflow input description
+* :ghissue:`3784`: Fix typo in test_template.yml input description (closes #3774)
+* :ghissue:`3765`: NF: add cli dipy_cluster_streamlines
+* :ghissue:`3766`: RF: improve CLI help formatting
+* :ghissue:`3767`: RF: Fix multiple cli
+* :ghissue:`3759`: DOC: Standardize docstring format across modules using numpydoc conventions
+* :ghissue:`3780`: Fix `numpydoc` validation issues in `fetcher.py`
+* :ghissue:`3764`: epsilon docstring mismatch
+* :ghissue:`3781`: Fix epsilon docstring mismatch
+* :ghissue:`3778`: CI: Add manual workflow trigger (workflow_dispatch) to test.yml
+* :ghissue:`3779`: CI: Add manual workflow trigger (workflow_dispatch) to test.yml
+* :ghissue:`3775`: CI: Add pip caching to build_docs.yml
+* :ghissue:`3776`: CI: Add pip caching to build_docs.yml
+* :ghissue:`3772`: CI: Add concurrency group to build_docs.yml
+* :ghissue:`3773`: CI: Add concurrency group to build_docs.yml
+* :ghissue:`3770`: Add a Pull Request template to standardize PR descriptions
+* :ghissue:`3771`: docs: Add a pull request template to standardize PR submissions.
+* :ghissue:`3768`: CI: Add workflow to clean up GitHub Actions caches on closed PRs
+* :ghissue:`3769`: CI: Add workflow to clean up GitHub Actions caches on closed PRs
+* :ghissue:`3777`:  CI: Add manual workflow trigger (workflow_dispatch) to test.yml
+* :ghissue:`3762`: NF: add new CLI dipy_brain_mask with its associated test
+* :ghissue:`3760`: [DOC] Fix typos and grammatical errors in documentation and code
+* :ghissue:`3761`:  [DOC] Fix grammatical errors and typos across documentation and codebase
+* :ghissue:`3753`: DOC: Typo in gitwash development_workflow guide
+* :ghissue:`3754`: DOC: Typo in gitwash development_workflow guide
+* :ghissue:`3757`: DOC: Fix missing space in `load_peaks` deprecation message
+* :ghissue:`3758`: DOC: Fix missing space in `load_peaks` deprecation message
+* :ghissue:`3755`: DOC: Update Gitter link to Matrix invite link
+* :ghissue:`3756`: DOC: Remove Gitter link
+* :ghissue:`3704`: Fix get simplified backward transform
+* :ghissue:`3751`: Fixed Github Workflow Issues
+* :ghissue:`3745`: Replace legacy nose-style `yield assert_raises` with `pytest.raises`
+* :ghissue:`3746`: TST: Replace legacy nose-style `yield assert_raises` with `pytest.raises`
+* :ghissue:`3750`: Update setuptools requirement from ~=69.5 to >=69.5,<83.0 in the python-dependencies group
+* :ghissue:`3738`: CI: Missing top-level permissions in CI workflow files
+* :ghissue:`3739`: CI: Add top-level permissions for least-privilege security
+* :ghissue:`3734`: CI: Benchmark workflow triggers on all pushes/PRs instead of master only
+* :ghissue:`3735`: CI: Restrict benchmark workflow triggers to master branch
+* :ghissue:`3732`: CI: Dependabot only monitors GitHub Actions, not pip dependencies
+* :ghissue:`3733`: CI: Add pip ecosystem tracking to Dependabot configuration
+* :ghissue:`3731`: MNT: Remove dead install type code paths from install.sh
+* :ghissue:`3728`: CI: Benchmark threading env vars don't persist to the benchmarking step
+* :ghissue:`3729`: CI: Fix threading env vars not persisting across steps in benchmark.yml
+* :ghissue:`3727`: CI: Update stale dependency pins in CI configuration
+* :ghissue:`3723`: CI: first_interaction.yml action pinned by tag instead of SHA on pull_request_target trigger
+* :ghissue:`3722`: CI: Pin actions/first-interaction by commit SHA in first_interaction.yml
+* :ghissue:`3720`: CI: label-pr.yml uses third-party action pinned by tag on pull_request_target trigger
+* :ghissue:`3721`: CI: Pin srvaroa/labeler action by commit SHA in label-pr.yml
+* :ghissue:`3718`: DOC: CONTRIBUTING.md references Travis CI instead of GitHub Actions
+* :ghissue:`3719`:  DOC: Update outdated Travis CI reference to GitHub Actions in CONTRIBUTING.md
+* :ghissue:`3717`: CI: Invalid cron schedule in test.yml runs ~1-2x/year instead of monthly
+* :ghissue:`3716`: CI: Fix invalid cron schedule in test.yml
+* :ghissue:`3714`: CI: Add missing timeout-minutes to workflow jobs
+* :ghissue:`3715`: CI: Add missing timeout-minutes to workflow jobs
+* :ghissue:`3749`: RF: Updated the list provide a table of dataset names.
+* :ghissue:`3724`: CI: Duplicate step names in nightly.yml upload_anaconda job make logs confusing
+* :ghissue:`3725`: CI: Rename duplicate 'Upload wheel' steps in nightly.yml for clarity
+* :ghissue:`3747`: Missing `__all__` exports in subpackage `__init__.py` files
+* :ghissue:`3748`: STY: Add missing `__all__` exports to subpackage `__init__.py` files
+* :ghissue:`3740`: Bump srvaroa/labeler from 1.13.0 to 1.14.0 in the actions group
+* :ghissue:`3741`: Replace deprecated `numpy.testing.assert_()` with plain `assert`
+* :ghissue:`3742`: TST: Replace deprecated `npt.assert_()` with plain `assert`
+* :ghissue:`3743`: Replace deprecated `assert_almost_equal` / `assert_array_almost_equal` with `assert_allclose`
+* :ghissue:`3744`: TST: Replace deprecated `assert_almost_equal` / `assert_array_almost_equal` with `assert_allclose`
+* :ghissue:`3736`: DOC: Remaining insecure `http://` URLs should be migrated to `https://`
+* :ghissue:`3737`:  DOC: Migrate remaining `http://` URLs to `https://`
+* :ghissue:`3710`: CI: Fix incorrect Cython file glob patterns in labeler.yml
+* :ghissue:`3711`: CI: Fix incorrect Cython file glob patterns in labeler.yml
+* :ghissue:`3708`: STYLE: Fix spelling mistakes in docstrings and comments
+* :ghissue:`3709`: STYLE: Fix spelling mistakes in docstrings and comments
+* :ghissue:`3712`: #CI: Remove duplicate `.mailmap` entry in labeler.yml
+* :ghissue:`3713`: CI: Remove duplicate .mailmap entry in labeler.yml
+* :ghissue:`3706`: RF: Add alternative to symlink for some  CLI
+* :ghissue:`3688`: dipy_horizon with Empty Streamline File
+* :ghissue:`3696`: BF: Handle empty tractograms gracefully in horizon
+* :ghissue:`3701`: Revert temporary suppression of SCS CSC conversion warning
+* :ghissue:`3697`: Fix dipy_horizon crash on empty tractogram files
+* :ghissue:`3694`: DOC: Fix numpydoc PR03 parameter order in path_length
+* :ghissue:`2760`: TRX integration
+* :ghissue:`3692`: DOC: Fixed DOC CI Issue
+* :ghissue:`3675`: Adding synthseg pytorch model
+* :ghissue:`3683`: DIPY_SLR Breaking with Wrong Error
+* :ghissue:`3686`: BF: Handle empty streamlines in slr_with_qbx after length filtering
+* :ghissue:`3684`: RF: address some edge cases in multiple workflows
+* :ghissue:`3222`: Issue with CWLS in dki
+* :ghissue:`3405`: Follow up for the Iteratively reweighted least squares
+* :ghissue:`3681`: Examples for IRLS (robust fitting)
+* :ghissue:`3516`: Do not require FURY to show information from a VTK/VTP tractography files
+* :ghissue:`2538`: [WIP] Registration public API for multi-slice 2D data
+* :ghissue:`3685`: DOC: fix some missing `:footcite:p` in documentation
+* :ghissue:`3671`: Increased speed and lisibility of connectivity matrix, added weights
+* :ghissue:`3680`: RF: Added max_version option to optional_package api.
+* :ghissue:`3682`: TST: Add interface tests for pure Python DirectionGetter implementations
+* :ghissue:`3677`: DOC: Fix file path in many tutorials.
+* :ghissue:`3676`: RF: Allow reslice to automatically determines isotropic resolution
+* :ghissue:`3678`: Build 3.14 nightly wheels
+* :ghissue:`3664`: DOC: Improve Horizon class docstring for clarity
+* :ghissue:`3665`: FIX: Correct path construction logic in fetcher data loader, Resolve path construction errors in read_bundles_2_subjects
+* :ghissue:`3673`: RF: Allow bvals file for medianOtsu workflow
+* :ghissue:`3674`: Bump scientific-python/upload-nightly-action from 0.6.2 to 0.6.3 in the actions group
+* :ghissue:`3542`: RF: Editing tranform_img in dipy.nn.utils
+* :ghissue:`3670`: Test: Add regression test for median_otsu autocrop deprecation
+* :ghissue:`3668`: MNT: Replace deprecated autocrop in brain_extraction_dwi.py, reconst_csa.py, reconst_csa_parallel.py, reconst_dti.py tutorial examples
+* :ghissue:`3672`: Bump the actions group with 3 updates
+* :ghissue:`3669`: DOC: Prefer BibTeX reference in GQSI example documentation
+* :ghissue:`3643`: Document pre-commit setup
+* :ghissue:`3657`: Document pre-commit setup for developers
+* :ghissue:`3667`: MNT: Replace deprecated autocrop in reconst_dti.py
+* :ghissue:`3439`: data fetching: problem with UW server ?
+* :ghissue:`3659`: NF: Intermediate map for symmetric diffeomorphic registration
+* :ghissue:`3397`: Adding Python Code Example for DIPY Horizon in Tutorials
+* :ghissue:`3660`: DOC: Programmatic DIPY Horizon usage (non-CLI)
+* :ghissue:`2950`: Clean up the non-local means denoising modules
+* :ghissue:`1259`: nlmeans does not respect boundaries
+* :ghissue:`1224`: Memory issue
+* :ghissue:`1131`: new non_local_means module seems to disregard 3D array of noise standard deviation
+* :ghissue:`1178`: Recheck indexing with nlmeans as some of it is indexing wrong positions
+* :ghissue:`3623`: RF: refactoring of ``nlmeans`` to allow the selection our classic version and the blockwise version
+* :ghissue:`3661`: CI: simplify cache, too many data was cached
+* :ghissue:`3662`: Bump actions/checkout from 5 to 6 in the actions group
+* :ghissue:`3552`: BF: Discards streamlines by size
+* :ghissue:`3652`: NF:  Reduce default iteration counts and make level_iters configurable in motion correction
+* :ghissue:`3618`: BF: manage empty file in dipy_slr cli to avoid enigmatic crash
+* :ghissue:`3655`: CI: remove fetch-data job
+* :ghissue:`3658`: Added interpolation parameter to dipy_apply_transform
+* :ghissue:`3621`: filename for statefulsurface and statefultractogram cannot have period in them anymore
+* :ghissue:`3648`: Revert split extension (for SFT and SFS)
+* :ghissue:`3636`: Bug with use of where
+* :ghissue:`3654`: RF: fix warnings introduced by the future Numpy version 2.4
+* :ghissue:`3651`: RF: handle bingham tests warnings
+* :ghissue:`3653`: RF: Fix imports in reconst
+* :ghissue:`3640`: First interaction workflow doesn't work
+* :ghissue:`3650`: BF: update first interaction Github action parameters
+* :ghissue:`3649`: Bump the actions group with 2 updates
+* :ghissue:`3638`: UnboundLocalError: local variable 'fits' referenced before assignment
+* :ghissue:`3635`: BF: Fix CVXPY warning
+* :ghissue:`3646`: [BF] Fix fwdti
+* :ghissue:`3639`: fix: BUG: fix UnboundLocalError in _single_sf_to_bingham when no valid peaks found
+* :ghissue:`3610`: NF: add dipy_fit_powermap workflows with its associated tests
+* :ghissue:`2087`: Single-shell Free Water DTI (Object Oriented)
+* :ghissue:`3634`: BF: expand requirements during its generation
+* :ghissue:`3425`: NF: add FWDTI Workflow
+* :ghissue:`2137`: Deep-learning-based registration example
+* :ghissue:`3631`: RF: Fixed weird volumes instead of denoised volumes in Patch2Self 3
+* :ghissue:`3633`: Patch2Self CLI provides wrong doc string for version
+* :ghissue:`3539`: FOSR implementation in Python for tractometry
+* :ghissue:`3629`: Bump actions/setup-python from 5 to 6 in the actions group
+* :ghissue:`3625`: docs: remove NeuroFedora
+* :ghissue:`3424`: NF: Automate requirement files
+* :ghissue:`3624`: Bump the actions group with 3 updates
+* :ghissue:`3605`: RF: Parallel `quantize_evecs`
+* :ghissue:`3613`: BF: Allow `length` to work with float16 streamlines
+* :ghissue:`3608`: Predicting from a fitted DTI model is broken?
+* :ghissue:`3612`: BF: fix lower triangular bug introduced in #3563
+* :ghissue:`3588`: In-house QP solver using numba for fitting MSMT
+* :ghissue:`1617`: NF: added streamline clipping function to utils
+* :ghissue:`3606`: RF: Address cvxpy 1.7.0 warnings.
+* :ghissue:`3609`: Bump actions/first-interaction from 1 to 2 in the actions group
+* :ghissue:`3551`: Shutting down the gitter live chat ?
+* :ghissue:`1164`: Parallel quantize_evecs + PEP8
+* :ghissue:`3124`: ENH: Add commentary on median otsu tutorial/change default parameters
+* :ghissue:`3560`: Doc: explicit ``finalize_mask`` information in CLI tutorial
+* :ghissue:`3602`: ENH: Adopt `pathlib` for workflows
+* :ghissue:`3604`: RF: replace old LocalTracking by our new tracking interface
+* :ghissue:`3506`: Make sure .trx is default everywhere
+* :ghissue:`3587`: RF: from TRK to TRX as default file format for tracks
+* :ghissue:`3603`: DOC: Fix workflows test utils parameter name in docstring
+* :ghissue:`3601`: DOC: Record API changes after `pathlib` adoption
+* :ghissue:`3593`: STYLE: Adopt `pathlib` for path manipulation
+* :ghissue:`3599`: TEST: Restore removed test case in io workflows
+* :ghissue:`3600`: MNT: Fix miscellaneous labeler regexes
+* :ghissue:`3597`: STYLE: Miscellaneous style fixes
+* :ghissue:`3598`: BF: Miscellaneous fixes to surfaces
+* :ghissue:`3592`: STYLE: Adopt a unified logger across the code base
+* :ghissue:`3596`: NF - Add DirectionGetter for Flocking Tractography
+* :ghissue:`3429`: StatefulSurface - Class to handle surfaces
+* :ghissue:`3595`: DOC: Remove default arguments from docstrings
+* :ghissue:`3594`: STYLE: Miscellaneous style fixes
+* :ghissue:`3513`: STYLE: Log message instead of printing orphan string
+* :ghissue:`3591`: STYLE: Apply `ruff` manually to all files
+* :ghissue:`3582`: NF: Add PR labeler workflow
+* :ghissue:`3586`: MNT: Change issue template file extensions
+* :ghissue:`3584`: MNT: Add GitHub issue templates
+* :ghissue:`3583`: DOC: Change unused commit prefixes to some other more useful ones
+* :ghissue:`3581`: SciPy deprecation of "disp" in optimizer
+* :ghissue:`3556`: RF: allow the saving of S0 estimate for dti workflow
+* :ghissue:`3497`: dipy_fit_dti does not return S0 estimate
+* :ghissue:`3418`: Division by 0 warning
+* :ghissue:`3563`: RF: Address some Zero division warnings
+* :ghissue:`3352`: Rumba and multivoxel fit decorator
+* :ghissue:`3565`: RF: use multi_voxel_fit for rumba
+* :ghissue:`3537`: Remove autocrop from median_otsu
+* :ghissue:`3541`: RF: Deprecate autocrop in median_otsu
+* :ghissue:`2866`: arm64 test failure with numpy 1.24.2
+* :ghissue:`3580`: TEST: uncomment and update test_cross
+* :ghissue:`1776`: make it really easy for DiPy to call graspy functions
+* :ghissue:`2269`: Allow dipy_fit_dti Workflow to Use Native Orientation of Provided Mask Image
+* :ghissue:`2682`: DIPY Free-Water Corrected DTI (FA output quality)
+* :ghissue:`2428`: dipy.align.reslice
+* :ghissue:`2399`: fitting free water mapping out of iterations
+* :ghissue:`2319`: Reconstruction with MSMT CSD example resulted in Nan values
+* :ghissue:`2329`: Slice to volume registration
+* :ghissue:`1974`: MAP-MRI optimization & validation errors
+* :ghissue:`2612`: Mean Diffusivity turns out low in CSF when reconstructing using ReconstDtiFlow
+* :ghissue:`687`: Refactor imaffine class structure.
+* :ghissue:`706`: Thoughts about using the SyN algorithm
+* :ghissue:`2184`: discussion: continuous integration using GPUs
+* :ghissue:`1991`: [DISCUSSION] b-tensor encoding gradient table format
+* :ghissue:`2186`: Pure-python implementation of boundary-based registration (BBR)?
+* :ghissue:`1852`: Telemetry
+* :ghissue:`2338`: Team DIPY Citations
+* :ghissue:`2663`: Plotting tensors in Fury: issue with right-handed coordinate system?
+* :ghissue:`3515`: RF: Improve `dipy_info` printed output
+* :ghissue:`2850`: Orthogonal Tensor Parameter (Moment) Maps
+* :ghissue:`1886`: NF - add the option to save the last point of streamlines
+* :ghissue:`3562`: DOC: Add missing opening backtick to reference syntax.
+* :ghissue:`3561`: STYLE: Make affine variable naming consistent
+* :ghissue:`3382`: Check use of affine in `streamline_tools` example
+* :ghissue:`3557`: DOC: fix streamline-tools tutorial by avoiding the use of identity affine
+* :ghissue:`2473`: Add Patch2self in our denoising CLI tutorial
+* :ghissue:`3559`: [RF]: Patch2self in denoising CLI tutorial
+* :ghissue:`2695`: Replace CENIR multishell with HBN POD2 data
+* :ghissue:`2728`: Do we have multi_processes method for streamline extraction
+* :ghissue:`2848`: Noise estimation of T1 brain MR images
+* :ghissue:`3500`: dipy_fit_csa does not use num_processes
+* :ghissue:`3517`: `dipy_info` provides misleading message when no reference is provided
+* :ghissue:`3555`: ENH: improve dipy_info message when no reference for some streamline files.
+* :ghissue:`3554`: Doc: Fix typo in multiple tutorial
+* :ghissue:`3413`: Tutorial Typos
+* :ghissue:`3492`: BF: Peaks working with world coordinates.
+* :ghissue:`1249`: Bias correction for local pca
+* :ghissue:`823`: WIP: "Out-of-core" LiFE
+* :ghissue:`3540`: Tractography with GFA as stopping criterion is not reproducible across runs
+* :ghissue:`3546`: BF: Make `StoppingCriterion` reproducible for multi-thread execution
+* :ghissue:`3545`: ENH: Add `StopingCriterion` reproducibility test
+* :ghissue:`3548`: RF: fix typo in hcp fetcher function argument name
+* :ghissue:`3549`: BF: Improves Cython enum management.
+* :ghissue:`3507`: Extract b0 interface throws value error with HCP 7T (MGH) - subject 1007
+* :ghissue:`3474`: Filenames missing in horizon for peaks objects
+* :ghissue:`3520`: ENH: Opacity slider turned off on hide
+* :ghissue:`3544`: ENH: Add `StopingCriterion` reproducibility test
+* :ghissue:`3493`: NF: allow broadcasting in dipy_math
+* :ghissue:`3488`: RF - changed min/max len from nbr pts to mm
+* :ghissue:`3536`: FA latex formula does not show correctly on DTI tutorial
+* :ghissue:`3538`: RF: Fixed the latex
+* :ghissue:`3519`: ENH: Horizon peaks fname support
+* :ghissue:`1404`: RF - DirectionGetter.get_direction function return
+* :ghissue:`3453`: Inconistancy between documentation and implementation on dipy.reconst.dti.nlls_fit_tensor
+* :ghissue:`3455`: Fix Bugs in #3453: Ensure Correct Weight Reshaping & Consistent Extra Output in iter_fit_tensor
+* :ghissue:`3535`: CI: Ignore fork() warnings.
+* :ghissue:`3501`: Probabilistic reference in docs seems incorrect
+* :ghissue:`3336`: Simplify CIs
+* :ghissue:`3528`: DOC: Changed documentation errors in dipy.sims.voxel
+* :ghissue:`3533`: CI: introduce cached Data.
+* :ghissue:`3531`: CI: Ignore specific cvxpy warnings to avoid CI failure.
+* :ghissue:`2494`: Potential speed up for the data fetchers
+* :ghissue:`3527`: BF: Search bar should come bigger in the center.
+* :ghissue:`3530`: STYLE: Add additional emojis to first interaction message
+* :ghissue:`3526`: Bump scientific-python/upload-nightly-action from 0.6.1 to 0.6.2 in the actions group
+* :ghissue:`3521`: Division by zero when machine has a single CPU
+* :ghissue:`3522`: FIX: Avoid division by zero on single-CPU systems (issue #3521)
+* :ghissue:`3510`: [RF]: Saving the figure in the example.
+* :ghissue:`3512`: STYLE: Call `warning` instead of the deprecated `warn` function
+* :ghissue:`3514`: DOC: Miscellaneous doc improvements
+* :ghissue:`3508`: New disco tracking tutorial not available in docs
+* :ghissue:`3495`: BF: Fixing minor issue in dipy_classify_tissue dam option
+* :ghissue:`3494`: publish wheels
+* :ghissue:`3481`: UPCOMING:  Release 1.11.0

--- a/doc/stateoftheart.rst
+++ b/doc/stateoftheart.rst
@@ -28,6 +28,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/release1.12
    release_notes/release1.11
    release_notes/release1.10
    release_notes/release1.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     'Operating System :: Unix',
     'Operating System :: MacOS',
 ]
-version = "1.12.0.dev0"
+version = "1.12.0"
 dependencies = [
     "numpy>=1.22.4",
     "scipy>=1.8",
@@ -206,14 +206,15 @@ Environments = [
 ]
 
 "Documentation" = [
-    "spin.cmds.meson.docs",
-    # ".spin/cmds.py:docs"
+    ".spin/cmds.py:docs",
 ]
 Metrics = [
     ".spin/cmds.py:bench",
     # ".spin/cmds.py:coverage
 ]
-# TODO: Add custom commands
+Release = [
+    ".spin/cmds.py:prepare_release",
+]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=dipy/testing/decorators.py --ignore-glob='bench*.py' --ignore-glob=**/benchmarks/*"

--- a/tools/doctest_extmods.py
+++ b/tools/doctest_extmods.py
@@ -10,14 +10,14 @@ Examples
     %prog dipy
 """
 
-from distutils.sysconfig import get_config_vars
 import doctest
 from optparse import OptionParser
 import os
 from os.path import abspath, dirname, join as pjoin, relpath, sep
+import sysconfig
 import sys
 
-EXT_EXT = get_config_vars('SO')[0]
+EXT_EXT = sysconfig.get_config_var('EXT_SUFFIX')
 
 
 def get_ext_modules(pkg_name):


### PR DESCRIPTION
Preparation for 1.12.0 release, targeting **August 22, 2025**

# Desired PR / issues (need review / feedback / update)

## PR

- [x] #3618
- [x] #3610 
- [ ] #3617

## Issues/Features without PR yet

- [x] https://github.com/dipy/dipy/issues/3621

Most of them can be done on time, I think :smile:

Please comment to flag any other issues or PR that should be addressed for this release

# Release checklist
- [ ] add release_notes 1.12.0
- [ ] Update changelog and api_changes
- [ ] Update .mailmap
- [ ] Set release number in info.py
- [ ] Check the copyright years in doc/conf.py and LICENSE
- [ ] Check documentation
- [ ] Check Tutorial
- [ ] Check unit test and USE-PRE
- [ ] Update index.rst
- [ ] Update Highligth.rst, old_news.rst, stateofheart.rst
- [ ] Update developers.rst list
- [ ] Update website
- [ ] Update deprecation cycle remove long deprecation