### PR TITLE
CI: Pin actions/first-interaction by commit SHA in first_interaction.yml

### DIFF
--- a/.github/workflows/first_interaction.yml
+++ b/.github/workflows/first_interaction.yml
@@ -12,33 +12,33 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/first-interaction@v3.1
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        issue_message: |
-          :pray: Thank you for contributing an issue !
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          issue_message: |
+            :pray: Thank you for contributing an issue !
 
-          :rocket: **We are glad that you are finding DIPY useful !**
+            :rocket: **We are glad that you are finding DIPY useful !**
 
-          This is an automatic message. Allow for time for DIPY maintainers to be able to read the issue and comment on it.
+            This is an automatic message. Allow for time for DIPY maintainers to be able to read the issue and comment on it.
 
-          If asking for help or advice, please move the issue to the [Discussions section](https://github.com/dipy/dipy/discussions): issues are intended to request new features or to report bugs.
+            If asking for help or advice, please move the issue to the [Discussions section](https://github.com/dipy/dipy/discussions): issues are intended to request new features or to report bugs.
 
-          We would appreciate if you took the time to submit a pull request to fix this issue should it happen to be one.
+            We would appreciate if you took the time to submit a pull request to fix this issue should it happen to be one.
 
-          :book: Please read our [CODE OF CONDUCT](https://github.com/dipy/dipy/blob/master/.github/CODE_OF_CONDUCT.md) and our [CONTRIBUTING guidelines](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) if you have not done that already.
+            :book: Please read our [CODE OF CONDUCT](https://github.com/dipy/dipy/blob/master/.github/CODE_OF_CONDUCT.md) and our [CONTRIBUTING guidelines](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) if you have not done that already.
 
-        pr_message: |
-          :pray: Thank you for contributing a pull request !
+          pr_message: |
+            :pray: Thank you for contributing a pull request !
 
-          :rocket: **We are glad that you are finding DIPY useful !**
+            :rocket: **We are glad that you are finding DIPY useful !**
 
-          This is an automatic message. Allow for time for DIPY maintainers to be able to read this pull request and comment on it.
+            This is an automatic message. Allow for time for DIPY maintainers to be able to read this pull request and comment on it.
 
-          :white_check_mark: Note that we require the **code formatting**, **testing** and **documentation builds** to **pass** in order to merge your pull request.
+            :white_check_mark: Note that we require the **code formatting**, **testing** and **documentation builds** to **pass** in order to merge your pull request.
 
-          GitHub will report on the status of each aspect as the builds become available. **Please, check their status and make the appropriate changes as necessary**.
+            GitHub will report on the status of each aspect as the builds become available. **Please, check their status and make the appropriate changes as necessary**.
 
-          :mag: It is **your responsibility** to ensure that the above checks pass to have your pull request reviewed in a timely manner and merged.
+            :mag: It is **your responsibility** to ensure that the above checks pass to have your pull request reviewed in a timely manner and merged.
 
-          :book: Please read our [CODE OF CONDUCT](https://github.com/dipy/dipy/blob/master/.github/CODE_OF_CONDUCT.md) and our [CONTRIBUTING guidelines](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) if you have not done that already.
+            :book: Please read our [CODE OF CONDUCT](https://github.com/dipy/dipy/blob/master/.github/CODE_OF_CONDUCT.md) and our [CONTRIBUTING guidelines](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) if you have not done that already.


### PR DESCRIPTION
Fixes #3723

## Description

The `first_interaction.yml` workflow runs on `pull_request_target` and `issues` events with `pull-requests: write` and `issues: write` permissions. The `actions/first-interaction` action is currently pinned by a **mutable tag** (`v3.1`).

This PR pins it by **full commit SHA** as a defense-in-depth security measure, consistent with GitHub's hardening recommendations for privileged workflows.

### Before

```yaml
- uses: actions/first-interaction@v3.1
```

### After

```yaml
- uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1
```

## Context

Although `actions/first-interaction` is a first-party GitHub action (lower risk than third-party), pinning by SHA is the consistent best practice for any action used in `pull_request_target` workflows. This also aligns with a similar fix applied to `label-pr.yml` (`srvaroa/labeler`).

## References

- [GitHub Security Hardening: Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

## Checklist

- [x] Change is limited to CI configuration (no source code changes)
- [x] No new dependencies added
- [x] Functionality is identical — same action, same version, just pinned by SHA
- [x] Follows the project's `CI:` commit prefix convention
