### PR TITLE
Build 3.14 nightly wheels

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64", "aarch64"]
     steps:
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, macos-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
         include:
           - os: macos-latest
             cibw_arch: x86_64
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
         cibw_arch: ["AMD64"]
     steps:
       - name: Setup Environment variables


### PR DESCRIPTION
Moving MNE-Python to testing 3.14 there are no 3.14 dipy wheels in scientific-python-nightly-wheels. This should fix it I think! :crossed_fingers: 