### PR TITLE
BF: revert to defaut value for optimizer in Image Registration

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -521,7 +521,6 @@ def affine_registration(
 
     """
     pipeline = pipeline or ["center_of_mass", "translation", "rigid", "affine"]
-    optimizer_options = optimizer_options or {"gtol": 1e-4, "ftol": 1e-3}
     if level_iters is None:
         level_iters = [1000, 500, 100]
         logger.info(
@@ -826,6 +825,15 @@ def register_dwi_series(
 
     """
     pipeline = pipeline or ["center_of_mass", "translation", "rigid", "affine"]
+    if not optimizer_options:
+        optimizer_options = {"gtol": 1e-4, "ftol": 1e-3}
+        logger.warning(
+            "Default optimizer_options have been updated to "
+            "{'gtol': 1e-4, 'ftol': 1e-3}  for performance improvement. Identical "
+            "results are expected. In case of any discrepancy, you can revert to the "
+            "previous default by setting "
+            "optimizer_options={'gtol': 1e-4, 'ftol': 2.220446049250313e-09}."
+        )
 
     data, affine = read_img_arr_or_path(data, affine=affine)
     if isinstance(gtab, collections.abc.Sequence):

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -1321,7 +1321,7 @@ class AffineRegistration:
             # Optimize this level
             if self.options is None:
                 # With L-BFGS-B, ftol value is 2.220446049250313e-09
-                self.options = {"gtol": 1e-4, "ftol": 1e-5}
+                self.options = {"gtol": 1e-4}
 
             if self.method == "L-BFGS-B":
                 self.options["maxfun"] = max_iter

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -356,7 +356,7 @@ def test_image_registration(rng):
             )
 
             dist = read_distance("rigid_q.txt")
-            npt.assert_almost_equal(dist, -0.4448226960942718, 1)
+            npt.assert_almost_equal(dist, -0.7246454252101615, 1)
             check_existence(out_moved, out_affine)
 
         def test_rigid_isoscaling():
@@ -377,7 +377,7 @@ def test_image_registration(rng):
             )
 
             dist = read_distance("rigid_isoscaling_q.txt")
-            npt.assert_almost_equal(dist, -0.44489703283487086, 1)
+            npt.assert_almost_equal(dist, -0.7357104551669915, 1)
             check_existence(out_moved, out_affine)
 
         def test_rigid_scaling():
@@ -419,7 +419,7 @@ def test_image_registration(rng):
             )
 
             dist = read_distance("affine_q.txt")
-            npt.assert_almost_equal(dist, -0.5482400695948723, 1)
+            npt.assert_almost_equal(dist, -0.7317371886943095, 1)
             check_existence(out_moved, out_affine)
 
         # Creating the erroneous behavior


### PR DESCRIPTION
This PR is a followup of #3816. Let me cite the discussion:

This is a critical issue, so a new release 1.12.1 will be done by the end of this week or beginning of next week @raj-magesh


<img width="892" height="1053" alt="image" src="https://github.com/user-attachments/assets/0e33617f-7094-4cf8-9120-8d8f5ba9334a" />
