### PR TITLE
CI: simplify cache, too many data was cached

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -123,10 +123,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.dipy
-        key: dipy-data-${{ runner.os }}-${{ hashFiles('dipy/data/fetcher.py') }}
+        key: dipy-downloaded-data-${{ hashFiles('dipy/data/fetcher.py') }}
         restore-keys: |
-          dipy-data-${{ runner.os }}-
-          dipy-data-
+          dipy-downloaded-data-
     - name: Install DIPY
       run: |
         if [ "${{ inputs.use-pre }}" == "true" ]; then


### PR DESCRIPTION
Some CI's are failing due to lack of space. 

This pull request makes a small update to the caching configuration in the GitHub Actions workflow. The cache key and restore-keys for DIPY data have been renamed for clarity.

- Updated the cache `key` and `restore-keys` in `.github/workflows/test_template.yml` from `dipy-data-*` to `dipy-downloaded-data-*` to improve naming consistency and clarity.