### PR TITLE
Fix epsilon docstring mismatch

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -620,7 +620,6 @@ class StatefulTractogram:
         ----------
         epsilon : float, optional
             Epsilon value for the bounding box verification.
-            Default is 1e-6.
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes the inconsistency in between the documented default value of `epsilon` in **remove_invalid_streamlines** and the actual function signature. 
Fixes #3764.
