### PR TITLE
NF: Extensive colormap support for Skyline

### DIFF
--- a/dipy/viz/skyline/UI/elements.py
+++ b/dipy/viz/skyline/UI/elements.py
@@ -970,7 +970,7 @@ def segmented_switch(label, options, value, *, width=0, height=28):
 
     imgui.push_id(label)
 
-    value_options = [option.lower() for option in options]
+    value_options = [option.title() for option in options]
     current_value = value if value in value_options else options[0]
     label_color = THEME["text"]
     imgui.push_style_var(imgui.StyleVar_.frame_padding, (12.0, 6.0))

--- a/dipy/viz/skyline/app.py
+++ b/dipy/viz/skyline/app.py
@@ -399,6 +399,28 @@ class Skyline:
         """
         self._refresh_requested = True
 
+    def _scene_op_key(self, func):
+        """Build a stable key for deferred scene operation coalescing.
+
+        Parameters
+        ----------
+        func : callable
+            Deferred scene operation callable.
+
+        Returns
+        -------
+        tuple or None
+            Comparable key for the operation, or None when unavailable.
+        """
+        method = getattr(func, "__func__", None)
+        owner = getattr(func, "__self__", None)
+        if method is not None and owner is not None:
+            return (id(owner), method.__name__)
+        name = getattr(func, "__name__", None)
+        if name is not None:
+            return (None, name)
+        return None
+
     def enqueue_scene_op(self, func, *args, **kwargs):
         """Handle enqueue scene op for ``Skyline``.
 
@@ -412,6 +434,14 @@ class Skyline:
             Value for ``kwargs``.
         """
         if self._is_drawing_ui:
+            op_key = self._scene_op_key(func)
+            if op_key is not None:
+                for idx in range(len(self._pending_scene_ops) - 1, -1, -1):
+                    old_func, _, _ = self._pending_scene_ops[idx]
+                    if self._scene_op_key(old_func) == op_key:
+                        self._pending_scene_ops[idx] = (func, args, kwargs)
+                        self.request_refresh()
+                        return
             self._pending_scene_ops.append((func, args, kwargs))
             self.request_refresh()
             return
@@ -485,7 +515,11 @@ class Skyline:
             try:
                 func(*args, **kwargs)
             except Exception as e:
-                logger.error(f"Failed to apply deferred scene operation: {e}")
+                logger.exception(
+                    "Failed to apply deferred scene operation %s: %s",
+                    getattr(func, "__qualname__", repr(func)),
+                    e,
+                )
         self._refresh_requested = True
 
     def _drain_pending_visualizations(self):

--- a/dipy/viz/skyline/render/image.py
+++ b/dipy/viz/skyline/render/image.py
@@ -30,6 +30,7 @@ if has_fury_v2:
         show_slices,
         volume_slicer,
     )
+    from fury.colormap import distinguishable_colormap
     from fury.lib import gfx
 
 imgui_bundle, has_imgui, _ = optional_package("imgui_bundle", min_version="1.92.600")
@@ -199,7 +200,26 @@ class Image3D(Visualization):
         self._volume_idx = 0
         self.interpolation = interpolation or "linear"
         self._value_percentiles = value_percentiles
-        self._colormap_options = ("Gray", "Inferno", "Magma", "Plasma", "Viridis")
+        self._colormap_options = (
+            "Gray",
+            "Inferno",
+            "Magma",
+            "Plasma",
+            "Viridis",
+            "Cool",
+            "Hot",
+            "Bone",
+            "Copper",
+            "Pink",
+            "Spring",
+            "Summer",
+            "Autumn",
+            "Winter",
+            "Jet",
+            "Cividis",
+            "Distinct",
+            "Divergent",
+        )
         self.colormap = colormap
         self._picked_voxel = None
         self._picked_intensity = None
@@ -225,16 +245,12 @@ class Image3D(Visualization):
         self._picked_intensity = self.active_volume[voxel]
 
     def _create_slicer_actor(self):
-        """Handle  create slicer actor for ``Image3D``.
-        None
-        """
+        """Handle  create slicer actor for ``Image3D``."""
         volume = self.active_volume
-        self.value_range = self._value_range_from_percentile(volume)
         self._slicer = volume_slicer(
             volume,
             affine=self.affine,
             interpolation=self.interpolation,
-            value_range=self.value_range,
             alpha_mode="bayer",
             depth_write=True,
         )
@@ -245,6 +261,26 @@ class Image3D(Visualization):
         self._slicer.add_event_handler(self._pick_voxel, "pointer_down")
         show_slices(self._slicer, self.state)
         self.render()
+
+    def _is_divergent_colormap(self):
+        """Handle  whether active colormap is divergent for ``Image3D``.
+
+        Returns
+        -------
+        bool
+            True when the active colormap is divergent.
+        """
+        return self.colormap.lower() == "divergent"
+
+    def _is_distinct_colormap(self):
+        """Handle  whether active colormap is distinct for ``Image3D``.
+
+        Returns
+        -------
+        bool
+            True when the active colormap is distinct.
+        """
+        return self.colormap.lower() == "distinct"
 
     def _value_range_from_percentile(self, volume):
         """Handle  value range from percentile for ``Image3D``.
@@ -272,12 +308,34 @@ class Image3D(Visualization):
             Colormap used for scalar volumes; ignored when ``rgb`` is True.
         """
         self.colormap = colormap
+        self.value_range = self._value_range_from_percentile(self.active_volume)
         if self.colormap.lower() == "gray":
             for actor in self._slicer.children:
                 actor.material.map = None
+                actor.material.clim = self.value_range
+        elif self.colormap.lower() == "divergent":
+            map_colors = np.array([[0, 0, 1], [1, 0, 0]], dtype=np.float32)
+            map = gfx.cm.create_colormap(map_colors, n=2)
+            max_abs = np.max(np.abs(self.active_volume))
+            if max_abs == 0:
+                max_abs = 1.0
+            for actor in self._slicer.children:
+                actor.material.map = map
+                actor.material.clim = (-float(max_abs), float(max_abs))
+                actor.material.interpolation = "nearest"
+        elif self.colormap.lower() == "distinct":
+            map_colors = np.asarray(
+                distinguishable_colormap(nb_colors=256), dtype=np.float32
+            )
+            map = gfx.cm.create_colormap(map_colors, n=256)
+            for actor in self._slicer.children:
+                actor.material.map = map
+                actor.material.interpolation = "nearest"
+                actor.material.clim = self.value_range
         else:
             for actor in self._slicer.children:
                 actor.material.map = getattr(gfx.cm, self.colormap.lower())
+                actor.material.clim = self.value_range
 
     @property
     def actor(self):
@@ -361,6 +419,10 @@ class Image3D(Visualization):
             for actor in self._slicer.children:
                 actor.material.depth_write = False
                 actor.material.alpha_mode = "blend"
+        else:
+            for actor in self._slicer.children:
+                actor.material.depth_write = True
+                actor.material.alpha_mode = "bayer"
 
     def _set_slice_state(self, visibility, state):
         """Handle  set slice state for ``Image3D``.
@@ -372,6 +434,8 @@ class Image3D(Visualization):
         state : array-like
             Current slice state for X/Y/Z.
         """
+        if self._slicer is None:
+            return
         set_group_visibility(self._slicer, visibility)
         show_slices(self._slicer, state)
 
@@ -383,6 +447,8 @@ class Image3D(Visualization):
         value_range : tuple(float, float)
             Scalar range used for display intensity limits.
         """
+        if self._slicer is None:
+            return
         for actor in self._slicer.children:
             actor.material.clim = value_range
 
@@ -394,8 +460,12 @@ class Image3D(Visualization):
         interpolation : str, optional
             Slice interpolation mode (``"linear"`` or ``"nearest"``).
         """
+
+        if self._slicer is None:
+            return
         for actor in self._slicer.children:
             actor.material.interpolation = interpolation
+        self.interpolation = interpolation
 
     def render_widgets(self):
         """Handle render widgets for ``Image3D``."""
@@ -478,20 +548,21 @@ class Image3D(Visualization):
         volume_for_range = (
             self.dwi[..., self._volume_idx] if self._has_directions else self.dwi
         )
-        intensity_changed, new_percentiles = two_disk_slider(
-            "Intensities",
-            self._value_percentiles,
-            0,
-            100,
-            text_format=".1f",
-            step=1,
-            min_gap=0.1,
-            display_values=self.value_range,
-        )
-        if intensity_changed:
-            self._value_percentiles = new_percentiles
-            self.value_range = self._value_range_from_percentile(volume_for_range)
-            self.apply_scene_op(self._set_clim, self.value_range)
+        if not self._is_divergent_colormap():
+            intensity_changed, new_percentiles = two_disk_slider(
+                "Intensities",
+                self._value_percentiles,
+                0,
+                100,
+                text_format=".1f",
+                step=1,
+                min_gap=0.1,
+                display_values=self.value_range,
+            )
+            if intensity_changed:
+                self._value_percentiles = new_percentiles
+                self.value_range = self._value_range_from_percentile(volume_for_range)
+                self.apply_scene_op(self._set_clim, self.value_range)
 
         if self._has_directions and not self.rgb:
             imgui.spacing()
@@ -544,10 +615,11 @@ class Image3D(Visualization):
         imgui.spacing()
         imgui.spacing()
         changed, new = segmented_switch(
-            "Interpolation", ["Linear", "Nearest"], self.interpolation
+            "Interpolation",
+            ["Linear", "Nearest"],
+            self.interpolation.title(),
         )
         if changed:
-            self.interpolation = new
-            self.apply_scene_op(self._set_interpolation, self.interpolation)
+            self.apply_scene_op(self._set_interpolation, new.lower())
 
         imgui.spacing()

--- a/dipy/viz/skyline/render/meson.build
+++ b/dipy/viz/skyline/render/meson.build
@@ -15,3 +15,5 @@ py3.install_sources(
   pure: false,
   subdir: 'dipy/viz/skyline/render'
 )
+
+subdir('tests')

--- a/dipy/viz/skyline/render/tests/meson.build
+++ b/dipy/viz/skyline/render/tests/meson.build
@@ -1,0 +1,11 @@
+python_sources = [
+  '__init__.py',
+  'test_image.py',
+  ]
+
+
+py3.install_sources(
+  python_sources,
+  pure: false,
+  subdir: 'dipy/viz/skyline/render/tests'
+)

--- a/dipy/viz/skyline/render/tests/test_image.py
+++ b/dipy/viz/skyline/render/tests/test_image.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("fury")
+
+from dipy.viz.skyline.render.image import Image3D  # noqa: E402
+
+
+def _image_stub():
+    """Build ``Image3D``-like object for lightweight method tests.
+
+    Returns
+    -------
+    Image3D
+        Instance with the minimum attributes needed by tested methods.
+    """
+    obj = Image3D.__new__(Image3D)
+    obj._synchronize = True
+    obj.state = np.array([0.0, 0.0, 0.0], dtype=float)
+    obj._has_directions = False
+    obj._volume_idx = 0
+    obj.dwi = np.zeros((2, 2, 2), dtype=np.float32)
+    obj.colormap = "Gray"
+    obj.interpolation = "linear"
+    obj._scene_calls = []
+    obj.apply_scene_op = lambda func, *args: obj._scene_calls.append(
+        (getattr(func, "__name__", ""), args)
+    )
+    return obj
+
+
+def test_set_interpolation_forces_nearest_for_divergent_colormap():
+    """``_set_interpolation`` enforces nearest when colormap is divergent."""
+    image = _image_stub()
+    image.colormap = "Divergent"
+
+    class _Material:
+        def __init__(self):
+            self.interpolation = "linear"
+
+    class _Actor:
+        def __init__(self):
+            self.material = _Material()
+
+    image._slicer = type("Slicer", (), {"children": [_Actor(), _Actor()]})()
+
+    image._set_interpolation("linear")
+
+    assert image.interpolation == "nearest"
+    assert all(
+        actor.material.interpolation == "nearest" for actor in image._slicer.children
+    )
+
+
+def test_update_state_updates_slice_state_without_direction_switch():
+    """``update_state`` updates slices and skips volume switch for 3-value state."""
+    image = _image_stub()
+    image._has_directions = True
+    image.dwi = np.zeros((2, 2, 2, 4), dtype=np.float32)
+    image._slicer = object()
+
+    image.update_state(np.array([1.0, 2.0, 3.0]))
+
+    assert np.array_equal(image.state, np.array([1.0, 2.0, 3.0]))
+    assert image._volume_idx == 0
+    assert len(image._scene_calls) == 1
+
+
+def test_update_state_switches_direction_when_index_is_valid():
+    """``update_state`` changes direction and recreates slicer for valid index."""
+    image = _image_stub()
+    image._has_directions = True
+    image.dwi = np.zeros((2, 2, 2, 5), dtype=np.float32)
+    image._slicer = object()
+
+    image.update_state(np.array([1.0, 1.0, 1.0, 3.0]))
+
+    assert image._volume_idx == 3
+    assert len(image._scene_calls) == 2

--- a/dipy/viz/skyline/tests/test_app.py
+++ b/dipy/viz/skyline/tests/test_app.py
@@ -81,3 +81,62 @@ def test_load_visualizations_sh_coeffs_happy_path():
     assert glyph.path == "unit_odf"
     assert glyph.shape == (1, 1, 1)
     assert glyph.viz_type == "sh_glyph"
+
+
+def _skyline_stub_for_deferred_behaviour():
+    """Build ``Skyline``-like object for deferred scene/sync tests.
+
+    Returns
+    -------
+    Skyline
+        Instance with the attributes needed by deferred operation methods.
+    """
+    obj = Skyline.__new__(Skyline)
+    obj._is_drawing_ui = True
+    obj._pending_scene_ops = []
+    obj._pending_sync_requests = []
+    obj._refresh_requested = False
+    obj.active_image = None
+    obj.request_refresh = lambda: setattr(obj, "_refresh_requested", True)
+    obj._synchronize_visualizations_from_source = lambda *args, **kwargs: None
+    obj._arrange_image_actors = lambda: None
+    return obj
+
+
+def test_enqueue_scene_op_coalesces_same_bound_method():
+    """``enqueue_scene_op`` keeps only the latest call for same bound method."""
+    sky = _skyline_stub_for_deferred_behaviour()
+    calls = []
+
+    class Recorder:
+        def record(self, value):
+            calls.append(value)
+
+    recorder = Recorder()
+    sky.enqueue_scene_op(recorder.record, 1)
+    sky.enqueue_scene_op(recorder.record, 2)
+    assert len(sky._pending_scene_ops) == 1
+
+    sky._flush_pending_scene_ops()
+    assert calls == [2]
+    assert sky._refresh_requested
+
+
+def test_synchronize_visualizations_queues_snapshot_while_drawing():
+    """``_synchronize_visualizations`` queues a copied state during UI draw."""
+    sky = _skyline_stub_for_deferred_behaviour()
+
+    class SourceViz:
+        _synchronize = True
+
+    source = SourceViz()
+    new_state = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+    sky._synchronize_visualizations(source, new_state)
+
+    assert len(sky._pending_sync_requests) == 1
+    queued_source, queued_state = sky._pending_sync_requests[0]
+    assert queued_source is source
+    assert np.array_equal(queued_state, new_state)
+    assert queued_state is not new_state
+    assert sky._refresh_requested


### PR DESCRIPTION
## Description

This PR introduces multiple changes

- It provides extensive colormap support.
- It provides de-bouncing for chocked up processes.
- It provides test cases for proposed changes.

## Motivation and Context

This change is required to introduce more colormaps for visualization of images. Like distinct and divergent.

## How Has This Been Tested?

You can load and 3D/4D image and change the colormaps and provide details about it.

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
