### PR TITLE
DOC: Fix file path in many tutorials.

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -29,7 +29,7 @@ from dipy.utils.optpkg import TripWire, optional_package
 
 # Set a user-writeable file-system location to put files:
 if "DIPY_HOME" in os.environ:
-    dipy_home = os.environ["DIPY_HOME"]
+    dipy_home = Path(os.environ["DIPY_HOME"])
 else:
     dipy_home = Path("~").expanduser() / ".dipy"
 
@@ -522,7 +522,7 @@ def _make_fetcher(
 
 fetch_isbi2013_2shell = _make_fetcher(
     "fetch_isbi2013_2shell",
-    Path(dipy_home) / "isbi2013",
+    dipy_home / "isbi2013",
     UW_RW_URL + "1773/38465/",
     ["phantom64.nii.gz", "phantom64.bval", "phantom64.bvec"],
     [Path("phantom64.nii.gz"), Path("phantom64.bval"), Path("phantom64.bvec")],
@@ -537,7 +537,7 @@ fetch_isbi2013_2shell = _make_fetcher(
 
 fetch_stanford_labels = _make_fetcher(
     "fetch_stanford_labels",
-    Path(dipy_home) / "stanford_hardi",
+    dipy_home / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["aparc-reduced.nii.gz", "label_info.txt"],
     [Path("aparc-reduced.nii.gz"), Path("label_info.txt")],
@@ -547,7 +547,7 @@ fetch_stanford_labels = _make_fetcher(
 
 fetch_sherbrooke_3shell = _make_fetcher(
     "fetch_sherbrooke_3shell",
-    Path(dipy_home) / "sherbrooke_3shell",
+    dipy_home / "sherbrooke_3shell",
     UW_RW_URL + "1773/38475/",
     ["HARDI193.nii.gz", "HARDI193.bval", "HARDI193.bvec"],
     [Path("HARDI193.nii.gz"), Path("HARDI193.bval"), Path("HARDI193.bvec")],
@@ -562,7 +562,7 @@ fetch_sherbrooke_3shell = _make_fetcher(
 
 fetch_stanford_hardi = _make_fetcher(
     "fetch_stanford_hardi",
-    Path(dipy_home) / "stanford_hardi",
+    dipy_home / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["dwi.nii.gz", "dwi.bvals", "dwi.bvecs"],
     [Path("HARDI150.nii.gz"), Path("HARDI150.bval"), Path("HARDI150.bvec")],
@@ -576,7 +576,7 @@ fetch_stanford_hardi = _make_fetcher(
 
 fetch_resdnn_tf_weights = _make_fetcher(
     "fetch_resdnn_tf_weights",
-    Path(dipy_home) / "histo_resdnn_weights",
+    dipy_home / "histo_resdnn_weights",
     "https://ndownloader.figshare.com/files/",
     ["22736240"],
     [Path("resdnn_weights_mri_2018.h5")],
@@ -586,7 +586,7 @@ fetch_resdnn_tf_weights = _make_fetcher(
 
 fetch_resdnn_torch_weights = _make_fetcher(
     "fetch_resdnn_torch_weights",
-    Path(dipy_home) / "histo_resdnn_weights",
+    dipy_home / "histo_resdnn_weights",
     "https://ndownloader.figshare.com/files/",
     ["50019429"],
     [Path("histo_weights.pth")],
@@ -596,7 +596,7 @@ fetch_resdnn_torch_weights = _make_fetcher(
 
 fetch_synb0_weights = _make_fetcher(
     "fetch_synb0_weights",
-    Path(dipy_home) / "synb0",
+    dipy_home / "synb0",
     "https://ndownloader.figshare.com/files/",
     ["36379914", "36379917", "36379920", "36379923", "36379926"],
     [
@@ -618,7 +618,7 @@ fetch_synb0_weights = _make_fetcher(
 
 fetch_synb0_test = _make_fetcher(
     "fetch_synb0_test",
-    Path(dipy_home) / "synb0",
+    dipy_home / "synb0",
     "https://ndownloader.figshare.com/files/",
     ["36379911", "36671850"],
     [Path("test_input_synb0.npz"), Path("test_output_synb0.npz")],
@@ -628,7 +628,7 @@ fetch_synb0_test = _make_fetcher(
 
 fetch_deepn4_tf_weights = _make_fetcher(
     "fetch_deepn4_tf_weights",
-    Path(dipy_home) / "deepn4",
+    dipy_home / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["44673313"],
     [Path("model_weights.h5")],
@@ -638,7 +638,7 @@ fetch_deepn4_tf_weights = _make_fetcher(
 
 fetch_deepn4_torch_weights = _make_fetcher(
     "fetch_deepn4_torch_weights",
-    Path(dipy_home) / "deepn4",
+    dipy_home / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["52285805"],
     [Path("deepn4_torch_weights")],
@@ -648,7 +648,7 @@ fetch_deepn4_torch_weights = _make_fetcher(
 
 fetch_deepn4_test = _make_fetcher(
     "fetch_deepn4_test",
-    Path(dipy_home) / "deepn4",
+    dipy_home / "deepn4",
     "https://ndownloader.figshare.com/files/",
     ["60270698"],
     ["d4_data.npz"],
@@ -658,7 +658,7 @@ fetch_deepn4_test = _make_fetcher(
 
 fetch_evac_tf_weights = _make_fetcher(
     "fetch_evac_tf_weights",
-    Path(dipy_home) / "evac",
+    dipy_home / "evac",
     "https://ndownloader.figshare.com/files/",
     ["43037191"],
     [Path("evac_default_weights.h5")],
@@ -668,7 +668,7 @@ fetch_evac_tf_weights = _make_fetcher(
 
 fetch_evac_torch_weights = _make_fetcher(
     "fetch_evac_torch_weights",
-    Path(dipy_home) / "evac",
+    dipy_home / "evac",
     "https://ndownloader.figshare.com/files/",
     ["50019432"],
     [Path("evac_weights.pth")],
@@ -678,7 +678,7 @@ fetch_evac_torch_weights = _make_fetcher(
 
 fetch_evac_test = _make_fetcher(
     "fetch_evac_test",
-    Path(dipy_home) / "evac",
+    dipy_home / "evac",
     "https://ndownloader.figshare.com/files/",
     ["60275369"],
     ["evac_test_data.npz"],
@@ -688,7 +688,7 @@ fetch_evac_test = _make_fetcher(
 
 fetch_stanford_t1 = _make_fetcher(
     "fetch_stanford_t1",
-    Path(dipy_home) / "stanford_hardi",
+    dipy_home / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["t1.nii.gz"],
     ["t1.nii.gz"],
@@ -697,7 +697,7 @@ fetch_stanford_t1 = _make_fetcher(
 
 fetch_stanford_pve_maps = _make_fetcher(
     "fetch_stanford_pve_maps",
-    Path(dipy_home) / "stanford_hardi",
+    dipy_home / "stanford_hardi",
     "https://stacks.stanford.edu/file/druid:yx282xq2090/",
     ["pve_csf.nii.gz", "pve_gm.nii.gz", "pve_wm.nii.gz"],
     [Path("pve_csf.nii.gz"), Path("pve_gm.nii.gz"), Path("pve_wm.nii.gz")],
@@ -710,7 +710,7 @@ fetch_stanford_pve_maps = _make_fetcher(
 
 fetch_stanford_tracks = _make_fetcher(
     "fetch_stanford_tracks",
-    Path(dipy_home) / "stanford_hardi",
+    dipy_home / "stanford_hardi",
     "https://raw.githubusercontent.com/dipy/dipy_datatest/main/",
     [
         "hardi-lr-superiorfrontal.trk",
@@ -727,7 +727,7 @@ fetch_stanford_tracks = _make_fetcher(
 
 fetch_taiwan_ntu_dsi = _make_fetcher(
     "fetch_taiwan_ntu_dsi",
-    Path(dipy_home) / "taiwan_ntu_dsi",
+    dipy_home / "taiwan_ntu_dsi",
     UW_RW_URL + "1773/38480/",
     ["DSI203.nii.gz", "DSI203.bval", "DSI203.bvec", "DSI203_license.txt"],
     [
@@ -750,7 +750,7 @@ fetch_taiwan_ntu_dsi = _make_fetcher(
 
 fetch_syn_data = _make_fetcher(
     "fetch_syn_data",
-    Path(dipy_home) / "syn_test",
+    dipy_home / "syn_test",
     UW_RW_URL + "1773/38476/",
     ["t1.nii.gz", "b0.nii.gz"],
     [Path("t1.nii.gz"), Path("b0.nii.gz")],
@@ -761,7 +761,7 @@ fetch_syn_data = _make_fetcher(
 
 fetch_mni_template = _make_fetcher(
     "fetch_mni_template",
-    Path(dipy_home) / "mni_template",
+    dipy_home / "mni_template",
     "https://ndownloader.figshare.com/files/",
     [
         "5572676?private_link=4b8666116a0128560fb5",
@@ -800,7 +800,7 @@ fetch_scil_b0 = _make_fetcher(
 
 fetch_bundles_2_subjects = _make_fetcher(
     "fetch_bundles_2_subjects",
-    Path(dipy_home) / "exp_bundles_and_maps",
+    dipy_home / "exp_bundles_and_maps",
     UW_RW_URL + "1773/38477/",
     ["bundles_2_subjects.tar.gz"],
     [Path("bundles_2_subjects.tar.gz")],
@@ -812,7 +812,7 @@ fetch_bundles_2_subjects = _make_fetcher(
 
 fetch_ivim = _make_fetcher(
     "fetch_ivim",
-    Path(dipy_home) / "ivim",
+    dipy_home / "ivim",
     "https://ndownloader.figshare.com/files/",
     ["5305243", "5305246", "5305249"],
     [Path("ivim.nii.gz"), Path("ivim.bval"), Path("ivim.bvec")],
@@ -826,7 +826,7 @@ fetch_ivim = _make_fetcher(
 
 fetch_cfin_multib = _make_fetcher(
     "fetch_cfin_multib",
-    Path(dipy_home) / "cfin_multib",
+    dipy_home / "cfin_multib",
     UW_RW_URL + "/1773/38488/",
     [
         "T1.nii",
@@ -856,7 +856,7 @@ fetch_cfin_multib = _make_fetcher(
 
 fetch_file_formats = _make_fetcher(
     "bundle_file_formats_example",
-    Path(dipy_home) / "bundle_file_formats_example",
+    dipy_home / "bundle_file_formats_example",
     "https://zenodo.org/record/3352379/files/",
     [
         "cc_m_sub.trk",
@@ -888,7 +888,7 @@ fetch_file_formats = _make_fetcher(
 
 fetch_bundle_atlas_hcp842 = _make_fetcher(
     "fetch_bundle_atlas_hcp842",
-    Path(dipy_home) / "bundle_atlas_hcp842",
+    dipy_home / "bundle_atlas_hcp842",
     "https://ndownloader.figshare.com/files/",
     ["13638644"],
     [Path("Atlas_80_Bundles.zip")],
@@ -900,7 +900,7 @@ fetch_bundle_atlas_hcp842 = _make_fetcher(
 
 fetch_30_bundle_atlas_hcp842 = _make_fetcher(
     "fetch_30_bundle_atlas_hcp842",
-    Path(dipy_home) / "bundle_atlas_hcp842",
+    dipy_home / "bundle_atlas_hcp842",
     "https://ndownloader.figshare.com/files/",
     ["26842853"],
     [Path("Atlas_30_Bundles.zip")],
@@ -912,7 +912,7 @@ fetch_30_bundle_atlas_hcp842 = _make_fetcher(
 
 fetch_target_tractogram_hcp = _make_fetcher(
     "fetch_target_tractogram_hcp",
-    Path(dipy_home) / "target_tractogram_hcp",
+    dipy_home / "target_tractogram_hcp",
     "https://ndownloader.figshare.com/files/",
     ["12871127"],
     [Path("hcp_tractogram.zip")],
@@ -925,7 +925,7 @@ fetch_target_tractogram_hcp = _make_fetcher(
 
 fetch_bundle_fa_hcp = _make_fetcher(
     "fetch_bundle_fa_hcp",
-    Path(dipy_home) / "bundle_fa_hcp",
+    dipy_home / "bundle_fa_hcp",
     "https://ndownloader.figshare.com/files/",
     ["14035265"],
     [Path("hcp_bundle_fa.nii.gz")],
@@ -937,7 +937,7 @@ fetch_bundle_fa_hcp = _make_fetcher(
 
 fetch_qtdMRI_test_retest_2subjects = _make_fetcher(
     "fetch_qtdMRI_test_retest_2subjects",
-    Path(dipy_home) / "qtdMRI_test_retest_2subjects",
+    dipy_home / "qtdMRI_test_retest_2subjects",
     "https://zenodo.org/record/996889/files/",
     [
         "subject1_dwis_test.nii.gz",
@@ -988,7 +988,7 @@ fetch_qtdMRI_test_retest_2subjects = _make_fetcher(
 
 fetch_gold_standard_io = _make_fetcher(
     "fetch_gold_standard_io",
-    Path(dipy_home) / "gold_standard_io",
+    dipy_home / "gold_standard_io",
     "https://zenodo.org/record/14538513/files/",
     [
         "gs_streamlines.trk",
@@ -1096,7 +1096,7 @@ fetch_gold_standard_io = _make_fetcher(
 
 fetch_real_data_io = _make_fetcher(
     "fetch_real_data_io",
-    Path(dipy_home) / "real_data_io",
+    dipy_home / "real_data_io",
     "https://zenodo.org/record/14537772/files/",
     [
         "anat.nii.gz",
@@ -1174,7 +1174,7 @@ fetch_real_data_io = _make_fetcher(
 
 fetch_qte_lte_pte = _make_fetcher(
     "fetch_qte_lte_pte",
-    Path(dipy_home) / "qte_lte_pte",
+    dipy_home / "qte_lte_pte",
     "https://zenodo.org/record/4624866/files/",
     ["lte-pte.nii.gz", "lte-pte.bval", "lte-pte.bvec", "mask.nii.gz"],
     [
@@ -1196,7 +1196,7 @@ fetch_qte_lte_pte = _make_fetcher(
 
 fetch_cti_rat1 = _make_fetcher(
     "fetch_cti_rat1",
-    Path(dipy_home) / "cti_rat1",
+    dipy_home / "cti_rat1",
     "https://zenodo.org/record/8276773/files/",
     [
         "Rat1_invivo_cti_data.nii",
@@ -1234,7 +1234,7 @@ fetch_cti_rat1 = _make_fetcher(
 
 fetch_fury_surface = _make_fetcher(
     "fetch_fury_surface",
-    Path(dipy_home) / "fury_surface",
+    dipy_home / "fury_surface",
     "https://raw.githubusercontent.com/fury-gl/fury-data/master/surfaces/",
     ["100307_white_lh.vtk"],
     [Path("100307_white_lh.vtk")],
@@ -1245,7 +1245,7 @@ fetch_fury_surface = _make_fetcher(
 
 fetch_DiB_70_lte_pte_ste = _make_fetcher(
     "fetch_DiB_70_lte_pte_ste",
-    Path(dipy_home) / "DiB_70_lte_pte_ste",
+    dipy_home / "DiB_70_lte_pte_ste",
     "https://github.com/filip-szczepankiewicz/Szczepankiewicz_DIB_2019/"
     "raw/master/DATA/brain/NII_Boito_SubSamples/",
     [
@@ -1278,7 +1278,7 @@ fetch_DiB_70_lte_pte_ste = _make_fetcher(
 
 fetch_DiB_217_lte_pte_ste = _make_fetcher(
     "fetch_DiB_217_lte_pte_ste",
-    Path(dipy_home) / "DiB_217_lte_pte_ste",
+    dipy_home / "DiB_217_lte_pte_ste",
     "https://github.com/filip-szczepankiewicz/Szczepankiewicz_DIB_2019/"
     "raw/master/DATA/brain/NII_Boito_SubSamples/",
     [
@@ -1315,7 +1315,7 @@ fetch_DiB_217_lte_pte_ste = _make_fetcher(
 
 fetch_ptt_minimal_dataset = _make_fetcher(
     "fetch_ptt_minimal_dataset",
-    Path(dipy_home) / "ptt_dataset",
+    dipy_home / "ptt_dataset",
     "https://raw.githubusercontent.com/dipy/dipy_datatest/main/",
     ["ptt_fod.nii", "ptt_seed_coords.txt", "ptt_seed_image.nii"],
     [Path("ptt_fod.nii"), Path("ptt_seed_coords.txt"), Path("ptt_seed_image.nii")],
@@ -1331,7 +1331,7 @@ fetch_ptt_minimal_dataset = _make_fetcher(
 
 fetch_bundle_warp_dataset = _make_fetcher(
     "fetch_bundle_warp_dataset",
-    Path(dipy_home) / "bundle_warp",
+    dipy_home / "bundle_warp",
     "https://ndownloader.figshare.com/files/",
     ["40026343", "40026346"],
     [
@@ -1345,7 +1345,7 @@ fetch_bundle_warp_dataset = _make_fetcher(
 
 fetch_disco1_dataset = _make_fetcher(
     "fetch_disco1_dataset",
-    Path(dipy_home) / "disco" / "disco_1",
+    dipy_home / "disco" / "disco_1",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -1522,7 +1522,7 @@ fetch_disco1_dataset = _make_fetcher(
 
 fetch_disco2_dataset = _make_fetcher(
     "fetch_disco2_dataset",
-    Path(dipy_home) / "disco" / "disco_2",
+    dipy_home / "disco" / "disco_2",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -1699,7 +1699,7 @@ fetch_disco2_dataset = _make_fetcher(
 
 fetch_disco3_dataset = _make_fetcher(
     "fetch_disco3_dataset",
-    Path(dipy_home) / "disco" / "disco_3",
+    dipy_home / "disco" / "disco_3",
     "https://data.mendeley.com/public-files/datasets/fgf86jdfg6/files/",
     [
         "028147aa-f17f-4514-80e6-24c7419da75e/file_downloaded",
@@ -2230,7 +2230,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_dwis_retest.nii.gz",
     ]
     for data_name in data_names:
-        data_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects" / data_name
+        data_loc = dipy_home / "qtdMRI_test_retest_2subjects" / data_name
         data.append(load_nifti_data(data_loc))
 
     cc_masks = []
@@ -2241,7 +2241,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_ccmask_retest.nii.gz",
     ]
     for mask_name in mask_names:
-        mask_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects" / mask_name
+        mask_loc = dipy_home / "qtdMRI_test_retest_2subjects" / mask_name
         cc_masks.append(load_nifti_data(mask_loc))
 
     gtabs = []
@@ -2252,7 +2252,7 @@ def read_qtdMRI_test_retest_2subjects():
         "subject2_scheme_retest.txt",
     ]
     for gtab_txt_name in gtab_txt_names:
-        txt_loc = Path(dipy_home) / "qtdMRI_test_retest_2subjects" / gtab_txt_name
+        txt_loc = dipy_home / "qtdMRI_test_retest_2subjects" / gtab_txt_name
         qtdmri_scheme = np.loadtxt(txt_loc, skiprows=1)
         bvecs = qtdmri_scheme[:, 1:4]
         G = qtdmri_scheme[:, 4] / 1e3  # because dipy takes T/mm not T/m
@@ -2413,7 +2413,7 @@ def fetch_tissue_data(*, include_optional=False):
     t1d = "https://ndownloader.figshare.com/files/6965981"
     ap = "https://ndownloader.figshare.com/files/6965984"
 
-    folder = Path(dipy_home) / "tissue_data"
+    folder = dipy_home / "tissue_data"
 
     md5_list = [
         "99c4b77267a6855cbfd96716d5d65b70",  # t1
@@ -2457,7 +2457,7 @@ def read_tissue_data(*, contrast="T1"):
         Nifti1Image
 
     """
-    folder = Path(dipy_home) / "tissue_data"
+    folder = dipy_home / "tissue_data"
     t1_name = Path(folder) / "t1_brain.nii.gz"
     t1d_name = Path(folder) / "t1_brain_denoised.nii.gz"
     ap_name = Path(folder) / "power_map.nii.gz"
@@ -2594,7 +2594,7 @@ def fetch_cenir_multib(*, with_raw=False, **kwargs):
         Whether to fetch the raw data. Per default, this is False, which means
         that only eddy-current/motion corrected data is fetched
     """
-    folder = Path(dipy_home) / "cenir_multib"
+    folder = dipy_home / "cenir_multib"
 
     fname_list = [
         "4D_dwi_eddycor_B200.nii.gz",
@@ -2770,7 +2770,7 @@ def read_bundles_2_subjects(
     .. footbibliography::
 
     """
-    dname = Path(dipy_home) / "exp_bundles_and_maps" / "bundles_2_subjects"
+    dname = dipy_home / "exp_bundles_and_maps" / "bundles_2_subjects"
 
     from dipy.tracking.streamline import Streamlines
 
@@ -2855,7 +2855,7 @@ def get_file_formats():
     bundles_list : all bundles (list)
     ref_anat : reference
     """
-    ref_anat = Path(dipy_home) / "bundle_file_formats_example" / "template0.nii.gz"
+    ref_anat = dipy_home / "bundle_file_formats_example" / "template0.nii.gz"
     bundles_list = []
     for filename in [
         "cc_m_sub.trk",
@@ -2864,7 +2864,7 @@ def get_file_formats():
         "raf_m_sub.vtk",
         "rpt_m_sub.dpy",
     ]:
-        bundles_list.append(Path(dipy_home) / "bundle_file_formats_example" / filename)
+        bundles_list.append(dipy_home / "bundle_file_formats_example" / filename)
 
     return bundles_list, ref_anat
 
@@ -2880,7 +2880,7 @@ def get_bundle_atlas_hcp842(*, size=80):
     size = 80 if size not in [80, 30] else size
 
     file1 = (
-        Path(dipy_home)
+        dipy_home
         / "bundle_atlas_hcp842"
         / f"Atlas_{size}_Bundles"
         / "whole_brain"
@@ -2888,7 +2888,7 @@ def get_bundle_atlas_hcp842(*, size=80):
     )
 
     file2 = (
-        Path(dipy_home)
+        dipy_home
         / "bundle_atlas_hcp842"
         / f"Atlas_{size}_Bundles"
         / "bundles"
@@ -2906,19 +2906,11 @@ def get_two_hcp842_bundles():
     file2 : string
     """
     file1 = (
-        Path(dipy_home)
-        / "bundle_atlas_hcp842"
-        / "Atlas_80_Bundles"
-        / "bundles"
-        / "AF_L.trk"
+        dipy_home / "bundle_atlas_hcp842" / "Atlas_80_Bundles" / "bundles" / "AF_L.trk"
     )
 
     file2 = (
-        Path(dipy_home)
-        / "bundle_atlas_hcp842"
-        / "Atlas_80_Bundles"
-        / "bundles"
-        / "CST_L.trk"
+        dipy_home / "bundle_atlas_hcp842" / "Atlas_80_Bundles" / "bundles" / "CST_L.trk"
     )
 
     return file1, file2
@@ -2930,9 +2922,7 @@ def get_target_tractogram_hcp():
     -------
     file1 : string
     """
-    file1 = (
-        Path(dipy_home) / "target_tractogram_hcp" / "hcp_tractogram" / "streamlines.trk"
-    )
+    file1 = dipy_home / "target_tractogram_hcp" / "hcp_tractogram" / "streamlines.trk"
 
     return file1
 
@@ -3177,7 +3167,7 @@ def fetch_hcp(
     bucket = s3.Bucket(hcp_bucket)
 
     if path is None:
-        if not Path(dipy_home).exists():
+        if not dipy_home.exists():
             os.mkdir(dipy_home)
         my_path = dipy_home
     else:
@@ -3373,7 +3363,7 @@ def fetch_hbn(subjects, *, path=None, include_afq=False):
     client = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
     if path is None:
-        if not Path(dipy_home).exists():
+        if not dipy_home.exists():
             os.mkdir(dipy_home)
         my_path = dipy_home
     else:

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -394,8 +394,8 @@ def create_tractogram_header(
     tractogram_type, affine, dimensions, voxel_sizes, voxel_order
 ):
     """Write a standard trk/tck header from spatial attribute"""
-    if isinstance(tractogram_type, str):
-        tractogram_type = detect_format(tractogram_type)
+    if isinstance(tractogram_type, (str, Path)):
+        tractogram_type = detect_format(str(tractogram_type))
 
     new_header = tractogram_type.create_empty_header()
     new_header[nib.streamlines.Field.VOXEL_SIZES] = tuple(voxel_sizes)

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -101,10 +101,10 @@ def test_io_fetch():
     fetch_flow = FetchFlow()
     with TemporaryDirectory() as out_dir:
         fetch_flow.run(["bundle_fa_hcp"])
-        npt.assert_equal(Path(Path(dipy_home) / "bundle_fa_hcp").is_dir(), True)
+        npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
 
         fetch_flow.run(["bundle_fa_hcp"], out_dir=out_dir)
-        npt.assert_equal(Path(Path(dipy_home) / "bundle_fa_hcp").is_dir(), True)
+        npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
 
 
 def test_io_fetch_fetcher_datanames():

--- a/doc/examples/afq_tract_profiles.py
+++ b/doc/examples/afq_tract_profiles.py
@@ -52,14 +52,14 @@ cst_l_file = (
     afq_path
     / "clean_bundles"
     / f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
-    "-RASMM_model-CSD_desc-prob-afq-CST_L_tractography.trk",
+    "-RASMM_model-CSD_desc-prob-afq-CST_L_tractography.trk"
 )
 
 arc_l_file = (
     afq_path
     / "clean_bundles"
     / f"sub-{subject}_ses-{session}_acq-64dir_space-T1w_desc-preproc_dwi_space"
-    "-RASMM_model-CSD_desc-prob-afq-ARC_L_tractography.trk",
+    "-RASMM_model-CSD_desc-prob-afq-ARC_L_tractography.trk"
 )
 
 cst_l = load_tractogram(

--- a/doc/examples/denoise_ascm.py
+++ b/doc/examples/denoise_ascm.py
@@ -34,8 +34,8 @@ import numpy as np
 from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.denoise.adaptive_soft_matching import adaptive_soft_matching
+from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.noise_estimate import estimate_sigma
-from dipy.denoise.non_local_means import non_local_means
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
 
@@ -67,7 +67,7 @@ sigma = estimate_sigma(data, N=4)
 # For the denoised version of the original data which preserves sharper
 # features, we perform non-local means with smaller patch size.
 
-den_small = non_local_means(
+den_small = nlmeans(
     data, sigma=sigma, mask=mask, patch_radius=1, block_radius=1, rician=True
 )
 
@@ -75,7 +75,7 @@ den_small = non_local_means(
 # For the denoised version of the original data that implies more smoothing, we
 # perform non-local means with larger patch size.
 
-den_large = non_local_means(
+den_large = nlmeans(
     data, sigma=sigma, mask=mask, patch_radius=2, block_radius=1, rician=True
 )
 

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -235,7 +235,6 @@ maskdata, mask = median_otsu(
     vol_idx=range(10, 50),
     median_radius=3,
     numpass=1,
-    autocrop=False,
     dilate=1,
 )
 

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -86,7 +86,7 @@ t = time()
 
 denoised_arr = localpca(data, sigma=sigma, tau_factor=2.3, patch_radius=2)
 
-print("Time taken for local PCA (slow)", -t + time())
+print("Time taken for local PCA", -t + time())
 
 ###############################################################################
 # The ``localpca`` function returns the denoised data which is plotted below

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -139,9 +139,7 @@ save_nifti("denoised_mppca.nii.gz", denoised_arr, affine)
 
 dkimodel = dki.DiffusionKurtosisModel(gtab)
 
-maskdata, mask = median_otsu(
-    data, vol_idx=[0, 1], median_radius=4, numpass=2, autocrop=False, dilate=1
-)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2, dilate=1)
 
 dki_orig = dkimodel.fit(data, mask=mask)
 dki_den = dkimodel.fit(denoised_arr, mask=mask)

--- a/doc/examples/reconst_bingham.py
+++ b/doc/examples/reconst_bingham.py
@@ -80,7 +80,7 @@ fodf_spheres = actor.odf_slicer(
 scene.add(fodf_spheres)
 
 print("Saving the illustration as csd_odfs.png")
-window.record(scene, out_path="csd_odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="csd_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 
@@ -145,7 +145,7 @@ fodf_spheres = actor.odf_slicer(
 scene.add(fodf_spheres)
 
 print("Saving the illustration as Bingham_odfs.png")
-window.record(scene, out_path="Bingham_odfs.png", size=(600, 600))
+window.record(scene=scene, out_path="Bingham_odfs.png", size=(600, 600))
 if interactive:
     window.show(scene)
 

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -30,7 +30,7 @@ bvals, bvecs = read_bvals_bvecs(hardi_bval_fname, hardi_bvec_fname)
 gtab = gradient_table(bvals, bvecs=bvecs)
 
 maskdata, mask = median_otsu(
-    data, vol_idx=range(10, 50), median_radius=3, numpass=1, autocrop=False, dilate=2
+    data, vol_idx=range(10, 50), median_radius=3, numpass=1, dilate=2
 )
 
 response, ratio = auto_response_ssst(gtab, maskdata, roi_radii=10, fa_thr=0.7)

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -138,9 +138,7 @@ gtab = gradient_table(bvals[bval_sel == 1], bvecs=bvecs[bval_sel == 1])
 # compute a brain mask to avoid unnecessary calculations on the background
 # of the image.
 
-datamask, mask = median_otsu(
-    data, vol_idx=[0, 1], median_radius=4, numpass=2, autocrop=False, dilate=1
-)
+datamask, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2, dilate=1)
 
 ###############################################################################
 # Since the diffusion kurtosis model involves the estimation of a large number

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -53,9 +53,7 @@ gtab = gradient_table(bvals, bvecs=bvecs)
 # :ref:`sphx_glr_examples_built_reconstruction_reconst_dki.py`).
 
 # data masking
-maskdata, mask = median_otsu(
-    data, vol_idx=[0, 1], median_radius=4, numpass=2, autocrop=False, dilate=1
-)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2, dilate=1)
 
 # Smoothing
 fwhm = 1.25

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -62,7 +62,7 @@ dwi_path = (
 
 img = nib.load(
     dwi_path
-    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz",
+    / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.nii.gz"
 )
 
 gtab = gradient_table(
@@ -70,7 +70,7 @@ gtab = gradient_table(
     / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bval",
     bvecs=(
         dwi_path
-        / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec",
+        / "sub-NDARAA948VFH_ses-HBNsiteRU_acq-64dir_space-T1w_desc-preproc_dwi.bvec"
     ),
 )
 

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -239,9 +239,7 @@ gtab = gradient_table(bvals, bvecs=bvecs)
 # :ref:`sphx_glr_examples_built_preprocessing_denoise_nlmeans.py` or the
 # local pca :ref:`sphx_glr_examples_built_preprocessing_denoise_localpca.py`).
 
-maskdata, mask = median_otsu(
-    data, vol_idx=[0, 1], median_radius=4, numpass=2, autocrop=False, dilate=1
-)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2, dilate=1)
 
 ###############################################################################
 # Now that we have loaded and pre-processed the data we can go forward

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -63,7 +63,6 @@ ax.hist(lengths, color="burlywood")
 ax.set_xlabel("Length")
 ax.set_ylabel("Count")
 # plt.show()
-plt.legend()
 plt.savefig("length_histogram.png")
 
 ###############################################################################

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -145,13 +145,17 @@ static_to_ref, moving_to_ref = sdr.get_intermediate_maps()
 # We have two more transforms to visualize
 #
 
-regtools.plot_2d_diffeomorphic_map(static_to_ref, 10, "static_to_ref_map.png")
+regtools.plot_2d_diffeomorphic_map(
+    static_to_ref, delta=10, fname="static_to_ref_map.png"
+)
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
 # Deformed lattice under the static-to-reference diffeomorphic map.
 
-regtools.plot_2d_diffeomorphic_map(moving_to_ref, 10, "moving_to_ref_map.png")
+regtools.plot_2d_diffeomorphic_map(
+    moving_to_ref, delta=10, fname="moving_to_ref_map.png"
+)
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
@@ -169,16 +173,16 @@ regtools.plot_2d_diffeomorphic_map(moving_to_ref, 10, "moving_to_ref_map.png")
 # same applies to mapping the moving image to the reference space.
 
 
-warped_static = static_to_ref.transform_inverse(static, "linear")
-warped_moving = moving_to_ref.transform_inverse(moving, "linear")
+warped_static = static_to_ref.transform_inverse(static, interpolation="linear")
+warped_moving = moving_to_ref.transform_inverse(moving, interpolation="linear")
 
 regtools.overlay_images(
     warped_static,
     warped_moving,
-    "Warped static",
-    "Overlay",
-    "Warped moving",
-    "intermediate_images.png",
+    title0="Warped static",
+    title_mid="Overlay",
+    title1="Warped moving",
+    fname="intermediate_images.png",
 )
 
 ###############################################################################

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -105,7 +105,7 @@ fname_fa = (
     / "exp_bundles_and_maps"
     / "bundles_2_subjects"
     / "subj_1"
-    "fa_1x1x1.nii.gz",
+    / "fa_1x1x1.nii.gz"
 )
 
 fa = load_nifti_data(fname_fa)
@@ -205,7 +205,7 @@ fa_actor.AddObserver("LeftButtonPressEvent", left_click_callback, 1.0)
 # parallel. We'll also need a new show manager and an associated callback.
 
 scene.clear()
-scene.projection("parallel")
+scene.projection(proj_type="parallel")
 
 result_position.message = ""
 result_value.message = ""


### PR DESCRIPTION
This pull request primarily refactors file path construction throughout the codebase to use the `/` operator with `Path` objects, improving readability and correctness. It also updates function calls to use keyword arguments for clarity and consistency, removes deprecated parameters, and fixes minor issues in visualization and denoising examples.

* Refactored all instances of file path construction in `dipy/data/fetcher.py` and various example scripts to use the `/` operator with `Path` objects instead of tuples, ensuring correct path formation and reducing errors. 
* Updated function calls in visualization and registration examples to use keyword arguments, improving code clarity (e.g., `window.record`, `regtools.plot_2d_diffeomorphic_map`, `transform_inverse`, and `overlay_images`.
* Removed deprecated or unnecessary parameters (such as `autocrop=False`) from `median_otsu` calls in multiple denoising and reconstruction examples for cleaner code. 
* Enhanced header creation in `dipy/io/utils.py` to support both `str` and `Path` types for tractogram format detection, improving robustness.