### PR TITLE
CI: Restrict benchmark workflow triggers to master branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,10 @@
 name: Benchmarks
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Fixes #3734

## Description

The benchmark workflow used an unfiltered `on: [push, pull_request]` trigger, unlike all other workflows in the project which filter to `branches: [ master ]`. This caused expensive ASV benchmark runs on every push to any branch.

### Before

```yaml
on: [push, pull_request] # Triggers on ALL branches
```

### After

```yaml
on:
  push:
    branches: [master] # Only master
  pull_request:
    branches: [master] # Only PRs targeting master
```

### Consistency with Other Workflows

All other workflows already use this pattern:

- `test.yml` → `branches: [ master ]`
- `test_viz.yml` → `branches: [ master ]`
- `build_docs.yml` → `branches: [ master ]`
- `check_format.yml` → `branches: [master]`

## Checklist

- [x] Change is limited to CI configuration (no source code changes)
- [x] No new dependencies added
- [x] Benchmark logic is unchanged — only trigger scope narrowed
- [x] Follows the project's `CI:` commit prefix convention
