### PR TITLE
Fix #3810: use warnings.warn() for empty tractogram

### DIFF
--- a/dipy/viz/horizon/app.py
+++ b/dipy/viz/horizon/app.py
@@ -496,7 +496,11 @@ class Horizon:
                 streamlines = sft.streamlines
 
                 if len(streamlines) == 0:
-                    logger.warning(f"Tractogram {t} is empty and will be skipped.")
+                    warn(
+                        f"Tractogram {t} is empty and will be skipped.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     continue
 
                 if "tracts" in self.random_colors:


### PR DESCRIPTION
## Description

Replaces `logger.warning()` with `warnings.warn()` when skipping empty
tractograms in `dipy/viz/horizon/app.py`.

## Motivation and Context

Fixes #3810

`test_horizon_empty_tractogram` uses `warnings.catch_warnings(record=True)`
which only captures `warnings.warn()` calls — not Python logging calls.
So `logger.warning()` was invisible to the test, causing `len(selected_w) >= 1`
to always fail.

## How Has This Been Tested?
```bash
pytest dipy/viz/tests/test_apps.py::test_horizon_empty_tractogram
1 passed
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
