### PR TITLE
FIX: Terminate workflow when output files exist without force flag (#3496)

### DIFF
--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -20,8 +20,9 @@ def test_force_overwrite():
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         first_time = os.path.getmtime(mask_file)
 
-        # re-run with no force overwrite, modified time should not change
-        mo_flow.run(data_path, out_dir=out_dir)
+        # re-run with no force overwrite should terminate early with a clear
+        # error, and therefore not modify existing outputs.
+        npt.assert_raises(ValueError, mo_flow.run, data_path, out_dir=out_dir)
         mask_file = mo_flow.last_generated_outputs["out_mask"]
         second_time = os.path.getmtime(mask_file)
         assert first_time == second_time

--- a/dipy/workflows/workflow.py
+++ b/dipy/workflows/workflow.py
@@ -53,8 +53,12 @@ class Workflow:
 
         if self.manage_output_overwrite():
             return io_it
-        else:
-            return []
+
+        raise ValueError(
+            "The following output files already exist, the workflow will "
+            "not continue processing any further. Add the --force flag "
+            "to allow output files overwrite."
+        )
 
     def update_flat_outputs(self, new_flat_outputs, io_it):
         """Update the flat outputs with new values.
@@ -105,7 +109,7 @@ class Workflow:
             if self._force_overwrite:
                 logger.info("The following output files are about to be overwritten.")
             else:
-                logger.info(
+                logger.error(
                     "The following output files already exist, the "
                     "workflow will not continue processing any "
                     "further. Add the --force flag to allow output "


### PR DESCRIPTION


## Description

Makes a hard stop (`ValueError`) in `workflow.py` if output files already exist without using the `--force` flag. Also, it changes the associated file logging to `logger.error` and adds a test for this exception.

## Motivation and Context

The current implementation does not handle the case where users forget to use the `--force` flag. As a result, the CLI will run with an empty output list, causing unnecessary memory consumption for downstream tools, such as `dipy_recobundles`, which attempt to load massive datasets into memory but ultimately crash.

A hard stop would eliminate this memory and performance bottleneck.

Closes #3496

## How Has This Been Tested?

- Locally verified the hard stop when files exist without `--force`.
- I updated `dipy/workflows/tests/test_workflow.py` to correctly test for this exception.
- Locally run the test suite to verify that all assertions pass.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
