### PR TITLE
CI: Fix incorrect Cython file glob patterns in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -120,8 +120,8 @@ area:workflows:
 
 type:cython:
   files:
-    - "**/.pxd"
-    - "**/.pyx"
+    - "**/*.pxd"
+    - "**/*.pyx"
 
 type:infrastructure:
   files:


### PR DESCRIPTION
Fixes #3710 

## Description

Fix incorrect glob patterns in [.github/labeler.yml](cci:7://file:///Users/satyam/dipy/.github/labeler.yml:0:0-0:0) for the `type:cython` label.

The patterns `**/.pxd` and `**/.pyx` match hidden files literally named
`.pxd` and `.pyx`, not actual Cython source files ending with those
extensions. Changed to `**/*.pxd` and `**/*.pyx` so that PRs modifying
Cython files are correctly labeled.

## Changes

- `**/.pxd` → `**/*.pxd`
- `**/.pyx` → `**/*.pyx`

## Checklist

- [x] Fix is limited to CI configuration (no code changes)
- [x] No new tests required