### PR TITLE
RF: improve CLI help formatting

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import re
 import shutil
 import sys
-import textwrap
 import warnings
 
 import numpy as np
@@ -36,6 +35,7 @@ from dipy.tracking.streamlinespeed import length
 from dipy.utils.logging import logger
 from dipy.utils.optpkg import optional_package
 from dipy.utils.tractogram import concatenate_tractogram
+from dipy.workflows.base import format_key_value_table
 from dipy.workflows.utils import handle_vol_idx
 from dipy.workflows.workflow import Workflow
 
@@ -350,44 +350,6 @@ def _print_tractography_information(
         tuple(map(float, sft.voxel_sizes)),
         alignment_space,
     )
-
-
-def format_key_value_table(data, key_header="Key", value_header="Value"):
-    """Format key-value pairs as a simple ASCII table.
-
-    Parameters
-    ----------
-    data : dict
-        Key-value pairs to display in the table.
-    key_header : str, optional
-        Header title for the key column.
-    value_header : str, optional
-        Header title for the value column.
-
-    Returns
-    -------
-    str
-        Key-value pairs formatted as an ASCII table.
-    """
-
-    sorted_data = sorted(data.items())
-    key_width = max([len(key_header), *[len(key) for key, _ in sorted_data]])
-    terminal_width = shutil.get_terminal_size(fallback=(120, 20)).columns
-    value_width = max(len(value_header), min(120, terminal_width - key_width - 7))
-    separator = f"+-{'-' * key_width}-+-{'-' * value_width}-+"
-    rows = [
-        separator,
-        f"| {key_header:<{key_width}} | {value_header:<{value_width}} |",
-        separator,
-    ]
-
-    for key, value in sorted_data:
-        wrapped_value = textwrap.wrap(value, width=value_width) or [""]
-        rows.append(f"| {key:<{key_width}} | {wrapped_value[0]:<{value_width}} |")
-        for extra_line in wrapped_value[1:]:
-            rows.append(f"| {'':<{key_width}} | {extra_line:<{value_width}} |")
-    rows.append(separator)
-    return "\n".join(rows)
 
 
 def format_data_names_table(data):

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -573,7 +573,7 @@ class ClassifyTissueFlow(Workflow):
                 class_list.append(["2", "Gray_Matter"])
 
             elif method.lower() == "synthseg":
-                synthseg = SynthSeg()
+                synthseg = SynthSeg(verbose=True)
                 segmentation_final, label_dict, _ = synthseg.predict(data, affine)
                 for label, name in label_dict.items():
                     class_list.append([f"{label}", name])
@@ -722,7 +722,7 @@ class BrainMaskFlow(Workflow):
 
         elif method == "synthseg":
             logger.info("Loading SynthSeg model...")
-            synthseg_model = SynthSeg(use_cuda=use_cuda)
+            synthseg_model = SynthSeg(verbose=True, use_cuda=use_cuda)
             logger.info("SynthSeg model loaded.")
 
         bvals_counter = 0


### PR DESCRIPTION
This pull request refactors and improves the formatting of the CLI help message.

before

```
❯ dipy_fit_dti --help
usage: dipy_fit_dti [-h] [--fit_method str] [--b0_threshold float] [--bvecs_tol float] [--npeaks int] [--sigma float]
                    [--save_metrics [str ...]] [--nifti_tensor] [--extract_pam_values] [--out_dir str] [--out_tensor str] [--out_fa str]
                    [--out_ga str] [--out_rgb str] [--out_md str] [--out_ad str] [--out_rd str] [--out_mode str] [--out_evec str]
                    [--out_eval str] [--out_pam str] [--out_peaks_dir str] [--out_peaks_values str] [--out_peaks_indices str]
                    [--out_sphere str] [--out_qa str] [--out_s0 str] [--force] [--version] [--out_strat string] [--mix_names]
                    [--log_level string] [--log_file string]
                    input_files bvalues_files bvectors_files mask_files

Workflow for tensor reconstruction and for computing DTI metrics using Weighted  Least-Squares.

Performs a tensor reconstruction :footcite:p:`Basser1994b`, :footcite:p:`Basser1996` on the files by 'globing' ``input_files`` and saves the DTI metrics in a directory specified by ``out_dir``.

positional arguments:
  input_files           Path to the input volumes. This path may contain wildcards to process multiple inputs at once.
  bvalues_files         Path to the bvalues files. This path may contain wildcards to use multiple bvalues files at once.
  bvectors_files        Path to the bvectors files. This path may contain wildcards to use multiple bvectors files at once.
  mask_files            Path to the input masks. This path may contain wildcards to use multiple masks at once.

options:
  -h, --help            show this help message and exit
  --fit_method str      can be one of the following: 'WLS' for weighted least squares :footcite:p:`Chung2006` 'LS' or 'OLS' for ordinary least squares :footcite:p:`Chung2006` 'NLLS' for non-linear least-squares 'RT' or 'restore' or 'RESTORE' for RESTORE robust tensor fitting :footcite:p:`Chang2005`. (default: WLS)
  --b0_threshold float  Threshold used to find b0 volumes. (default: 50)
  --bvecs_tol float     Threshold used to check that norm(bvec) = 1 +/- bvecs_tol (default: 0.01)
  --npeaks int          Number of peaks/eigen vectors to save in each voxel. DTI generates 3 eigen values and eigen vectors. The principal eigenvector is saved by default. (default: 1)
  --sigma float         An estimate of the variance. :footcite:t:`Chang2005` recommend to use 1.5267 * std(background_noise), where background_noise is estimated from some part of the image known to contain no signal (only noise) b-vectors are unit vectors. (default: None)
  --save_metrics [str ...]
                        List of metrics to save. Possible values: fa, ga, rgb, md, ad, rd, mode, tensor, evec, eval, s0 (default: None)
  --nifti_tensor        Whether the tensor is saved in the standard Nifti format or in an alternate format that is used by other software (e.g., FSL): a 4-dimensional volume (shape (i, j, k, 6)) with Dxx, Dxy, Dxz, Dyy, Dyz, Dzz on the last dimension. (default: True)
  --extract_pam_values  Save or not to save pam volumes as single nifti files. (default: False)
  --force               Force overwriting output files.
  --version             show program's version number and exit
  --out_strat string    Strategy to manage output creation.
  --mix_names           Prepend mixed input names to output names.
  --log_level string    Log messages display level. Accepted options include CRITICAL, ERROR, WARNING, INFO, DEBUG and NOTSET (default INFO).
  --log_file string     Log file to be saved.

output arguments(optional):
  --out_dir str         Output directory. (default:  current directory)
  --out_tensor str      Name of the tensors volume to be saved. Per default, this will be saved following the nifti standard: with the tensor elements as Dxx, Dxy, Dyy, Dxz, Dyz, Dzz on the last (5th) dimension of the volume (shape: (i, j, k, 1, 6)). If `nifti_tensor` is False, this will be saved in an alternate format that is used by other software (e.g., FSL): a 4-dimensional volume (shape (i, j, k, 6)) with Dxx, Dxy, Dxz, Dyy, Dyz, Dzz on the last dimension. (default: tensors.nii.gz)
  --out_fa str          Name of the fractional anisotropy volume to be saved. (default: fa.nii.gz)
  --out_ga str          Name of the geodesic anisotropy volume to be saved. (default: ga.nii.gz)
  --out_rgb str         Name of the color fa volume to be saved. (default: rgb.nii.gz)
  --out_md str          Name of the mean diffusivity volume to be saved. (default: md.nii.gz)
  --out_ad str          Name of the axial diffusivity volume to be saved. (default: ad.nii.gz)
  --out_rd str          Name of the radial diffusivity volume to be saved. (default: rd.nii.gz)
  --out_mode str        Name of the mode volume to be saved. (default: mode.nii.gz)
  --out_evec str        Name of the eigenvectors volume to be saved. (default: evecs.nii.gz)
  --out_eval str        Name of the eigenvalues to be saved. (default: evals.nii.gz)
  --out_pam str         Name of the peaks volume to be saved. (default: peaks.pam5)
  --out_peaks_dir str   Name of the peaks directions volume to be saved. (default: peaks_dirs.nii.gz)
  --out_peaks_values str
                        Name of the peaks values volume to be saved. (default: peaks_values.nii.gz)
  --out_peaks_indices str
                        Name of the peaks indices volume to be saved. (default: peaks_indices.nii.gz)
  --out_sphere str      Sphere vertices name to be saved. (default: sphere.txt)
  --out_qa str          Name of the Quantitative Anisotropy to be saved. (default: qa.nii.gz)
  --out_s0 str          Name of the S0 estimate to be saved. (default: s0.nii.gz)

References: 
.. footbibliography::

Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem, S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith. Dipy, a library for the analysis of diffusion MRI data. Frontiers in Neuroinformatics, 1-18, 2014.
```

after

```
❯ dipy_fit_dti --help
usage: dipy_fit_dti [-h] [--fit_method str] [--b0_threshold float] [--bvecs_tol float] [--npeaks int] [--sigma float]
                    [--save_metrics [str ...]] [--nifti_tensor] [--extract_pam_values] [--out_dir str] [--out_tensor str] [--out_fa str]
                    [--out_ga str] [--out_rgb str] [--out_md str] [--out_ad str] [--out_rd str] [--out_mode str] [--out_evec str]
                    [--out_eval str] [--out_pam str] [--out_peaks_dir str] [--out_peaks_values str] [--out_peaks_indices str]
                    [--out_sphere str] [--out_qa str] [--out_s0 str] [--force] [--version] [--out_strat string] [--mix_names]
                    [--log_level string] [--log_file string]
                    input_files bvalues_files bvectors_files mask_files


Workflow for tensor reconstruction and for computing DTI metrics using Weighted  Least-Squares.

Performs a tensor reconstruction :footcite:p:`Basser1994b`, :footcite:p:`Basser1996` on the files by 'globing' ``input_files`` and saves the DTI metrics in a directory specified by ``out_dir``.

positional arguments:

+----------------+--------------------------------------------------------------------------------------------------------------------------+
| Argument       | Description                                                                                                              |
+----------------+--------------------------------------------------------------------------------------------------------------------------+
| input_files    | Path to the input volumes. This path may contain wildcards to process multiple inputs at once.                           |
| bvalues_files  | Path to the bvalues files. This path may contain wildcards to use multiple bvalues files at once.                        |
| bvectors_files | Path to the bvectors files. This path may contain wildcards to use multiple bvectors files at once.                      |
| mask_files     | Path to the input masks. This path may contain wildcards to use multiple masks at once.                                  |
+----------------+--------------------------------------------------------------------------------------------------------------------------+

options:

+------------------------+------------------------------------------------------------------------------------------------------------------+
| Argument               | Description                                                                                                      |
+------------------------+------------------------------------------------------------------------------------------------------------------+
| -h, --help             | show this help message and exit                                                                                  |
| --fit_method <str>     | can be one of the following: 'WLS' for weighted least squares :footcite:p:`Chung2006` 'LS' or 'OLS' for ordinary |
|                        | least squares :footcite:p:`Chung2006` 'NLLS' for non-linear least-squares 'RT' or 'restore' or 'RESTORE' for     |
|                        | RESTORE robust tensor fitting :footcite:p:`Chang2005`. (default: WLS)                                            |
| --b0_threshold <float> | Threshold used to find b0 volumes. (default: 50)                                                                 |
| --bvecs_tol <float>    | Threshold used to check that norm(bvec) = 1 +/- bvecs_tol (default: 0.01)                                        |
| --npeaks <int>         | Number of peaks/eigen vectors to save in each voxel. DTI generates 3 eigen values and eigen vectors. The         |
|                        | principal eigenvector is saved by default. (default: 1)                                                          |
| --sigma <float>        | An estimate of the variance. :footcite:t:`Chang2005` recommend to use 1.5267 * std(background_noise), where      |
|                        | background_noise is estimated from some part of the image known to contain no signal (only noise) b-vectors are  |
|                        | unit vectors. (default: None)                                                                                    |
| --save_metrics <str>   | List of metrics to save. Possible values: fa, ga, rgb, md, ad, rd, mode, tensor, evec, eval, s0 (default: None)  |
| --nifti_tensor         | Whether the tensor is saved in the standard Nifti format or in an alternate format that is used by other         |
|                        | software (e.g., FSL): a 4-dimensional volume (shape (i, j, k, 6)) with Dxx, Dxy, Dxz, Dyy, Dyz, Dzz on the last  |
|                        | dimension. (default: True)                                                                                       |
| --extract_pam_values   | Save or not to save pam volumes as single nifti files. (default: False)                                          |
| --force                | Force overwriting output files.                                                                                  |
| --version              | show program's version number and exit                                                                           |
| --out_strat <string>   | Strategy to manage output creation.                                                                              |
| --mix_names            | Prepend mixed input names to output names.                                                                       |
| --log_level <string>   | Log messages display level. Accepted options include CRITICAL, ERROR, WARNING, INFO, DEBUG and NOTSET (default   |
|                        | INFO).                                                                                                           |
| --log_file <string>    | Log file to be saved.                                                                                            |
+------------------------+------------------------------------------------------------------------------------------------------------------+

output arguments(optional):

+---------------------------+---------------------------------------------------------------------------------------------------------------+
| Argument                  | Description                                                                                                   |
+---------------------------+---------------------------------------------------------------------------------------------------------------+
| --out_dir <str>           | Output directory. (default:  current directory)                                                               |
| --out_tensor <str>        | Name of the tensors volume to be saved. Per default, this will be saved following the nifti standard: with    |
|                           | the tensor elements as Dxx, Dxy, Dyy, Dxz, Dyz, Dzz on the last (5th) dimension of the volume (shape: (i, j,  |
|                           | k, 1, 6)). If `nifti_tensor` is False, this will be saved in an alternate format that is used by other        |
|                           | software (e.g., FSL): a 4-dimensional volume (shape (i, j, k, 6)) with Dxx, Dxy, Dxz, Dyy, Dyz, Dzz on the    |
|                           | last dimension. (default: tensors.nii.gz)                                                                     |
| --out_fa <str>            | Name of the fractional anisotropy volume to be saved. (default: fa.nii.gz)                                    |
| --out_ga <str>            | Name of the geodesic anisotropy volume to be saved. (default: ga.nii.gz)                                      |
| --out_rgb <str>           | Name of the color fa volume to be saved. (default: rgb.nii.gz)                                                |
| --out_md <str>            | Name of the mean diffusivity volume to be saved. (default: md.nii.gz)                                         |
| --out_ad <str>            | Name of the axial diffusivity volume to be saved. (default: ad.nii.gz)                                        |
| --out_rd <str>            | Name of the radial diffusivity volume to be saved. (default: rd.nii.gz)                                       |
| --out_mode <str>          | Name of the mode volume to be saved. (default: mode.nii.gz)                                                   |
| --out_evec <str>          | Name of the eigenvectors volume to be saved. (default: evecs.nii.gz)                                          |
| --out_eval <str>          | Name of the eigenvalues to be saved. (default: evals.nii.gz)                                                  |
| --out_pam <str>           | Name of the peaks volume to be saved. (default: peaks.pam5)                                                   |
| --out_peaks_dir <str>     | Name of the peaks directions volume to be saved. (default: peaks_dirs.nii.gz)                                 |
| --out_peaks_values <str>  | Name of the peaks values volume to be saved. (default: peaks_values.nii.gz)                                   |
| --out_peaks_indices <str> | Name of the peaks indices volume to be saved. (default: peaks_indices.nii.gz)                                 |
| --out_sphere <str>        | Sphere vertices name to be saved. (default: sphere.txt)                                                       |
| --out_qa <str>            | Name of the Quantitative Anisotropy to be saved. (default: qa.nii.gz)                                         |
| --out_s0 <str>            | Name of the S0 estimate to be saved. (default: s0.nii.gz)                                                     |
+---------------------------+---------------------------------------------------------------------------------------------------------------+

References: 
.. footbibliography::

Garyfallidis, E., M. Brett, B. Amirbekian, A. Rokem, S. Van Der Walt, M. Descoteaux, and I. Nimmo-Smith. Dipy, a library for the analysis of diffusion MRI data. Frontiers in Neuroinformatics, 1-18, 2014.
```

