### PR TITLE
RF: CLI Docsting fixes

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -7,8 +7,6 @@ import textwrap
 from dipy.utils.logging import logger
 from dipy.workflows.docstring_parser import NumpyDocString
 
-# LaTeX commands used in DIPY workflow docstrings. Add new entries here when
-# a new symbol shows up in a workflow docstring and needs CLI rendering.
 _LATEX_SYMBOLS = {
     r"\pm": "±",
     r"\mu": "μ",
@@ -16,12 +14,35 @@ _LATEX_SYMBOLS = {
 
 
 def _strip_rst_markup(text):
-    """Strip RST inline markup for plain-text CLI display."""
-    # :role:`content` → content
+    """Convert RST and LaTeX inline markup to plain text for CLI display.
+
+    Workflow docstrings are written in reStructuredText with embedded LaTeX
+    so they render correctly in Sphinx HTML. When those docstrings are
+    surfaced in argparse ``--help`` output, the raw markup is unreadable.
+    This helper applies three substitutions, in order:
+
+    1. Strip RST inline roles, keeping the content
+       (e.g. ``:math:`x = 1``` → ``x = 1``).
+    2. Strip LaTeX commands that wrap content in braces, keeping the content
+       (e.g. ``\\text{bvec}`` → ``bvec``).
+    3. Replace known standalone LaTeX symbols with their Unicode equivalents
+       (see ``_LATEX_SYMBOLS``).
+
+    Only the returned string is modified; the original docstring on the
+    function is untouched, so Sphinx HTML rendering is unaffected.
+
+    Parameters
+    ----------
+    text : str
+        Docstring fragment that may contain RST roles or LaTeX commands.
+
+    Returns
+    -------
+    str
+        Plain-text version safe to display in a terminal.
+    """
     text = re.sub(r":[a-z]+:`([^`]*)`", r"\1", text)
-    # \command{content} → content (e.g. \text{bvec} → bvec)
     text = re.sub(r"\\[a-z]+\{([^}]*)\}", r"\1", text)
-    # known LaTeX symbols
     for cmd, sym in _LATEX_SYMBOLS.items():
         text = text.replace(cmd, sym)
     return text
@@ -214,9 +235,9 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
         npds = NumpyDocString(doc)
         add_default_args_to_docstring(npds, workflow.run)
         self.doc = npds["Parameters"]
-        self.description = (
-            f"{' '.join(npds['Summary'])}\n\n{'\n'.join(npds['Extended Summary'])}"
-        )
+        summary = " ".join(npds["Summary"])
+        extended = "\n".join(npds["Extended Summary"])
+        self.description = f"{summary}\n\n{extended}"
 
         if npds["References"]:
             ref_text = [text or "\n" for text in npds["References"]]

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -1,10 +1,30 @@
 import argparse
 import inspect
+import re
 import shutil
 import textwrap
 
 from dipy.utils.logging import logger
 from dipy.workflows.docstring_parser import NumpyDocString
+
+# LaTeX commands used in DIPY workflow docstrings. Add new entries here when
+# a new symbol shows up in a workflow docstring and needs CLI rendering.
+_LATEX_SYMBOLS = {
+    r"\pm": "±",
+    r"\mu": "μ",
+}
+
+
+def _strip_rst_markup(text):
+    """Strip RST inline markup for plain-text CLI display."""
+    # :role:`content` → content
+    text = re.sub(r":[a-z]+:`([^`]*)`", r"\1", text)
+    # \command{content} → content (e.g. \text{bvec} → bvec)
+    text = re.sub(r"\\[a-z]+\{([^}]*)\}", r"\1", text)
+    # known LaTeX symbols
+    for cmd, sym in _LATEX_SYMBOLS.items():
+        text = text.replace(cmd, sym)
+    return text
 
 
 def format_key_value_table(data, key_header="Key", value_header="Value", *, sort=True):
@@ -38,7 +58,15 @@ def format_key_value_table(data, key_header="Key", value_header="Value", *, sort
     ]
 
     for key, value in items:
-        wrapped_value = textwrap.wrap(value, width=value_width) or [""]
+        wrapped_value = []
+        for line in value.split("\n"):
+            stripped = line.lstrip()
+            indent = line[: len(line) - len(stripped)]
+            available = max(value_width - len(indent), 10)
+            wrapped_value.extend(
+                indent + w for w in (textwrap.wrap(stripped, width=available) or [""])
+            )
+        wrapped_value = wrapped_value or [""]
         rows.append(f"| {key:<{key_width}} | {wrapped_value[0]:<{value_width}} |")
         for extra_line in wrapped_value[1:]:
             rows.append(f"| {'':<{key_width}} | {extra_line:<{value_width}} |")
@@ -187,7 +215,7 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
         add_default_args_to_docstring(npds, workflow.run)
         self.doc = npds["Parameters"]
         self.description = (
-            f"{' '.join(npds['Summary'])}\n\n{' '.join(npds['Extended Summary'])}"
+            f"{' '.join(npds['Summary'])}\n\n{'\n'.join(npds['Extended Summary'])}"
         )
 
         if npds["References"]:
@@ -233,7 +261,7 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
 
             typestr = self.doc[i][1]
             dtype, isnarg = self._select_dtype(typestr)
-            help_msg = " ".join(self.doc[i][2])
+            help_msg = _strip_rst_markup("\n".join(self.doc[i][2]))
 
             _args = [f"{prefix}{arg}"]
             _kwargs = {"help": help_msg, "type": dtype, "action": "store"}
@@ -319,7 +347,7 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
                 prefix = "--"
                 typestr = _doc[i][1]
                 dtype, isnarg = self._select_dtype(typestr)
-                help_msg = "".join(_doc[i][2])
+                help_msg = _strip_rst_markup("\n".join(_doc[i][2]))
 
                 _args = [f"{prefix}{arg_name}"]
                 _kwargs = {

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -250,7 +250,7 @@ def _print_bval_data_information(bvals, b0_threshold, bshell_thr, alignment_spac
 
 
 def _print_bvec_data_information(bvecs, bvecs_tol, alignment_space):
-    """Print b-vector information.
+    r"""Print b-vector information.
 
     Parameters
     ----------
@@ -258,7 +258,7 @@ def _print_bvec_data_information(bvecs, bvecs_tol, alignment_space):
         b-vectors.
     bvecs_tol : float
         Threshold used to check that
-        :math:`norm(\text{bvec}) = 1 \\pm \text{bvecs_tol}` b-vectors are
+        :math:`norm(\text{bvec}) = 1 \pm \text{bvecs_tol}` b-vectors are
         unit vectors.
     alignment_space : int
         Character width for the property, value pair alignment.
@@ -417,7 +417,7 @@ class IoInfoFlow(Workflow):
         bshell_thr=100,
         reference=None,
     ):
-        """Provides useful information about different files used in
+        r"""Provides useful information about different files used in
         medical imaging. Any number of input files can be provided. The
         program identifies the type of file by its extension.
 
@@ -429,7 +429,7 @@ class IoInfoFlow(Workflow):
             Threshold used to find b0 volumes.
         bvecs_tol : float, optional
             Threshold used to check that
-            :math:`norm(\text{bvec}) = 1 \\pm \text{bvecs_tol}` b-vectors are
+            :math:`norm(\text{bvec}) = 1 \pm \text{bvecs_tol}` b-vectors are
             unit vectors.
         bshell_thr : float, optional
             Threshold for distinguishing b-values in different shells.
@@ -627,7 +627,8 @@ class FetchFlow(Workflow):
     ):
         """Download files to folder and check their md5 checksums.
 
-        To see all available datasets, please type "list" in data_names.
+        - To see all available datasets, please type "dipy_fetch list".
+        - To download all datasets, please type "dipy_fetch all".
 
         Parameters
         ----------

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -23,7 +23,7 @@ from dipy.reconst.shm import convert_sh_descoteaux_tournier
 from dipy.testing import assert_true, assert_warns
 from dipy.utils.optpkg import optional_package
 from dipy.utils.tripwire import TripWireError
-from dipy.workflows.base import format_key_value_table
+from dipy.workflows.base import _strip_rst_markup, format_key_value_table
 from dipy.workflows.io import (
     ConcatenateTractogramFlow,
     ConvertSHFlow,
@@ -210,6 +210,55 @@ def test_format_key_value_table():
     npt.assert_equal(len(unsorted_lines), 2)
     npt.assert_equal("zebra" in unsorted_lines[0], True)
     npt.assert_equal("apple" in unsorted_lines[1], True)
+
+    # Newlines in values are preserved as separate output rows
+    multiline = format_key_value_table(
+        {"key": "first line\nsecond line"},
+        key_header="Key",
+        value_header="Value",
+    )
+    npt.assert_equal(
+        any("first line" in line for line in multiline.splitlines()), True
+    )
+    npt.assert_equal(
+        any("second line" in line for line in multiline.splitlines()), True
+    )
+
+    # Leading whitespace on a value line is preserved in the rendered row
+    indented = format_key_value_table(
+        {"key": "    indented text"},
+        key_header="Key",
+        value_header="Value",
+    )
+    npt.assert_equal(
+        any("    indented text" in line for line in indented.splitlines()), True
+    )
+
+
+def test_strip_rst_markup():
+    # Plain text passes through untouched
+    npt.assert_equal(_strip_rst_markup("hello world"), "hello world")
+
+    # RST inline roles are stripped, content preserved
+    npt.assert_equal(_strip_rst_markup(":math:`x = 1`"), "x = 1")
+    npt.assert_equal(_strip_rst_markup(":footcite:`Smith2020`"), "Smith2020")
+
+    # LaTeX brace commands are stripped, content preserved
+    npt.assert_equal(_strip_rst_markup(r"\text{bvec}"), "bvec")
+    npt.assert_equal(_strip_rst_markup(r"\mathbf{x}"), "x")
+
+    # Known LaTeX symbols are replaced with Unicode equivalents
+    npt.assert_equal(_strip_rst_markup(r"a \pm b"), "a ± b")
+    npt.assert_equal(_strip_rst_markup(r"\mu"), "μ")
+
+    # All three rules combined in one expression
+    npt.assert_equal(
+        _strip_rst_markup(r":math:`norm(\text{bvec}) = 1 \pm \text{bvecs_tol}`"),
+        "norm(bvec) = 1 ± bvecs_tol",
+    )
+
+    # Unknown LaTeX symbols are left as-is
+    npt.assert_equal(_strip_rst_markup(r"\unknown"), r"\unknown")
 
 
 def test_format_data_names_table():

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -217,9 +217,7 @@ def test_format_key_value_table():
         key_header="Key",
         value_header="Value",
     )
-    npt.assert_equal(
-        any("first line" in line for line in multiline.splitlines()), True
-    )
+    npt.assert_equal(any("first line" in line for line in multiline.splitlines()), True)
     npt.assert_equal(
         any("second line" in line for line in multiline.splitlines()), True
     )


### PR DESCRIPTION
## Description

Improves CLI documentation rendering for DIPY workflows in two ways:

1. **`dipy_fetch` help text** — replaces the cryptic `'type "list" in data_names'` line with explicit bullet usage hints (`dipy_fetch list`, `dipy_fetch all`).
2. **CLI plain-text rendering of docstrings** — adds a small RST/LaTeX stripper in `dipy/workflows/base.py` so `:math:\`...\`` blocks, `\text{...}` wrappers, and a couple of math symbols (`\pm`, `\mu`) render as readable plain text in `--help` output instead of leaking raw markup. Also preserves intentional line breaks (e.g., bullet lists) when joining multi-line docstring sections.
3. **Two `r"""` docstring fixes in `dipy/workflows/io.py`** — `_print_bvec_data_information` and `IoInfoFlow.run` contain `\text{...}` inside `:math:` blocks. Without raw-string mode, Python eats `\t` as a TAB, garbling both Sphinx HTML and CLI output. Marking the docstrings as raw fixes both.

The stripping logic does **not** affect Sphinx HTML rendering. `_strip_rst_markup` runs only inside `IntrospectiveArgumentParser` when building argparse `--help` strings — it operates on a copy of the docstring text destined for the terminal, never on the source `__doc__` attribute. Sphinx autodoc continues to read the original docstring directly and renders `:math:\`...\`` as proper math, exactly as before.

The `_LATEX_SYMBOLS` dict only contains `\pm` and `\mu` — the two LaTeX commands currently used in DIPY workflow docstrings. Other symbols can be added when a docstring actually needs them. I didn't want to do speculative dump. I can add most common, let me know if that makes more sense.

## Motivation and Context

`dipy_info --help` and `dipy_fetch --help` were rendering raw RST/LaTeX markup, which is hard to read in a terminal. 
This makes the CLI help output user-friendly.

## How Has This Been Tested?

- Manually verified `dipy_info --help` renders the `--bvecs_tol` description as
  `Threshold used to check that norm(bvec) = 1 ± bvecs_tol b-vectors are unit vectors.`
  instead of the previous raw-markup output with stray tab characters.
- Manually verified `dipy_fetch --help` shows the new bullet usage hints.
- Targeted test runs:
```
pytest dipy/workflows/tests/test_io.py::test_format_key_value_table
pytest dipy/workflows/tests/test_io.py::test_io_info
pytest dipy/workflows/tests/test_io.py::test_io_fetch_list_outputs_table
```

| Before | After |
|---|---|
| <img width="450" src="https://github.com/user-attachments/assets/4a59c50f-a48d-4c36-9db7-aa6acca15526" /> | <img width="450" src="https://github.com/user-attachments/assets/7f9b7f4a-6b8d-49ce-b024-7417ad6b931a" /> |
| <img width="450" src="https://github.com/user-attachments/assets/c2ca4cc0-1f5c-4dac-9c3b-2e1b921dc674" /> | <img width="450" src="https://github.com/user-attachments/assets/9f0b3b6e-6177-4457-bb94-d8a760cda316" /> |
| <img width="450" src="https://github.com/user-attachments/assets/178a6b4f-c41c-4081-9d41-cd5a0244b5b9" /> | <img width="450" src="https://github.com/user-attachments/assets/28031255-a890-4b75-b00d-65d4e941f9ae" /> |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure