### PR TITLE
MNT: Remove dead install type code paths from install.sh

### DIFF
--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -15,23 +15,7 @@ fi
 
 #---------- DIPY Installation -----------------
 
-if [ "$INSTALL_TYPE" == "setup" ]; then
-    python setup.py install
-elif [ "$INSTALL_TYPE" == "pip" ]; then
-    $PIPI -vv .
-elif [ "$INSTALL_TYPE" == "sdist" ]; then
-    # python -m pep517.build
-    python setup_egg.py egg_info  # check egg_info while we're here
-    python setup_egg.py sdist
-    $PIPI dist/*.tar.gz
-elif [ "$INSTALL_TYPE" == "wheel" ]; then
-    pip install wheel
-    python setup_egg.py bdist_wheel
-    $PIPI dist/*.whl
-elif [ "$INSTALL_TYPE" == "requirements" ]; then
-    $PIPI -r requirements.txt
-    python setup.py install
-elif [ "$INSTALL_TYPE" == "conda" ]; then
+if [ "$INSTALL_TYPE" == "pip" ] || [ "$INSTALL_TYPE" == "conda" ]; then
     $PIPI -vv .
 fi
 


### PR DESCRIPTION
Fixes #3730

## Description

The project migrated from `setup.py` to **Meson build** (`meson.build` + `pyproject.toml`), but `tools/ci/install.sh` still had branches for 4 install types that reference files that no longer exist.

### Before (6 branches, 4 dead)

```bash
if [ "$INSTALL_TYPE" == "setup" ]; then        # ❌ setup.py removed
    python setup.py install
elif [ "$INSTALL_TYPE" == "pip" ]; then         # ✅ Active
    $PIPI -vv .
elif [ "$INSTALL_TYPE" == "sdist" ]; then       # ❌ setup_egg.py removed
    python setup_egg.py egg_info
    python setup_egg.py sdist
    $PIPI dist/*.tar.gz
elif [ "$INSTALL_TYPE" == "wheel" ]; then       # ❌ setup_egg.py removed
    pip install wheel
    python setup_egg.py bdist_wheel
    $PIPI dist/*.whl
elif [ "$INSTALL_TYPE" == "requirements" ]; then # ❌ setup.py removed
    $PIPI -r requirements.txt
    python setup.py install
elif [ "$INSTALL_TYPE" == "conda" ]; then       # ✅ Active
    $PIPI -vv .
fi
```

### After (1 combined branch)

```bash
if [ "$INSTALL_TYPE" == "pip" ] || [ "$INSTALL_TYPE" == "conda" ]; then
    $PIPI -vv .
fi
```

Both `pip` and `conda` executed the same command (`$PIPI -vv .`), so they are combined into one conditional.

## Verification

- Confirmed `setup.py` and `setup_egg.py` do **not exist** in the repo
- Confirmed no CI workflow sets `INSTALL_TYPE` to `setup`, `sdist`, `wheel`, or `requirements`
- Only `pip` (default) and `conda` are used

## Checklist

- [x] Removed 16 lines of dead code
- [x] No behavioral change — active install types (`pip`, `conda`) work identically
- [x] Follows the project's `MNT:` commit prefix convention
