### PR TITLE
BF: add mask input for biasfield correction cli

### DIFF
--- a/dipy/workflows/nn.py
+++ b/dipy/workflows/nn.py
@@ -6,7 +6,7 @@ import numpy as np
 from dipy.core.gradients import gradient_table
 from dipy.denoise.bias_correction import bias_field_correction
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.image import load_nifti, save_nifti
+from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.nn.deepn4 import DeepN4
 from dipy.nn.evac import EVACPlus
 from dipy.utils.logging import logger
@@ -90,6 +90,7 @@ class BiasFieldCorrectionFlow(Workflow):
         input_files,
         bval=None,
         bvec=None,
+        mask=None,
         method="auto",
         threshold=0.5,
         use_cuda=False,
@@ -117,6 +118,9 @@ class BiasFieldCorrectionFlow(Workflow):
             Path to the b-value file.
         bvec : string or Path, optional
             Path to the b-vector file.
+        mask : string or Path, optional
+            Path to the brain mask file. If not provided, a mask will be estimated
+            from the input volume using Otsu's method for 'poly' and 'bspline' methods.
         method : string, optional
             Bias field correction method. Choose from:
                 - 'n4': DeepN4 bias field correction.
@@ -207,9 +211,11 @@ class BiasFieldCorrectionFlow(Workflow):
                 gtab = gradient_table(bvals, bvecs=bvecs)
                 levels = tuple(int(x.strip()) for x in pyramid_levels.split(","))
                 n_ctrl = (int(n_control_points),) * 3
+                mask_arr = load_nifti_data(mask) if mask is not None else None
                 corrected_data, bias = bias_field_correction(
                     data,
                     gtab,
+                    mask=mask_arr,
                     method=method.lower(),
                     order=int(order),
                     n_control_points=n_ctrl,

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -88,6 +88,30 @@ def test_correct_biasfield_flow():
     npt.assert_raises(SystemExit, bias_flow.run, **args)
 
 
+def test_correct_biasfield_flow_with_mask():
+    """Test that a mask file can be passed to BiasFieldCorrectionFlow."""
+    with TemporaryDirectory() as out_dir:
+        fdata, fbval, fbvec = get_fnames(name="small_25")
+        volume, affine = load_nifti(fdata)
+        mask_data = np.ones(volume.shape[:3], dtype=np.uint8)
+        mask_path = Path(out_dir) / "mask.nii.gz"
+        save_nifti(mask_path, mask_data, affine)
+
+        args = {
+            "input_files": fdata,
+            "bval": fbval,
+            "bvec": fbvec,
+            "mask": str(mask_path),
+            "out_dir": out_dir,
+        }
+        bias_flow = BiasFieldCorrectionFlow()
+        bias_flow.run(**args)
+
+        corrected_name = bias_flow.last_generated_outputs["out_corrected"]
+        corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
+        assert corrected_data.shape == volume.shape
+
+
 def test_correct_biasfield_flow_with_bias_output():
     """Test that out_bias_field is saved when using poly/bspline methods."""
     with TemporaryDirectory() as out_dir:


### PR DESCRIPTION

This pull request enhances the bias field correction workflow in `dipy` by adding support for an optional brain mask input, allowing users to provide a mask file for more precise bias correction. The workflow and its tests are updated accordingly to handle this new feature.

It was an issue when mask was generated with another method. Without this option, biasfield was generating its own mask and we got a misalignment between both mask. 

ps: Using this PR to test backport functionality also for the future release 1.12.1