### PR TITLE
CI: Add missing timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ jobs:
   benchmark:
     name: Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,6 +13,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   pre-commit:
-
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,7 @@ jobs:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     if: github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -82,6 +83,7 @@ jobs:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     if: github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +132,7 @@ jobs:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     if: github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -171,6 +174,7 @@ jobs:
     if: github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
     needs: [build_linux_wheels]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -203,6 +207,7 @@ jobs:
       needs: [build_linux_wheels, build_osx_wheels, build_windows_wheels]
       if: ${{ always() }} && github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
       runs-on: ubuntu-latest
+      timeout-minutes: 10
       steps:
       - uses: actions/download-artifact@v7
         id: download


### PR DESCRIPTION
Fixes #3714 

## Description

Add explicit `timeout-minutes` to all CI workflow jobs that were relying on the default 360-minute (6-hour) GitHub Actions timeout. This prevents stuck or hanging jobs from consuming CI minutes unnecessarily.

## Changes

| Workflow | Job | Timeout |
|---|---|---|
| [benchmark.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/benchmark.yml:0:0-0:0) | `benchmark` | 60 min |
| [build_docs.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/build_docs.yml:0:0-0:0) | `build` | 30 min |
| [check_format.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/check_format.yml:0:0-0:0) | `pre-commit` | 10 min |
| [nightly.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/nightly.yml:0:0-0:0) | `build_linux_wheels` | 90 min |
| [nightly.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/nightly.yml:0:0-0:0) | `build_osx_wheels` | 90 min |
| [nightly.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/nightly.yml:0:0-0:0) | `build_windows_wheels` | 90 min |
| [nightly.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/nightly.yml:0:0-0:0) | `test_wheels` | 30 min |
| [nightly.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/nightly.yml:0:0-0:0) | `upload_anaconda` | 10 min |

Note: [test_template.yml](cci:7://file:///Users/satyam/dipy/.github/workflows/test_template.yml:0:0-0:0) already has `timeout-minutes: 120` and was not changed.

## Rationale

- **Build jobs (90 min):** Wheel compilation, especially on aarch64 via QEMU, can be slow but should not exceed 90 minutes.
- **Benchmark (60 min):** Compilation + benchmark suite execution.
- **Doc build (30 min):** Sphinx rendering with examples skipped.
- **Pre-commit (10 min):** Linting and formatting checks are fast.
- **Upload (10 min):** Simple artifact download + upload to Anaconda.

## Checklist

- [x] Fix is limited to CI configuration (no code changes)
- [x] No new tests required