### PR TITLE
CI: Add pip ecosystem tracking to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Set update schedule for GitHub Actions
+# Set update schedule for GitHub Actions and pip dependencies
 
 version: 2
 updates:
@@ -10,5 +10,15 @@ updates:
       interval: "weekly"
     groups:
       actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      # Check for updates to Python dependencies every month
+      interval: "monthly"
+    groups:
+      python-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
Fixes #3732 

## Description

Dependabot only monitored GitHub Actions for updates. This PR adds **pip ecosystem tracking** so outdated Python dependencies in `pyproject.toml` and `requirements/` files are also flagged automatically.

### Before

```yaml
updates:
  - package-ecosystem: "github-actions" # Only this
```

### After

```yaml
updates:
  - package-ecosystem: "github-actions"
    # ...

  - package-ecosystem: "pip" # New
    directory: "/"
    schedule:
      interval: "monthly"
    groups:
      python-dependencies:
        patterns:
          - "*"
```

### Design Choices

- **Monthly schedule** instead of weekly — reduces noise since the project has many pinned dependencies for compatibility testing
- **Grouped updates** — all pip dependency updates are batched into a single PR to keep the PR count manageable

## Checklist

- [x] Change is limited to CI configuration (no source code changes)
- [x] No new dependencies added
- [x] Existing GitHub Actions monitoring unchanged
- [x] Follows the project's `CI:` commit prefix convention
