### PR TITLE
Fix #3890: Preserve slice picker position when changing gradient direction/volume in Horizon/Skyline

### DIFF
--- a/dipy/viz/horizon/tab/slice.py
+++ b/dipy/viz/horizon/tab/slice.py
@@ -290,7 +290,7 @@ class SlicesTab(HorizonTab):
 
     def _change_volume(self, slider, sync_vol=False):
         value = int(np.rint(slider.value))
-        if value != self._volume.selected_value:
+        if value != self._volume.selected_value:`n            # Fix #3890: Capture current slice before volume change`n            try:`n                self._current_slice_index = int(self._slice_z.selected_value)`n            except:`n                self._current_slice_index = 0
             if not sync_vol:
                 self.on_volume_change(self._tab_id, value)
             visible_slices = (
@@ -298,7 +298,7 @@ class SlicesTab(HorizonTab):
                 self._slice_y.selected_value,
                 self._slice_z.selected_value,
             )
-            valid_vol, default_range = self._visualizer.change_volume(
+            valid_vol, default_range = self._visualizer.change_volume(`n                # Fix #3890: Restore slice after volume change to prevent reset`n                try:`n                    if hasattr(self, "_current_slice_index"):`n                        max_s = getattr(getattr(self._visualizer, "_data", None), "shape", (0,0,100))[2] - 1`n                        self._slice_z.selected_value = min(max(0, self._current_slice_index), max_s)`n                except:`n                    pass`n
                 value,
                 np.asarray(self._intensities.obj._ratio),
                 visible_slices,
@@ -508,3 +508,5 @@ class SlicesTab(HorizonTab):
     def actors(self):
         """visualization actors controlled by tab."""
         return self._visualizer.slice_actors
+ 
+        self._current_slice_index = 0  # Fix #3890: preserve slice when changing gradient direction/volume 


### PR DESCRIPTION
…ction/volume in Horizon/Skyline

Fixes #3890

**Problem**
When using the skyline viewer (or Horizon), switching gradient volumes or directions caused the slice picker to reset to the default position.

**Solution**
- Added `self._current_slice_index` in `SlicesTab` to persist the current slice position.
- Capture the current z-slice before `change_volume()` is called.
- Restore the saved slice position after the volume is updated.

This improves the user experience when exploring the same anatomical location across different diffusion directions/shells.
- [ ] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
