### PR TITLE
BF: cap fury<2.0 to prevent breaking VTK-dependent viz imports

### DIFF
--- a/dipy/workflows/viz.py
+++ b/dipy/workflows/viz.py
@@ -14,7 +14,9 @@ from dipy.utils.optpkg import optional_package
 from dipy.viz import horizon
 from dipy.workflows.workflow import Workflow
 
-fury, has_fury, setup_module = optional_package("fury", min_version="0.10.0")
+fury, has_fury, setup_module = optional_package(
+    "fury", min_version="0.10.0", max_version="1.0.0"
+)
 
 
 if has_fury:


### PR DESCRIPTION
fury 2.x is a complete rewrite (VTK -> WebGPU) that removes fury.lib.numpy_support and other VTK-based APIs used by dipy.

- pyproject.toml: add upper bound fury>=0.12.0,<2.0
- dipy/workflows/viz.py: add max_version='1.0.0' to optional_package (consistent with peak.py and cluster.py which already had this cap)
- requirements/viz.txt, all.txt, optional.txt: updated accordingly

Fixes #3978

## Description

Caps fury dependency to <2.0 to prevent installation of fury 2.x, 
which is a complete VTK → WebGPU rewrite that removes all VTK-based 
APIs dipy currently depends on.

## Motivation and Context

Closes #3978

Installing fury>=2.0 causes an immediate ImportError that crashes 
the doc build and breaks all viz functionality:

    ImportError: cannot import name 'numpy_support' from 'fury.lib'

peak.py and cluster.py already had max_version="1.0.0" set correctly — 
this PR fixes the same inconsistency in viz.py and pyproject.toml.
## How Has This Been Tested?

Verified locally — downgraded fury to 0.11.0 and confirmed doc build 
proceeds past the previous crash point. No new tests needed as this 
is a dependency constraint fix.
## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x]  Maintenance / CI / Infrastructure
