### PR TITLE
DOC: fix static/moving description in metrics.py

### DIFF
--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -307,7 +307,7 @@ class CCMetric(SimilarityMetric):
         for i, grad in enumerate(gradient(self.static_image)):
             self.gradient_static[..., i] = grad
 
-        # Convert moving image's gradient field from voxel to physical space
+        # Convert static image's gradient field from voxel to physical space
         if self.static_spacing is not None:
             self.gradient_static /= self.static_spacing
         if self.static_direction is not None:
@@ -489,7 +489,7 @@ class EMMetric(SimilarityMetric):
         for i, grad in enumerate(gradient(self.static_image)):
             self.gradient_static[..., i] = grad
 
-        # Convert moving image's gradient field from voxel to physical space
+        # Convert static image's gradient field from voxel to physical space
         if self.static_spacing is not None:
             self.gradient_static /= self.static_spacing
         if self.static_direction is not None:
@@ -789,7 +789,7 @@ class SSDMetric(SimilarityMetric):
         for i, grad in enumerate(gradient(self.moving_image)):
             self.gradient_moving[..., i] = grad
 
-        # Convert static image's gradient field from voxel to physical space
+        # Convert moving image's gradient field from voxel to physical space
         if self.moving_spacing is not None:
             self.gradient_moving /= self.moving_spacing
         if self.moving_direction is not None:


### PR DESCRIPTION
## Description

This PR fixes minor inconsistencies in the docstrings within `metrics.py`.

While reviewing the documentation, I noticed that some static image function descriptions incorrectly referred to **"moving images"**, likely due to copy-paste errors. These references have been corrected so that the terminology accurately reflects the intended function behavior.

The changes are documentation-only and do not modify any functionality.

## Motivation and Context

Correct documentation is important for users and contributors to understand the intended role of parameters and functions. These changes improve clarity and prevent confusion when reading the code or using the API.


## How Has This Been Tested?

Since the changes only affect docstrings, no functional behavior was modified.

I verified that:

* The file compiles normally.
* No additional changes were introduced beyond the documentation updates.


## Checklist

* [x] I have read the CONTRIBUTING guidelines.
* [x] My code follows the DIPY coding style.
* [ ] I have added tests that cover my changes (not applicable for documentation-only changes).
* [ ] All new and existing tests pass locally (not applicable).
* [x] I have updated the documentation accordingly.


## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Documentation update
* [ ] Maintenance / CI / Infrastructure
