### PR TITLE
DOC: fix some missing `:footcite:p` in documentation

### DIFF
--- a/doc/examples/affine_registration_masks.py
+++ b/doc/examples/affine_registration_masks.py
@@ -4,8 +4,8 @@ Affine Registration with Masks
 ==============================
 
 This example explains how to compute a transformation to register two 3D
-volumes by maximization of their Mutual Information [Mattes03]_. The
-optimization strategy is similar to that implemented in ANTS [Avants11]_.
+volumes by maximization of their Mutual Information :footcite:p:`Mattes2003`. The
+optimization strategy is similar to that implemented in ANTS :footcite:p:`Avants2011`.
 
 We will use masks to define which pixels are used in the Mutual Information.
 Masking can also be done for registration of 2D images rather than 3D volumes.
@@ -369,9 +369,5 @@ regtools.overlay_slices(
 # References
 # ----------
 #
-# .. [Mattes03] Mattes, D., Haynor, D. R., Vesselle, H., Lewellen, T. K.,
-#               Eubank, W. (2003). PET-CT image registration in the chest using
-#               free-form deformations. IEEE Transactions on Medical Imaging,
-#               22(1), 120-8.
-# .. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-#               Normalization Tools (ANTS), 1-35.
+# .. footbibliography::
+#

--- a/doc/examples/denoise_patch2self.py
+++ b/doc/examples/denoise_patch2self.py
@@ -3,11 +3,11 @@
 Patch2Self: Self-Supervised Denoising via Statistical Independence
 ==================================================================
 
-Patch2Self :footcite:p:`Fadnavis2020` and :footcite:p:`Fadnavis2024` is  a self-supervised learning method for
-denoising DWI data, which uses the entire volume to learn a full-rank locally
-linear denoiser for that volume. By taking advantage of the oversampled q-space
-of DWI data, Patch2Self can separate structure from noise without requiring an
-explicit model for either.
+Patch2Self :footcite:p:`Fadnavis2020` and :footcite:p:`Fadnavis2024` is
+a self-supervised learning method for denoising DWI data, which uses the
+entire volume to learn a full-rank locally linear denoiser for that volume.
+By taking advantage of the oversampled q-space of DWI data, Patch2Self can
+separate structure from noise without requiring an explicit model for either.
 
 Classical denoising algorithms such as Local PCA :footcite:p:`Manjon2013`,
 :footcite:p:`Veraart2016b`, Non-local Means :footcite:p:`Coupe2008`, Total

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -18,8 +18,8 @@ acquisition with 2-shells, one at b=1000 $s/mm^2$ and one at b=2500 $s/mm^2$.
 For both shells let's say that we want a specific number of gradients (64) and
 we want to have the points on the sphere evenly distributed.
 
-This is possible using the ``disperse_charges`` which is an implementation of
-electrostatic repulsion :footcite:t:`Jones1999` .
+This is possible using the :func:`dipy.core.sphere.disperse_charges` which is
+an implementation of electrostatic repulsion :footcite:t:`Jones1999` .
 
 Let's start by importing the necessary modules.
 """
@@ -41,8 +41,9 @@ phi = 2 * np.pi * rng.random(n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 
 ###############################################################################
-# Next, we call ``disperse_charges`` which will iteratively move the points so
-# that the electrostatic potential energy is minimized.
+# Next, we call :func:`dipy.core.sphere.disperse_charges` which will
+# iteratively move the points so that the electrostatic potential energy is
+# minimized.
 
 hsph_updated, potential = disperse_charges(hsph_initial, 5000)
 

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -4,7 +4,7 @@ Parallel reconstruction using Q-Ball
 ====================================
 
 We show an example of parallel reconstruction using a Q-Ball Constant Solid
-Angle model (see Aganj et al. (MRM 2010)) and `peaks_from_model`.
+Angle model (see :footcite:p:`Aganj2010`) and `peaks_from_model`.
 
 Import modules, fetch and read data, and compute the mask.
 """


### PR DESCRIPTION
This pull request updates several example documentation files to improve citation formatting and code references. 

* Updated references in `doc/examples/affine_registration_masks.py` to use `footcite` for inline citations and `footbibliography` for the bibliography, replacing the previous reference list format. [[1]](diffhunk://#diff-c169dbe9f6d3cec89eb4f18327039ac898b0ec2f1257c162e657ca8c83290fe9L7-R8) [[2]](diffhunk://#diff-c169dbe9f6d3cec89eb4f18327039ac898b0ec2f1257c162e657ca8c83290fe9L372-R373)
* Changed the inline citation for the Q-Ball Constant Solid Angle model in `doc/examples/reconst_csa_parallel.py` to use `footcite`.
* Reformatted citations and line wrapping in `doc/examples/denoise_patch2self.py` for consistency and readability.
* Updated references to the `disperse_charges` function in `doc/examples/gradients_spheres.py` to use the Sphinx `:func:` role, improving documentation clarity and linking. [[1]](diffhunk://#diff-99c2c2fa62f66cd05196c02479c329502fb64bdf00e81829d787044820977b88L21-R22) [[2]](diffhunk://#diff-99c2c2fa62f66cd05196c02479c329502fb64bdf00e81829d787044820977b88L44-R46)