### PR TITLE
DOC: Fix docstring errors in dipy/io/pickles.py

### DIFF
--- a/dipy/io/pickles.py
+++ b/dipy/io/pickles.py
@@ -10,7 +10,7 @@ def save_pickle(fname, dix):
     ----------
     fname : str
        filename to save object e.g. a dictionary
-    dix : str
+    dix : object
        dictionary or other object
 
     Examples
@@ -50,7 +50,7 @@ def load_pickle(fname):
     dix : object
        dictionary or other object
 
-    Examples
+    See Also
     --------
     dipy.io.pickles.save_pickle
 


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
Fix two docstring errors in `dipy/io/pickles.py`.

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->
Closes #3830 

1. `save_pickle`: parameter `dix` was typed as `str` — incorrect since
   the function accepts any Python object. Changed to `object`.

2. `load_pickle`: the `Examples` section contained only a plain-text
   module path with no `>>>` code, which is invalid per the NumPy
   docstring standard. Converted to a `See Also` section, matching
   the pattern already used in `save_pickle`.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details such as test commands, test coverage, etc. -->
- Ran `python -c "from dipy.io.pickles import load_pickle; help(load_pickle)"`
  to confirm `See Also` renders correctly
- Ran `python -m pytest dipy/io/tests/ -v` — all tests pass
- Ran `ruff check dipy/io/pickles.py` — no errors

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
