### PR TITLE
Test: Add regression test for median_otsu autocrop deprecation

### DIFF
--- a/dipy/segment/tests/test_mask.py
+++ b/dipy/segment/tests/test_mask.py
@@ -115,4 +115,6 @@ def test_median_otsu():
     assert_raises(ValueError, median_otsu, data2)
 
     with pytest.warns(ArgsDeprecationWarning, match=r"autocrop"):
-        median_otsu(data2, median_radius=3, numpass=2, vol_idx=[0, 1], dilate=2, autocrop=True)
+        median_otsu(
+            data2, median_radius=3, numpass=2, vol_idx=[0, 1], dilate=2, autocrop=True
+        )

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -86,6 +86,7 @@ signal, sticks = multi_tensor(
 signal_noisy, sticks = multi_tensor(
     gtab, mevals, S0=100, angles=angles, fractions=fractions, snr=20
 )
+plt.figure()
 
 plt.plot(signal, label="noiseless")
 


### PR DESCRIPTION
## Description
This PR adds a regression test to `dipy/segment/tests/test_mask.py`. It ensures that the `autocrop` parameter in `median_otsu` correctly raises an `ArgsDeprecationWarning`.

This addresses the request by @jhlegarreta in #3667  to ensure the warning remains active and checked until version 1.13 is released.

## Changes
- Modified `dipy/segment/tests/test_mask.py`:
    - Added a `pytest.warns` block inside `test_median_otsu` to catch `ArgsDeprecationWarning` when `autocrop=True` is used.
    - Included a specific match for the string "autocrop" to ensure the correct warning is caught.

## Verification
- [x] Ran `pytest dipy/segment/tests/test_mask.py` locally.
- [x] **Green Test:** Confirmed the test passes when `autocrop=True` is present and respectively fails when `autocrop' is missed.