### PR TITLE
Restore missing function body of _orient_by_roi_list in streamline.pyFix orient by roi missing body

### DIFF
--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -459,6 +459,16 @@ def _orient_by_roi_list(out, roi1, roi2):
         streamlines flipped in place so that they are oriented
         from roi1 towards roi2.
     """
+    for idx, sl in enumerate(out):
+        dist1 = cdist(sl, roi1, "euclidean")
+        dist2 = cdist(sl, roi2, "euclidean")
+        min1 = np.argmin(dist1, 0)
+        min2 = np.argmin(dist2, 0)
+        if min1[0] > min2[0]:
+            out[idx][:, 0] = sl[::-1][:, 0]
+            out[idx][:, 1] = sl[::-1][:, 1]
+            out[idx][:, 2] = sl[::-1][:, 2]
+    return out
 
 
 @warning_for_keywords()

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -573,7 +573,30 @@ def _orient_by_sl_generator(out, std_array, fgarray):
 
 
 def _orient_by_sl_list(out, std_array, fgarray):
-    """Helper function that implements the sequence version of this"""
+    """Helper function that implements the sequence version of orient_by_sl.
+
+    Orients streamlines in place to match the direction of a standard
+    streamline by comparing direct and flipped Euclidean distances.
+
+    Parameters
+    ----------
+    out : list of ndarray
+        A list of streamlines each of shape (N, 3) to be oriented
+        in place based on comparison with `std_array`.
+    std_array : ndarray, shape (N, 3)
+        The standard streamline used as a reference for orientation.
+        Each streamline in `fgarray` is compared against this.
+    fgarray : list of ndarray
+        A list of streamlines each of shape (N, 3) used to compute
+        distances against `std_array` to determine orientation.
+
+    Returns
+    -------
+    out : list of ndarray
+        The same list of streamlines passed as input, with some
+        streamlines flipped in place to match the direction of
+        `std_array`.
+    """
     for idx, sl in enumerate(fgarray):
         dist_direct = np.sum(np.sqrt(np.sum((sl - std_array) ** 2, -1)))
         dist_flipped = np.sum(np.sqrt(np.sum((sl[::-1] - std_array) ** 2, -1)))

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -430,25 +430,35 @@ def _orient_by_roi_generator(out, roi1, roi2):
 
 
 def _orient_by_roi_list(out, roi1, roi2):
-    """
-    Helper function to `orient_by_rois`
+    """Helper function to `orient_by_rois`.
 
     Performs the inner loop separately. This is needed, because functions with
     `yield` always return a generator.
 
     Flips the streamlines in place (as needed) and returns a reference to the
     updated list.
+
+    Parameters
+    ----------
+    out : list of ndarray
+        A list of streamlines, each of shape (N, 3), to be oriented
+        in place based on their proximity to the two ROIs.
+    roi1 : ndarray, shape (M, 3)
+        An array of coordinates representing the first region of
+        interest. Streamlines will be oriented so that they start
+        closer to roi1.
+    roi2 : ndarray, shape (K, 3)
+        An array of coordinates representing the second region of
+        interest. Streamlines will be oriented so that they end
+        closer to roi2.
+
+    Returns
+    -------
+    out : list of ndarray
+        The same list of streamlines passed as input, with some
+        streamlines flipped in place so that they are oriented
+        from roi1 towards roi2.
     """
-    for idx, sl in enumerate(out):
-        dist1 = cdist(sl, roi1, "euclidean")
-        dist2 = cdist(sl, roi2, "euclidean")
-        min1 = np.argmin(dist1, 0)
-        min2 = np.argmin(dist2, 0)
-        if min1[0] > min2[0]:
-            out[idx][:, 0] = sl[::-1][:, 0]
-            out[idx][:, 1] = sl[::-1][:, 1]
-            out[idx][:, 2] = sl[::-1][:, 2]
-    return out
 
 
 @warning_for_keywords()

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -787,5 +787,17 @@ def values_from_volume(data, streamlines, affine):
 
 
 def nbytes(streamlines):
-    """Calculate the memory footprint of a streamlines object."""
+    """Calculate the memory footprint of a streamlines object.
+
+    Parameters
+    ----------
+    streamlines : StatefulTractogram or ArraySequence
+        A streamlines object with a `_data` attribute containing
+        the raw streamline data as a numpy array.
+
+    Returns
+    -------
+    size : float
+        The memory footprint of the streamlines data in megabytes (MB).
+    """
     return streamlines._data.nbytes / 1024.0**2

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -541,7 +541,28 @@ def orient_by_rois(
 
 
 def _orient_by_sl_generator(out, std_array, fgarray):
-    """Helper function that implements the generator version of this"""
+    """Helper function that implements the generator version of orient_by_sl.
+
+    Yields streamlines oriented to match the direction of a standard
+    streamline by comparing direct and flipped Euclidean distances.
+
+    Parameters
+    ----------
+    out : list of ndarray
+        A list of streamlines each of shape (N, 3) to be oriented.
+    std_array : ndarray, shape (N, 3)
+        The standard streamline used as a reference for orientation.
+        Each streamline in `fgarray` is compared against this.
+    fgarray : list of ndarray
+        A list of streamlines each of shape (N, 3) used to compute
+        distances against `std_array` to determine orientation.
+
+    Yields
+    ------
+    sl : ndarray, shape (N, 3)
+        Each streamline from `out` yielded in the correct orientation
+        to match the direction of `std_array`.
+    """
     for idx, sl in enumerate(fgarray):
         dist_direct = np.sum(np.sqrt(np.sum((sl - std_array) ** 2, -1)))
         dist_flipped = np.sum(np.sqrt(np.sum((sl[::-1] - std_array) ** 2, -1)))


### PR DESCRIPTION
## Description
Restores the accidentally removed function body of `_orient_by_roi_list`
in `dipy/tracking/streamline.py`. The implementation was missing after
a previous documentation PR inadvertently deleted the code.

## Motivation and Context
The function `_orient_by_roi_list` was missing its implementation body
after PR #3995 accidentally removed it while adding docstrings. This
caused `test_orient_by_rois` to fail because the function was returning
`None` instead of the expected streamlines array.

## How Has This Been Tested?
This restores the original function implementation that was accidentally
removed. The existing tests in `test_streamline.py::test_orient_by_rois`
verify the correct behavior.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure