### PR TITLE
BF: Handle empty streamlines in slr_with_qbx after length filtering

### DIFF
--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -1120,6 +1120,25 @@ def slr_with_qbx(
 
     streamlines1 = Streamlines(static[np.array([check_range(s) for s in static])])
     streamlines2 = Streamlines(moving[np.array([check_range(s) for s in moving])])
+
+    if len(streamlines1) == 0:
+        msg = (
+            "No streamlines remain in 'static' after length filtering. "
+            f"All streamlines have length outside the range "
+            f"({greater_than}, {less_than}). "
+            "Please adjust the 'greater_than' and 'less_than' parameters."
+        )
+        raise ValueError(msg)
+
+    if len(streamlines2) == 0:
+        msg = (
+            "No streamlines remain in 'moving' after length filtering. "
+            f"All streamlines have length outside the range "
+            f"({greater_than}, {less_than}). "
+            "Please adjust the 'greater_than' and 'less_than' parameters."
+        )
+        raise ValueError(msg)
+
     if verbose:
         logger.info(f"Static streamlines after length reduction {len(streamlines1)}")
         logger.info(f"Moving streamlines after length reduction {len(streamlines2)}")

--- a/dipy/align/tests/test_whole_brain_slr.py
+++ b/dipy/align/tests/test_whole_brain_slr.py
@@ -126,3 +126,42 @@ def test_slr_one_streamline():
         qbx_thr=[2],
         progressive=True,
     )
+
+
+def test_slr_empty_after_length_filtering():
+    """Test that slr_with_qbx raises ValueError when all streamlines are
+    filtered out by length constraints.
+    """
+    fname = get_fnames(name="fornix")
+
+    fornix = load_tractogram(fname, "same", bbox_valid_check=False).streamlines
+
+    f = Streamlines(fornix)
+    f1 = f.copy()
+    f2 = f.copy()
+
+    assert_raises(
+        ValueError,
+        slr_with_qbx,
+        f1,
+        f2,
+        verbose=False,
+        rm_small_clusters=1,
+        greater_than=1000,
+        less_than=np.inf,
+        qbx_thr=[2],
+        progressive=True,
+    )
+
+    assert_raises(
+        ValueError,
+        slr_with_qbx,
+        f1,
+        f2,
+        verbose=False,
+        rm_small_clusters=1,
+        greater_than=0,
+        less_than=1,
+        qbx_thr=[2],
+        progressive=True,
+    )

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 from warnings import warn
 
 import numpy as np
@@ -281,23 +280,30 @@ class SlrWithQbxFlow(Workflow):
 
             if not len(static_obj.streamlines):
                 logger.error(f"Static file {static_file} is empty")
-                sys.exit(1)
+                continue
             if not len(moving_obj.streamlines):
                 logger.error(f"Moving file {moving_file} is empty")
-                sys.exit(1)
+                continue
 
-            moved, affine, centroids_static, centroids_moving = slr_with_qbx(
-                static_obj.streamlines,
-                moving_obj.streamlines,
-                x0=x0,
-                rm_small_clusters=rm_small_clusters,
-                greater_than=greater_than,
-                less_than=less_than,
-                qbx_thr=qbx_thr,
-                progressive=progressive,
-                nb_pts=nb_pts,
-                num_threads=num_threads,
-            )
+            try:
+                moved, affine, centroids_static, centroids_moving = slr_with_qbx(
+                    static_obj.streamlines,
+                    moving_obj.streamlines,
+                    x0=x0,
+                    rm_small_clusters=rm_small_clusters,
+                    greater_than=greater_than,
+                    less_than=less_than,
+                    qbx_thr=qbx_thr,
+                    progressive=progressive,
+                    nb_pts=nb_pts,
+                    num_threads=num_threads,
+                )
+            except Exception as e:
+                logger.error(f"SLR with QBX failed: {e}")
+                logger.warning(
+                    "Skipping this pair of tractograms, " "continuing with next pair."
+                )
+                continue
 
             logger.info(f"Saving output file {out_moved_file}")
 


### PR DESCRIPTION
this PR fixes #3683

This pull request improves error handling in the streamline filtering process and adds corresponding tests to ensure robustness. The main focus is to provide clear feedback when all streamlines are filtered out due to length constraints, preventing silent failures and making debugging easier