### PR TITLE
DOC: Add troubleshooting note for macOS OpenMP ImportError - closes #3637

### DIFF
--- a/doc/devel/installation_from_source.rst
+++ b/doc/devel/installation_from_source.rst
@@ -169,6 +169,8 @@ Make sure you have Xcode_ and Anaconda_ installed.
 
 From here follow the :ref:`install-source-nix` instructions.
 
+.. _openmp-macos:
+
 OpenMP with macOS
 -----------------
 OpenMP_ is a standard library for efficient multithreaded applications. This
@@ -215,6 +217,25 @@ Building and installing
 Whether you are using Anaconda_ or Homebrew/python.org Python, you will need to then
 run ``pip install dipy``. When you do that, it should now
 compile the code with this OpenMP-enabled compiler, and things should go faster!
+
+Troubleshooting: ImportError on macOS with PyPI wheels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you installed DIPY via PyPI (``pip install dipy``) on macOS and encounter
+an ``ImportError`` like this::
+
+    ImportError: dlopen(.../bundlemin.cpython-312-darwin.so, 0x0002):
+    symbol not found in flat namespace '___kmpc_barrier'
+
+This is a known OpenMP linking issue with pre-built PyPI wheels on macOS
+(see `GitHub issue #3637 <https://github.com/dipy/dipy/issues/3637>`__).
+macOS does not include OpenMP support by default, causing dynamic linking
+failures for modules that use multithreading (e.g., ``dipy.align``).
+
+**Solution**: Install DIPY from source with OpenMP enabled, following the
+instructions above in the :ref:`openmp-macos` section.
+Building from source compiles DIPY against your local OpenMP installation,
+ensuring symbols like ``___kmpc_barrier`` are correctly linked.
 
 Setting up pre-commit (optional but recommended)
 =================================================


### PR DESCRIPTION
## Description

Adds a troubleshooting subsection to `doc/devel/installation_from_source.rst`
for the known macOS OpenMP linking error with PyPI wheels.

## Motivation and Context

Closes #3637

Changes made:
- Added `.. _openmp-macos:` label to the "OpenMP with macOS" section
- Added "Troubleshooting: ImportError on macOS with PyPI wheels" subsection
  explaining the `___kmpc_barrier` symbol error and linking to the fix
- Used proper RST `:ref:` cross-reference to the OpenMP section

## How Has This Been Tested?

Documentation only — verified RST formatting and cross-references manually.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
