### PR TITLE
Fix numpydoc grad tensor docstrings

### DIFF
--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -122,7 +122,7 @@ def streamline_gradients(streamline):
 
 def grad_tensor(grad, evals):
     """
-    Calculate the 3 by 3 tensor for a given spatial gradient, 
+    Calculate the 3 by 3 tensor for a given spatial gradient,
     given a canonical tensor shape (also as a 3 by 3), pointing at [1,0,0]
 
     Parameters
@@ -133,12 +133,12 @@ def grad_tensor(grad, evals):
     evals : 1d array of shape (3,)
         The eigenvalues of a canonical tensor to be used as a response
         function.
-    
+
         Returns
         -------
         tensor : ndarray, shape (3, 3)
                The 3 by 3 diffusion tensor rotated to point in the direction
-               of the given spatial gradient 
+               of the given spatial gradient
     """
     # This is the rotation matrix from [1, 0, 0] to this gradient of the sl:
     R = la.svd([grad], overwrite_a=True)[2]
@@ -276,7 +276,7 @@ class LifeSignalMaker:
         sig_out : ndarray, shape (N, M)
             The estimated signal at each node of the streamline,
             where N is the number of nodes and M is the number of
-            non-b0 directions in the gradient table.                
+            non-b0 directions in the gradient table.
         """
         grad = streamline_gradients(streamline)
         sig_out = np.zeros((grad.shape[0], self.signal.shape[-1]))

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -130,10 +130,14 @@ def grad_tensor(grad, evals):
     grad : 1d array of shape (3,)
         The spatial gradient (e.g between two nodes of a streamline).
 
-    evals: 1d array of shape (3,)
+    evals : 1d array of shape (3,)
         The eigenvalues of a canonical tensor to be used as a response
         function.
-
+    
+        Returns
+        -------
+        tensor :  ndarray, shape (3, 3)
+               The 3 by 3 diffusion tensor rotated to point in the direction of the given spacial gradient 
     """
     # This is the rotation matrix from [1, 0, 0] to this gradient of the sl:
     R = la.svd([grad], overwrite_a=True)[2]
@@ -259,6 +263,19 @@ class LifeSignalMaker:
     def streamline_signal(self, streamline):
         """
         Approximate the signal for a given streamline
+
+        Parameters
+        ----------
+        streamline : nadarray , shape (N, 3)
+                A single streamline ,represented as an
+                array of N points in 3D space
+
+        Returns
+        -------
+        sig_out : ndarray, shape (N, M)
+            The estimated signal at each node of the streamline,
+            where N is the number of nodes and M is the number of
+            non-b0 directions in the gradient table.                
         """
         grad = streamline_gradients(streamline)
         sig_out = np.zeros((grad.shape[0], self.signal.shape[-1]))

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -122,8 +122,8 @@ def streamline_gradients(streamline):
 
 def grad_tensor(grad, evals):
     """
-    Calculate the 3 by 3 tensor for a given spatial gradient, given a canonical
-    tensor shape (also as a 3 by 3), pointing at [1,0,0]
+    Calculate the 3 by 3 tensor for a given spatial gradient, 
+    given a canonical tensor shape (also as a 3 by 3), pointing at [1,0,0]
 
     Parameters
     ----------
@@ -136,8 +136,9 @@ def grad_tensor(grad, evals):
     
         Returns
         -------
-        tensor :  ndarray, shape (3, 3)
-               The 3 by 3 diffusion tensor rotated to point in the direction of the given spacial gradient 
+        tensor : ndarray, shape (3, 3)
+               The 3 by 3 diffusion tensor rotated to point in the direction
+               of the given spatial gradient 
     """
     # This is the rotation matrix from [1, 0, 0] to this gradient of the sl:
     R = la.svd([grad], overwrite_a=True)[2]
@@ -266,9 +267,9 @@ class LifeSignalMaker:
 
         Parameters
         ----------
-        streamline : nadarray , shape (N, 3)
-                A single streamline ,represented as an
-                array of N points in 3D space
+        streamline : ndarray, shape (N, 3)
+            A single streamline, represented as an
+            array of N points in 3D space
 
         Returns
         -------


### PR DESCRIPTION
## Description
Fix numpydoc validation warnings in `dipy/tracking/life.py` as part of #3270.

- Fixed missing `Returns` section in `grad_tensor` function
- Fixed missing `Parameters` and `Returns` sections in
  `TissueClassifierACT.streamline_signal` method

## Motivation and Context
This is a continuation of the numpydoc docstring improvements across DIPY
modules. Fixing these warnings improves documentation consistency and helps
new users understand the API more clearly.

Relates to #3270

## How Has This Been Tested?
This is a documentation-only change. No functional code was modified.
All existing tests remain unaffected.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure