### PR TITLE
CI: Fix threading env vars not persisting across steps in benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,9 +33,9 @@ jobs:
         pip install .[dev,test,ml,extra,benchmark]
     - name: Set threading parameters for reliable benchmarking
       run: |
-        export OPENBLAS_NUM_THREADS=1
-        export MKL_NUM_THREADS=1
-        export OMP_NUM_THREADS=1
+        echo "OPENBLAS_NUM_THREADS=1" >> $GITHUB_ENV
+        echo "MKL_NUM_THREADS=1" >> $GITHUB_ENV
+        echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
     - name: Run benchmarks
       run: |
         asv machine --yes --config ${GITHUB_WORKSPACE}/benchmarks/asv.conf.json


### PR DESCRIPTION
Fixes #3728 

## Description

The benchmark workflow sets threading parameters (`OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `OMP_NUM_THREADS`) via `export` in a dedicated step, but these variables **don't persist** to the subsequent "Run benchmarks" step because each GitHub Actions `run:` step executes in a **separate shell process**.

This means benchmarks have been running without the intended single-threaded constraints, potentially causing non-deterministic results and higher variance.

### Before

```yaml
- name: Set threading parameters for reliable benchmarking
  run: |
    export OPENBLAS_NUM_THREADS=1   # ❌ Lost when this step's shell exits
    export MKL_NUM_THREADS=1
    export OMP_NUM_THREADS=1
- name: Run benchmarks # ❌ New shell — no threading controls
  run: |
    asv machine --yes ...
    asv run ...
```

### After

```yaml
- name: Set threading parameters for reliable benchmarking
  run: |
    echo "OPENBLAS_NUM_THREADS=1" >> $GITHUB_ENV   # ✅ Persists across steps
    echo "MKL_NUM_THREADS=1" >> $GITHUB_ENV
    echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
- name: Run benchmarks # ✅ Sees all three vars
  run: |
    asv machine --yes ...
    asv run ...
```

## References

- [GitHub Docs: Passing values between steps](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#passing-values-between-steps-and-jobs-in-a-workflow)

## Checklist

- [x] Change is limited to CI configuration (no source code changes)
- [x] No new dependencies added
- [x] Benchmark logic is unchanged — only how env vars are set
- [x] Follows the project's `CI:` commit prefix convention
