### PR TITLE
DOC: Fix numpydoc PR03 parameter order in path_length

### DIFF
--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -1019,11 +1019,11 @@ def path_length(streamlines, affine, aoi, *, fill_value=-1):
     streamlines : seq of (N, 3) arrays
         A sequence of streamlines, path length is given in mm along the curve
         of the streamline.
-    aoi : array, 3d
-        A mask (binary array) of voxels from which to start computing distance.
     affine : array (4, 4)
         The mapping between voxel indices and the point space for seeds.
         The voxel_to_rasmm matrix, typically from a NIFTI file.
+    aoi : array, 3d
+        A mask (binary array) of voxels from which to start computing distance.
     fill_value : float
         The value of voxel in the path length map that are not connected to the
         aoi.


### PR DESCRIPTION
This PR helps in #3270 a numpydoc PR03 warning by reordering the Parameters section
of `dipy.tracking.utils.path_length` to match the function signature.
