### PR TITLE
CI: Remove duplicate .mailmap entry in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -133,7 +133,6 @@ type:infrastructure:
     - ".gitattributes"
     - ".gitignore"
     - ".mailmap"
-    - ".mailmap"
     - ".pre-commit-config.yaml"
     - "Makefile"
     - "pyproject.toml"


### PR DESCRIPTION
Fixes #3712 

## Description

Remove duplicate `.mailmap` entry from the `type:infrastructure` file patterns in `.github/labeler.yml`.

The `.mailmap` file was listed twice:

```diff
 type:infrastructure:
   files:
     ...
     - ".mailmap"
-    - ".mailmap"
     ...
```

## Changes

- Removed the duplicate `.mailmap` line from `type:infrastructure` in `.github/labeler.yml`

## Checklist

- [x] Fix is limited to CI configuration (no code changes)
- [x] No new tests required
