### PR TITLE
BUG: Decouple VTK/FURY optional imports and add dependency guards in vtk.py

### DIFF
--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -8,9 +8,13 @@ fury, have_fury, setup_module = optional_package(
     "fury", min_version="0.10.0", max_version="1.0.0"
 )
 
+vtk, have_vtk, _ = optional_package("vtk")
+
 if have_fury:
     import fury.io
     import fury.utils
+
+if have_vtk:
     import vtk
     import vtk.util.numpy_support as ns
 


### PR DESCRIPTION
Fixes #3932 — Optional dependency coupling in vtk.py causes NameError when FURY is unavailable.
 Changes
This PR makes three targeted changes to dipy/io/vtk.py (33 insertions, 1 deletion):
1. Decouple VTK and FURY optional imports
Previously, vtk, vtk.util.numpy_support, and DATATYPE_DICT were all defined inside if have_fury:, coupling VTK availability to FURY. They are now imported independently via a separate optional_package("vtk") call:
vtk, have_vtk, _ = optional_package("vtk")
