### PR TITLE
MNT: fix typo in 36cadff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dipy"
 description = "Diffusion MRI Imaging in Python"
 license = "BSD-3-Clause"
-license-file = ["LICENSE"]
+license-files = ["LICENSE"]
 readme = "README.rst"
 requires-python = ">=3.12"
 authors = [{ name = "DIPY developers", email = "dipy@python.org" }]


### PR DESCRIPTION
## Description

Fix typo. I introduced this error in 36cadff.

## Motivation and Context

I noticed the issue here (bottom of page):
https://learn.scientific-python.org/development/guides/repo-review/?repo=dipy%2Fdipy&ref=HEAD&refType=branch

## How Has This Been Tested?

CI tests pass.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Maintenance / CI / Infrastructure
