### PR TITLE
RF: simplify reslice when not needed by updating out_resliced

### DIFF
--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -1,8 +1,7 @@
-import os
 from pathlib import Path
-import shutil
 from warnings import warn
 
+import nibabel as nib
 import numpy as np
 
 from dipy.align import affine_registration, motion_correction
@@ -121,9 +120,11 @@ class ResliceFlow(Workflow):
         """
 
         io_it = self.get_io_iterator()
+        corrected_outputs = list(self.flat_outputs)
 
-        for inputfile, outpfile in io_it:
-            data, affine, zooms = load_nifti(inputfile, return_voxsize=True)
+        for i, (inputfile, outpfile) in enumerate(io_it):
+            img = nib.load(inputfile)
+            zooms = img.header.get_zooms()[:3]
             logger.info(f"Processing {inputfile}")
 
             if new_vox_size is None:
@@ -148,31 +149,16 @@ class ResliceFlow(Workflow):
             if np.allclose(zooms_spatial, new_vox_size_to_use, rtol=1e-3, atol=1e-3):
                 logger.info(
                     f"Voxel size {tuple(zooms)} already matches target "
-                    f"{tuple(new_vox_size_to_use)}. Skipping reslicing."
-                    "return original data as a symlink."
+                    f"{tuple(new_vox_size_to_use)}. Skipping reslicing, "
+                    f"returning original path."
                 )
-                source_file = Path(inputfile)
-                link_file = Path(outpfile)
-                if link_file.exists() and link_file.resolve() == source_file.resolve():
-                    logger.debug(f"{outpfile} already linked/copied. Skipping.")
-                    continue
-                if link_file.exists() or link_file.is_symlink():
-                    link_file.unlink()
-                try:
-                    link_file.symlink_to(source_file.resolve())
-                except OSError:
-                    # Symlinks may need elevated privileges on Windows; try a hard
-                    # link before falling back to copying large volumes.
-                    try:
-                        os.link(source_file, link_file)
-                        logger.info(f"Hard link created for {outpfile}")
-                    except OSError:
-                        shutil.copy(source_file, link_file)
-                        logger.warning(
-                            f"Link creation for {outpfile} failed, copied instead."
-                        )
+                corrected_outputs[i] = Path(inputfile)
+                img.uncache()
                 continue
             else:
+                data = np.asanyarray(img.dataobj)
+                affine = img.affine
+                img.uncache()
                 new_data, new_affine = reslice(
                     data,
                     affine,
@@ -185,6 +171,9 @@ class ResliceFlow(Workflow):
                 )
                 save_nifti(outpfile, new_data, new_affine)
                 logger.info(f"Resliced file save in {outpfile}")
+
+        if corrected_outputs != self.flat_outputs:
+            self.update_flat_outputs(corrected_outputs, io_it)
 
 
 class SlrWithQbxFlow(Workflow):

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -148,6 +148,33 @@ def test_reslice_skip_idempotent(caplog):
         )
 
 
+def test_reslice_skip_returns_original_path(caplog):
+    """Test ResliceFlow returns original input path when voxel size matches."""
+    with TemporaryDirectory() as tmp_dir:
+        data_path, _, _ = get_fnames(name="small_25")
+        data, affine, zooms = load_nifti(data_path, return_voxsize=True)
+
+        nii_path = Path(tmp_dir) / "input.nii"
+        nib.save(nib.Nifti1Image(data, affine), str(nii_path))
+
+        out_dir = Path(tmp_dir) / "out"
+        out_dir.mkdir()
+
+        with caplog.at_level(logging.INFO, logger="dipy"):
+            reslice_flow = ResliceFlow()
+            reslice_flow.run(
+                str(nii_path), new_vox_size=list(zooms[:3]), out_dir=str(out_dir)
+            )
+
+        out_path = Path(reslice_flow.last_generated_outputs["out_resliced"])
+        assert out_path.resolve() == nii_path.resolve(), (
+            f"Expected original input path {nii_path}, got {out_path}"
+        )
+
+        resliced = np.array(load_nifti_data(str(out_path)))
+        npt.assert_equal(resliced.shape, data.shape)
+
+
 def test_slr_flow(caplog):
     with TemporaryDirectory() as out_dir:
         data_path = get_fnames(name="fornix")


### PR DESCRIPTION
## Description

simplify `dipy_reslice` when reslicing is not needed by updating `out_resliced`

## Motivation and Context

Before, symbolic link or copy were created which increase complexity and disk space.
Also, Symbolic link was breaking when input extension were different than output extension


## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
