### PR TITLE
Fix #3837: Latest DIPY broken on headless environments

### DIFF
--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -16,7 +16,6 @@ from dipy.io.utils import (
     is_header_compatible,
     split_filename_extension,
 )
-from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.logging import logger
 
@@ -100,6 +99,8 @@ def save_tractogram(
         nib.streamlines.save(fileobj, str(filename))
 
     elif extension in [".vtk", ".vtp", ".fib"]:
+        from dipy.io.vtk import save_vtk_streamlines
+
         binary = extension in [".vtk", ".fib"]
         save_vtk_streamlines(sft.streamlines, filename, binary=binary, to_lps=False)
         logger.warning(
@@ -218,6 +219,8 @@ def load_tractogram(
             data_per_streamline = tractogram_obj.data_per_streamline
 
     elif extension in [".vtk", ".vtp", ".fib"]:
+        from dipy.io.vtk import load_vtk_streamlines
+
         streamlines = load_vtk_streamlines(filename, to_lps=False)
         logger.warning(
             "StatefulTractogram was previously saving in LPSMM space.\n"

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -255,6 +255,22 @@ def test_low_io_vtk():
         npt.assert_array_almost_equal(tracks[1], STREAMLINE, decimal=4)
 
 
+def test_streamline_import_does_not_trigger_vtk():
+    # Regression test for gh-3837: importing dipy.io.streamline must not
+    # eagerly import dipy.io.vtk (and thus fury/GPU libraries).
+    import sys
+
+    # Remove dipy.io.vtk from sys.modules if already loaded so we can detect
+    # a fresh import triggered by dipy.io.streamline.
+    sys.modules.pop("dipy.io.vtk", None)
+    import importlib
+
+    importlib.reload(sys.modules["dipy.io.streamline"])
+    assert "dipy.io.vtk" not in sys.modules, (
+        "dipy.io.streamline should not import dipy.io.vtk at module level"
+    )
+
+
 def trk_loader(filename):
     try:
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Closes #3837

## Description

Lazily import `dipy.io.vtk` inside `save_tractogram` and `load_tractogram` instead of at module level in `dipy/io/streamline.py`. The top-level `from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines` import is removed; equivalent local imports are placed inside the `elif extension in [".vtk", ".vtp", ".fib"]` branches of each function.

## Motivation and Context

Importing `dipy.io.streamline` (e.g., `from dipy.io.streamline import save_tractogram`) unconditionally pulled in `dipy.io.vtk`, which imports `fury.io`, which initialises a WebGPU device at module load time. On headless environments with no GPU drivers this raises:

```
RuntimeError: Request adapter failed (3): Validation Error
No suitable graphics adapter found; ...
```

This means any code that touches `dipy.io.streamline`—even for purely non-graphical formats like `.trk` or `.trx`—crashes on headless CI runners and servers unless GPU libraries happen to be present. The VTK import is only needed when the user explicitly reads or writes a `.vtk`/`.vtp`/`.fib` file, so deferring it to the call site is the correct fix.

## How Has This Been Tested?

A regression test `test_streamline_import_does_not_trigger_vtk` is added in `dipy/io/tests/test_streamline.py`. It:

1. Removes `dipy.io.vtk` from `sys.modules` to reset import state.
2. Reloads `dipy.io.streamline` via `importlib.reload`.
3. Asserts `"dipy.io.vtk" not in sys.modules`, confirming the eager import no longer occurs.

The existing `test_low_io_vtk` test continues to exercise the actual VTK read/write paths.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure