### PR TITLE
STYLE: Fix spelling mistakes in docstrings and comments

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -544,7 +544,7 @@ def directional_kurtosis(
         `min_diffusivity`. Default = 0
     min_kurtosis : float, optional
         Because high-amplitude negative values of kurtosis are not physically
-        and biologicaly pluasible, and these cause artefacts in
+        and biologically plausible, and these cause artifacts in
         kurtosis-based measures, directional kurtosis values smaller than
         `min_kurtosis` are replaced with `min_kurtosis`.
         (theoretical kurtosis limit for regions that consist of water confined
@@ -609,7 +609,7 @@ def apparent_kurtosis_coef(
         `min_diffusivity`.
     min_kurtosis : float, optional
         Because high-amplitude negative values of kurtosis are not physically
-        and biologicaly pluasible, and these cause artefacts in
+        and biologically plausible, and these cause artifacts in
         kurtosis-based measures, directional kurtosis values smaller than
         `min_kurtosis` are replaced with `min_kurtosis`. Default = -3./7
         (theoretical kurtosis limit for regions that consist of water confined

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -472,7 +472,7 @@ class IvimModelTRR(ReconstModel):
             If the data was a 3D image of 10x10x10 grid with 21 bvalues,
             the multi_voxel decorator will run the single voxel fitting
             on all the 1000 voxels to get the parameters in
-            IvimFit.model_paramters. The shape of the parameter array
+            IvimFit.model_parameters. The shape of the parameter array
             will be (data[:-1], 4).
 
         x0 : array

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -37,7 +37,7 @@ def simple_plot(file_name, title, x, y, xlabel, ylabel):
         y-axis values to be plotted
     xlabel : string
         label for x-axis
-    ylable : string
+    ylabel : string
         label for y-axis
 
     """


### PR DESCRIPTION
## Description

Fixes minor spelling mistakes found in docstrings and comments across 3 files. No functional changes.

Fixes #3708 

## Changes

| File | Typo | Fix |
|------|------|-----|
| `dipy/reconst/ivim.py:475` | `paramters` | `parameters` |
| `dipy/viz/regtools.py:40` | `ylable` | `ylabel` |
| `dipy/reconst/dki.py:547,612` | `biologicaly pluasible` | `biologically plausible` |
| `dipy/reconst/dki.py:547,612` | `artefacts` | `artifacts` |

## How it was found

Used `codespell` (already configured in `.codespellrc`) and targeted `grep` searches for common misspellings across all `.py` and `.pyx` files.

## Checklist

- [x] Changes are limited to comments/docstrings only — no code logic changes
- [x] No new dependencies
- [x] Follows DIPY coding style guidelines
