### PR TITLE
CI: Add manual workflow trigger (workflow_dispatch) to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: DIPY Test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to `test.yml` so the test suite can be manually triggered from the GitHub Actions UI.

## Motivation

Currently, re-running the full test matrix after a flaky failure requires pushing an empty commit or waiting for the monthly schedule. `nightly.yml` already supports `workflow_dispatch`; this brings the same capability to `test.yml`.

Closes #3778

## Changes

- **Modified:** `.github/workflows/test.yml`
  - Added `workflow_dispatch:` to the `on:` trigger block

## How Has This Been Tested

Verified YAML syntax. The `workflow_dispatch` trigger is additive — it does not affect existing push, pull_request, or schedule triggers.
