### PR TITLE
DOC: Add macOS OpenMP warning to user guide - closes #3857

### DIFF
--- a/doc/devel/installation_from_source.rst
+++ b/doc/devel/installation_from_source.rst
@@ -218,6 +218,8 @@ Whether you are using Anaconda_ or Homebrew/python.org Python, you will need to 
 run ``pip install dipy``. When you do that, it should now
 compile the code with this OpenMP-enabled compiler, and things should go faster!
 
+.. _macos-openmp-troubleshooting:
+
 Troubleshooting: ImportError on macOS with PyPI wheels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -95,7 +95,16 @@ OSX
 
     pip install nibabel
 
-#. Finally, we are ready to install DIPY itself. Same as with `nibabel` above, we will type at the terminal shell command line::
+#. Finally, we are ready to install DIPY itself. Same as with `nibabel` above, we will type at the terminal shell command line.
+
+   .. warning::
+
+      On macOS, pre-built PyPI wheels may cause an ``ImportError`` related
+      to OpenMP linking (e.g., ``symbol not found '___kmpc_barrier'``).
+      If you encounter this, install from source instead — see
+      :ref:`macos-openmp-troubleshooting` for details.
+
+   Run the following command::
 
     pip install dipy
 


### PR DESCRIPTION
## Description

Adds a `.. warning::` directive to `doc/user_guide/installation.rst`
in the OSX section, warning users about the known OpenMP linking error
with PyPI wheels on macOS. Also adds the `.. _macos-openmp-troubleshooting:`
label to `doc/devel/installation_from_source.rst` to enable cross-referencing.

## Motivation and Context

Closes #3857

Follow-up to PR #3855 which added the troubleshooting note to the
developer docs. This PR ensures the user-facing installation guide
also warns macOS users before they hit the error.

## How Has This Been Tested?

Documentation only — verified RST formatting and cross-references manually.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
