### PR TITLE
FIX: preserve slice positions when changing gradient direction in Sky…

### DIFF
--- a/dipy/viz/skyline/render/image.py
+++ b/dipy/viz/skyline/render/image.py
@@ -207,7 +207,7 @@ class Image3D(Visualization):
         self._synchronize = True
         self._sync_callabck = sync_callabck
         super().__init__(name, render_callback)
-
+        self.state = None
         self._create_slicer_actor()
         self.opacity = opacity
 
@@ -241,7 +241,8 @@ class Image3D(Visualization):
 
         self._apply_colormap(self.colormap)
         self.bounds = self._slicer.get_bounding_box()
-        self.state = np.mean(self.bounds, axis=0)
+        if self.state is None:
+            self.state = np.mean(self.bounds, axis=0)
         self._slicer.add_event_handler(self._pick_voxel, "pointer_down")
         show_slices(self._slicer, self.state)
         self.render()

--- a/dipy/viz/skyline/render/tests/test_image.py
+++ b/dipy/viz/skyline/render/tests/test_image.py
@@ -1,0 +1,44 @@
+"""Tests for dipy.viz.skyline.render.image."""
+
+import numpy as np
+import pytest
+
+try:
+    from dipy.viz.skyline.render.image import Image3D
+
+    HAS_SKYLINE = True
+except Exception:
+    HAS_SKYLINE = False
+
+pytestmark = pytest.mark.skipif(not HAS_SKYLINE, reason="Requires Fury >= 2.0.0a6")
+
+
+@pytest.fixture
+def image_3d_4d():
+    """Fixture to create an Image3D with 4D data."""
+    rng = np.random.default_rng(42)
+    data = rng.random((20, 20, 20, 5)).astype(np.float32)
+    affine = np.eye(4)
+    return Image3D("test_4d", data, affine=affine, render_callback=None)
+
+
+def test_slice_state_preserved_on_direction_change(image_3d_4d):
+    """Slice positions must not reset when changing gradient direction.
+
+    Regression test for https://github.com/dipy/dipy/issues/3890
+    """
+    img = image_3d_4d
+
+    # Move to a non-default slice position
+    img.state = np.array([3.0, 7.0, 12.0])
+    saved_state = img.state.copy()
+
+    # Simulate direction change — this calls _create_slicer_actor internally
+    img._volume_idx = 1
+    img._create_slicer_actor()
+
+    np.testing.assert_array_equal(
+        img.state,
+        saved_state,
+        err_msg="Slice state reset after direction change (issue #3890)",
+    )


### PR DESCRIPTION
## Description

When changing gradient direction in `dipy_skyline`, slice positions reset
to the midpoint on every direction change.

## Motivation and Context

`Image3D._create_slicer_actor()` in `dipy/viz/skyline/render/image.py`
unconditionally overwrote `self.state` with `np.mean(self.bounds, axis=0)`
on every call — including when triggered by a direction change. This caused
the slice sliders to jump back to center every time the user switched
gradient direction.

Fix: initialize `self.state = None` in `__init__`, then only set it to
the midpoint on the first call in `_create_slicer_actor()`:

    if self.state is None:
        self.state = np.mean(self.bounds, axis=0)

Subsequent calls preserve the user's current slice positions.

Fixes #3890

## How Has This Been Tested?

Added regression test `test_slice_state_preserved_on_direction_change`
in `dipy/viz/skyline/render/tests/test_image.py`.

    python -m pytest dipy/viz/skyline/render/tests/test_image.py -v
    # 1 skipped (Fury >= 2.0.0a6 not available locally, will run on CI)

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the DIPY coding style.
- [x] I have added tests that cover my changes.
- [x] All new and existing tests pass locally.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)