### PR TITLE
DOC: Add module docstrings and fix false "Empty" warnings in apigen.py - closes #3894

### DIFF
--- a/dipy/core/__init__.py
+++ b/dipy/core/__init__.py
@@ -1,2 +1,1 @@
-# Init for core dipy objects
 """Core objects"""

--- a/dipy/core/math.pyx
+++ b/dipy/core/math.pyx
@@ -4,6 +4,12 @@
 # cython: wraparound=False
 # cython: nonecheck=False
 # cython: overflowcheck=False
+"""Fast math utilities for arrays (Cython).
+
+Low-level C functions for minimum, maximum, and other array
+operations used throughout DIPY core modules.
+"""
+
 
 
 from dipy.align.fused_types cimport floating

--- a/dipy/denoise/__init__.py
+++ b/dipy/denoise/__init__.py
@@ -1,1 +1,6 @@
+"""Denoising algorithms for diffusion MRI.
+
+Provides noise reduction methods such as Non-Local Means, Patch2Self,
+MP-PCA, and local PCA for dMRI volumes.
+"""
 # init for denoise aka the denoising module

--- a/dipy/direction/__init__.py
+++ b/dipy/direction/__init__.py
@@ -1,3 +1,9 @@
+"""Direction and ODF tools.
+
+Utilities for working with fiber directions, peaks, and orientation
+distribution functions (ODF).
+"""
+
 from .bootstrap_direction_getter import BootDirectionGetter
 from .closest_peak_direction_getter import ClosestPeakDirectionGetter
 from .peaks import (

--- a/dipy/io/__init__.py
+++ b/dipy/io/__init__.py
@@ -1,3 +1,8 @@
+"""Input/Output utilities.
+
+Reading and writing of diffusion MRI data, bvals/bvecs, gradients,
+and related file formats.
+"""
 # init for io routines
 
 from . import utils

--- a/dipy/nn/__init__.py
+++ b/dipy/nn/__init__.py
@@ -1,4 +1,8 @@
-# init for nn aka the deep neural network module
+"""Neural network tools.
+
+Deep learning models and utilities for diffusion MRI processing.
+"""
+
 import os
 import sys
 

--- a/dipy/nn/tf/__init__.py
+++ b/dipy/nn/tf/__init__.py
@@ -1,1 +1,2 @@
+"""Neural network tools using TensorFlow backend."""
 # init for nn aka the deep neural network module that uses TensorFlow

--- a/dipy/nn/torch/__init__.py
+++ b/dipy/nn/torch/__init__.py
@@ -1,1 +1,2 @@
+"""Neural network tools using PyTorch backend."""
 # init for nn aka the deep neural network module that uses PyTorch

--- a/dipy/reconst/__init__.py
+++ b/dipy/reconst/__init__.py
@@ -1,3 +1,8 @@
+"""Diffusion MRI reconstruction models.
+
+Implements DTI, CSD, CSA, MAP-MRI, multi-shell, and other
+reconstruction techniques.
+"""
 # init for reconst aka the reconstruction module
 
 from dipy.reconst.force import FORCEFit as FORCEFit, FORCEModel as FORCEModel

--- a/dipy/segment/__init__.py
+++ b/dipy/segment/__init__.py
@@ -1,0 +1,5 @@
+"""Streamline segmentation and clustering.
+
+Tools for tissue segmentation, clustering, and grouping of
+streamlines.
+"""

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -1,4 +1,10 @@
 # cython: wraparound=False, cdivision=True, boundscheck=False
+"""Cython utilities for memory views and shapes.
+
+Internal helpers for efficient memoryview operations, shape
+manipulation, and low-level data structures used in segmentation.
+"""
+
 
 import numpy as np
 cimport numpy as cnp

--- a/dipy/sims/__init__.py
+++ b/dipy/sims/__init__.py
@@ -1,3 +1,8 @@
+"""Simulation of diffusion MRI data.
+
+Generation of synthetic diffusion-weighted images and signals
+for testing and validation.
+"""
 # init for simulations
 
 from dipy.sims.force import (

--- a/dipy/stats/__init__.py
+++ b/dipy/stats/__init__.py
@@ -1,1 +1,6 @@
+"""Statistical analysis of diffusion data.
+
+Tools for statistical analysis, group studies, and quality
+assessment of dMRI results.
+"""
 # code support tractometric statistical analysis for dipy

--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -1,4 +1,3 @@
-# Init for tracking module
 """Tracking objects"""
 
 from nibabel.streamlines import ArraySequence as Streamlines

--- a/dipy/viz/__init__.py
+++ b/dipy/viz/__init__.py
@@ -1,3 +1,9 @@
+"""Visualization tools.
+
+Functions and classes for visualizing diffusion MRI data,
+streamlines, and tensors (powered by FURY and Matplotlib).
+"""
+
 # Init file for visualization package
 import warnings
 

--- a/dipy/viz/horizon/__init__.py
+++ b/dipy/viz/horizon/__init__.py
@@ -1,0 +1,1 @@
+"""Horizon interactive visualization application."""

--- a/dipy/viz/horizon/tab/__init__.py
+++ b/dipy/viz/horizon/tab/__init__.py
@@ -1,3 +1,5 @@
+"""Tab components for the Horizon visualization application."""
+
 from dipy.viz.horizon.tab.base import (
     HorizonTab,
     TabManager,

--- a/dipy/viz/horizon/visualizer/__init__.py
+++ b/dipy/viz/horizon/visualizer/__init__.py
@@ -1,3 +1,5 @@
+"""Visualizer components for the Horizon application."""
+
 from dipy.viz.horizon.visualizer.cluster import ClustersVisualizer
 from dipy.viz.horizon.visualizer.peak import PeaksVisualizer
 from dipy.viz.horizon.visualizer.slice import SlicesVisualizer

--- a/dipy/workflows/__init__.py
+++ b/dipy/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line workflows for diffusion MRI processing."""

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -355,7 +355,14 @@ class ApiDocWriter:
         # get the names of all classes and functions
         functions, classes, constants = self._parse_module_with_import(uri)
         if not len(functions) and not len(classes) and DEBUG:
-            print("WARNING: Empty -", uri)  # dbg
+            # Only warn if module has no docstring either
+            try:
+                from importlib import import_module
+                mod = import_module(uri)
+                if not getattr(mod, "__doc__", None) or not mod.__doc__.strip():
+                    print("WARNING: Empty -", uri)  # dbg
+            except Exception:
+                print("WARNING: Empty -", uri)  # dbg
 
         # Make a shorter version of the uri that omits the package name for
         # titles


### PR DESCRIPTION
## Description

While building the DIPY docs locally with `spin docs --no-plot`, 
I found 20 "WARNING: Empty" messages appearing for most submodules.

I traced the root cause to two things:
1. Most `__init__.py` files had `#` comments instead of proper 
   `"""docstrings"""` that Sphinx and apigen.py can read
2. `doc/tools/apigen.py` was printing the warning even for modules 
   that have a docstring but no top-level functions/classes

## Motivation and Context

Closes #3894

Before: 20 Empty warnings when building docs
After: 0 Empty warnings

## How Has This Been Tested?

spin docs --no-plot --clean

Confirmed 0 "WARNING: Empty" messages remain.

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the DIPY coding style.
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Documentation update
