### PR TITLE
Revert temporary suppression of SCS CSC conversion warning

### DIFF
--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -557,10 +557,7 @@ class PositiveDefiniteLeastSquares:
                     return np.asarray(self._h.value).squeeze()
 
             # Solve constrained problem
-            with warnings.catch_warnings():
-                if self._y.value.shape[0] < 1000:
-                    warnings.filterwarnings("ignore", message="Converting A to a CSC")
-                self.problem.solve(**kwargs)
+            self.problem.solve(**kwargs)
 
             # Check solution status
             status = self.problem.status


### PR DESCRIPTION
This reverts the temporary warning suppression added in #3606.

Recent SCS releases no longer emit the
"Converting A to a CSC (compressed sparse column)" warning,
making the local suppression unnecessary.

Core tests pass locally on Python 3.12.

Closes #3614.
