### PR TITLE
DOC: Typo in gitwash development_workflow guide

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -65,7 +65,7 @@ When you are ready to make some changes to the code, you should start a new
 branch.  Branches that are for a collection of related edits are often called
 'feature branches'.
 
-Making an new branch for each set of related changes will make it easier for
+Making a new branch for each set of related changes will make it easier for
 someone reviewing your branch to see what you are doing.
 
 Choose an informative name for the branch to remind yourself and the rest of us
@@ -134,7 +134,7 @@ In more detail
 #. Check what the actual changes are with ``git diff`` (`git diff`_).
 #. Add any new files to version control ``git add new_file_name`` (see
    `git add`_).
-#. To commit all modified files into the local copy of your repo,, do
+#. To commit all modified files into the local copy of your repo, do
    ``git commit -am 'A commit message'``.  Note the ``-am`` options to
    ``commit``. The ``m`` flag just signals that you're going to type a
    message on the command line.  The ``a`` flag |emdash| you can just take on
@@ -180,7 +180,7 @@ Delete a branch on github
    # delete branch on github
    git push origin :my-unwanted-branch
 
-(Note the colon ``:`` before ``test-branch``.  See also: `remove remote branch`_.
+(Note the colon ``:`` before ``my-unwanted-branch``.  See also: `remove remote branch`_.
 
 Several people sharing a single repository
 ------------------------------------------
@@ -201,7 +201,7 @@ collaborator:
 
 Now all those people can do::
 
-    git clone git@githhub.com:your-user-name/dipy.git
+    git clone git@github.com:your-user-name/dipy.git
 
 Remember that links starting with ``git@`` use the ssh protocol and are
 read-write; links starting with ``git://`` are read-only.
@@ -331,7 +331,7 @@ Rewriting commit history
 
    Do this only for your own feature branches.
 
-There's an embarrassing typo in a commit you made? Or perhaps the you
+There's an embarrassing typo in a commit you made? Or perhaps you
 made several false starts you would like the posterity not to see.
 
 This can be done via *interactive rebasing*.
@@ -344,7 +344,7 @@ Suppose that the commit history looks like this::
     2dec1ac Fix a few bugs + disable
     13d7934 First implementation
     6ad92e5 * masked is now an instance of a new object, MaskedConstant
-    29001ed Add pre-nep for a copule of structured_array_extensions.
+    29001ed Add pre-nep for a couple of structured_array_extensions.
     ...
 
 and ``6ad92e5`` is the last commit in the ``cool-feature`` branch. Suppose we


### PR DESCRIPTION
This PR fixes a minor grammatical error (a redundant word) in the gitwash/development_workflow.rst file.

Six minor documentation Changes i have made:

Line 64: "Making an new branch" -> "Making a new branch"
Line 117: Double comma "repo,, do" -> "repo, do"
Line 175: Inconsistent reference "test-branch" -> "my-unwanted-branch" (to match the actual example used )
Line 190: Typo "githhub.com" -> "github.com"
Line 334: "Or perhaps the you" -> "Or perhaps you"
Line 371: Spelling error "copule" -> "couple"

Fixes
Fixes #3753 