### PR TITLE
Add ASV benchmarks for nlmeans

### DIFF
--- a/benchmarks/benchmarks/bench_denoise.py
+++ b/benchmarks/benchmarks/bench_denoise.py
@@ -1,0 +1,31 @@
+"""Benchmarks for ``dipy.denoise`` module."""
+
+import numpy as np
+
+from dipy.denoise.nlmeans import nlmeans
+from dipy.denoise.noise_estimate import estimate_sigma
+
+
+class BenchNLMeans:
+    def setup(self):
+        rng = np.random.default_rng(1234)
+        
+        # 3D Data (Magnitude MRI Simulation)
+        clean_3d = np.ones((40, 40, 40)) * 100.0
+        self.data_3d = np.abs(clean_3d + rng.standard_normal((40, 40, 40)) * 10)
+        self.sigma_3d = estimate_sigma(self.data_3d, N=1)
+
+        # 4D Data (DWI Simulation)
+        self.data_4d = np.abs(
+            np.ones((20, 20, 20, 10)) * 100.0 + rng.standard_normal((20, 20, 20, 10)) * 10
+        )
+        self.sigma_4d = np.full(10, self.sigma_3d)
+        
+    def time_nlmeans_3d_classic(self):
+        nlmeans(self.data_3d, self.sigma_3d, rician=True, method="classic")
+
+    def time_nlmeans_3d_blockwise(self):
+        nlmeans(self.data_3d, self.sigma_3d, rician=True, method="blockwise")
+
+    def time_nlmeans_4d_blockwise(self):
+        nlmeans(self.data_4d, self.sigma_4d, rician=True, method="blockwise")


### PR DESCRIPTION
## Description

Adds the first  ASV performance benchmarks for `dipy.denoise.nlmeans` in a new file `bench_denoise.py.`
It benchmarks three common workflows using rician=True:
1. `time_nlmeans_3d_classic`
2. `time_nlmeans_3d_blockwise`
3. `time_nlmeans_4d_blockwise`
 

## Motivation and Context
`nlmeans` is a computationally heavy function relying on `denspeed.pyx`, but currently has no baseline performance tracking in DIPY's ASV suite. 

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
