### PR TITLE
DOC: Improve docstrings for SimilarityMetric in align.metrics

### DIFF
--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -89,6 +89,12 @@ class SimilarityMetric:
         ----------
         static_image : array, shape (R, C) or (S, R, C)
             the static image
+        static_affine : array, shape (dim+1, dim+1)
+            affine mapping from voxel indices to world coordinates
+        static_spacing : tuple or array, length dim
+            voxel spacing along each dimension
+        static_direction : array, shape (dim, dim)
+            direction cosine matrix describing image orientation
         """
         self.static_image = static_image
         self.static_affine = static_affine
@@ -103,7 +109,7 @@ class SimilarityMetric:
         (as the transformation of an original static image). This method is
         called by the optimizer just after it sets the static image.
         Transformation will be an instance of DiffeomorphicMap or None
-        if the original_static_image equals self.moving_image.
+        if the original_static_image equals self.static_image.
 
         Parameters
         ----------
@@ -128,6 +134,12 @@ class SimilarityMetric:
         ----------
         moving_image : array, shape (R, C) or (S, R, C)
             the moving image
+        moving_affine : array, shape (dim+1, dim+1)
+            affine mapping from voxel indices to world coordinates
+        moving_spacing : tuple or array, length dim
+            voxel spacing along each dimension
+        moving_direction : array, shape (dim, dim)
+            direction cosine matrix describing image orientation
         """
         self.moving_image = moving_image
         self.moving_affine = moving_affine
@@ -138,9 +150,9 @@ class SimilarityMetric:
         r"""This is called by the optimizer just after setting the moving image
 
         This method allows the metric to compute any useful
-        information from knowing how the current static image was generated
-        (as the transformation of an original static image). This method is
-        called by the optimizer just after it sets the static image.
+        information from knowing how the current moving image was generated
+        (as the transformation of an original moving image). This method is
+        called by the optimizer just after it sets the moving image.
         Transformation will be an instance of DiffeomorphicMap or None if
         the original_moving_image equals self.moving_image.
 
@@ -177,7 +189,7 @@ class SimilarityMetric:
 
     @abc.abstractmethod
     def compute_forward(self):
-        r"""Computes one step bringing the reference image towards the static.
+        r"""Computes one step bringing the moving image towards the static.
 
         Computes the forward update field to register the moving image towards
         the static image in a gradient-based optimization algorithm
@@ -193,10 +205,11 @@ class SimilarityMetric:
 
     @abc.abstractmethod
     def get_energy(self):
-        r"""Numerical value assigned by this metric to the current image pair
+        r"""Return the scalar energy for the current static/moving image pair.
 
-        Must return the numeric value of the similarity between the given
-        static and moving images
+        Called by the optimizer to evaluate how well the current warped moving
+        image matches the current static image. Lower energy is typically
+        considered better (optimizer minimizes).
         """
 
 


### PR DESCRIPTION

## Description

Improves the clarity and readability of the docstrings in the `SimilarityMetric` base class in `dipy/align/metrics.py`. The updated documentation provides clearer explanations of the purpose of the class and the role of key attributes used during the registration process.

## Motivation and Context

The existing docstrings were brief and could be difficult for new contributors and users to understand when exploring the registration module. This update improves the wording and structure of the documentation to make the responsibilities of the `SimilarityMetric` class clearer without modifying any functionality.

## How Has This Been Tested?

This change only modifies documentation and does not affect code behavior.
Linting and formatting checks were run locally using:
`pre-commit run --files dipy/align/metrics.py`
All checks passed successfully.

## Checklist

- [x] I have read the [CONTRIBUTING](htt`ps://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (not applicable for documentation changes).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure



