### PR TITLE
Fix numpydoc local tracking

### DIFF
--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -23,10 +23,30 @@ from dipy.utils.deprecator import deprecate_with_version
     until="2.0.0",
 )
 def _warn_old_eudx_localtracking_api():
+    """Warn users about the deprecated EuDX local tracking API.
+
+    This function serves as a placeholder for backwards compatibility
+    and does not perform any operation.
+    """
     pass
 
 
 def _is_eudx_direction_getter(direction_getter):
+    """Check if a direction getter is an EuDX direction getter.
+
+    Parameters
+    ----------
+    direction_getter : object
+        The direction getter object to check. This can be any object
+        that has a class hierarchy accessible via ``__mro__``.
+
+    Returns
+    -------
+    bool
+        True if the direction getter is an instance of
+        ``EuDXDirectionGetter`` from
+        ``dipy.reconst.eudx_direction_getter``, False otherwise.
+    """
     return any(
         cls.__name__ == "EuDXDirectionGetter"
         and cls.__module__ == "dipy.reconst.eudx_direction_getter"

--- a/dipy/tracking/local_tracking.py
+++ b/dipy/tracking/local_tracking.py
@@ -206,6 +206,24 @@ class LocalTracking:
         self.save_seeds = save_seeds
 
     def _tracker(self, seed, first_step, streamline):
+        """Track a streamline from a seed point using local tracking.
+
+        Parameters
+        ----------
+        seed : ndarray, shape (3,)
+            The seed point in voxel coordinates where tracking starts.
+        first_step : ndarray, shape (3,)
+            The initial direction of the first tracking step.
+        streamline : ndarray
+            An array to store the streamline points generated
+            during tracking.
+
+        Returns
+        -------
+        end : int
+            An integer indicating the stopping criterion that ended
+            the streamline tracking.
+        """
         return local_tracker(
             self.direction_getter,
             self.stopping_criterion,
@@ -218,6 +236,17 @@ class LocalTracking:
         )
 
     def __iter__(self):
+        """Iterate over tractogram streamlines.
+
+        Generates streamlines from seeds, transforms them to point
+        space and returns them.
+
+        Yields
+        ------
+        streamline : ndarray, shape (N, 3)
+            A single streamline in world coordinates. If `save_seeds`
+            is True, yields a tuple of (streamline, seed).
+        """
         # Make tracks, move them to point space and return
         track = self._generate_tractogram()
 
@@ -226,7 +255,18 @@ class LocalTracking:
         )
 
     def _generate_tractogram(self):
-        """A streamline generator"""
+        """Generate a tractogram by tracking streamlines from seeds.
+
+        Tracks streamlines in both forward and backward directions
+        from each seed point using the direction getter and stopping
+        criterion. Applies random seeding if specified.
+
+        Yields
+        ------
+        streamline : ndarray, shape (N, 3)
+            A single streamline in voxel coordinates. If `save_seeds`
+            is True, yields a tuple of (streamline, seed).
+        """
 
         # Get inverse transform (lin/offset) for seeds
         inv_A = np.linalg.inv(self.affine)
@@ -472,6 +512,24 @@ class ParticleFilteringTracking(LocalTracking):
         )
 
     def _tracker(self, seed, first_step, streamline):
+        """Track a streamline using particle filtering tractography.
+
+        Parameters
+        ----------
+        seed : ndarray, shape (3,)
+            The seed point in voxel coordinates where tracking starts.
+        first_step : ndarray, shape (3,)
+            The initial direction of the first tracking step.
+        streamline : ndarray
+            An array to store the streamline points generated
+            during tracking.
+
+        Returns
+        -------
+        end : int
+            An integer indicating the stopping criterion that ended
+            the streamline tracking.
+        """
         return pft_tracker(
             self.direction_getter,
             self.stopping_criterion,

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -460,6 +460,16 @@ def _orient_by_roi_list(out, roi1, roi2):
         streamlines flipped in place so that they are oriented
         from roi1 towards roi2.
     """
+    for idx, sl in enumerate(out):
+        dist1 = cdist(sl, roi1, "euclidean")
+        dist2 = cdist(sl, roi2, "euclidean")
+        min1 = np.argmin(dist1, 0)
+        min2 = np.argmin(dist2, 0)
+        if min1[0] > min2[0]:
+            out[idx][:, 0] = sl[::-1][:, 0]
+            out[idx][:, 1] = sl[::-1][:, 1]
+            out[idx][:, 2] = sl[::-1][:, 2]
+    return out
 
 
 @warning_for_keywords()

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -460,16 +460,6 @@ def _orient_by_roi_list(out, roi1, roi2):
         streamlines flipped in place so that they are oriented
         from roi1 towards roi2.
     """
-    for idx, sl in enumerate(out):
-        dist1 = cdist(sl, roi1, "euclidean")
-        dist2 = cdist(sl, roi2, "euclidean")
-        min1 = np.argmin(dist1, 0)
-        min2 = np.argmin(dist2, 0)
-        if min1[0] > min2[0]:
-            out[idx][:, 0] = sl[::-1][:, 0]
-            out[idx][:, 1] = sl[::-1][:, 1]
-            out[idx][:, 2] = sl[::-1][:, 2]
-    return out
 
 
 @warning_for_keywords()


### PR DESCRIPTION
## Description
Add missing numpydoc docstrings to `dipy/tracking/local_tracking.py`
as part of #3270.

- Added docstring to `_warn_old_eudx_localtracking_api`
- Added Parameters and Returns to `_is_eudx_direction_getter`
- Added Parameters and Returns to `LocalTracking._tracker`
- Added Yields section to `LocalTracking.__iter__`
- Added Yields section to `LocalTracking._generate_tractogram`
- Added Parameters and Returns to `ParticleFilteringTracking._tracker`

## Motivation and Context
Fixes numpydoc validation warnings as part of the ongoing
docstring improvements across DIPY modules.

Relates to #3270

## How Has This Been Tested?
Documentation-only change. No functional code was modified.
All existing tests remain unaffected.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure