### PR TITLE
docs: Add a pull request template to standardize PR submissions.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Description
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Motivation and Context
+
+<!-- Why is this change needed? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->
+
+## How Has This Been Tested?
+
+<!-- Describe the tests you ran to verify your changes. -->
+<!-- Include relevant details such as test commands, test coverage, etc. -->
+
+## Checklist
+
+<!-- Please check all that apply. -->
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
+- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
+- [ ] I have added tests that cover my changes (if applicable).
+- [ ] All new and existing tests pass locally.
+- [ ] I have updated the documentation accordingly (if applicable).
+
+## Type of Change
+
+<!-- Check the relevant option(s). -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Maintenance / CI / Infrastructure


### PR DESCRIPTION
Fixes #3770 

## Summary

Adds a pull request template (`.github/PULL_REQUEST_TEMPLATE.md`) to standardize PR descriptions across contributions.

## Motivation

DIPY has issue templates but no PR template. This leads to inconsistent PR descriptions and missing context for reviewers. A template ensures contributors provide the necessary information upfront, reducing review cycles.


## Changes

- **New file:** `.github/PULL_REQUEST_TEMPLATE.md`
  - Description and motivation sections
  - Testing section
  - Checklist aligned with [CONTRIBUTING.md](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) (coding style, tests, docs)
  - Type of change selector (bug fix, feature, breaking change, docs, CI)

## How Has This Been Tested

This is a template file — no code changes. Verified that the template renders correctly in GitHub's PR creation form by previewing the markdown.
