### PR TITLE
 DOC: Migrate remaining `http://` URLs to `https://`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: doc/_static/images/logos/dipy-logo.png
   :height: 180px
-  :target: http://dipy.org
+  :target: https://dipy.org
   :alt: DIPY - Diffusion Imaging in Python
 
 |
@@ -35,7 +35,7 @@ in clinical settings.
 Website
 =======
 
-Current information can always be found from the DIPY website - http://dipy.org
+Current information can always be found from the DIPY website - https://dipy.org
 
 Mailing Lists
 =============
@@ -57,9 +57,9 @@ You can find our sources and single-click downloads:
 * Documentation_ for all releases and current development tree.
 * Download as a tar/zip file the `current trunk`_.
 
-.. _main repository: http://github.com/dipy/dipy
-.. _Documentation: http://dipy.org
-.. _current trunk: http://github.com/dipy/dipy/archives/master
+.. _main repository: https://github.com/dipy/dipy
+.. _Documentation: https://dipy.org
+.. _current trunk: https://github.com/dipy/dipy/archives/master
 
 
 Installing DIPY

--- a/dipy/core/histeq.py
+++ b/dipy/core/histeq.py
@@ -7,7 +7,7 @@ from dipy.testing.decorators import warning_for_keywords
 def histeq(arr, *, num_bins=256):
     """Performs an histogram equalization on ``arr``.
     This was taken from:
-    http://www.janeriksolem.net/2009/06/histogram-equalization-with-python-and.html
+    https://www.janeriksolem.net/2009/06/histogram-equalization-with-python-and.html
 
     Parameters
     ----------

--- a/dipy/core/onetime.py
+++ b/dipy/core/onetime.py
@@ -49,7 +49,7 @@ to their 'untriggered' state.
 References
 ----------
 .. [1] How-To Guide for Descriptors, Raymond
-   Hettinger. http://users.rcn.com/python/download/Descriptor.htm
+   Hettinger. https://users.rcn.com/python/download/Descriptor.htm
 
 .. [2] Python data model, https://docs.python.org/reference/datamodel.html
 """

--- a/dipy/core/optimize.py
+++ b/dipy/core/optimize.py
@@ -223,7 +223,7 @@ def spdot(A, B):
     sparse matrix. Otherwise, a dense result is returned
 
     See discussion here:
-    http://mail.scipy.org/pipermail/scipy-user/2010-November/027700.html
+    https://mail.scipy.org/pipermail/scipy-user/2010-November/027700.html
 
     """
     return A @ B

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -5,7 +5,7 @@ key features of the HDF5 (hierarchical data format) API [1]_.
 
 References
 ----------
-.. [1] http://www.hdfgroup.org/HDF5/doc/H5.intro.html
+.. [1] https://www.hdfgroup.org/HDF5/doc/H5.intro.html
 """
 
 import h5py

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -178,7 +178,7 @@ def test_tensor_model():
         for i in range(3):
             # Eigenvectors have intrinsic sign ambiguity
             # (see
-            # http://prod.sandia.gov/techlib/access-control.cgi/2007/076422.pdf)
+            # https://prod.sandia.gov/techlib/access-control.cgi/2007/076422.pdf)
             # so we need to allow for sign flips. One of the following should
             # always be true:
             npt.assert_(

--- a/dipy/reconst/tests/test_reco_utils.py
+++ b/dipy/reconst/tests/test_reco_utils.py
@@ -29,7 +29,7 @@ def test_argmax_from_countarrs():
     #
     # The tests below cause odd errors and segfaults with numpy SVN
     # vintage June 2010 (sometime after 1.4.0 release) - see
-    # http://groups.google.com/group/cython-users/browse_thread/thread/624c696293b7fe44?pli=1
+    # https://groups.google.com/group/cython-users/browse_thread/thread/624c696293b7fe44?pli=1
     """
     yield assert_raises(ValueError,
                         argmax_from_countarrs,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -389,13 +389,13 @@ html_theme_options = {
             "links": [
                 {
                     "name": "Nipy Projects",
-                    "link": "http://nipy.org/",
+                    "link": "https://nipy.org/",
                     "link_type": "external",
                 },
-                {"name": "FURY", "link": "http://fury.gl/", "link_type": "external"},
+                {"name": "FURY", "link": "https://fury.gl/", "link_type": "external"},
                 {
                     "name": "Nibabel",
-                    "link": "http://nipy.org/nibabel",
+                    "link": "https://nipy.org/nibabel",
                     "link_type": "external",
                 },
                 {

--- a/doc/devel/gitwash/forking_hell.rst
+++ b/doc/devel/gitwash/forking_hell.rst
@@ -5,7 +5,7 @@ Making your own copy (fork) of DIPY
 ======================================================
 
 You need to do this only once. The instructions here are very similar
-to the instructions at http://help.github.com/forking/ |emdash| please see
+to the instructions at https://help.github.com/forking/ |emdash| please see
 that page for more detail. We're repeating some of it here just to give the
 specifics for the `DIPY`_ project, and to suggest some default names.
 

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -232,7 +232,7 @@ tag to github, so the buildbots can find the released code and build it.
 
     * An account on a macOS box with sudo (Admin user) on which to run the
       script.
-    * ssh access to the buildbot server http://nipy.bic.berkeley.edu (ask
+    * ssh access to the buildbot server https://nipy.bic.berkeley.edu (ask
       Matthew or Eleftherios).
     * a development version of ``bdist_mpkg`` installed from
       https://github.com/matthew-brett/bdist_mpkg.  You need this second for the

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -328,7 +328,7 @@ fig.savefig("spatial_errors.png")
 # streamlines generated in
 # :ref:`sphx_glr_examples_built_fiber_tracking_tracking_probabilistic.py`, see
 # `this IPython notebook
-# <http://nbviewer.ipython.org/gist/arokem/bc29f34ebc97510d9def>`_.
+# <https://nbviewer.ipython.org/gist/arokem/bc29f34ebc97510d9def>`_.
 #
 # For the Matlab implementation of LiFE, head over to `Franco Pestilli's github
 # webpage <https://francopestilli.github.io/life/>`_.

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -22,7 +22,7 @@ from dipy.viz import actor, window
 # Download and read the data for this tutorial.
 
 # ``fetch_isbi2013_2shell()`` provides data from the `ISBI HARDI contest 2013
-# <http://hardi.epfl.ch/static/events/2013_ISBI/>`_ acquired for two shells at
+# <https://hardi.epfl.ch/static/events/2013_ISBI/>`_ acquired for two shells at
 # b-values 1500 $s/mm^2$ and 2500 $s/mm^2$.
 
 # The six parameters of these two functions define the ROI where to reconstruct

--- a/doc/gimbal_lock.rst
+++ b/doc/gimbal_lock.rst
@@ -84,7 +84,7 @@ When $\sin(\beta) = 1$:
 From the `angle sum and difference identities
 <https://en.wikipedia.org/wiki/List_of_trigonometric_identities#Angle_sum_and_difference_identities>`_
 (see also `geometric proof
-<http://www.themathpage.com/atrig/sum-proof.htm>`_, `Mathworld treatment
+<https://www.themathpage.com/atrig/sum-proof.htm>`_, `Mathworld treatment
 <https://mathworld.wolfram.com/TrigonometricAdditionFormulas.html>`_) we
 remind ourselves that, for any two angles $\alpha$ and $\beta$:
 
@@ -115,5 +115,5 @@ rotation about the $z$ axis.
 
 It's easy to do the same set of reductions, with the same conclusion,
 for the case where $\sin(\beta) = -1$ - see
-http://www.gregslabaugh.name/publications/euler.pdf.
+https://www.gregslabaugh.name/publications/euler.pdf.
 

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -280,7 +280,7 @@ DIPY was an **official exhibitor** for OHBM 2015.
 .. raw :: html
 
   <div style="width: 80% max-width=800px">
-    <a href="http://www.humanbrainmapping.org/i4a/pages/index.cfm?pageID=3625" target="_blank"><img alt=" " class="align-center" src="_static/hbm2015_exhibitors.jpg" style="width: 90%;max-height: 90%"></a>
+    <a href="https://www.humanbrainmapping.org/i4a/pages/index.cfm?pageID=3625" target="_blank"><img alt=" " class="align-center" src="_static/hbm2015_exhibitors.jpg" style="width: 90%;max-height: 90%"></a>
   </div>
 
 
@@ -305,7 +305,7 @@ For more information about DIPY_, read the `DIPY paper`_  in Frontiers in Neuroi
 .. raw :: html
 
   <div style="width: 80% max-width=800px">
-    <a href="http://www.frontiersin.org/Neuroinformatics/10.3389/fninf.2014.00008/abstract" target="_blank"><img alt=" " class="align-center" src="_static/dipy_paper_logo.jpg" style="width: 90%;max-height: 90%"></a>
+    <a href="https://www.frontiersin.org/Neuroinformatics/10.3389/fninf.2014.00008/abstract" target="_blank"><img alt=" " class="align-center" src="_static/dipy_paper_logo.jpg" style="width: 90%;max-height: 90%"></a>
   </div>
 
 So, how similar are your bundles to the real anatomy? Learn how to optimize your analysis as we did to create the fornix of the figure above, by reading the tutorials in our :ref:`gallery <examples>`.
@@ -315,7 +315,7 @@ In DIPY_ we care about methods which can solve complex problems efficiently and 
 
 .. raw:: html
 
-    <iframe width="420" height="315" src="http://www.youtube.com/embed/kstL7KKqu94" frameborder="0" allowfullscreen></iframe>
+    <iframe width="420" height="315" src="https://www.youtube.com/embed/kstL7KKqu94" frameborder="0" allowfullscreen></iframe>
 
 
 .. include:: links_names.inc

--- a/doc/old_news.rst
+++ b/doc/old_news.rst
@@ -37,7 +37,7 @@ Past Announcements
 - :doc:`DIPY 0.7.1 <release_notes/release0.7>` Released!, 16 January, 2014.
 - :doc:`DIPY 0.7.0 <release_notes/release0.7>` Released!, 23 December, 2013.
 - **Spherical Deconvolution** algorithms are now included in the current development version 0.7.0dev. See the examples in :ref:`gallery <examples>`, 24 June 2013.
-- A team of DIPY developers **wins** the `IEEE ISBI HARDI challenge <http://hardi.epfl.ch/static/events/2013_ISBI/workshop.html#results>`_, 7 April, 2013.
+- A team of DIPY developers **wins** the `IEEE ISBI HARDI challenge <https://hardi.epfl.ch/static/events/2013_ISBI/workshop.html#results>`_, 7 April, 2013.
 - **Hands on DIPY** seminar took place at the dMRI course of the CREATE-MIA summer school, 5-7 June, McGill, Montreal, 2013.
 - :doc:`DIPY 0.6.0 <release_notes/release0.6>` Released!, 30 March, 2013.
 - **DIPY 3rd Sprint**, Berkeley, CA, 8-18 April, 2013.

--- a/doc/user_guide/dataset_list.rst
+++ b/doc/user_guide/dataset_list.rst
@@ -55,7 +55,7 @@
      - Multi shell data: b-vals: [0, 1500, 2500] (s/mm^2); 64 gradient directions
      -
      - isbi2013_2shell
-     - Daducci, A., et al. Quantitative Comparison of Reconstruction Methods for Intra-Voxel Fiber Recovery From Diffusion MRI. IEEE Transactions on Medical Imaging, vol. 33, no. 2, pp. 384-399, Feb. 2014. <a href='http://hardi.epfl.ch/static/events/2013_ISBI/testing_data.html'>HARDI reconstruction challenge 2013</a>
+     - Daducci, A., et al. Quantitative Comparison of Reconstruction Methods for Intra-Voxel Fiber Recovery From Diffusion MRI. IEEE Transactions on Medical Imaging, vol. 33, no. 2, pp. 384-399, Feb. 2014. <a href='https://hardi.epfl.ch/static/events/2013_ISBI/testing_data.html'>HARDI reconstruction challenge 2013</a>
    * - IVIM dataset
      - Human
      - Multi shell data: b-vals: [0, 10, 20, 30, 40, 60, 80, 100, 120, 140, 160, 180, 200, 300, 400, 500, 600, 700, 800, 900, 1000] (s/mm^2); 21 gradient directions
@@ -79,13 +79,13 @@
      - b0
      - GE (1.5, 3 T), Philips (3 T); Siemens (1.5, 3 T)
      - scil_b0
-     - <a href='http://scil.dinf.usherbrooke.ca'>Sherbrooke Connectivity Imaging Lab (SCIL)</a>
+     - <a href='https://scil.dinf.usherbrooke.ca'>Sherbrooke Connectivity Imaging Lab (SCIL)</a>
    * - Sherbrooke 3 shells
      - Human
      - Multi shell data: b-vals: [0, 1000, 2000; 3500] (s/mm^2); 193 gradient directions
      -
      - sherbrooke_3shell
-     - <a href='http://scil.dinf.usherbrooke.ca'>Sherbrooke Connectivity Imaging Lab (SCIL)</a>
+     - <a href='https://scil.dinf.usherbrooke.ca'>Sherbrooke Connectivity Imaging Lab (SCIL)</a>
    * - SNAIL dataset
      -
      - 2 subjects: T1; Fractional Anisotropy (FA); 27 bundles

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -138,7 +138,7 @@ def make_link_targets(proj_name,
     if url is not None:
         lines.append(f'.. _`{proj_name}`: {url}\n')
     if not have_gh_url:
-        gh_url = f'http://github.com/{user_name}/{repo_name}\n'
+        gh_url = f'https://github.com/{user_name}/{repo_name}\n'
         lines.append(f'.. _`{proj_name} github`: {gh_url}\n')
     if ml_url is not None:
         lines.append(f'.. _`{proj_name} mailing list`: {ml_url}\n')


### PR DESCRIPTION
Fixes: #3736 

## Description

Migrates **28 insecure `http://` URLs to `https://`** across 17 files in documentation, source code docstrings/comments, and tooling.

This continues the work started in PR #2915 (DIPY 1.8.0) which missed several URLs. All updated URLs have been verified to support HTTPS.

## Changes

- **README.rst**: Updated 5 URLs (`dipy.org`, `github.com/dipy/dipy`)
- **doc/conf.py**: Updated 3 footer links (`nipy.org`, `fury.gl`, `nipy.org/nibabel`)
- **doc/old_highlights.rst**: Updated 3 embedded HTML links
- **doc/old_news.rst**: Updated 1 URL (`hardi.epfl.ch`)
- **doc/user_guide/dataset_list.rst**: Updated 3 citation/reference links
- **doc/gimbal_lock.rst**: Updated 2 reference URLs
- **doc/devel/make_release.rst**: Updated 1 URL (`nipy.bic.berkeley.edu`)
- **doc/devel/gitwash/forking_hell.rst**: Updated 1 URL (`help.github.com`)
- **doc/examples/linear_fascicle_evaluation.py**: Updated 1 URL in docstring
- **doc/examples/reconst_shore.py**: Updated 1 URL in docstring
- **dipy/core/histeq.py**: Updated 1 URL in docstring
- **dipy/core/onetime.py**: Updated 1 URL in docstring
- **dipy/core/optimize.py**: Updated 1 URL in docstring
- **dipy/io/dpy.py**: Updated 1 URL in docstring
- **dipy/reconst/tests/test_reco_utils.py**: Updated 1 URL in comment
- **dipy/reconst/tests/test_dti.py**: Updated 1 URL in comment
- **tools/gitwash_dumper.py**: Updated 1 generated URL from `http://` to `https://`

## Not Changed (intentionally)

- `dipy/data/tests/test_fetcher.py` — uses `http://127.0.0.1:8001/` (localhost test server)
- `doc/release_notes/release1.8.rst` — historical mention of the previous `http → https` migration

## Type of Change

- [x] Documentation update (no functional changes)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] No functional code changes — documentation and comments only
- [x] All updated URLs verified to support HTTPS
- [x] Localhost test URLs preserved as `http://`
