### PR TITLE
RF: Allow bvals file for medianOtsu workflow

### DIFF
--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -6,8 +6,6 @@ import time
 import numpy.testing as npt
 
 from dipy.data import get_fnames
-from dipy.testing import assert_warns
-from dipy.utils.deprecator import ArgsDeprecationWarning
 from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.workflow import Workflow
 
@@ -18,8 +16,7 @@ def test_force_overwrite():
         mo_flow = MedianOtsuFlow(output_strategy="absolute")
 
         # Generate the first results
-        with assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         first_time = os.path.getmtime(mask_file)
 
@@ -34,8 +31,7 @@ def test_force_overwrite():
         # Make sure that at least one second elapsed, so that time-stamp is
         # different (sometimes measured in whole seconds)
         time.sleep(1)
-        with assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
+        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         third_time = os.path.getmtime(mask_file)
         assert third_time != second_time


### PR DESCRIPTION
This PR add bvals files as an option to define the volume index for the median otsu algorithms.

This bring a bit of automation for this CLI instead of doing this step manually (until now). Associated tests has been added.

1. Support for bvalues_files parameter to automatically use b0 vo…lumes. 
2. Warning when both vol_idx and bvalues_files are provided.
3. improves autocrop deprecation management
