### PR TITLE
BF: Fix PTT initialization threshold and probe position, adjust defau…

### DIFF
--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -502,6 +502,7 @@ cdef void initialize_ptt_candidate(TrackerParameters params,
 
     """
     cdef double[3] position
+    cdef double fod_amp
     cdef int count
     cdef int i
     cdef double* pmf
@@ -522,8 +523,10 @@ cdef void initialize_ptt_candidate(TrackerParameters params,
     stream_data[22] = 0  # last_val
 
     if params.ptt.probe_count == 1:
-        stream_data[22] = pmf_gen.get_pmf_value_c(&stream_data[19],
-                                                  &stream_data[1])  # position, frame[0]
+        fod_amp = pmf_gen.get_pmf_value_c(&stream_data[19],
+                                          &stream_data[1])  # position, frame[0]
+        fod_amp = fod_amp if fod_amp > params.sh.pmf_threshold else 0
+        stream_data[22] = fod_amp
     else:
         for count in range(params.ptt.probe_count):
             for i in range(3):
@@ -537,8 +540,10 @@ cdef void initialize_ptt_candidate(TrackerParameters params,
                               * sin(count * params.ptt.angular_separation)
                               * params.inv_voxel_size[i])
 
-            stream_data[22] += pmf_gen.get_pmf_value_c(&stream_data[19],
-                                                       &stream_data[1])
+            fod_amp = pmf_gen.get_pmf_value_c(position,
+                                              &stream_data[1])
+            fod_amp = fod_amp if fod_amp > params.sh.pmf_threshold else 0
+            stream_data[22] += fod_amp
 
 
 cdef void prepare_ptt_propagator(TrackerParameters params,

--- a/dipy/workflows/tracking.py
+++ b/dipy/workflows/tracking.py
@@ -42,7 +42,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
         step_size=0.5,
         tracking_method="deterministic",
         pmf_threshold=0.1,
-        max_angle=30.0,
+        max_angle=None,
         sphere_name=None,
         save_seeds=False,
         nbr_threads=0,
@@ -98,6 +98,7 @@ class LocalFiberTrackingPAMFlow(Workflow):
             Threshold for ODF functions.
         max_angle : float, optional
             Maximum angle between streamline segments (range [0, 90]).
+            Default is 30 degrees for most methods, 10 degrees for PTT.
         sphere_name : string, optional
             The sphere used for tracking. If None, the sphere saved in the
             pam_files is used. For faster tracking, use a smaller
@@ -154,6 +155,10 @@ class LocalFiberTrackingPAMFlow(Workflow):
             seeds = utils.seeds_from_mask(
                 seed_mask, affine, density=[seed_density, seed_density, seed_density]
             )
+
+            if max_angle is None:
+                max_angle = 10.0 if tracking_method in ["ptt"] else 30.0
+                logger.info(f"max_angle not set by user, defaulting to {max_angle}")
 
             logger.info("Starting to track")
             if tracking_method in ["closestpeaks", "cp"]:


### PR DESCRIPTION
 ## Description                                                                                                                                                                                               
                                                            
  Fix two bugs in PTT initialization (`initialize_ptt_candidate`) and adjust the default `max_angle` for PTT in the workflow.                                                                                  
                                                                                                                                                                                                               
  ## Motivation and Context                                                                                                                                                                                    
                                                            
  1. **Missing pmf_threshold in initialization**: `compute_ptt_likelihood` thresholds FOD amplitudes below `pmf_threshold` to zero, but `initialize_ptt_candidate` did not. This caused inconsistent likelihood scoring between initialization and propagation, where noisy/weak FOD lobes could inflate the initial likelihood.
                                                                                                                                                                                                               
  2. **Wrong probe position in multi-probe path**: When `probe_count > 1`, the code computed offset probe positions into `position` but then passed `&stream_data[19]` (the center point) to `get_pmf_value_c`. All probes were sampling the same center point, defeating the purpose of multi-probe sampling.
                                                                                                                                                                                                               
  3. **Default max_angle too loose for PTT**: The workflow passed `max_angle=30.0` (the global default) to PTT, overriding PTT's own default of 10 degrees. Now the workflow defaults `max_angle` to `None` and resolves it per-method: 10 degrees for PTT, 30 degrees for all others. If the user explicitly sets any value, it is respected. A logger info message is emitted when the default is applied, informing the user which value was chosen.                                                                                                                                                                                 
                                                            
  ## How Has This Been Tested?

  Tested locally with PTT tracking on existing data. Verified that the threshold is applied during initialization, probes sample at correct positions, and max_angle defaults/overrides work as expected.

  ## Checklist

  - [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.                                                                                           
  - [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
  - [ ] I have added tests that cover my changes (if applicable).                                                                                                                                              
  - [x] All new and existing tests pass locally.            
  - [x] I have updated the documentation accordingly (if applicable).                                                                                                                                          
                                                            
  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Maintenance / CI / Infrastructure