### PR TITLE
CI: Add workflow to clean up GitHub Actions caches on closed PRs

### DIFF
--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
Fixes #3768 

# PR Description

## Summary

Adds a new GitHub Actions workflow that automatically deletes runner caches associated with a pull request when it is closed (merged or abandoned).

## Motivation

DIPY's CI uses `actions/cache@v5` in `test_template.yml` to cache test data. GitHub provides a 10 GB shared cache quota per repository. When PRs are closed, their associated cache entries become stale but remain stored, potentially evicting useful caches from active branches.

## Changes

- **New file:** `.github/workflows/cleanup_cache.yml`
  - Triggers on `pull_request: closed` events
  - Uses the `gh` CLI to list and delete all cache entries for the closed PR's merge ref (`refs/pull/<number>/merge`)
  - Requires only the `actions: write` permission
  - Uses `set +e` to ensure partial failures (e.g., already-evicted caches) don't fail the workflow

## Testing

This workflow is event-driven and will activate automatically on the next closed PR. It can be verified by:

1. Observing the "Actions" tab after closing/merging a PR
2. Checking cache usage via `gh cache list` before and after

## References

- [GitHub docs: Force deleting cache entries](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries)
