### PR TITLE
BF: Slice should adjust to existing state for new load.

### DIFF
--- a/dipy/viz/skyline/app.py
+++ b/dipy/viz/skyline/app.py
@@ -233,6 +233,7 @@ class Skyline:
         self.window.resize_callback(self.handle_resize)
         self._color_gen = distinguishable_colormap()
         self.active_image = None
+        self._slice_focus_viz = None
 
         if self._visualizer_type != "stealth":
             gpu_texture = load_image_as_wgpu_texture_view(
@@ -522,12 +523,67 @@ class Skyline:
                 )
         self._refresh_requested = True
 
+    def _get_reference_slice_state(self):
+        """Return a snapshot of the current slice pose for load-time alignment.
+
+        Returns
+        -------
+        np.ndarray or list or tuple or None
+            Snapshot of slice state from an existing synchronizable visualization,
+            or None when no such visualization exists (first load).
+        """
+        if self.active_image is not None:
+            return self._snapshot_state(
+                np.asarray(self.active_image.state, dtype=float)
+            )
+        if self._slice_focus_viz is not None:
+            if self._slice_focus_viz not in self.visualizations:
+                self._slice_focus_viz = None
+            else:
+                return self._snapshot_state(
+                    np.asarray(self._slice_focus_viz.state, dtype=float)
+                )
+        for viz in reversed(self.visualizations):
+            if isinstance(viz, (Image3D, Peak3D, SHGlyph3D)):
+                return self._snapshot_state(np.asarray(viz.state, dtype=float))
+        return None
+
+    def _apply_reference_slice_state_to_new_visualizations(
+        self, reference_state, n_img_before, n_peak_before, n_sh_before
+    ):
+        """Apply a pre-load slice pose to visualizations created in this batch.
+
+        Parameters
+        ----------
+        reference_state : array-like or None
+            Snapshot from ``_get_reference_slice_state`` before loading, or None.
+        n_img_before : int
+            Length of ``_image_visualizations`` before ``_load_visualiations``.
+        n_peak_before : int
+            Length of ``_peak_visualizations`` before ``_load_visualiations``.
+        n_sh_before : int
+            Length of ``_sh_glyph_visualizations`` before ``_load_visualiations``.
+        """
+        if reference_state is None:
+            return
+        new_visualizations = (
+            self._image_visualizations[n_img_before:]
+            + self._peak_visualizations[n_peak_before:]
+            + self._sh_glyph_visualizations[n_sh_before:]
+        )
+        for viz in new_visualizations:
+            viz.update_state(reference_state)
+
     def _drain_pending_visualizations(self):
         """Handle  drain pending visualizations for ``Skyline``.
         None
         """
         if self._pending_loaded_files:
             loaded_files = self._pending_loaded_files.pop(0)
+            n_img_before = len(self._image_visualizations)
+            n_peak_before = len(self._peak_visualizations)
+            n_sh_before = len(self._sh_glyph_visualizations)
+            reference_slice_state = self._get_reference_slice_state()
             self._load_visualiations(
                 loaded_files["images"],
                 loaded_files["peaks"],
@@ -538,11 +594,12 @@ class Skyline:
                 is_cluster=loaded_files.get("is_cluster_override"),
                 async_clustering=loaded_files.get("async_clustering_override"),
             )
-
-            if self.active_image is not None:
-                self._synchronize_visualizations_from_source(
-                    self.active_image, self.active_image.state
-                )
+            self._apply_reference_slice_state_to_new_visualizations(
+                reference_slice_state,
+                n_img_before,
+                n_peak_before,
+                n_sh_before,
+            )
 
             if self._visualizer_type != "stealth":
                 self._update_tractogram_helper()
@@ -848,6 +905,9 @@ class Skyline:
         else:
             raise ValueError("Unsupported visualization type")
 
+        if viz is self._slice_focus_viz:
+            self._slice_focus_viz = None
+
         if len(self.visualizations) == 0:
             self.UI_window.request_file_dialog = True
 
@@ -893,7 +953,6 @@ class Skyline:
                 viz.update_state(new_state)
 
     def _synchronize_visualizations(self, source_viz, new_state):
-        # Source-side guard: only push if this view has sync enabled.
         """Handle  synchronize visualizations for ``Skyline``.
 
         Parameters
@@ -906,6 +965,9 @@ class Skyline:
         if not getattr(source_viz, "_synchronize", True):
             return
 
+        if isinstance(source_viz, (Image3D, Peak3D, SHGlyph3D)):
+            self._slice_focus_viz = source_viz
+
         new_state = self._snapshot_state(new_state)
 
         if self._is_drawing_ui:
@@ -914,8 +976,6 @@ class Skyline:
             return
         self._synchronize_visualizations_from_source(source_viz, new_state)
         self.active_image and self._arrange_image_actors()
-
-    # self.window.render()
 
     def _update_background_color(self, new_color):
         """Handle  update background color for ``Skyline``.
@@ -934,9 +994,7 @@ class Skyline:
         self._render_window()
 
     def _process_tractogram_switches(self):
-        """Handle  process tractogram switches for ``Skyline``.
-        None
-        """
+        """Handle  process tractogram switches for ``Skyline``."""
         if not self._pending_tractogram_switches:
             return
         pending = self._pending_tractogram_switches.copy()

--- a/dipy/viz/skyline/tests/test_app.py
+++ b/dipy/viz/skyline/tests/test_app.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
 
-pytest.importorskip("fury")
+from dipy.viz.skyline.app import Skyline
+from dipy.viz.skyline.render.image import Image3D
+from dipy.viz.skyline.render.sh_slicer import SHGlyph3D
 
-from dipy.viz.skyline.app import Skyline  # noqa: E402
-from dipy.viz.skyline.render.sh_slicer import SHGlyph3D  # noqa: E402
+pytest.importorskip("fury")
 
 
 def _skyline_stub_for_load_visualizations():
@@ -91,7 +92,7 @@ def _skyline_stub_for_deferred_behaviour():
     Skyline
         Instance with the attributes needed by deferred operation methods.
     """
-    obj = Skyline.__new__(Skyline)
+    obj = Skyline(visualizer_type="stealth")
     obj._is_drawing_ui = True
     obj._pending_scene_ops = []
     obj._pending_sync_requests = []
@@ -140,3 +141,169 @@ def test_synchronize_visualizations_queues_snapshot_while_drawing():
     assert np.array_equal(queued_state, new_state)
     assert queued_state is not new_state
     assert sky._refresh_requested
+
+
+def test_get_reference_slice_state_none_when_empty():
+    """``_get_reference_slice_state`` returns None when no sync-capable views exist."""
+    sky = Skyline(visualizer_type="stealth")
+    sky.active_image = None
+    sky._slice_focus_viz = None
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = []
+    assert sky._get_reference_slice_state() is None
+
+
+def test_get_reference_slice_state_prefers_active_image():
+    """``_get_reference_slice_state`` uses ``active_image.state`` when set."""
+    sky = Skyline(visualizer_type="stealth")
+    sky._slice_focus_viz = None
+    img_first = Image3D.__new__(Image3D)
+    img_first.state = np.array([1.0, 1.0, 1.0], dtype=float)
+    img_active = Image3D.__new__(Image3D)
+    img_active.state = np.array([4.0, 5.0, 6.0], dtype=float)
+    sky._image_visualizations = [img_first, img_active]
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = []
+    sky.active_image = img_active
+    ref = sky._get_reference_slice_state()
+    assert np.array_equal(ref, np.array([4.0, 5.0, 6.0]))
+
+
+def test_get_reference_slice_state_uses_slice_focus_when_no_active_image():
+    """``_get_reference_slice_state`` follows ``_slice_focus_viz`` when set."""
+    sky = Skyline(visualizer_type="stealth")
+    sky.active_image = None
+    glyph = SHGlyph3D.__new__(SHGlyph3D)
+    glyph.state = np.array([2.0, 3.0, 4.0], dtype=float)
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = [glyph]
+    sky._slice_focus_viz = glyph
+    ref = sky._get_reference_slice_state()
+    assert np.array_equal(ref, np.array([2.0, 3.0, 4.0]))
+
+
+def test_get_reference_slice_state_reversed_fallback():
+    """``_get_reference_slice_state`` uses the last sync-capable vis in stack order."""
+    sky = Skyline.__new__(Skyline)
+    sky.active_image = None
+    sky._slice_focus_viz = None
+    g_a = SHGlyph3D.__new__(SHGlyph3D)
+    g_a.state = np.array([0.0, 0.0, 0.0], dtype=float)
+    g_b = SHGlyph3D.__new__(SHGlyph3D)
+    g_b.state = np.array([7.0, 8.0, 9.0], dtype=float)
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = [g_a, g_b]
+    ref = sky._get_reference_slice_state()
+    assert np.array_equal(ref, np.array([7.0, 8.0, 9.0]))
+
+
+def test_get_reference_slice_state_clears_stale_focus():
+    """``_get_reference_slice_state`` drops stale ``_slice_focus_viz`` references."""
+    sky = Skyline.__new__(Skyline)
+    sky.active_image = None
+    orphan = SHGlyph3D.__new__(SHGlyph3D)
+    sky._slice_focus_viz = orphan
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = []
+    assert sky._get_reference_slice_state() is None
+    assert sky._slice_focus_viz is None
+
+
+def test_apply_reference_slice_state_to_new_visualizations():
+    """``_apply_reference_slice_state_to_new_visualizations`` on update."""
+    sky = Skyline(visualizer_type="stealth")
+
+    class Viz:
+        def __init__(self):
+            self.last = None
+
+        def update_state(self, s):
+            self.last = np.asarray(s, dtype=float).copy()
+
+    old = Viz()
+    new = Viz()
+    sky._image_visualizations = [old, new]
+    sky._peak_visualizations = []
+    sky._sh_glyph_visualizations = []
+    ref = np.array([10.0, 20.0, 30.0], dtype=float)
+    sky._apply_reference_slice_state_to_new_visualizations(ref, 1, 0, 0)
+    assert old.last is None
+    assert np.array_equal(new.last, ref)
+
+
+def test_apply_reference_slice_state_to_new_visualizations_noop_when_none():
+    """``_apply_reference_slice_state_to_new_visualizations`` skips when ref is None."""
+    sky = Skyline(visualizer_type="stealth")
+
+    class Viz:
+        def __init__(self):
+            self.called = False
+
+        def update_state(self, s):
+            self.called = True
+
+    new = Viz()
+    sky._image_visualizations = [new]
+    sky._peak_visualizations = []
+    sky._sh_glyph_visualizations = []
+    sky._apply_reference_slice_state_to_new_visualizations(None, 0, 0, 0)
+    assert new.called is False
+
+
+def test_remove_visualization_clears_slice_focus():
+    """``_remove_visualization`` clears ``_slice_focus_viz`` on removal."""
+    sky = Skyline(visualizer_type="stealth")
+    sky.active_image = None
+    sky.UI_window = None
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    g_keep = SHGlyph3D.__new__(SHGlyph3D)
+    g_focus = SHGlyph3D.__new__(SHGlyph3D)
+    sky._sh_glyph_visualizations = [g_keep, g_focus]
+    sky._slice_focus_viz = g_focus
+    sky._remove_visualization(g_focus)
+    assert sky._slice_focus_viz is None
+    assert sky._sh_glyph_visualizations == [g_keep]
+
+
+def test_synchronize_visualizations_sets_slice_focus():
+    """``_synchronize_visualizations`` stores the source for load-time reference."""
+    sky = Skyline(visualizer_type="stealth")
+    sky.active_image = None
+    sky._is_drawing_ui = False
+    sky._pending_sync_requests = []
+    sky._slice_focus_viz = None
+    sky._image_visualizations = []
+    sky._peak_visualizations = []
+    sky._roi_visualizations = []
+    sky._surface_visualizations = []
+    sky._tractogram_visualizations = []
+    sky._sh_glyph_visualizations = []
+    sky._synchronize_visualizations_from_source = lambda *a, **k: None
+    sky._arrange_image_actors = lambda: None
+    img = Image3D.__new__(Image3D)
+    img._synchronize = True
+    sky._synchronize_visualizations(img, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    assert sky._slice_focus_viz is img


### PR DESCRIPTION
## Description
When you have any slice based visualization open at different slice than mid point and a newer visualization gets added. It reset slices to center. This behavior was annoying if you are looking at a specific slice.

## Motivation and Context

The change provides a stable way to check if a reference state exists for the new slice based visualization, if yes synchronize with it otherwise update the reference with its own position.

## How Has This Been Tested?

- Load any 3D/4D image, peaks, odfs.
- Move slices to some other than the default.
- Load another data and that should align with existing slices instead of resetting.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure

closes #3890 