### PR TITLE
MNT: tomllib is always available since Python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,6 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        additional_dependencies:
-          - tomli
   - repo: local
     hooks:
       - id: generate_requirements.py

--- a/doc/sphinxext/prepare_gallery.py
+++ b/doc/sphinxext/prepare_gallery.py
@@ -8,10 +8,7 @@ import sys
 
 from sphinx.util import logging
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
+import tomllib
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ doc = [
     "sphinxcontrib-bibtex>=2.5.0",
     "sphinx_design>=0.5.0",
     "sphinx-gallery>=0.10.0",
-    "tomli>=2.0.1",
     "grg-sphinx-theme>=0.4.0",
     "Jinja2"
 ]

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -24,7 +24,6 @@ texext
 sphinxcontrib-bibtex>=2.5.0
 sphinx_design>=0.5.0
 sphinx-gallery>=0.10.0
-tomli>=2.0.1
 grg-sphinx-theme>=0.4.0
 Jinja2
 scikit_learn

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,6 +6,5 @@ texext
 sphinxcontrib-bibtex>=2.5.0
 sphinx_design>=0.5.0
 sphinx-gallery>=0.10.0
-tomli>=2.0.1
 grg-sphinx-theme>=0.4.0
 Jinja2

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -2,15 +2,9 @@
 """Generate requirements/*.txt files from pyproject.toml."""
 
 import sys
+import tomllib
 from pathlib import Path
 
-try:  # standard module since Python 3.11
-    import tomllib as toml
-except ImportError:
-    try:  # available for older Python via pip
-        import tomli as toml
-    except ImportError:
-        sys.exit("Please install `tomli` first: `pip install tomli`")
 
 script_pth = Path(__file__)
 repo_dir = script_pth.parent.parent
@@ -203,7 +197,7 @@ def expand_project_extras(
 
 def main():
     """Load ``pyproject.toml`` and regenerate the requirements directory."""
-    pyproject = toml.loads((repo_dir / "pyproject.toml").read_text())
+    pyproject = tomllib.loads((repo_dir / "pyproject.toml").read_text())
     project = pyproject["project"]
     project_name = project["name"]
     optional_deps = project.get("optional-dependencies", {})


### PR DESCRIPTION
## Description

`tomllib` is always available from Python 3.11 and up.

## Motivation and Context


## How Has This Been Tested?

CI tests pass.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Maintenance / CI / Infrastructure
