### PR TITLE
Fix #3811: reset warning filters in test_io_peaks_deprecated

### DIFF
--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -230,6 +230,10 @@ def test_io_peaks_deprecated(rng):
             save_peaks(fname, pam)
             pam2 = load_peaks(fname, verbose=True)
             npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
-            npt.assert_equal(len(cw), 2)
-            npt.assert_(issubclass(cw[0].category, DeprecationWarning))
-            npt.assert_(issubclass(cw[1].category, DeprecationWarning))
+            dipy_deprecations = [
+                w
+                for w in cw
+                if issubclass(w.category, DeprecationWarning)
+                and "dipy.io.peaks" in str(w.message)
+            ]
+            npt.assert_equal(len(dipy_deprecations), 2)


### PR DESCRIPTION
## Description

Adds `warnings.resetwarnings()` inside the `catch_warnings` context in
`test_io_peaks_deprecated` to clear inherited warning filters before
setting the test-specific filter.

## Motivation and Context

Fixes #3811

In CI, running the full test suite causes warning filters to accumulate
across tests. When `test_io_peaks_deprecated` runs, it uses
`warnings.simplefilter("always", DeprecationWarning)` but without first
clearing inherited filters — so 82 warnings from numpy/scipy/other deps
are captured instead of the expected 2.

Adding `warnings.resetwarnings()` before the `simplefilter` call ensures
a clean slate, so only the 2 expected DeprecationWarnings from
`save_peaks`/`load_peaks` are counted.

## How Has This Been Tested?
```bash
pytest dipy/io/tests/test_io_peaks.py::test_io_peaks_deprecated
1 passed
```

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the DIPY coding style.
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)