### PR TITLE
CI: Update stale dependency pins in CI configuration

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,12 +13,12 @@ on:
     #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #        │ │ │ │ │
-    - cron: "0 0 * * 0,3"  # Every Sunday and Wednesday at midnight
+    - cron: "0 0 * * 0,3" # Every Sunday and Wednesday at midnight
 
 env:
   BUILD_COMMIT: "master"
   CIBW_BUILD_VERBOSITY: 2
-  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest==8.0.0"
+  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest>=8.0.0"
   CIBW_TEST_COMMAND: pytest --pyargs dipy
   CIBW_CONFIG_SETTINGS: "compile-args=-v"
 
@@ -64,19 +64,19 @@ jobs:
       - name: Build the wheel
         run: python -m cibuildwheel --output-dir dist
         env:
-            CIBW_BUILD: ${{ matrix.cibw_python }}
-            CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
-            CIBW_SKIP: "*-musllinux_*"
-            CIBW_TEST_SKIP: "*"  # "*_aarch64"
-            CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-            CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-            CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_TEST_SKIP: "*" # "*_aarch64"
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
       - name: Rename Python version
         run: echo "PY_VERSION=$(echo ${{ matrix.cibw_python }} | cut -d- -f1)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v6
         with:
-            name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_manylinux }}-${{ matrix.cibw_arch }}
-            path: ./dist/*.whl
+          name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_manylinux }}-${{ matrix.cibw_arch }}
+          path: ./dist/*.whl
 
   build_osx_wheels:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
@@ -113,18 +113,18 @@ jobs:
       - name: Build the wheel
         run: python -m cibuildwheel --output-dir dist
         env:
-            CIBW_BEFORE_ALL_MACOS: "brew install llvm libomp"
-            CIBW_BUILD: ${{ matrix.cibw_python }}
-            CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
-            CIBW_TEST_SKIP: "*"  # "*_aarch64 *-macosx_arm64"
-            CIBW_ENVIRONMENT_MACOS: ${{ matrix.compiler_env }}
-            CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+          CIBW_BEFORE_ALL_MACOS: "brew install llvm libomp"
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
+          CIBW_TEST_SKIP: "*" # "*_aarch64 *-macosx_arm64"
+          CIBW_ENVIRONMENT_MACOS: ${{ matrix.compiler_env }}
+          CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
       - name: Rename Python version
         run: echo "PY_VERSION=$(echo ${{ matrix.cibw_python }} | cut -d- -f1)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v6
         with:
-            name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_manylinux }}-${{ matrix.cibw_arch }}
-            path: ./dist/*.whl
+          name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_manylinux }}-${{ matrix.cibw_arch }}
+          path: ./dist/*.whl
 
   build_windows_wheels:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
@@ -154,17 +154,17 @@ jobs:
       - name: Build the wheel
         run: python -m cibuildwheel --output-dir dist
         env:
-            CIBW_BUILD: ${{ matrix.cibw_python }}
-            CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-            CIBW_CONFIG_SETTINGS: "setup-args=--vsenv compile-args=-v"
-            CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          CIBW_CONFIG_SETTINGS: "setup-args=--vsenv compile-args=-v"
+          CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
       - name: Rename Python version
         shell: bash
         run: echo "PY_VERSION=$(echo ${{ matrix.cibw_python }} | cut -d- -f1)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v6
         with:
-            name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_arch }}
-            path: ./dist/*.whl
+          name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_arch }}
+          path: ./dist/*.whl
 
   test_wheels:
     name: Test wheels
@@ -197,13 +197,13 @@ jobs:
           python -c "from dipy.align.imaffine import AffineMap"
 
   upload_anaconda:
-      permissions:
-        contents: write # for softprops/action-gh-release to create GitHub release
-      name: Upload to Anaconda
-      needs: [build_linux_wheels, build_osx_wheels, build_windows_wheels]
-      if: ${{ always() }} && github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
-      runs-on: ubuntu-latest
-      steps:
+    permissions:
+      contents: write # for softprops/action-gh-release to create GitHub release
+    name: Upload to Anaconda
+    needs: [build_linux_wheels, build_osx_wheels, build_windows_wheels]
+    if: ${{ always() }} && github.repository_owner == 'dipy' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/download-artifact@v7
         id: download
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,11 @@ name: DIPY Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '0 0 5 * 0' # 1 per month
-
+    - cron: "0 0 5 * 0" # 1 per month
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -39,7 +38,7 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: dask joblib ray==2.9.3 protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211
+      extra-depends: dask joblib ray
 
   minimal-py311:
     uses: ./.github/workflows/test_template.yml

--- a/tools/ci/install_dependencies.sh
+++ b/tools/ci/install_dependencies.sh
@@ -28,7 +28,7 @@ else
         PIPI="$PIPI --pre --index-url $PRE_WHEELS --extra-index-url https://pypi.org/simple";
     fi
 
-    $PIPI pytest==8.0.0
+    $PIPI "pytest>=8.0.0"
     $PIPI numpy
     if [ -n "$DEPENDS" ]; then $PIPI $DEPENDS $EXTRA_DEPENDS; fi
     if [ "$COVERAGE" == "1" ] || [ "$COVERAGE" = true ]; then pip install coverage coveralls; fi


### PR DESCRIPTION
Fixes #3726 

## Description

Several dependency pins in the CI configuration are outdated. This PR updates the ones that are safe to change while preserving intentional backward-compatibility pins.

### Changes Made

#### 1. Removed `ray==2.9.3` + `protobuf<4.0.0` in `test.yml`

```diff
- extra-depends: dask joblib ray==2.9.3 protobuf<4.0.0 # More info here https://github.com/ray-project/ray/pull/25211
+ extra-depends: dask joblib ray
```

**Rationale:** The `protobuf<4.0.0` constraint was a workaround for [ray-project/ray#25211](https://github.com/ray-project/ray/pull/25211), fixed in Ray 1.13.0 (June 2022). Modern Ray (2.53.0) ships with `protobuf==4.25.8`, confirming full compatibility. The `ray==2.9.3` pin was ~18 months behind current releases.

#### 2. Relaxed `pytest==8.0.0` → `pytest>=8.0.0`

In **`tools/ci/install_dependencies.sh`**:

```diff
- $PIPI pytest==8.0.0
+ $PIPI "pytest>=8.0.0"
```

In **`.github/workflows/nightly.yml`**:

```diff
- CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest==8.0.0"
+ CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest>=8.0.0"
```

**Rationale:** The exact pin prevented receiving pytest bug fixes (current: 8.3+). A minimum version constraint maintains compatibility while allowing updates.

### Intentionally NOT Changed

| Dependency                            | Location                | Reason                                    |
| ------------------------------------- | ----------------------- | ----------------------------------------- |
| `scipy==1.10.1`                       | optional-deps jobs      | Backward compatibility testing            |
| `numpy==1.24.2`, `h5py==3.11.0`, etc. | optional-deps-pip       | Backward compatibility testing            |
| `minimal-py311` pins                  | minimal-py311 job       | Minimum supported version testing         |
| `tensorflow==2.18`                    | coverage job            | DL frameworks need specific pins          |
| `setuptools~=69.5`                    | install_dependencies.sh | Already uses compatible-release specifier |

## Checklist

- [x] Only safe-to-update pins were changed
- [x] Backward-compatibility test pins were preserved
- [x] Changes applied consistently across `test.yml`, `install_dependencies.sh`, and `nightly.yml`
- [x] Follows the project's `CI:` commit prefix convention
