### PR TITLE
FIX: Correct docstrings in EMMetric and SSDMetric compute_forward met…

### DIFF
--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -530,7 +530,7 @@ class EMMetric(SimilarityMetric):
         del self.gradient_static
 
     def compute_forward(self):
-        """Computes one step bringing the reference image towards the static.
+        r"""Computes one step bringing the moving image towards the static.
 
         Computes the forward update field to register the moving image towards
         the static image in a gradient-based optimization algorithm
@@ -808,7 +808,7 @@ class SSDMetric(SimilarityMetric):
             self.reorient_vector_field(self.gradient_static, self.static_direction)
 
     def compute_forward(self):
-        r"""Computes one step bringing the reference image towards the static.
+        r"""Computes one step bringing the moving image towards the static.
 
         Computes the update displacement field to be used for registration of
         the moving image towards the static image


### PR DESCRIPTION
…hods

Fixed inconsistent docstrings in EMMetric.compute_forward() and SSDMetric.compute_forward() which incorrectly referred to "reference image" instead of "moving image", inconsistent with CCMetric and the actual behavior of the method. Also added missing r prefix to raw docstrings for consistency with the rest of the file.

## Description
Fixed inconsistent docstrings in EMMetric.compute_forward() and SSDMetric.compute_forward() which incorrectly referred to "reference image" instead of "moving image", inconsistent with CCMetric and the actual behavior of the method. Also added missing r prefix to raw docstrings for consistency with the rest of the file.
<!-- Briefly describe what this PR does and why. -->

## Motivation and Context
The inconsistent terminology ("reference image" vs "moving image") could confuse new contributors trying to understand the codebase. CCMetric correctly uses "moving image" in its compute_forward docstring, EMMetric and SSDMetric should match.
<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->

## How Has This Been Tested?
This is a Documentation-only change. No functional code has been modified.
<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details such as test commands, test coverage, etc. -->

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
