### PR TITLE
BUG: ensure Skyline file dialog works without .dipy

### DIFF
--- a/dipy/viz/skyline/UI/elements.py
+++ b/dipy/viz/skyline/UI/elements.py
@@ -27,6 +27,34 @@ _NUMERIC_INPUT_DRAFT = {}
 _LAST_DIR = Path("~").expanduser() / ".dipy"
 
 
+def _ensure_last_dir():
+    """Return a valid directory for native file dialogs.
+
+    Ensures ``_LAST_DIR`` points to an existing directory. If the path points to
+    a file, its parent directory is used. If directory creation fails, falls
+    back to the user home directory.
+
+    Returns
+    -------
+    pathlib.Path
+        Existing directory to use as dialog start location.
+    """
+
+    global _LAST_DIR
+
+    try:
+        if _LAST_DIR.is_file():
+            _LAST_DIR = _LAST_DIR.parent
+        _LAST_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning(
+            f"Could not initialize skyline dialog directory at {_LAST_DIR}: {exc}"
+        )
+        _LAST_DIR = Path.home()
+
+    return _LAST_DIR
+
+
 def render_file_dialog(
     *,
     title="Select File(s)",
@@ -63,17 +91,18 @@ def render_file_dialog(
     None
     """
     global _LAST_DIR
+    dialog_dir = _ensure_last_dir()
     if dialog_type == "open":
         dialog = pfd.open_file(
             title,
-            str(_LAST_DIR),
+            str(dialog_dir),
             [name, extensions],
             pfd.opt.multiselect if multiselect else pfd.opt.none,
         )
     elif dialog_type == "save":
         dialog = pfd.save_file(
             title,
-            str(_LAST_DIR / file_name),
+            str(dialog_dir / file_name),
             [name, extensions],
         )
     if dialog.result():

--- a/dipy/viz/skyline/UI/elements.py
+++ b/dipy/viz/skyline/UI/elements.py
@@ -56,7 +56,13 @@ def _ensure_last_dir():
 
 
 def _set_last_dir(path):
-    """Update ``_LAST_DIR`` using a selected file path."""
+    """Update ``_LAST_DIR`` using a selected file path.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Selected file path returned by the file dialog.
+    """
     global _LAST_DIR
     _LAST_DIR = Path(path).parent
 
@@ -94,7 +100,6 @@ def render_file_dialog(
     type : str, optional
         Callback convention: ``"viz"`` (``filenames=``), ``"roi"`` (``rois=``),
         ``"shm_coeff"`` (``shm_coeffs=``), or ``"buan_pvals"`` (raw list/None).
-    None
     """
     dialog_dir = _ensure_last_dir()
     if dialog_type == "open":

--- a/dipy/viz/skyline/UI/elements.py
+++ b/dipy/viz/skyline/UI/elements.py
@@ -55,6 +55,12 @@ def _ensure_last_dir():
     return _LAST_DIR
 
 
+def _set_last_dir(path):
+    """Update ``_LAST_DIR`` using a selected file path."""
+    global _LAST_DIR
+    _LAST_DIR = Path(path).parent
+
+
 def render_file_dialog(
     *,
     title="Select File(s)",
@@ -90,7 +96,6 @@ def render_file_dialog(
         ``"shm_coeff"`` (``shm_coeffs=``), or ``"buan_pvals"`` (raw list/None).
     None
     """
-    global _LAST_DIR
     dialog_dir = _ensure_last_dir()
     if dialog_type == "open":
         dialog = pfd.open_file(
@@ -116,7 +121,7 @@ def render_file_dialog(
                 callback(shm_coeffs=selected_files)
             elif type == "buan_pvals":
                 callback(selected_files)
-        _LAST_DIR = Path(selected_files[0]).parent
+        _set_last_dir(selected_files[0])
     if not dialog.result() and dialog.kill():
         if callback is not None:
             if type == "buan_pvals":

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+def _load_elements_or_skip():
+    pytest.importorskip("PIL")
+    pytest.importorskip("fury", minversion="2.0.0a6")
+    from dipy.viz.skyline.UI import elements
+
+    return elements
+
+
+def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
+    elements = _load_elements_or_skip()
+    missing_dir = tmp_path / "new" / ".dipy"
+    monkeypatch.setattr(elements, "_LAST_DIR", missing_dir)
+
+    resolved_dir = elements._ensure_last_dir()
+
+    assert resolved_dir == missing_dir
+    assert missing_dir.exists()
+    assert missing_dir.is_dir()
+
+
+def test_ensure_last_dir_uses_parent_when_last_dir_is_file(tmp_path, monkeypatch):
+    elements = _load_elements_or_skip()
+    file_path = tmp_path / "last_location.txt"
+    file_path.write_text("placeholder")
+    monkeypatch.setattr(elements, "_LAST_DIR", file_path)
+
+    resolved_dir = elements._ensure_last_dir()
+
+    assert resolved_dir == file_path.parent
+    assert resolved_dir.exists()
+    assert resolved_dir.is_dir()

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -1,11 +1,12 @@
 import pytest
 
 from dipy.utils.optpkg import optional_package
+from dipy.viz.skyline.UI import elements
 
-elements, has_elements, _ = optional_package("dipy.viz.skyline.UI.elements")
+_, has_imgui, _ = optional_package("imgui_bundle", min_version="1.92.600")
 
 
-@pytest.mark.skipif(not has_elements, reason="Requires dipy.viz.skyline.UI.elements")
+@pytest.mark.skipif(not has_imgui, reason="Requires imgui_bundle>=1.92.600")
 def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
     missing_dir = tmp_path / "new" / ".dipy"
     monkeypatch.setattr(elements, "_LAST_DIR", missing_dir)
@@ -17,7 +18,7 @@ def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
     assert missing_dir.is_dir()
 
 
-@pytest.mark.skipif(not has_elements, reason="Requires dipy.viz.skyline.UI.elements")
+@pytest.mark.skipif(not has_imgui, reason="Requires imgui_bundle>=1.92.600")
 def test_ensure_last_dir_uses_parent_when_last_dir_is_file(tmp_path, monkeypatch):
     file_path = tmp_path / "last_location.txt"
     file_path.write_text("placeholder")

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -1,10 +1,12 @@
 import pytest
 
+from dipy.utils.tripwire import TripWireError
+
 
 def _load_elements_or_skip():
     try:
         from dipy.viz.skyline.UI import elements
-    except ImportError as exc:
+    except (ImportError, TripWireError) as exc:
         pytest.skip(f"dipy.viz.skyline.UI.elements is not importable: {exc}")
 
     return elements

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -1,19 +1,12 @@
 import pytest
 
-from dipy.utils.tripwire import TripWireError
+from dipy.utils.optpkg import optional_package
+
+elements, has_elements, _ = optional_package("dipy.viz.skyline.UI.elements")
 
 
-def _load_elements_or_skip():
-    try:
-        from dipy.viz.skyline.UI import elements
-    except (ImportError, TripWireError) as exc:
-        pytest.skip(f"dipy.viz.skyline.UI.elements is not importable: {exc}")
-
-    return elements
-
-
+@pytest.mark.skipif(not has_elements, reason="Requires dipy.viz.skyline.UI.elements")
 def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
-    elements = _load_elements_or_skip()
     missing_dir = tmp_path / "new" / ".dipy"
     monkeypatch.setattr(elements, "_LAST_DIR", missing_dir)
 
@@ -24,8 +17,8 @@ def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
     assert missing_dir.is_dir()
 
 
+@pytest.mark.skipif(not has_elements, reason="Requires dipy.viz.skyline.UI.elements")
 def test_ensure_last_dir_uses_parent_when_last_dir_is_file(tmp_path, monkeypatch):
-    elements = _load_elements_or_skip()
     file_path = tmp_path / "last_location.txt"
     file_path.write_text("placeholder")
     monkeypatch.setattr(elements, "_LAST_DIR", file_path)

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -2,9 +2,10 @@ import pytest
 
 
 def _load_elements_or_skip():
-    pytest.importorskip("PIL")
-    pytest.importorskip("fury", minversion="2.0.0a6")
-    from dipy.viz.skyline.UI import elements
+    try:
+        from dipy.viz.skyline.UI import elements
+    except ImportError as exc:
+        pytest.skip(f"dipy.viz.skyline.UI.elements is not importable: {exc}")
 
     return elements
 

--- a/dipy/viz/skyline/UI/tests/test_elements.py
+++ b/dipy/viz/skyline/UI/tests/test_elements.py
@@ -7,25 +7,33 @@ _, has_imgui, _ = optional_package("imgui_bundle", min_version="1.92.600")
 
 
 @pytest.mark.skipif(not has_imgui, reason="Requires imgui_bundle>=1.92.600")
-def test_ensure_last_dir_creates_missing_directory(tmp_path, monkeypatch):
+def test_ensure_last_dir_creates_missing_directory(tmp_path):
     missing_dir = tmp_path / "new" / ".dipy"
-    monkeypatch.setattr(elements, "_LAST_DIR", missing_dir)
+    original_last_dir = elements._LAST_DIR
+    elements._LAST_DIR = missing_dir
 
-    resolved_dir = elements._ensure_last_dir()
+    try:
+        resolved_dir = elements._ensure_last_dir()
 
-    assert resolved_dir == missing_dir
-    assert missing_dir.exists()
-    assert missing_dir.is_dir()
+        assert resolved_dir == missing_dir
+        assert missing_dir.exists()
+        assert missing_dir.is_dir()
+    finally:
+        elements._LAST_DIR = original_last_dir
 
 
 @pytest.mark.skipif(not has_imgui, reason="Requires imgui_bundle>=1.92.600")
-def test_ensure_last_dir_uses_parent_when_last_dir_is_file(tmp_path, monkeypatch):
+def test_ensure_last_dir_uses_parent_when_last_dir_is_file(tmp_path):
     file_path = tmp_path / "last_location.txt"
     file_path.write_text("placeholder")
-    monkeypatch.setattr(elements, "_LAST_DIR", file_path)
+    original_last_dir = elements._LAST_DIR
+    elements._LAST_DIR = file_path
 
-    resolved_dir = elements._ensure_last_dir()
+    try:
+        resolved_dir = elements._ensure_last_dir()
 
-    assert resolved_dir == file_path.parent
-    assert resolved_dir.exists()
-    assert resolved_dir.is_dir()
+        assert resolved_dir == file_path.parent
+        assert resolved_dir.exists()
+        assert resolved_dir.is_dir()
+    finally:
+        elements._LAST_DIR = original_last_dir


### PR DESCRIPTION
## Summary
Fixes #3956 by ensuring Skyline always has a valid existing start directory for native file dialogs.

## What changed
- Added `_ensure_last_dir()` in `dipy/viz/skyline/UI/elements.py`.
- `render_file_dialog()` now calls `_ensure_last_dir()` and uses that directory for open/save dialogs.
- Behavior now:
  - creates missing `~/.dipy` (or current `_LAST_DIR`) directory,
  - if `_LAST_DIR` points to a file, falls back to its parent directory,
  - if directory creation fails, falls back to `Path.home()`.
- Added regression tests in `dipy/viz/skyline/UI/tests/test_elements.py` for:
  - missing directory creation,
  - file-path fallback to parent directory.

## Validation
- `pre-commit run --files dipy/viz/skyline/UI/elements.py dipy/viz/skyline/UI/tests/test_elements.py`
- `pytest dipy/viz/skyline/UI/tests/test_elements.py -q`

Both passed locally.