### PR TITLE
CI: Add concurrency group to build_docs.yml

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Adds a `concurrency` group to `build_docs.yml` to cancel in-progress doc builds when a new push arrives for the same PR.

## Motivation

All other PR-triggered workflows (`test.yml`, `benchmark.yml`, `test_viz.yml`, `check_format.yml`) already use concurrency groups to avoid wasting CI resources on superseded builds. `build_docs.yml` was missing this, likely an oversight.

Closes #3772

## Changes

- **Modified:** `.github/workflows/build_docs.yml`
  - Added `concurrency` block matching the existing pattern:
    ```yaml
    concurrency:
      group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
      cancel-in-progress: true
    ```

## How Has This Been Tested

This is a workflow configuration change. Verified by:
1. Confirming the YAML is valid
2. Confirming the concurrency pattern matches `test.yml`, `benchmark.yml`, and `test_viz.yml`
