### PR TITLE
NF: API to get orientation and change orientation from affine.

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from warnings import warn
 
+import nibabel as nib
 import numpy as np
 from scipy.linalg import inv, polar
 
@@ -1228,8 +1229,20 @@ def params_to_btens(bval, bdelta, b_eta):
 
 
 def ornt_mapping(ornt1, ornt2):
-    """Calculate the mapping needing to get from orn1 to orn2."""
+    """Calculate the mapping needing to get from orn1 to orn2.
 
+    Parameters
+    ----------
+    ornt1 : ndarray
+        The first orientation array.
+    ornt2 : ndarray
+        The second orientation array.
+
+    Returns
+    -------
+    mapping : ndarray
+        The mapping array.
+    """
     mapping = np.empty((len(ornt1), 2), "int")
     mapping[:, 0] = -1
     A = ornt1[:, 0].argsort()
@@ -1296,8 +1309,82 @@ def reorient_on_axis(bvecs, current_ornt, new_ornt, *, axis=0):
     return output
 
 
+def get_orientation_from_affine(affine):
+    """Get the orientation of the affine transformation matrix.
+
+    Parameters
+    ----------
+    affine : ndarray
+        The affine transformation matrix of shape (4, 4).
+
+    Returns
+    -------
+    orientation : str
+        The orientation of the affine transformation matrix.
+    """
+    if not isinstance(affine, np.ndarray) or affine.shape != (4, 4):
+        raise ValueError("affine must be a (4, 4) numpy array")
+    return "".join(nib.aff2axcodes(affine))
+
+
+def get_affine_with_new_orientation(affine, *, new_orientation="RAS"):
+    """Ensure the affine transformation matrix is in the new orientation.
+
+    Parameters
+    ----------
+    affine : ndarray
+        The affine transformation matrix of shape (4, 4).
+    new_orientation : str, optional
+        The new orientation to ensure. Valid orientations are 3 letter combinations
+        of the letters R, A, S, L, P, I. Where each letter should be used only once.
+
+    Returns
+    -------
+    new_affine : ndarray
+        The affine transformation matrix of shape (4, 4) in the new orientation.
+    """
+    current_orientation = get_orientation_from_affine(affine)
+    if (
+        not isinstance(new_orientation, str)
+        or len(new_orientation) != 3
+        or not all(
+            letter.lower() in {"r", "l", "a", "p", "s", "i"}
+            for letter in new_orientation
+        )
+    ):
+        raise ValueError(
+            "new_orientation must be a string containing the new orientation. "
+            "Valid orientations are 3 letter combinations of the letters "
+            "R, A, S, L, P, I. Where each letter should be used only once."
+        )
+
+    if current_orientation.lower() != new_orientation.lower():
+        co_mapping = orientation_from_string(current_orientation)
+        no_mapping = orientation_from_string(new_orientation)
+        mapping = ornt_mapping(co_mapping, no_mapping)
+
+        voxel_xform = np.zeros((4, 4), dtype=affine.dtype)
+        voxel_xform[3, 3] = 1
+        for out_axis, (in_axis, sign) in enumerate(mapping):
+            voxel_xform[int(in_axis), out_axis] = sign
+
+        new_affine = np.dot(affine, voxel_xform)
+    return new_affine
+
+
 def orientation_from_string(string_ornt):
-    """Return an array representation of an ornt string."""
+    """Return an array representation of an ornt string.
+
+    Parameters
+    ----------
+    string_ornt : str
+        The orientation string to convert to an array.
+
+    Returns
+    -------
+    ornt : ndarray
+        The orientation array.
+    """
     orientation_dict = {
         "r": (0, 1),
         "l": (0, -1),
@@ -1315,7 +1402,18 @@ def orientation_from_string(string_ornt):
 
 
 def orientation_to_string(ornt):
-    """Return a string representation of a 3d ornt."""
+    """Return a string representation of a 3d ornt.
+
+    Parameters
+    ----------
+    ornt : ndarray
+        The orientation array to convert to a string.
+
+    Returns
+    -------
+    string_ornt : str
+        The orientation string.
+    """
     if _check_ornt(ornt):
         msg = repr(ornt) + " does not seem to be a valid orientation"
         raise ValueError(msg)

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -15,7 +15,9 @@ from dipy.core.gradients import (
     extract_b0,
     extract_dwi_shell,
     generate_bvecs,
+    get_affine_with_new_orientation,
     get_bval_indices,
+    get_orientation_from_affine,
     gradient_table,
     gradient_table_from_bvals_bvecs,
     gradient_table_from_gradient_strength_bvecs,
@@ -1081,3 +1083,52 @@ def test_extract_dwi_shell():
 
     npt.assert_raises(ValueError, extract_dwi_shell, dwi, gtab, bvals_to_extract=[5000])
     assert_warns(UserWarning, extract_dwi_shell, dwi, gtab, bvals_to_extract=[])
+
+
+def test_ensure_orientation():
+    affine = np.asarray(
+        [
+            [0.00000000e00, 0.00000000e00, 1.19999695e00, -8.86398926e01],
+            [-9.30352330e-01, 1.15545668e-01, 0.00000000e00, 1.16532005e02],
+            [1.15545668e-01, 9.30352330e-01, -2.49799545e-16, -1.12113556e02],
+            [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+        ]
+    )
+    ras_affine = get_affine_with_new_orientation(affine)
+    npt.assert_equal(get_orientation_from_affine(ras_affine), "RAS")
+
+    with pytest.raises(ValueError, match="affine must be a \\(4, 4\\) numpy array"):
+        get_affine_with_new_orientation(np.eye(3))
+    with pytest.raises(ValueError, match="affine must be a \\(4, 4\\) numpy array"):
+        get_affine_with_new_orientation([[1, 0, 0, 0]] * 4)
+
+    with pytest.raises(ValueError, match="new_orientation must be a string"):
+        get_affine_with_new_orientation(affine, new_orientation=123)
+    with pytest.raises(ValueError, match="new_orientation must be a string"):
+        get_affine_with_new_orientation(affine, new_orientation="RA")
+    with pytest.raises(ValueError, match="new_orientation must be a string"):
+        get_affine_with_new_orientation(affine, new_orientation="RAX")
+    with pytest.raises(
+        ValueError, match="does not seem to be a valid orientation string"
+    ):
+        get_affine_with_new_orientation(affine, new_orientation="RRA")
+
+
+def test_get_orientation():
+    affine = np.asarray(
+        [
+            [0.00000000e00, 0.00000000e00, 1.19999695e00, -8.86398926e01],
+            [-9.30352330e-01, 1.15545668e-01, 0.00000000e00, 1.16532005e02],
+            [1.15545668e-01, 9.30352330e-01, -2.49799545e-16, -1.12113556e02],
+            [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+        ]
+    )
+    npt.assert_equal(get_orientation_from_affine(affine), "PSR")
+
+    affine = np.eye(4)
+    npt.assert_equal(get_orientation_from_affine(affine), "RAS")
+
+    with pytest.raises(ValueError, match="affine must be a \\(4, 4\\) numpy array"):
+        get_orientation_from_affine(np.eye(3))
+    with pytest.raises(ValueError, match="affine must be a \\(4, 4\\) numpy array"):
+        get_orientation_from_affine([[1, 0, 0, 0]] * 4)


### PR DESCRIPTION
- Provides two methods `get_orientation` and `ensure_orientation`.
- Provides tests for the same.

## Description

This PR provides downstream (affine consuming) apis additional information to decide how to process the data.

## Motivation and Context

- Visualization API is required to know what is the final orientation form the Affine to present it correctly to the user.
- Now viz api will consume the `ensure_orientation` with `RAS`  while applying it to the visualization engine so all the data is shown according to the gizmo presented.
- It will provide the info of the default affine and its orientation for the user's information.

## How Has This Been Tested?

- I have provided test cases for both simulated affine and a real PSR affine to test both functions that are introduced in the PR.

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
