### PR TITLE
FIX: Tissue classification of heavily masked data

### DIFF
--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -412,7 +412,7 @@ def test_classify():
 
     # Now we test what happens with heavily masked data
     masked_image = np.copy(image)
-    masked_image[masked_image.shape[0] // 2:, :, :] = 0
+    masked_image[masked_image.shape[0] // 2 :, :, :] = 0
     seg_init, seg_final, PVE = imgseg.classify(masked_image, nclasses, beta)
 
     npt.assert_(seg_final.max() == nclasses)

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -410,6 +410,14 @@ def test_classify():
     npt.assert_(seg_final.max() == nclasses)
     npt.assert_(seg_final.min() == 0.0)
 
+    # Now we test what happens with heavily masked data
+    masked_image = np.copy(image)
+    masked_image[masked_image.shape[0] // 2:, :, :] = 0
+    seg_init, seg_final, PVE = imgseg.classify(masked_image, nclasses, beta)
+
+    npt.assert_(seg_final.max() == nclasses)
+    npt.assert_(seg_final.min() == 0.0)
+
     # Next we test saving the history of accumulated energies from ICM
     imgseg = TissueClassifierHMRF(save_history=True)
 

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -410,13 +410,16 @@ def test_classify():
     npt.assert_(seg_final.max() == nclasses)
     npt.assert_(seg_final.min() == 0.0)
 
-    # Now we test what happens with heavily masked data
+    # Heavily masked data (50% zeroed) must not cause non-convergence
     masked_image = np.copy(image)
     masked_image[masked_image.shape[0] // 2 :, :, :] = 0
     seg_init, seg_final, PVE = imgseg.classify(masked_image, nclasses, beta)
 
+    npt.assert_(seg_init.max() == nclasses)
+    npt.assert_(seg_init.min() == 0.0)
     npt.assert_(seg_final.max() == nclasses)
     npt.assert_(seg_final.min() == 0.0)
+    npt.assert_(PVE.shape[-1] == nclasses)
 
     # Next we test saving the history of accumulated energies from ICM
     imgseg = TissueClassifierHMRF(save_history=True)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -26,7 +26,8 @@ class TissueClassifierHMRF:
         self.verbose = verbose
 
     @warning_for_keywords()
-    def classify(self, image, nclasses, beta, *, tolerance=1e-05, max_iter=100):
+    def classify(self, image, nclasses, beta, *, tolerance=1e-05, max_iter=100,
+                 min_var=1e-6):
         """
         This method uses the Maximum a posteriori - Markov Random Field
         approach for segmentation by using the Iterative Conditional Modes
@@ -54,6 +55,9 @@ class TissueClassifierHMRF:
             explicitly set to 0, this early stopping mechanism is disabled,
             and the algorithm will run for the specified number of
             iterations unless another stopping criterion is met.
+        min_var : float, optional
+            Minimum variance within each tissue class to prevent division by 
+            zero. Default is 1e-6.
 
         Returns
         -------
@@ -81,9 +85,8 @@ class TissueClassifierHMRF:
         neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
-        min_sigmasq = 1e-6
         mu, sigmasq = com.seg_stats(image, seg_init, nclasses)
-        sigmasq = np.maximum(sigmasq, min_sigmasq)
+        sigmasq = np.maximum(sigmasq, min_var)
 
         zero = np.zeros_like(image) + 0.001
         zero_noise = add_noise(zero, 10000, 1, noise_type="gaussian")
@@ -103,7 +106,8 @@ class TissueClassifierHMRF:
             ind = np.argsort(mu_upd)
             mu_upd = mu_upd[ind]
             sigmasq_upd = sigmasq_upd[ind]
-            sigmasq_upd = np.maximum(sigmasq_upd, min_sigmasq)
+            print(f"{i}: sigmasq_upd: {sigmasq_upd}")
+            sigmasq_upd = np.maximum(sigmasq_upd, min_var)
 
             negll = com.negloglikelihood(image_gauss, mu_upd, sigmasq_upd, nclasses)
             final_segmentation, energy = icm.icm_ising(negll, beta, seg_init)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -81,8 +81,9 @@ class TissueClassifierHMRF:
         neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
+        min_sigmasq = 1e-6
         mu, sigmasq = com.seg_stats(image, seg_init, nclasses)
-        sigmasq = np.maximum(sigmasq, 1e-6)
+        sigmasq = np.maximum(sigmasq, min_sigmasq)
 
         zero = np.zeros_like(image) + 0.001
         zero_noise = add_noise(zero, 10000, 1, noise_type="gaussian")
@@ -102,7 +103,7 @@ class TissueClassifierHMRF:
             ind = np.argsort(mu_upd)
             mu_upd = mu_upd[ind]
             sigmasq_upd = sigmasq_upd[ind]
-            sigmasq_upd = np.maximum(sigmasq_upd, 1e-6)
+            sigmasq_upd = np.maximum(sigmasq_upd, min_sigmasq)
 
             negll = com.negloglikelihood(image_gauss, mu_upd, sigmasq_upd, nclasses)
             final_segmentation, energy = icm.icm_ising(negll, beta, seg_init)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -82,6 +82,7 @@ class TissueClassifierHMRF:
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
         mu, sigmasq = com.seg_stats(image, seg_init, nclasses)
+        sigmasq = np.maximum(sigmasq, 1e-6)
 
         zero = np.zeros_like(image) + 0.001
         zero_noise = add_noise(zero, 10000, 1, noise_type="gaussian")
@@ -101,6 +102,7 @@ class TissueClassifierHMRF:
             ind = np.argsort(mu_upd)
             mu_upd = mu_upd[ind]
             sigmasq_upd = sigmasq_upd[ind]
+            sigmasq_upd = np.maximum(sigmasq_upd, 1e-6)
 
             negll = com.negloglikelihood(image_gauss, mu_upd, sigmasq_upd, nclasses)
             final_segmentation, energy = icm.icm_ising(negll, beta, seg_init)

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -77,16 +77,16 @@ class TissueClassifierHMRF:
         if image.max() > 1:
             image = np.interp(image, [0, image.max()], [0.0, 1.0])
 
-        mu, sigmasq = com.initialize_param_uniform(image, nclasses)
+        mu, var = com.initialize_param_uniform(image, nclasses)
         p = np.argsort(mu)
         mu = mu[p]
-        sigmasq = sigmasq[p]
+        var = var[p]
 
-        neglogl = com.negloglikelihood(image, mu, sigmasq, nclasses)
+        neglogl = com.negloglikelihood(image, mu, var, nclasses)
         seg_init = icm.initialize_maximum_likelihood(neglogl)
 
-        mu, sigmasq = com.seg_stats(image, seg_init, nclasses)
-        sigmasq = np.maximum(sigmasq, min_var)
+        mu, var = com.seg_stats(image, seg_init, nclasses)
+        var = np.maximum(var, min_var)
 
         zero = np.zeros_like(image) + 0.001
         zero_noise = add_noise(zero, 10000, 1, noise_type="gaussian")
@@ -100,16 +100,16 @@ class TissueClassifierHMRF:
                 logger.info(f">> Iteration: {i}")
 
             PLN = icm.prob_neighborhood(seg_init, beta, nclasses)
-            PVE = com.prob_image(image_gauss, nclasses, mu, sigmasq, PLN)
+            PVE = com.prob_image(image_gauss, nclasses, mu, var, PLN)
 
-            mu_upd, sigmasq_upd = com.update_param(image_gauss, PVE, mu, nclasses)
+            mu_upd, var_upd = com.update_param(image_gauss, PVE, mu, nclasses)
             ind = np.argsort(mu_upd)
             mu_upd = mu_upd[ind]
-            sigmasq_upd = sigmasq_upd[ind]
-            print(f"{i}: sigmasq_upd: {sigmasq_upd}")
-            sigmasq_upd = np.maximum(sigmasq_upd, min_var)
+            var_upd = var_upd[ind]
+            print(f"{i}: var_upd: {var_upd}")
+            var_upd = np.maximum(var_upd, min_var)
 
-            negll = com.negloglikelihood(image_gauss, mu_upd, sigmasq_upd, nclasses)
+            negll = com.negloglikelihood(image_gauss, mu_upd, var_upd, nclasses)
             final_segmentation, energy = icm.icm_ising(negll, beta, seg_init)
 
             energy_sum.append(energy[energy > -np.inf].sum())
@@ -132,7 +132,7 @@ class TissueClassifierHMRF:
 
             seg_init = final_segmentation
             mu = mu_upd
-            sigmasq = sigmasq_upd
+            var = var_upd
 
         PVE = PVE[..., 1:]
 

--- a/dipy/segment/tissue.py
+++ b/dipy/segment/tissue.py
@@ -26,8 +26,9 @@ class TissueClassifierHMRF:
         self.verbose = verbose
 
     @warning_for_keywords()
-    def classify(self, image, nclasses, beta, *, tolerance=1e-05, max_iter=100,
-                 min_var=1e-6):
+    def classify(
+        self, image, nclasses, beta, *, tolerance=1e-05, max_iter=100, min_var=1e-6
+    ):
         """
         This method uses the Maximum a posteriori - Markov Random Field
         approach for segmentation by using the Iterative Conditional Modes
@@ -56,8 +57,8 @@ class TissueClassifierHMRF:
             and the algorithm will run for the specified number of
             iterations unless another stopping criterion is met.
         min_var : float, optional
-            Minimum variance within each tissue class to prevent division by 
-            zero. Default is 1e-6.
+            Minimum variance within each tissue class to prevent division by
+            zero when the image is heavily masked.
 
         Returns
         -------
@@ -81,6 +82,7 @@ class TissueClassifierHMRF:
         p = np.argsort(mu)
         mu = mu[p]
         var = var[p]
+        var = np.maximum(var, min_var)
 
         neglogl = com.negloglikelihood(image, mu, var, nclasses)
         seg_init = icm.initialize_maximum_likelihood(neglogl)
@@ -106,7 +108,6 @@ class TissueClassifierHMRF:
             ind = np.argsort(mu_upd)
             mu_upd = mu_upd[ind]
             var_upd = var_upd[ind]
-            print(f"{i}: var_upd: {var_upd}")
             var_upd = np.maximum(var_upd, min_var)
 
             negll = com.negloglikelihood(image_gauss, mu_upd, var_upd, nclasses)


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
There's a bug where the HMRF tissue classification doesn't converge if the data is heavily masked.

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. e.g., Closes #1234 -->

This is linked to the issue raised in #3943.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. -->
<!-- Include relevant details such as test commands, test coverage, etc. -->

I've added a test that masks out more of the sample data then tries to segment the tissue. Without my fix, this test fails; with the fix, the test passes. The new lines are covered by the tests.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
