### PR TITLE
CI: Add pip caching to build_docs.yml

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION

## Summary

Adds pip caching to `build_docs.yml` to skip re-downloading packages on repeated runs.

## Motivation

Doc builds currently reinstall all dependencies from scratch every time. The `actions/setup-python` action supports built-in pip caching that automatically invalidates when dependency files change.

Closes #3775 

## Changes

- **Modified:** `.github/workflows/build_docs.yml`
  - Added `cache: 'pip'` to the `actions/setup-python@v6` step

## How Has This Been Tested

Verified YAML syntax. The `cache: 'pip'` option is a standard feature of `actions/setup-python@v6` — no custom configuration needed.
