### PR TITLE
NF: Provide a way to capture screenshot

### DIFF
--- a/dipy/viz/skyline/UI/manager.py
+++ b/dipy/viz/skyline/UI/manager.py
@@ -1,5 +1,7 @@
 """Skyline sidebar window: section grouping, file dialogs, and font setup."""
 
+from collections.abc import Callable
+
 from dipy.utils.optpkg import optional_package
 from dipy.viz.skyline.UI.elements import (
     color_picker,
@@ -84,6 +86,7 @@ class UIWindow:
         render_callback=None,
         file_dialog_callback=None,
         bg_color_callback=None,
+        snapshot_callback=None,
     ):
         """Represent ``UIWindow`` in Skyline.
 
@@ -107,6 +110,8 @@ class UIWindow:
             Callback invoked after file selection.
         bg_color_callback : callable, optional
             Callback invoked when background color changes.
+        snapshot_callback : callable, optional
+            Callback invoked when a snapshot path is selected.
         """
         self.title = title
         self.is_open = default_open
@@ -123,10 +128,20 @@ class UIWindow:
         self._title_text = "DIPY SKYLINE"
         self._show_loader = False
         self._loading_message = "Loading..."
-        if render_callback is None:
+        self.render_callback = render_callback
+        if render_callback is None or not isinstance(render_callback, Callable):
             self.render_callback = lambda: None
         self.file_dialog_callback = file_dialog_callback
+        if file_dialog_callback is None or not isinstance(
+            file_dialog_callback, Callable
+        ):
+            self.file_dialog_callback = lambda: None
         self.bg_color_callback = bg_color_callback
+        if bg_color_callback is None or not isinstance(bg_color_callback, Callable):
+            self.bg_color_callback = lambda: None
+        self.snapshot_callback = snapshot_callback
+        if snapshot_callback is None or not isinstance(snapshot_callback, Callable):
+            self.snapshot_callback = lambda: None
         self._bg_color = (0.1, 0.1, 0.1)
         self._draft_color = self._bg_color
         self._color_picker_open = False
@@ -331,6 +346,22 @@ class UIWindow:
                 self._update_bg_color(self._draft_color)
             self._draft_color = self._bg_color
         self._color_picker_open = is_open
+        imgui.same_line(0, 8)
+        snapshot_icon = icons_fontawesome_6.ICON_FA_CAMERA
+        imgui.text_colored(THEME["text"], snapshot_icon)
+        if imgui.is_item_hovered():
+            imgui.set_item_tooltip("Take Snapshot")
+        if imgui.is_item_clicked(imgui.MouseButton_.left):
+            render_file_dialog(
+                title="Save Snapshot",
+                name="PNG Files (*.png)",
+                extensions="*.png",
+                multiselect=False,
+                callback=self._snapshot_dialog_closed,
+                dialog_type="save",
+                file_name="snapshot.png",
+                type="viz",
+            )
 
         imgui.set_cursor_screen_pos(org_start)
         imgui.dummy((available_width, self.logo_size[1] + spacing * 5 + 1))
@@ -461,6 +492,28 @@ class UIWindow:
         self._bg_color = new_color
         if self.bg_color_callback is not None:
             self.bg_color_callback(new_color)
+
+    def _snapshot_dialog_closed(self, *, filenames=None, rois=None, shm_coeffs=None):
+        """Forward snapshot path to :attr:`snapshot_callback` when selected.
+
+        Parameters
+        ----------
+        filenames : list, str, or None, optional
+            Selected save target path(s) from the dialog.
+        rois : list or None, optional
+            Unused; kept for callback signature compatibility.
+        shm_coeffs : list or None, optional
+            Unused; kept for callback signature compatibility.
+        """
+        if self.snapshot_callback is None or filenames is None:
+            return
+        if isinstance(filenames, str):
+            snapshot_path = filenames
+        elif len(filenames) > 0:
+            snapshot_path = filenames[0]
+        else:
+            return
+        self.snapshot_callback(snapshot_path)
 
     def update_loader(self, *, show, message=None):
         """Toggle the modal loading overlay.

--- a/dipy/viz/skyline/app.py
+++ b/dipy/viz/skyline/app.py
@@ -247,6 +247,7 @@ class Skyline:
                 logo_tex_ref=logo_tex_ref,
                 file_dialog_callback=self._append_visualization,
                 bg_color_callback=self._update_background_color,
+                snapshot_callback=self._save_snapshot,
             )
             self.window._imgui.set_gui(self.draw_ui)
         else:
@@ -1067,6 +1068,21 @@ class Skyline:
         """
         if self.UI_window is not None:
             self.UI_window.update_loader(show=show, message=message)
+
+    def _save_snapshot(self, snapshot_path):
+        """Save a snapshot image using the ShowManager.
+
+        Parameters
+        ----------
+        snapshot_path : str
+            Target file path where the PNG snapshot will be saved.
+        """
+        _, extension = split_filename_extension(snapshot_path)
+        if extension == "":
+            snapshot_path = f"{snapshot_path}.png"
+
+        logger.info(f"Saving snapshot to {snapshot_path}")
+        self.enqueue_scene_op(self.window.snapshot, snapshot_path)
 
     @property
     def visualizations(self):

--- a/dipy/viz/skyline/tests/test_app.py
+++ b/dipy/viz/skyline/tests/test_app.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from dipy.viz.skyline.UI.manager import UIWindow
 from dipy.viz.skyline.app import Skyline
 from dipy.viz.skyline.render.image import Image3D
 from dipy.viz.skyline.render.sh_slicer import SHGlyph3D
@@ -307,3 +308,48 @@ def test_synchronize_visualizations_sets_slice_focus():
     img._synchronize = True
     sky._synchronize_visualizations(img, np.array([1.0, 2.0, 3.0], dtype=np.float32))
     assert sky._slice_focus_viz is img
+
+
+@pytest.mark.parametrize(
+    "filenames,expected_path",
+    [
+        (["/tmp/skyline_snapshot.png"], "/tmp/skyline_snapshot.png"),
+        ("/tmp/skyline_snapshot.png", "/tmp/skyline_snapshot.png"),
+    ],
+)
+def test_uiwindow_snapshot_dialog_closed_forwards_selected_path(
+    filenames, expected_path
+):
+    """``_snapshot_dialog_closed`` forwards save path through callback."""
+    ui_window = UIWindow.__new__(UIWindow)
+    captured_paths = []
+    ui_window.snapshot_callback = captured_paths.append
+
+    ui_window._snapshot_dialog_closed(filenames=filenames, rois=None, shm_coeffs=None)
+
+    assert captured_paths == [expected_path]
+
+
+@pytest.mark.parametrize(
+    "input_path,expected_path",
+    [
+        ("/tmp/scene", "/tmp/scene.png"),
+        ("/tmp/scene.png", "/tmp/scene.png"),
+    ],
+)
+def test_save_snapshot_uses_show_manager_snapshot(input_path, expected_path):
+    """``_save_snapshot`` delegates to ``ShowManager.snapshot`` with PNG extension."""
+    sky = Skyline.__new__(Skyline)
+    captured_paths = []
+
+    class _Window:
+        def snapshot(self, path):
+            captured_paths.append(path)
+
+    sky.window = _Window()
+    sky._is_drawing_ui = False
+    sky.request_refresh = lambda: None
+
+    sky._save_snapshot(input_path)
+
+    assert captured_paths == [expected_path]


### PR DESCRIPTION
## Description

This PR provides a way to capture screenshot of the window, excluding the control section for the user.
It provides a dialog to decide where to save the image.
Closes #3988 

## Motivation and Context

- User would want to store the image for any analysis or presentation and would like to keep all of them in the same form factor or standardize.
- This is a great way to provide standardized images.

## How Has This Been Tested?

- Open any visualization on dipy_skyline and press the icon camera.
- That should open a dialog box to save the image.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
