### PR TITLE
RF: improve prepare release script and documentation

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -499,7 +499,7 @@ def _check_copyright_year():
         )
 
 
-def _generate_release_notes(*, last_tag, new_version):
+def _generate_release_notes(*, last_tag, new_version, branch=None):
     """Generate release notes via tools/github_stats.py.
 
     Parameters
@@ -508,10 +508,18 @@ def _generate_release_notes(*, last_tag, new_version):
         The previous release tag (e.g. ``"1.11.0"``).
     new_version : str
         The new version string (e.g. ``"1.12.0"``).
+    branch : str or None
+        When set, pass ``--branch`` to github_stats.py so that only pull
+        requests targeting this branch are included (used for maintenance
+        releases to exclude master-branch PRs).
     """
     notes_path = f"doc/release_notes/release{new_version}.rst"
     click.secho(f"--- Generating release notes → {notes_path} ---", bold=True)
-    _run_shell(f"python3 tools/github_stats.py {last_tag} > {notes_path}", check=False)
+    branch_arg = f" --branch {branch}" if branch else ""
+    _run_shell(
+        f"python3 tools/github_stats.py {last_tag}{branch_arg} > {notes_path}",
+        check=False,
+    )
     click.secho(
         f"\nPlease open {notes_path} and add a header / highlights section "
         "above the auto-generated stats.",
@@ -1026,7 +1034,26 @@ RELEASE_STEPS = [
     "website",  # 22
 ]
 
+# Reduced step list for patch releases on a maintenance branch.
+# Major-release-only steps (api-changes, doc/website updates, deprecations,
+# version-switcher, stateoftheart, toolchain, tutorials) are intentionally
+# omitted.
+MAINT_RELEASE_STEPS = [
+    "fetch-tag",  #  1
+    "mailmap",  #  2
+    "version",  #  3  (proposes X.Y.Z+1 patch bump)
+    "author",  #  4
+    "release-notes",  #  5  (filters PRs by base branch)
+    "changelog",  #  6
+    "pyproject",  #  7
+    "doctest",  #  8
+    "tests",  #  9
+]
+
 STEP_HELP = "\n".join(f"  {i + 1:>2}. {s}" for i, s in enumerate(RELEASE_STEPS))
+MAINT_STEP_HELP = "\n".join(
+    f"  {i + 1:>2}. {s}" for i, s in enumerate(MAINT_RELEASE_STEPS)
+)
 
 
 @click.command(name="prepare-release")
@@ -1034,8 +1061,8 @@ STEP_HELP = "\n".join(f"  {i + 1:>2}. {s}" for i, s in enumerate(RELEASE_STEPS))
     "--from-step",
     default=1,
     metavar="N",
-    help=("Resume from step N (1-based). Steps:\n" + STEP_HELP),
-    type=click.IntRange(1, len(RELEASE_STEPS)),
+    help="Resume from step N (1-based). See step list in the command help.",
+    type=click.IntRange(1, max(len(RELEASE_STEPS), len(MAINT_RELEASE_STEPS))),
 )
 @click.option(
     "--last-tag", default=None, metavar="TAG", help="Override auto-detected last tag."
@@ -1043,32 +1070,110 @@ STEP_HELP = "\n".join(f"  {i + 1:>2}. {s}" for i, s in enumerate(RELEASE_STEPS))
 @click.option(
     "--new-version", default=None, metavar="VER", help="Skip version prompt, use VER."
 )
-def prepare_release(*, from_step, last_tag, new_version):
-    (
-        """🚀 Prepare a DIPY release (interactive checklist).
+@click.option(
+    "--maint-branch",
+    default=None,
+    metavar="BRANCH",
+    help=(
+        "Release from a maintenance branch (e.g. 'maint/1.12.x'). "
+        "Runs a reduced 9-step checklist and filters GitHub stats to that "
+        "branch. Auto-detected when the current branch starts with 'maint/'."
+    ),
+)
+def prepare_release(*, from_step, last_tag, new_version, maint_branch):
+    """Prepare a DIPY release (interactive checklist).
 
-    Runs each preparation step in order. Use --from-step N to resume
+    Runs each preparation step in order.  Use --from-step N to resume
     after an interruption.
 
     \b
-    Steps:
-    """
-        + STEP_HELP
-    )  # noqa: E501
+    Full release steps (master):
+      1. fetch-tag        – detect the previous release tag
+      2. mailmap          – deduplicate authors in .mailmap
+      3. version          – choose the new version number
+      4. author           – regenerate the AUTHOR file
+      5. copyright        – update copyright years
+      6. release-notes    – generate doc/release_notes/releaseX.Y.Z.rst
+      7. changelog        – prepend entry in Changelog
+      8. api-changes      – review doc/api_changes.rst
+      9. index            – add announcement to doc/index.rst
+     10. old-news         – rotate old announcements to doc/old_news.rst
+     11. highlights       – move highlights to doc/old_highlights.rst
+     12. stateoftheart    – add release to doc/stateoftheart.rst toctree
+     13. toolchain        – update doc/devel/toolchain.rst
+     14. version-switcher – promote version in doc/_static/version_switcher.json
+     15. developers       – review doc/developers.rst contributor list
+     16. pyproject        – set version in pyproject.toml
+     17. deprecations     – confirm deprecated code removed
+     18. doctest          – run extension module doctests
+     19. tests            – run full test suite
+     20. docs             – build HTML documentation
+     21. tutorials        – build and review tutorials
+     22. website          – deploy docs and verify version switcher
+
+    \b
+    Maintenance release steps (--maint-branch):
+      1. fetch-tag        – detect the previous release tag
+      2. mailmap          – deduplicate authors in .mailmap
+      3. version          – propose patch-level bump (X.Y.Z+1)
+      4. author           – regenerate the AUTHOR file
+      5. release-notes    – generate notes filtered to the maint branch
+      6. changelog        – prepend entry in Changelog
+      7. pyproject        – set version in pyproject.toml
+      8. doctest          – run extension module doctests
+      9. tests            – run full test suite
+    """  # noqa: E501
     if not os.path.isdir("dipy") or not os.path.isfile("pyproject.toml"):
         raise click.ClickException("Run this command from the root 'dipy' directory.")
 
+    # ── Auto-detect maintenance branch ────────────────────────────────────
+    if maint_branch is None:
+        try:
+            import subprocess as _sp
+
+            current = _sp.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+            ).strip()
+            if current.startswith("maint/"):
+                maint_branch = current
+                click.secho(
+                    f"Auto-detected maintenance branch: {maint_branch}",
+                    fg="cyan",
+                )
+        except Exception:
+            pass
+
+    is_maint = maint_branch is not None
+    steps = MAINT_RELEASE_STEPS if is_maint else RELEASE_STEPS
+    N = len(steps)
+
+    if is_maint:
+        click.secho(
+            f"\nMaintenance release mode — branch: {maint_branch} " f"({N} steps)",
+            bold=True,
+            fg="cyan",
+        )
+
     ctx = {"last_tag": last_tag, "new_version": new_version}
 
-    def skip(step_n):
-        return step_n < from_step
+    def skip(step_name):
+        """Return True if the step should be skipped (before --from-step)."""
+        try:
+            idx = steps.index(step_name)
+        except ValueError:
+            return True  # step not in this release's list → skip
+        return (idx + 1) < from_step
 
-    N = len(RELEASE_STEPS)
+    def header(step_name, label):
+        try:
+            idx = steps.index(step_name) + 1
+        except ValueError:
+            return
+        click.secho(f"\n[Step {idx}/{N}] {label}", bold=True, fg="green")
 
-    # ── Step 1: Fetch latest tag ──────────────────────────────────────────
-    step = 1
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Fetch latest tag", bold=True, fg="green")
+    # ── Step: fetch-tag ───────────────────────────────────────────────────
+    if not skip("fetch-tag"):
+        header("fetch-tag", "Fetch latest tag")
         if ctx["last_tag"] is None:
             ctx["last_tag"] = _get_latest_tag()
         if ctx["last_tag"] is None:
@@ -1081,178 +1186,133 @@ def prepare_release(*, from_step, last_tag, new_version):
             "Enter the last release tag (required, e.g., 1.11.0)"
         )
 
-    # ── Step 2: Update .mailmap / contributors ────────────────────────────
-    step = 2
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Update .mailmap and contributors",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: mailmap ─────────────────────────────────────────────────────
+    if not skip("mailmap"):
+        header("mailmap", "Update .mailmap and contributors")
         _update_mailmap(last_tag=ctx["last_tag"])
 
-    # ── Step 3: Determine new version ────────────────────────────────────
-    step = 3
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Determine new version", bold=True, fg="green")
+    # ── Step: version ─────────────────────────────────────────────────────
+    if not skip("version"):
+        header("version", "Determine new version")
         if ctx["new_version"] is None:
             last_ver = Version(ctx["last_tag"])
-            major, minor, _patch = last_ver.release
-            proposed = f"{major}.{minor + 1}.0"
+            major, minor, patch = last_ver.release
+            proposed = (
+                f"{major}.{minor}.{patch + 1}" if is_maint else f"{major}.{minor + 1}.0"
+            )
+            hint = "patch" if is_maint else "minor"
             while True:
-                entered = click.prompt("Enter new version", default=proposed)
+                entered = click.prompt(
+                    f"Enter new version ({hint} bump suggested)", default=proposed
+                )
                 if re.match(r"^\d+\.\d+\.\d+([a-zA-Z0-9]+)?$", entered):
                     ctx["new_version"] = entered
                     break
-                click.echo("Version must follow semver (e.g., 1.12.0 or 1.12.0rc1).")
+                click.echo("Version must follow semver (e.g., 1.12.1 or 1.12.0rc1).")
         click.echo(f"New version: {ctx['new_version']}")
     elif ctx["new_version"] is None:
         ctx["new_version"] = click.prompt(
-            "Enter the new version (required, e.g., 1.12.0)"
+            "Enter the new version (required, e.g., 1.12.1)"
         )
 
-    # ── Step 4: Update AUTHOR file ────────────────────────────────────────
-    step = 4
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Update AUTHOR file", bold=True, fg="green")
+    # ── Step: author ──────────────────────────────────────────────────────
+    if not skip("author"):
+        header("author", "Update AUTHOR file")
         _update_author()
 
-    # ── Step 5: Check copyright years ─────────────────────────────────────
-    step = 5
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Check copyright years", bold=True, fg="green")
+    # ── Step: copyright (full releases only) ──────────────────────────────
+    if not skip("copyright"):
+        header("copyright", "Check copyright years")
         _check_copyright_year()
 
-    # ── Step 6: Generate release notes ────────────────────────────────────
-    step = 6
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Generate release notes", bold=True, fg="green"
-        )
+    # ── Step: release-notes ───────────────────────────────────────────────
+    if not skip("release-notes"):
+        header("release-notes", "Generate release notes")
         _generate_release_notes(
-            last_tag=ctx["last_tag"], new_version=ctx["new_version"]
+            last_tag=ctx["last_tag"],
+            new_version=ctx["new_version"],
+            branch=maint_branch,
         )
 
-    # ── Step 7: Update Changelog ──────────────────────────────────────────
-    step = 7
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Update Changelog", bold=True, fg="green")
+    # ── Step: changelog ───────────────────────────────────────────────────
+    if not skip("changelog"):
+        header("changelog", "Update Changelog")
         _update_changelog(new_version=ctx["new_version"])
 
-    # ── Step 8: Review API changes ────────────────────────────────────────
-    step = 8
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Review API changes", bold=True, fg="green")
+    # ── Step: api-changes (full releases only) ────────────────────────────
+    if not skip("api-changes"):
+        header("api-changes", "Review API changes")
         _update_api_changes()
 
-    # ── Step 9: Update doc/index.rst announcements ────────────────────────
-    step = 9
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Update doc/index.rst announcements",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: index (full releases only) ──────────────────────────────────
+    if not skip("index"):
+        header("index", "Update doc/index.rst announcements")
         _update_index_announcements(new_version=ctx["new_version"])
 
-    # ── Step 10: Rotate old announcements to old_news.rst ─────────────────
-    step = 10
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Rotate old announcements → old_news.rst",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: old-news (full releases only) ───────────────────────────────
+    if not skip("old-news"):
+        header("old-news", "Rotate old announcements → old_news.rst")
         _update_old_news(new_version=ctx["new_version"])
 
-    # ── Step 11: Rotate highlights to old_highlights.rst ──────────────────
-    step = 11
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Rotate Highlights → old_highlights.rst",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: highlights (full releases only) ─────────────────────────────
+    if not skip("highlights"):
+        header("highlights", "Rotate Highlights → old_highlights.rst")
         _update_highlights(new_version=ctx["new_version"])
 
-    # ── Step 12: Update stateoftheart.rst toctree ─────────────────────────
-    step = 12
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Update stateoftheart.rst toctree",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: stateoftheart (full releases only) ──────────────────────────
+    if not skip("stateoftheart"):
+        header("stateoftheart", "Update stateoftheart.rst toctree")
         _update_stateoftheart(new_version=ctx["new_version"])
 
-    # ── Step 13: Update toolchain.rst ─────────────────────────────────────
-    step = 13
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Update toolchain.rst", bold=True, fg="green")
+    # ── Step: toolchain (full releases only) ──────────────────────────────
+    if not skip("toolchain"):
+        header("toolchain", "Update toolchain.rst")
         _update_toolchain(new_version=ctx["new_version"])
 
-    # ── Step 14: Update version switcher ──────────────────────────────────
-    step = 14
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Update version switcher", bold=True, fg="green"
-        )
+    # ── Step: version-switcher (full releases only) ───────────────────────
+    if not skip("version-switcher"):
+        header("version-switcher", "Update version switcher")
         _update_version_switcher(new_version=ctx["new_version"])
 
-    # ── Step 15: Review developers.rst ────────────────────────────────────
-    step = 15
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Review developers.rst", bold=True, fg="green")
+    # ── Step: developers (full releases only) ─────────────────────────────
+    if not skip("developers"):
+        header("developers", "Review developers.rst")
         _update_developers()
 
-    # ── Step 16: Update pyproject.toml version ────────────────────────────
-    step = 16
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Update pyproject.toml version",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: pyproject ───────────────────────────────────────────────────
+    if not skip("pyproject"):
+        header("pyproject", "Update pyproject.toml version")
         _update_pyproject_version(new_version=ctx["new_version"])
 
-    # ── Step 17: Check deprecations ───────────────────────────────────────
-    step = 17
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Check deprecations", bold=True, fg="green")
+    # ── Step: deprecations (full releases only) ───────────────────────────
+    if not skip("deprecations"):
+        header("deprecations", "Check deprecations")
         _confirm(
             "Have you checked deprecated functions/modules and removed"
             " those past their cycle?"
         )
 
-    # ── Step 18: Run Cython/extension doctests ────────────────────────────
-    step = 18
-    if not skip(step):
-        click.secho(
-            f"\n[Step {step}/{N}] Run extension module doctests",
-            bold=True,
-            fg="green",
-        )
+    # ── Step: doctest ─────────────────────────────────────────────────────
+    if not skip("doctest"):
+        header("doctest", "Run extension module doctests")
         _run_shell("./tools/doctest_extmods.py dipy", check=False)
         _confirm("Did the extension module doctests pass?")
 
-    # ── Step 19: Run test suite ───────────────────────────────────────────
-    step = 19
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Run test suite", bold=True, fg="green")
+    # ── Step: tests ───────────────────────────────────────────────────────
+    if not skip("tests"):
+        header("tests", "Run test suite")
         _run_shell("pytest -svv --doctest-modules dipy", check=False)
         _confirm("Did the test suite pass?")
 
-    # ── Step 20: Build documentation ──────────────────────────────────────
-    step = 20
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Build documentation", bold=True, fg="green")
+    # ── Step: docs (full releases only) ───────────────────────────────────
+    if not skip("docs"):
+        header("docs", "Build documentation")
         _run_shell("make -C doc clean && make -C doc html", check=False)
         _confirm("Have you reviewed the generated docs (API pages, figures)?")
 
-    # ── Step 21: Check tutorials ──────────────────────────────────────────
-    step = 21
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Check tutorials", bold=True, fg="green")
+    # ── Step: tutorials (full releases only) ──────────────────────────────
+    if not skip("tutorials"):
+        header("tutorials", "Check tutorials")
         click.secho(
             "Run `spin docs <tutorial_name>` to build and inspect individual "
             "tutorials. Check plots, outputs, and narrative text.",
@@ -1260,10 +1320,9 @@ def prepare_release(*, from_step, last_tag, new_version):
         )
         _confirm("Have you reviewed the tutorials?")
 
-    # ── Step 22: Update website ───────────────────────────────────────────
-    step = 22
-    if not skip(step):
-        click.secho(f"\n[Step {step}/{N}] Update website", bold=True, fg="green")
+    # ── Step: website (full releases only) ────────────────────────────────
+    if not skip("website"):
+        header("website", "Update website")
         click.secho(
             "Deploy updated docs to docs.dipy.org and verify the version "
             "switcher reflects the new stable release.",
@@ -1273,15 +1332,37 @@ def prepare_release(*, from_step, last_tag, new_version):
 
     v = ctx["new_version"]
     click.secho("\n✅ Release preparation complete!", bold=True, fg="bright_green")
-    click.echo(
-        f"\nNext steps:\n"
-        f"  1. Stage and commit: git commit -m 'REL: set version to {v}'\n"
-        f"  2. Open a Pull Request and get it merged.\n"
-        f"  3. After merge, tag:  git tag -am 'Public release {v}' {v}\n"
-        f"  4. Build source dist: git clean -dfx && python -m build\n"
-        f"  5. Upload to PyPI:    twine upload dist/*\n"
-        f"  6. Push tag:          git push upstream {v}\n"
-        f"  7. Create maint branch: git checkout -b maint/{v}\n"
-        f"  8. Bump master version to {v.rsplit('.', 1)[0]}.dev0 in pyproject.toml.\n"
-        f"  9. Announce on mailing lists.\n"
-    )
+
+    if is_maint:
+        click.echo(
+            f"\nNext steps (maintenance release from {maint_branch}):\n"
+            f"  1. Stage and commit: git commit -m 'REL: set version to {v}'\n"
+            f"  2. Push to upstream {maint_branch} (or open a PR targeting it).\n"
+            f"  3. After merge, tag:  git tag -am 'Public release {v}' {v}\n"
+            f"  4. Build source dist: git clean -dfx && python -m build --sdist\n"
+            f"  5. Upload sdist:      twine upload dist/dipy-{v}.tar.gz\n"
+            f"  6. Push tag:          git push upstream {v}\n"
+            f"  7. Trigger wheels: "
+            f"gh workflow run nightly.yml --field branch_or_tag={v}\n"
+            f"  8. Download wheels: "
+            f"gh run download <run-id> --dir dist-wheels/\n"
+            f"     Upload wheels:  twine upload dist-wheels/**/*.whl\n"
+            f"  9. GitHub release: "
+            f"gh release create {v} --title 'DIPY {v}'\n"
+            f" 10. Bump maint version to next dev in pyproject.toml.\n"
+            f" 11. Announce on mailing lists.\n"
+        )
+    else:
+        next_dev = f"{v.rsplit('.', 1)[0]}.dev0"
+        click.echo(
+            f"\nNext steps:\n"
+            f"  1. Stage and commit: git commit -m 'REL: set version to {v}'\n"
+            f"  2. Open a Pull Request and get it merged.\n"
+            f"  3. After merge, tag: git tag -am 'Public release {v}' {v}\n"
+            f"  4. Build source dist: git clean -dfx && python -m build\n"
+            f"  5. Upload to PyPI:   twine upload dist/*\n"
+            f"  6. Push tag:         git push upstream {v}\n"
+            f"  7. Create maint branch: git checkout -b maint/{v}\n"
+            f"  8. Bump master version to {next_dev} in pyproject.toml.\n"
+            f"  9. Announce on mailing lists.\n"
+        )

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -6,10 +6,17 @@ A guide to making a DIPY release
 
 A guide for developers who are doing a DIPY release
 
+.. contents:: Contents
+   :local:
+   :depth: 2
+
 .. _release-checklist:
 
+Major / minor releases (from master)
+=====================================
+
 Automated release preparation
-==============================
+-------------------------------
 
 Most of the manual steps below are automated by the ``spin prepare-release``
 command.  Run it from the root of the DIPY repository::
@@ -64,7 +71,7 @@ Before running the script, make sure to:
 * Check the ``README`` in the root directory and verify all links are still valid.
 
 Notes on individual steps
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Step 2 – mailmap**
   The script parses ``git log`` to detect duplicate authors automatically
@@ -86,16 +93,16 @@ Notes on individual steps
   A skeleton entry is prepended to ``Changelog``.  You are paused to fill in
   the highlights (derived from the release notes) before continuing.
 
-**Step 11 – doctest**
+**Step 18 – doctest**
   Runs ``./tools/doctest_extmods.py dipy``.  No output means all doctests
   passed; the exit code is always printed so you can tell the command
   actually ran.  Requires the package to be built in-place
   (``spin build`` or ``pip install --no-build-isolation -e .``).
 
-**Step 12 – tests**
+**Step 19 – tests**
   Runs ``pytest -svv --doctest-modules dipy`` from the repo root.
 
-**Step 13 – docs**
+**Step 20 – docs**
   Runs ``make clean && make html`` inside ``doc/``.  Review the generated
   output for broken tutorials, figures, or API pages before confirming.
 
@@ -109,8 +116,46 @@ Notes on individual steps
   Tutorial names are matched as regex substrings against the example file
   path; multiple names are joined with ``|`` (union).
 
+Doing the major/minor release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once ``spin prepare-release`` completes successfully:
+
+1. Stage and commit all changes::
+
+    git commit -m "REL: set version to <version>"
+
+2. Open a Pull Request, get it reviewed and merged.
+
+3. After the merge, create an annotated tag on the merge commit::
+
+    git tag -am 'Public release <version>' <version>
+
+4. Build the source distribution::
+
+    git clean -dfx
+    python -m build
+
+5. Upload to PyPI::
+
+    pip install twine
+    twine upload dist/*
+
+6. Push the tag to trigger wheel builds on CI::
+
+    git push upstream <version>
+
+7. Create a maintenance branch and bump the development version::
+
+    git checkout -b maint/<version>
+    # set version to <major>.<minor+1>.0.dev0 in pyproject.toml on master
+    git checkout master
+    git merge -s ours maint/<version>
+
+8. Announce to the mailing lists.
+
 Release checklist (manual reference)
-=====================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The steps below are the manual equivalent of what ``spin prepare-release``
 does, kept here for reference.
@@ -135,7 +180,7 @@ does, kept here for reference.
 
 * Regenerate the ``AUTHOR`` file from git history::
 
-    git log --format=’%aN’ | sort -u > AUTHOR
+    git log --format='%aN' | sort -u > AUTHOR
 
 * Check copyright years in ``LICENSE`` and ``doc/conf.py``.
 
@@ -158,43 +203,145 @@ does, kept here for reference.
 * Build and test the DIPY wheels via `DIPY Github Actions`_.  Wheels are
   built automatically on CI when a release tag is pushed.
 
-Doing the release
-=================
 
-Once ``spin prepare-release`` completes successfully:
+.. _maint-release-guide:
 
-1. Stage and commit all changes::
+Patch releases (from a maintenance branch)
+===========================================
 
+Patch releases (e.g. ``1.12.1``) are cut from an existing ``maint/X.Y.x``
+branch, **not** from master.  They carry only backported bug fixes and require
+a much shorter preparation process — most documentation and website steps are
+skipped.
+
+Prerequisites
+--------------
+
+* The ``maint/X.Y.x`` branch must already exist (created when ``X.Y.0`` was
+  released).
+* All fixes to be included must already be backported to the branch (use the
+  ``backport-maint/X.Y.x`` label on PRs to trigger the automated backport
+  workflow, then verify each backport PR was merged).
+* Verify that CI is green on ``maint/X.Y.x`` before starting.
+
+Automated preparation
+----------------------
+
+Switch to the maintenance branch and run ``spin prepare-release``.  The tool
+**auto-detects** that you are on a ``maint/`` branch and activates the reduced
+9-step checklist automatically::
+
+    git fetch upstream
+    git checkout maint/1.12.x
+    git merge --ff-only upstream/maint/1.12.x
+    spin prepare-release
+
+You can also pass ``--maint-branch`` explicitly (useful when resuming a
+partially-complete run from a detached HEAD or a different branch name)::
+
+    spin prepare-release --maint-branch maint/1.12.x
+
+To resume after an interruption::
+
+    spin prepare-release --from-step 5
+
+Reduced step list (9 steps):
+
+.. code-block:: text
+
+     1. fetch-tag        – detect the previous release tag on this branch
+     2. mailmap          – deduplicate authors (.mailmap updated for backport authors)
+     3. version          – propose patch bump (X.Y.Z+1); confirm or enter manually
+     4. author           – regenerate the AUTHOR file
+     5. release-notes    – generate notes filtered to PRs targeting maint/X.Y.x
+     6. changelog        – prepend patch entry in Changelog
+     7. pyproject        – set version in pyproject.toml
+     8. doctest          – run Cython / extension module doctests
+     9. tests            – run the full test suite
+
+Notes on maintenance-specific steps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Step 5 – release-notes**
+  ``tools/github_stats.py`` is called with ``--branch maint/X.Y.x`` so that
+  only pull requests whose *base* (target) branch is the maintenance branch
+  are included.  Master-branch PRs do not appear in the list.
+
+  You can also run it manually::
+
+      python3 tools/github_stats.py <last_tag> --branch maint/1.12.x \
+          > doc/release_notes/release<version>.rst
+
+  Edit the file to add a short header; no full highlights section is needed
+  for a patch release.
+
+**Step 7 – pyproject**
+  Changes ``version = "X.Y.Z.dev0"`` to ``version = "X.Y.Z"`` in
+  ``pyproject.toml``.
+
+Doing the patch release
+------------------------
+
+Once ``spin prepare-release`` finishes, follow these steps:
+
+1. Commit the release preparation changes::
+
+    git add pyproject.toml doc/release_notes/release<version>.rst Changelog .mailmap
     git commit -m "REL: set version to <version>"
 
-2. Open a Pull Request, get it reviewed and merged.
+2. Push to ``maint/X.Y.x`` (directly or via a short-lived PR targeting that
+   branch — **not** master)::
 
-3. After the merge, create an annotated tag on the merge commit::
+    git push upstream maint/X.Y.x
 
-    git tag -am ‘Public release <version>’ <version>
+3. After the commit lands on the branch, create an annotated tag::
+
+    git fetch upstream
+    git merge --ff-only upstream/maint/X.Y.x
+    git tag -am 'Public release <version>' <version>
 
 4. Build the source distribution::
 
     git clean -dfx
-    python -m build
+    python -m build --sdist
 
-5. Upload to PyPI::
+5. Upload the sdist to PyPI::
 
-    pip install twine
-    twine upload dist/*
+    twine upload dist/dipy-<version>.tar.gz
 
-6. Push the tag to trigger wheel builds on CI::
+6. Push the tag::
 
     git push upstream <version>
 
-7. Create a maintenance branch and bump the development version::
+7. Trigger wheel builds via ``workflow_dispatch`` on the ``nightly.yml``
+   workflow — the ``upload_anaconda`` job will be skipped (it only runs for
+   master), but all wheels will be built and saved as artifacts::
 
-    git checkout -b maint/<version>
-    # set version to <major>.<minor+1>.0.dev0 in pyproject.toml on master
-    git checkout master
-    git merge -s ours maint/<version>
+    gh workflow run nightly.yml --repo dipy/dipy --field branch_or_tag=<version>
 
-8. Announce to the mailing lists.
+   Wait for all platform builds to finish (~40–60 min), then download and
+   upload the wheels::
+
+    gh run download <run-id> --dir dist-wheels/
+    twine upload dist-wheels/**/*.whl
+
+8. Create the GitHub release::
+
+    gh release create <version> --repo dipy/dipy --title "DIPY <version>"
+
+9. Bump the maintenance branch to the next patch dev version::
+
+    # edit pyproject.toml: version = "X.Y.(Z+1).dev0"
+    git commit -am "REL: bump version to X.Y.(Z+1).dev0"
+    git push upstream maint/X.Y.x
+
+10. Announce to the mailing lists.
+
+.. note::
+
+   Do **not** update ``doc/index.rst``, ``doc/stateoftheart.rst``,
+   ``doc/devel/toolchain.rst``, or ``doc/_static/version_switcher.json`` for a
+   patch release.  These files track major/minor versions only.
 
 Other stuff that needs doing for the release
 ============================================

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -3,16 +3,28 @@
 
 Taken from ipython
 
+Usage
+-----
+List all issues/PRs since a tag (whole repo)::
+
+    python3 tools/github_stats.py 1.12.0
+
+List only PRs merged into a specific branch (for maintenance releases)::
+
+    python3 tools/github_stats.py 1.12.0 --branch maint/1.12.x
+
 """
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
 
+import argparse
 from datetime import datetime, timedelta
 import json
 import re
 from subprocess import check_output
 import sys
+from urllib.parse import quote
 from urllib.request import urlopen
 
 # -----------------------------------------------------------------------------
@@ -85,12 +97,29 @@ def is_pull_request(issue):
     return 'pull_request_url' in issue
 
 
-def issues_closed_since(period=LAST_RELEASE, project="dipy/dipy", pulls=False):
+def issues_closed_since(
+    period=LAST_RELEASE, *, project="dipy/dipy", pulls=False, branch=None
+):
     """Get all issues closed since a particular point in time.
 
-    Period can either be a datetime object, or a timedelta object. In the
-    latter case, it is used as a time before the present.
+    Parameters
+    ----------
+    period : datetime or timedelta
+        If a timedelta, it is subtracted from the current time to get the
+        cutoff datetime.
+    project : str
+        GitHub project in ``owner/repo`` format.
+    pulls : bool
+        If True fetch pull requests; otherwise fetch regular issues.
+    branch : str or None
+        When ``pulls=True`` and a branch name is given, only pull requests
+        whose *base* (target) branch matches this value are returned.
+        Has no effect when ``pulls=False``.
 
+    Returns
+    -------
+    list
+        Closed issues (or merged PRs) since *period*.
     """
     which = 'pulls' if pulls else 'issues'
 
@@ -100,16 +129,20 @@ def issues_closed_since(period=LAST_RELEASE, project="dipy/dipy", pulls=False):
         f"https://api.github.com/repos/{project}/{which}?state=closed"
         f"&sort=updated&since={period.strftime(ISO8601)}&per_page={PER_PAGE}"
     )
+    if pulls and branch:
+        url += f"&base={quote(branch, safe='')}"
 
     allclosed = get_paged_request(url)
-    # allclosed = get_issues(project=project, state='closed', pulls=pulls,
-    #                        since=period)
     filtered = [i for i in allclosed
                 if _parse_datetime(i['closed_at']) > period]
 
-    # exclude rejected PRs
     if pulls:
+        # exclude unmerged PRs
         filtered = [pr for pr in filtered if pr['merged_at']]
+    else:
+        # exclude pull requests from the issues list to avoid duplicates;
+        # the /issues endpoint returns both issues and PRs
+        filtered = [i for i in filtered if 'pull_request' not in i]
 
     return filtered
 
@@ -139,16 +172,50 @@ if __name__ == "__main__":
     # Whether to add reST urls for all issues in printout.
     show_urls = True
 
-    # By default, search one month back
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate GitHub statistics for DIPY release notes.\n\n"
+            "Examples:\n"
+            "  # All issues/PRs since tag (master/full-repo release):\n"
+            "  python3 tools/github_stats.py 1.12.0\n\n"
+            "  # Only PRs merged into a maintenance branch:\n"
+            "  python3 tools/github_stats.py 1.12.0 --branch maint/1.12.x\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "tag_or_days",
+        nargs="?",
+        metavar="TAG_OR_DAYS",
+        help=(
+            "A git tag (e.g. '1.12.0') to use as the start of the period, "
+            "or an integer number of days to look back. "
+            "Defaults to the most recent tag."
+        ),
+    )
+    parser.add_argument(
+        "--branch", "-b",
+        default=None,
+        metavar="BRANCH",
+        help=(
+            "Filter pull requests by base (target) branch. "
+            "Use this for maintenance releases to avoid listing master PRs. "
+            "Example: --branch maint/1.12.x"
+        ),
+    )
+    args = parser.parse_args()
+
     tag = None
-    if len(sys.argv) > 1:
-        try:
-            days = int(sys.argv[1])
-        except:
-            tag = sys.argv[1]
-    else:
+    days = None
+
+    if args.tag_or_days is None:
         tag = check_output(['git', 'describe', '--abbrev=0'],
                            text=True).strip()
+    else:
+        try:
+            days = int(args.tag_or_days)
+        except ValueError:
+            tag = args.tag_or_days
 
     if tag:
         cmd = ['git', 'log', '-1', '--format=%ai', tag]
@@ -157,12 +224,16 @@ if __name__ == "__main__":
     else:
         since = datetime.now() - timedelta(days=days)
 
+    branch = args.branch
+
     print(f"fetching GitHub stats since {since} (tag: {tag})",
           file=sys.stderr)
-    # turn off to play interactively without redownloading, use %run -i
-    if 1:
-        issues = issues_closed_since(since, pulls=False)
-        pulls = issues_closed_since(since, pulls=True)
+    if branch:
+        print(f"filtering pull requests by base branch: {branch}",
+              file=sys.stderr)
+
+    issues = issues_closed_since(since, pulls=False)
+    pulls = issues_closed_since(since, pulls=True, branch=branch)
 
     # For regular reports, it's nice to show them in reverse
     # chronological order
@@ -184,30 +255,48 @@ if __name__ == "__main__":
     if tag:
         # print git info, in addition to GitHub info:
         since_tag = tag + '..'
-        cmd = ['git', 'log', '--oneline', since_tag]
+        if branch:
+            # limit git log to the specific branch when filtering
+            cmd = ['git', 'log', '--oneline', since_tag, branch]
+        else:
+            cmd = ['git', 'log', '--oneline', since_tag]
         ncommits = len(check_output(cmd, text=True).splitlines())
 
-        author_cmd = ['git', 'log', '--format=* %aN', since_tag]
-        all_authors = check_output(author_cmd, text=True) \
-            .splitlines()
+        if branch:
+            author_cmd = ['git', 'log', '--format=* %aN', since_tag, branch]
+        else:
+            author_cmd = ['git', 'log', '--format=* %aN', since_tag]
+        all_authors = check_output(author_cmd, text=True).splitlines()
         unique_authors = sorted(set(all_authors))
 
         if not unique_authors:
             print("No commits during this period.")
         else:
-            print(f"The following {len(unique_authors)} authors contributed {ncommits} commits.")
+            print(f"The following {len(unique_authors)} authors contributed"
+                  f" {ncommits} commits.")
             print()
             print('\n'.join(unique_authors))
             print()
 
             print()
-            print(f"We closed a total of {n_total} issues,"
-                  f" {n_pulls} pull requests and {n_issues} regular issues;\n"
-                  "this is the full list (generated with the script \n"
-                  ":file:`tools/github_stats.py`):")
+            if branch:
+                print(
+                    f"We closed a total of {n_pulls} pull requests"
+                    f" (merged into ``{branch}``);\n"
+                    "this is the full list (generated with the script \n"
+                    ":file:`tools/github_stats.py`):"
+                )
+            else:
+                print(
+                    f"We closed a total of {n_total} issues,"
+                    f" {n_pulls} pull requests and {n_issues} regular issues;\n"
+                    "this is the full list (generated with the script \n"
+                    ":file:`tools/github_stats.py`):"
+                )
             print()
             print(f'Pull Requests ({n_pulls}):\n')
             report(pulls, show_urls)
-            print()
-            print(f'Issues ({n_issues}):\n')
-            report(issues, show_urls)
+            if not branch:
+                print()
+                print(f'Issues ({n_issues}):\n')
+                report(issues, show_urls)


### PR DESCRIPTION
This PR update scripts to do a release from a maintenance branch. Documentation has also been update.

here the list of what has been done: 
- `tools/github_stats.py`: add `--branch/-b` to filter PRs by target branch; fix duplicate PRs appearing in the issues
   list; switch to argparse
- `.spin/cmds.py`: add 9-step `MAINT_RELEASE_STEPS`; add `--maint-branch` flag (auto-detected from branch name);
   version step proposes patch bump; release-notes step passes `--branch` to github_stats
- `doc/devel/make_release.rst`: add maintenance branch release section