### PR TITLE
BF: fix bounds_de being unconditionally overwritten in IvimModelVP.fit

### DIFF
--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -581,7 +581,8 @@ class IvimModelVP(ReconstModel):
         b = self.bvals
 
         # Setting up the bounds for differential_evolution
-        bounds_de = np.array([(0.005, 0.01), (10**-4, 0.001)])
+        if bounds_de is None:
+            bounds_de = np.array([(0.005, 0.01), (10**-4, 0.001)])
 
         # Optimizer #1: Differential Evolution
         res_one = differential_evolution(

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -24,7 +24,7 @@ from numpy.testing import (
 import pytest
 
 from dipy.core.gradients import generate_bvecs, gradient_table
-from dipy.reconst.ivim import IvimModel, ivim_prediction
+from dipy.reconst.ivim import IvimModel, differential_evolution, ivim_prediction
 from dipy.sims.voxel import multi_tensor
 from dipy.testing import assert_greater_equal
 from dipy.utils.optpkg import optional_package
@@ -668,3 +668,22 @@ def test_D_vp():
     """
     ivim_fit_VP = ivim_model_VP.fit(data_single)
     assert_array_almost_equal(ivim_fit_VP.D, D_VP, decimal=4)
+
+
+@needs_cvxpy
+def test_fit_bounds_de(monkeypatch):
+    """Test that custom bounds_de is used by IvimModelVP.fit."""
+    captured = {}
+
+    def capturing_de(func, bounds, *args, **kwargs):
+        captured["bounds"] = np.asarray(bounds)
+        return differential_evolution(func, bounds, *args, **kwargs)
+
+    monkeypatch.setattr("dipy.reconst.ivim.differential_evolution", capturing_de)
+
+    ivim_model_VP.fit(data_single)
+    assert_array_equal(captured["bounds"], np.array([(0.005, 0.01), (10**-4, 0.001)]))
+
+    custom_bounds = np.array([(0.003, 0.02), (10**-5, 0.002)])
+    ivim_model_VP.fit(data_single, bounds_de=custom_bounds)
+    assert_array_equal(captured["bounds"], custom_bounds)


### PR DESCRIPTION
## Description

IvimModelVP.fit() accepts a bounds_de parameter intended to define the search space for the Differential Evolution optimizer. However, this parameter was being unconditionally overwritten within the method body, preventing users from supplying custom optimization bounds. This is reported in #3786.

## Motivation and Context

This bug was introduced by https://github.com/dipy/dipy/commit/dafcad05b, where `bounds_de` was added to the function signature but remained non-functional.

The MIX algorithm's design (Farooq et al. 2016) assumes that parameter spaces are acquisition-dependent. Hard-coding the search bounds in IvimModelVP.fit creates a bottleneck that limits the model’s adaptability to varying tissue characteristics.

ref: https://static-content.springer.com/esm/art%3A10.1038%2Fsrep38927/MediaObjects/41598_2016_BFsrep38927_MOESM1_ESM.pdf

## How Has This Been Tested?

Added `test_fit_bounds_de` to `dipy/reconst/tests/test_ivim.py`.
Verified:
1. Default behavior: When `bounds_de=None`, the defaults [(0.005, 0.01), (1e-4, 0.001)] are forwarded.
2. Custom behavior: When a custom list of tuples is provided, it is passed to the optimizer.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
