### PR TITLE
MNT: Replace deprecated autocrop in reconst_dti.py

### DIFF
--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -96,12 +96,22 @@ First of all, we mask and crop the data. This is a quick way to avoid
 calculating Tensors on the background of the image. This is done using DIPY_'s
 ``mask`` module.
 """
-
-from dipy.segment.mask import median_otsu
+from dipy.segment.mask import median_otsu, crop, bounding_box
 
 maskdata, mask = median_otsu(
-    data, vol_idx=range(10, 50), median_radius=3, numpass=1, autocrop=True, dilate=2
+    data, vol_idx=range(10, 50), median_radius=3, numpass=1, dilate=2
 )
+
+mins, maxs = bounding_box(mask)
+
+"""
+The ``bounding_box`` function returns the minimum and maximum indices of the
+non-zero voxels in every dimension. We use these indices to crop the data
+and mask to the smallest possible region that contains all the non-zero voxels.
+"""
+
+maskdata = crop(maskdata, mins, maxs)
+mask = crop(mask, mins, maxs)
 print(f"maskdata.shape {maskdata.shape}")
 
 """


### PR DESCRIPTION
## Description
The `autocrop` parameter in `median_otsu` was deprecated in version 1.11.0 and will be removed in 1.13.0. This causes an `ArgsDeprecationWarning` when running the `reconst_dti.py` example.

This PR replaces the deprecated argument with an explicit call to the `crop()` function using the bounding box from the mask. This removes the warning while maintaining identical behavior.

## Changes
- Removed `autocrop=True` from `median_otsu` call in `doc/examples/reconst_dti.py`.
- Added `bounding_box` calculation on the mask.
- Applied `crop()` to both `maskdata` and `mask` using the calculated indices.
- Updated the example documentation to explain the new cropping step.

## Verification
- [x] Ran the example script locally (`python doc/examples/reconst_dti.py`).
- [x] Confirmed the `ArgsDeprecationWarning` is gone.
- [x] Verified the output shape of `maskdata` remains `(71, 88, 62, 160)` (consistent with previous behavior).
- [x] Confirmed output images (`tensor_ellipsoids.png`, `tensor_odfs.png`) are generated correctly.