### PR TITLE
DOC: Fix missing space in `load_peaks` deprecation message

### DIFF
--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -30,7 +30,7 @@ def _safe_save(group, array, name):
 
 
 @deprecate_with_version(
-    "dipy.io.peaks.load_peaks is deprecated, Please usedipy.io.peaks.load_pam instead",
+    "dipy.io.peaks.load_peaks is deprecated, Please use dipy.io.peaks.load_pam instead",
     since="1.10",
     until="1.12",
 )


### PR DESCRIPTION
fixes: #3757 

## Description

Fixed a typo in the deprecation warning message for `dipy.io.peaks.load_peaks` where `"Please usedipy"` was missing a space and should read `"Please use dipy"`.

### Changes

- **`dipy/io/peaks.py`**: Added missing space between `use` and `dipy` in the `@deprecate_with_version` decorator message (line 33).

```diff
- "dipy.io.peaks.load_peaks is deprecated, Please usedipy.io.peaks.load_pam instead"
+ "dipy.io.peaks.load_peaks is deprecated, Please use dipy.io.peaks.load_pam instead"
```

### Checklist

- [x] No new features or API changes
- [x] Documentation/string-only fix
- [x] No tests needed (string correction only)
