### PR TITLE
DOC: Add missing Parameters and Returns sections to nbytes in streaml…

### DIFF
--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -733,5 +733,17 @@ def values_from_volume(data, streamlines, affine):
 
 
 def nbytes(streamlines):
-    """Calculate the memory footprint of a streamlines object."""
+    """Calculate the memory footprint of a streamlines object.
+
+    Parameters
+    ----------
+    streamlines : StatefulTractogram or ArraySequence
+        A streamlines object with a `_data` attribute containing
+        the raw streamline data as a numpy array.
+
+    Returns
+    -------
+    size : float
+        The memory footprint of the streamlines data in megabytes (MB).
+    """
     return streamlines._data.nbytes / 1024.0**2


### PR DESCRIPTION
## Description
Add missing numpydoc docstrings to `dipy/tracking/streamline.py`
as part of #3270.

- Added missing Parameters and Returns to `_orient_by_roi_list`
- Added missing Parameters and Yields to `_orient_by_sl_generator`
- Added missing Parameters and Returns to `_orient_by_sl_list`
- Added missing Parameters and Returns to `nbytes`

## Motivation and Context
Fixes numpydoc validation warnings as part of the ongoing
docstring improvements across DIPY modules.

Relates to #3270

## How Has This Been Tested?
Documentation-only change. No functional code was modified.
All existing tests remain unaffected.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure