### PR TITLE
DOC: Fix numpydoc warnings in ndbincount in utils.py

### DIFF
--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -262,6 +262,15 @@ def ndbincount(x, *, weights=None, shape=None):
         each element represents the number of occurrences
         of the corresponding index combination.
     """
+    x = np.asarray(x)
+    if shape is None:
+        shape = x.max(1) + 1
+
+    x = np.ravel_multi_index(x, shape)
+    out = np.bincount(x, weights, minlength=np.prod(shape))
+    out = out.reshape(shape)
+
+    return out
 
 
 def reduce_labels(label_volume):

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -1004,6 +1004,27 @@ def reduce_rois(rois, include):
 
 
 def _min_at(a, index, value):
+    """Set minimum values at given indices of an array.
+
+    A fallback implementation of ``np.minimum.at`` for environments
+    where it is not available.
+
+    Parameters
+    ----------
+    a : ndarray
+        The array to update in place with minimum values.
+    index : sequence of array-like
+        Indices into `a` where the minimum operation is applied.
+        Each element corresponds to one dimension of `a`.
+    value : ndarray
+        Values to compare against the current values in `a`.
+        The minimum of the existing and new values is stored.
+
+    Returns
+    -------
+    None
+        The array `a` is modified in place.
+    """
     index = np.asarray(index)
     sort_keys = [value] + list(index)
     order = np.lexsort(sort_keys)

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -268,6 +268,22 @@ def reduce_labels(label_volume):
     """Reduce an array of labels to the integers from 0 to n with smallest
     possible n.
 
+    Parameters
+    ----------
+    label_volume : ndarray
+        An array of labels represented as integers. The labels do not
+        need to be contiguous or start from zero.
+
+    Returns
+    -------
+    new_labels : ndarray
+        An array of the same shape as `label_volume` where each label
+        has been replaced by its index in the sorted unique labels array,
+        giving contiguous integers starting from 0.
+    lookup : ndarray, shape (n,)
+        A 1D array of the unique labels in sorted order. The original
+        labels can be recovered using ``lookup[new_labels]``.
+
     Examples
     --------
     >>> labels = np.array([[1, 3, 9],

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -247,22 +247,21 @@ def ndbincount(x, *, weights=None, shape=None):
 
     Parameters
     ----------
-    x : array_like (N, M)
+    x : array-like (N, M)
         M indices to a an Nd-array
-    weights : array_like (M,), optional
+    weights : array-like (M,), optional
         Weights associated with indices
-    shape : optional
-        the shape of the output
+    shape : tuple, optional
+        The shape of the output array. If not provided,
+        the shape is inferred from the maximum indices.
+
+    Returns
+    -------
+    out : ndarray
+        An Nd-array of counts (or weighted counts) where
+        each element represents the number of occurrences
+        of the corresponding index combination.
     """
-    x = np.asarray(x)
-    if shape is None:
-        shape = x.max(1) + 1
-
-    x = np.ravel_multi_index(x, shape)
-    out = np.bincount(x, weights, minlength=np.prod(shape))
-    out = out.reshape(shape)
-
-    return out
 
 
 def reduce_labels(label_volume):

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -1100,6 +1100,27 @@ def path_length(streamlines, affine, aoi, *, fill_value=-1):
 
 
 def _part_segments(streamline, break_points):
+    """Generate segments of a streamline based on break points.
+
+    Splits a streamline at the given break points and yields each
+    segment that has more than one point, skipping the first segment
+    (all points before the first break point).
+
+    Parameters
+    ----------
+    streamline : ndarray, shape (N, 3)
+        A single streamline represented as an array of N points
+        in 3D space.
+    break_points : ndarray, shape (N,)
+        A boolean or integer array indicating where to split the
+        streamline. Non-zero values mark the break positions.
+
+    Yields
+    ------
+    segment : ndarray, shape (M, 3)
+        Each segment of the streamline with more than one point.
+    """
+
     segments = np.split(streamline, break_points.nonzero()[0])
     # Skip first segment, all points before first break
     # first segment is empty when break_points[0] == 0
@@ -1110,6 +1131,26 @@ def _part_segments(streamline, break_points):
 
 
 def _as_segments(streamline, break_points):
+    """Generate all segments of a streamline in both directions.
+
+    Yields segments from the streamline in forward direction followed
+    by segments from the streamline in reverse direction.
+
+    Parameters
+    ----------
+    streamline : ndarray, shape (N, 3)
+        A single streamline represented as an array of N points
+        in 3D space.
+    break_points : ndarray, shape (N,)
+        A boolean or integer array indicating where to split the
+        streamline. Non-zero values mark the break positions.
+
+    Yields
+    ------
+    segment : ndarray, shape (M, 3)
+        Each segment of the streamline with more than one point,
+        yielded in forward then reverse direction.
+    """
     for seg in _part_segments(streamline, break_points):
         yield seg
     for seg in _part_segments(streamline[::-1], break_points[::-1]):


### PR DESCRIPTION
## Description
Fix numpydoc validation warnings in `dipy/tracking/utils.py`
as part of #3270.

- Fixed parameter type format: `array_like` to `array-like, shape (N, M)`
  for `x` parameter
- Fixed parameter type format: `array_like` to `array-like, shape (M,)`
  for `weights` parameter
- Fixed `shape` parameter description and type
- Added missing `Returns` section to `ndbincount` function

## Motivation and Context
Fixes numpydoc validation warnings as part of the ongoing
docstring improvements across DIPY modules.

Relates to #3270

## How Has This Been Tested?
Documentation-only change. No functional code was modified.
All existing tests remain unaffected.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure