### PR TITLE
CI: Add top-level permissions for least-privilege security

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,9 @@ name: Benchmarks
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
 

--- a/.github/workflows/first_interaction.yml
+++ b/.github/workflows/first_interaction.yml
@@ -4,6 +4,9 @@ on:
   - pull_request_target
   - issues
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,6 +3,9 @@ name: Label PRs
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   stable:
     uses: ./.github/workflows/test_template.yml

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -49,6 +49,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_viz.yml
+++ b/.github/workflows/test_viz.yml
@@ -16,6 +16,9 @@ concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   VIZ:
     uses: ./.github/workflows/test_template.yml


### PR DESCRIPTION
Fixes #3738 

## Description

Add a top-level `permissions: contents: read` to all CI workflow files that currently lack explicit permissions, restricting the default `GITHUB_TOKEN` to read-only for all jobs.

This follows GitHub's [security hardening recommendations](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-the-least-privilege-approach) for the principle of least privilege.

## Changes

Jobs that already have job-level permissions (`label-pr`, `first_interaction`, `nightly/upload_anaconda`) are unaffected — job-level overrides take precedence.

Workflows updated:

| Workflow                | What it does                                  | Write access needed? |
| ----------------------- | --------------------------------------------- | -------------------- |
| `benchmark.yml`         | checkout + build + test                       | No                   |
| `build_docs.yml`        | checkout + build docs                         | No                   |
| `check_format.yml`      | checkout + pre-commit                         | No                   |
| `test.yml`              | calls `test_template.yml`                     | No                   |
| `test_template.yml`     | checkout + cache + test + codecov             | No                   |
| `test_viz.yml`          | calls `test_template.yml`                     | No                   |
| `label-pr.yml`          | labels PRs (job-level `pull-requests: write`) | Job-level only       |
| `first_interaction.yml` | welcome messages (job-level permissions)      | Job-level only       |

## Type of Change

- [x] CI/CD configuration (no functional code changes)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] No functional code changes — workflow permissions only
- [x] Job-level permissions preserved where needed
- [x] `nightly.yml` already had top-level permissions — unchanged
- [x] CI should remain green (no behavioral change)
