### PR TITLE
[FIX] Remove non-useful warning at saving time

### DIFF
--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -78,7 +78,9 @@ def save_tractogram(
     old_origin = deepcopy(sft.origin)
 
     timer = time.time()
-    if extension in [".trk", ".tck", ".trx"]:
+    if extension in [".trk", ".tck", ".trx"] and not (
+        to_origin == Origin.NIFTI and to_space == Space.RASMM
+    ):
         to_origin = Origin.NIFTI
         to_space = Space.RASMM
         logger.warning(


### PR DESCRIPTION
## Description

When saving as trk, tck or trx, a warning is always shown. Removing the warning if not needed.

## Motivation and Context

Not useful.

## How Has This Been Tested?

Can be tested with any script using that function. 
I personally tested it with scilpy's scripts. 

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
