### PR TITLE
MNT: Bump `pytest` everywhere

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ env:
   CIBW_BUILD: "cp3{12,13,14}-*"
   CIBW_BUILD_FRONTEND: 'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
   CIBW_TEST_SKIP: "*"
-  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest==8.0.0"
+  CIBW_TEST_REQUIRES: "-r requirements/build.txt pytest"
   CIBW_TEST_COMMAND: pytest --pyargs dipy
   CIBW_CONFIG_SETTINGS: "compile-args=-v"
 


### PR DESCRIPTION
## Description

Bump `pytest` everywhere.

## Motivation and Context

I updated to `pytest>=9` in #4021 / d9ec88b, but forgot to bump `pytest==8.0.0` here:
https://github.com/dipy/dipy/blob/b26039dc9e363c0c42a9e25aae69ae0fe5dce30a/.github/workflows/nightly.yml#L27

Revert d9ec88b which was a temporary fix. The issue it worked around appears to have been fixed:
	pytest-dev/pytest#12013

## How Has This Been Tested?

Pass CI tests.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Maintenance / CI / Infrastructure
