### PR TITLE
FIX: preserve slice positions when changing gradient volume in Horizon

### DIFF
--- a/dipy/viz/horizon/tab/tests/test_slices.py
+++ b/dipy/viz/horizon/tab/tests/test_slices.py
@@ -58,3 +58,33 @@ def test_toggle_actors(slice_viz):
         tab._toggle_actors(tab._actor_toggle.obj)
         mock_hide.assert_called_with(*tab.actors)
         assert mock_hide.call_count == 2
+
+
+@pytest.fixture
+@set_random_number_generator()
+def slice_viz_4d(rng):
+    """Fixture to create a SlicesVisualizer with 4D data."""
+    affine = np.eye(4)
+    data = 255 * rng.random((20, 20, 20, 5))
+
+    class MockScene:
+        def add(self, *actor):
+            pass
+
+        def rm(self, *actor):
+            pass
+
+    return SlicesVisualizer(None, MockScene(), data, affine=affine, fname="mock_4d")
+
+
+@pytest.mark.skipif(skip_it, reason="Needs xvfb")
+def test_selected_slices_preserved_on_volume_change(slice_viz_4d):
+    """Test that slice positions are preserved when changing gradient volume.
+
+    Regression test for https://github.com/dipy/dipy/issues/3890
+    """
+    visible_slices = (3, 7, 12)
+    intensity_ratios = np.array([0.0, 1.0])
+    valid, _ = slice_viz_4d.change_volume(1, intensity_ratios, visible_slices)
+    assert valid
+    np.testing.assert_array_equal(slice_viz_4d.selected_slices, visible_slices)

--- a/dipy/viz/horizon/visualizer/slice.py
+++ b/dipy/viz/horizon/visualizer/slice.py
@@ -225,6 +225,7 @@ class SlicesVisualizer:
         self._create_and_resize_actors(vol_data, self._int_range)
 
         self._add_slice_actors_to_scene(visible_slices)
+        self._sel_slices = np.asarray(visible_slices)
 
         return True, default_range
 


### PR DESCRIPTION
## Description

When changing gradient direction/volume in `dipy_skyline`/`dipy_horizon`,
the slice sliders reset to their default (midpoint) positions.

## Root Cause

`change_volume()` in `SlicesVisualizer` correctly received the current
`visible_slices` and passed them to `_add_slice_actors_to_scene()`, but
never updated `self._sel_slices`. So `selected_slices` always returned
the initial midpoint values from `__init__`, causing downstream sync
logic to reset slice positions on every volume change.

## Fix

One line added in `change_volume()` in `dipy/viz/horizon/visualizer/slice.py`:

    self._sel_slices = np.asarray(visible_slices)

## How Has This Been Tested?

Added regression test `test_selected_slices_preserved_on_volume_change`
in `dipy/viz/horizon/tab/tests/test_slices.py` using a 4D mock dataset
to verify slice positions survive a volume change.

    python -m pytest dipy/viz/horizon/tab/tests/test_slices.py -v
    # 2 passed

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the DIPY coding style.
- [x] I have added tests that cover my changes.
- [x] All new and existing tests pass locally.

Fixes #3890