### PR TITLE
docs: remove NeuroFedora

### DIFF
--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -33,7 +33,6 @@
 .. _pip: https://www.pip-installer.org/en/latest/
 .. _easy_install: https://pypi.python.org/pypi/setuptools
 .. _homebrew: https://brew.sh/
-.. _neurofedora: https://neuro.fedoraproject.org/
 
 .. Documentation tools
 .. _graphviz: https://www.graphviz.org/

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -117,11 +117,6 @@ For Debian, Ubuntu and Mint set up the NeuroDebian_ repositories - see
 
     sudo apt-get install python-dipy
 
-In Fedora DIPY can be installed from the main repositories courtesy of
-NeuroFedora_::
-
-    sudo dnf install python3-dipy
-
 We hope to get packages for the other Linux distributions, but for now, please
 try :ref:`install-pip` instead.
 


### PR DESCRIPTION
NeuroFedora has moved to testing Python packages on Fedora instead of packaging them:

https://neuroblog.fedoraproject.org/2025/08/02/packaging-changes-at-neurofedora.html

List of tested neuroimaging software is here:

https://docs.fedoraproject.org/en-US/neurofedora/imaging-tools/

(dipy has been added, will be on the list by the end of the day once the doc generation pipeline has run again)