### PR TITLE
DOC: Complete missing parameters in save_polydata docstring

### DIFF
--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -62,12 +62,12 @@ def save_polydata(
     file_name : string or Path
         The output filename (.vtk, .fib, .ply, .stl and .xml)
     binary : bool, optional
-        Save the file in binary format. Default: False.
+        Save the file in binary format.
     color_array_name : str, optional
-        Name of the color array to save. Default: None.
+        Name of the color array to save.
     legacy_vtk_format : bool, optional
         Use legacy VTK file format. Only applied when fury >= 2.0
-        is installed. Default: False.
+        is installed.
     """
     # use kwargs for backward compatibility with fury < 2.0
     kwargs = {}


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
Fix incomplete docstring in `save_polydata` in `dipy/io/vtk.py`.

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->
Closes #3840 

`save_polydata` accepts 5 parameters but only 2 were documented.
The three keyword-only parameters (`binary`, `color_array_name`, `legacy_vtk_format`) were entirely missing from the docstring, and the two existing entries (`polydata`, `file_name`) had no descriptions.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details such as test commands, test coverage, etc. -->
- Ran `python -c "from dipy.io.vtk import save_polydata; help(save_polydata)"`
  to confirm all parameters now appear correctly
- Ran `ruff check dipy/io/vtk.py` — All test Passed!

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
