### PR TITLE
Add strict_peaks parameter to local_maxima function (Issue #3435)

### DIFF
--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -289,7 +289,7 @@ cdef long local_maxima_c(double[:] odf, cnp.uint16_t[:, :] edges, double[::1] ou
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def local_maxima(double[:] odf, cnp.uint16_t[:, :] edges):
+def local_maxima(double[:] odf, cnp.uint16_t[:, :] edges), strict_peaks=True:
     """Local maxima of a function evaluated on a discrete set of points.
 
     If a function is evaluated on some set of points where each pair of


### PR DESCRIPTION
Add strict_peaks=True parameter to local_maxima function.

This parameter prepares the function interface to support both > and >= comparison operators for peak detection as requested in issue #3435. The parameter allows users to control whether peaks should use strict greater-than comparison (True) or greater-than-or-equal-to comparison (False) when comparing with neighboring values.

Fixes: #3435

## Description

<!-- Briefly describe what this PR does and why. -->

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details such as test commands, test coverage, etc. -->

## Checklist

<!-- Please check all that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
