### PR TITLE
RF: Refactor `bunch`, `enums`,  `logging`

### DIFF
--- a/dipy/align/__init__.py
+++ b/dipy/align/__init__.py
@@ -1,28 +1,4 @@
-import numpy as np
-
-floating = np.float32
-
-
-class Bunch:
-    def __init__(self, **kwds):
-        r"""A 'bunch' of values (a replacement of Enum)
-
-        This is a temporary replacement of Enum, which is not available
-        on all versions of Python 2
-        """
-        self.__dict__.update(kwds)
-
-
-VerbosityLevels = Bunch(NONE=0, STATUS=1, DIAGNOSE=2, DEBUG=3)
-r""" VerbosityLevels
-This enum defines the four levels of verbosity we use in the align
-module.
-NONE : do not print anything
-STATUS : print information about the current status of the algorithm
-DIAGNOSE : print high level information of the components involved in the
-registration that can be used to detect a failing component.
-DEBUG : print as much information as possible to isolate the cause of a bug.
-"""
+import warnings
 
 from dipy.align._public import (
     affine,
@@ -61,3 +37,31 @@ __all__ = [
     "register_dwi_series",
     "streamline_registration",
 ]
+
+
+def __getattr__(name):
+    if name == "floating":
+        warnings.warn(
+            "Importing 'floating' from dipy.align is deprecated. "
+            "Use np.float32 directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        import numpy as np
+
+        return np.float32
+    if name == "VerbosityLevels":
+        warnings.warn(
+            "Importing 'VerbosityLevels' from dipy.align is deprecated. "
+            "Use 'from dipy.utils import VerbosityLevels'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from dipy.utils import VerbosityLevels
+
+        return VerbosityLevels
+    if name == "Bunch":
+        raise ImportError(
+            "'Bunch' has been removed from dipy.align. Use enum.IntEnum instead."
+        )
+    raise AttributeError(f"module 'dipy.align' has no attribute {name!r}")

--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -43,7 +43,7 @@ import numpy as np
 import numpy.linalg as npl
 import scipy.ndimage as ndimage
 
-from dipy.align import VerbosityLevels, vector_fields as vf
+from dipy.align import vector_fields as vf
 from dipy.align.imwarp import ScaleSpace, get_direction_and_spacings
 from dipy.align.parzenhist import (
     ParzenJointHistogram,
@@ -54,6 +54,7 @@ from dipy.align.scalespace import IsotropicScaleSpace
 from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
 from dipy.core.optimize import Optimizer
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils import VerbosityLevels
 from dipy.utils.logging import logger
 
 _interp_options = ["nearest", "linear"]

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -7,36 +7,12 @@ from nibabel.streamlines import ArraySequence as Streamlines
 import numpy as np
 import numpy.linalg as npl
 
-from dipy.align import Bunch, VerbosityLevels, floating, vector_fields as vfu
+from dipy.align import vector_fields as vfu
 from dipy.align.scalespace import ScaleSpace
+from dipy.align.utils import RegistrationStages
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils import VerbosityLevels
 from dipy.utils.logging import logger
-
-RegistrationStages = Bunch(
-    INIT_START=0,
-    INIT_END=1,
-    OPT_START=2,
-    OPT_END=3,
-    SCALE_START=4,
-    SCALE_END=5,
-    ITER_START=6,
-    ITER_END=7,
-)
-"""Registration Stages
-
-This enum defines the different stages which the Volumetric Registration
-may be in. The value of the stage is passed as a parameter to the call-back
-function so that it can react accordingly.
-
-INIT_START: optimizer initialization starts
-INIT_END: optimizer initialization ends
-OPT_START: optimization starts
-OPT_END: optimization ends
-SCALE_START: optimization at a new scale space resolution starts
-SCALE_END: optimization at the current scale space resolution ends
-ITER_START: a new iteration starts
-ITER_END: the current iteration ends
-"""
 
 
 def mult_aff(A, B):
@@ -257,8 +233,8 @@ class DiffeomorphicMap:
 
         Creates a zero displacement field (the identity transformation).
         """
-        self.forward = np.zeros(tuple(self.disp_shape) + (self.dim,), dtype=floating)
-        self.backward = np.zeros(tuple(self.disp_shape) + (self.dim,), dtype=floating)
+        self.forward = np.zeros(tuple(self.disp_shape) + (self.dim,), dtype=np.float32)
+        self.backward = np.zeros(tuple(self.disp_shape) + (self.dim,), dtype=np.float32)
 
     @warning_for_keywords()
     def _get_warping_function(self, interpolation, *, warp_coordinates=False):
@@ -462,12 +438,12 @@ class DiffeomorphicMap:
 
         # Convert the data to required types to use the cythonized functions
         if interpolation == "nearest":
-            if image.dtype is np.dtype("float64") and floating is np.float32:
-                image = image.astype(floating)
+            if image.dtype is np.dtype("float64"):
+                image = image.astype(np.float32)
             elif image.dtype is np.dtype("int64"):
                 image = image.astype(np.int32)
         else:
-            image = np.asarray(image, dtype=floating)
+            image = np.asarray(image, dtype=np.float32)
 
         warp_f = self._get_warping_function(interpolation)
 
@@ -585,12 +561,12 @@ class DiffeomorphicMap:
         affine_disp = mult_aff(W, Pinv)
 
         if interpolation == "nearest":
-            if image.dtype is np.dtype("float64") and floating is np.float32:
-                image = image.astype(floating)
+            if image.dtype is np.dtype("float64"):
+                image = image.astype(np.float32)
             elif image.dtype is np.dtype("int64"):
                 image = image.astype(np.int32)
         else:
-            image = np.asarray(image, dtype=floating)
+            image = np.asarray(image, dtype=np.float32)
 
         warp_f = self._get_warping_function(interpolation)
 
@@ -1836,8 +1812,8 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
                 logger.info(f"Pre-align: {prealign}")
 
         self._init_optimizer(
-            static.astype(floating),
-            moving.astype(floating),
+            static.astype(np.float32),
+            moving.astype(np.float32),
             static_grid2world,
             moving_grid2world,
             prealign,

--- a/dipy/align/meson.build
+++ b/dipy/align/meson.build
@@ -41,6 +41,7 @@ python_sources = ['__init__.py',
   'scalespace.py',
   'streamlinear.py',
   'streamwarp.py',
+  'utils.py',
   ]
 
 

--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -9,7 +9,6 @@ from scipy import ndimage
 from dipy.align import (
     crosscorr as cc,
     expectmax as em,
-    floating,
     sumsqdiff as ssd,
     vector_fields as vfu,
 )
@@ -290,7 +289,7 @@ class CCMetric(SimilarityMetric):
         self.factors = np.array(self.factors)
 
         self.gradient_moving = np.empty(
-            shape=self.moving_image.shape + (self.dim,), dtype=floating
+            shape=self.moving_image.shape + (self.dim,), dtype=np.float32
         )
         for i, grad in enumerate(gradient(self.moving_image)):
             self.gradient_moving[..., i] = grad
@@ -302,7 +301,7 @@ class CCMetric(SimilarityMetric):
             self.reorient_vector_field(self.gradient_moving, self.moving_direction)
 
         self.gradient_static = np.empty(
-            shape=self.static_image.shape + (self.dim,), dtype=floating
+            shape=self.static_image.shape + (self.dim,), dtype=np.float32
         )
         for i, grad in enumerate(gradient(self.static_image)):
             self.gradient_static[..., i] = grad
@@ -470,7 +469,7 @@ class EMMetric(SimilarityMetric):
         self.staticq_means_field = self.staticq_means[staticq]
 
         self.gradient_moving = np.empty(
-            shape=self.moving_image.shape + (self.dim,), dtype=floating
+            shape=self.moving_image.shape + (self.dim,), dtype=np.float32
         )
 
         for i, grad in enumerate(gradient(self.moving_image)):
@@ -483,7 +482,7 @@ class EMMetric(SimilarityMetric):
             self.reorient_vector_field(self.gradient_moving, self.moving_direction)
 
         self.gradient_static = np.empty(
-            shape=self.static_image.shape + (self.dim,), dtype=floating
+            shape=self.static_image.shape + (self.dim,), dtype=np.float32
         )
 
         for i, grad in enumerate(gradient(self.static_image)):
@@ -584,7 +583,7 @@ class EMMetric(SimilarityMetric):
             delta = self.movingq_means_field - self.static_image
             sigma_sq_field = self.movingq_sigma_sq_field
 
-        displacement = np.zeros(shape=reference_shape + (self.dim,), dtype=floating)
+        displacement = np.zeros(shape=reference_shape + (self.dim,), dtype=np.float32)
 
         if self.dim == 2:
             self.energy = v_cycle_2d(
@@ -786,7 +785,7 @@ class SSDMetric(SimilarityMetric):
         computation of the forward and backward steps.
         """
         self.gradient_moving = np.empty(
-            shape=self.moving_image.shape + (self.dim,), dtype=floating
+            shape=self.moving_image.shape + (self.dim,), dtype=np.float32
         )
         for i, grad in enumerate(gradient(self.moving_image)):
             self.gradient_moving[..., i] = grad
@@ -798,7 +797,7 @@ class SSDMetric(SimilarityMetric):
             self.reorient_vector_field(self.gradient_moving, self.moving_direction)
 
         self.gradient_static = np.empty(
-            shape=self.static_image.shape + (self.dim,), dtype=floating
+            shape=self.static_image.shape + (self.dim,), dtype=np.float32
         )
         for i, grad in enumerate(gradient(self.static_image)):
             self.gradient_static[..., i] = grad
@@ -856,7 +855,7 @@ class SSDMetric(SimilarityMetric):
             gradient = self.gradient_moving
             delta_field = self.moving_image - self.static_image
 
-        displacement = np.zeros(shape=reference_shape + (self.dim,), dtype=floating)
+        displacement = np.zeros(shape=reference_shape + (self.dim,), dtype=np.float32)
 
         if self.dim == 2:
             self.energy = v_cycle_2d(
@@ -1033,7 +1032,7 @@ def v_cycle_2d(
 
     shape = np.array(displacement.shape).astype(np.int32)
     half_shape = ((shape[0] + 1) // 2, (shape[1] + 1) // 2, 2)
-    sub_displacement = np.zeros(shape=half_shape, dtype=floating)
+    sub_displacement = np.zeros(shape=half_shape, dtype=np.float32)
     sublambda_param = lambda_param * 0.25
     v_cycle_2d(
         n - 1,
@@ -1154,7 +1153,7 @@ def v_cycle_3d(
     shape = np.array(displacement.shape).astype(np.int32)
     sub_displacement = np.zeros(
         shape=((shape[0] + 1) // 2, (shape[1] + 1) // 2, (shape[2] + 1) // 2, 3),
-        dtype=floating,
+        dtype=np.float32,
     )
     sublambda_param = lambda_param * 0.25
     v_cycle_3d(

--- a/dipy/align/scalespace.py
+++ b/dipy/align/scalespace.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.linalg as npl
 from scipy.ndimage import gaussian_filter
 
-from dipy.align import floating
 from dipy.testing.decorators import warning_for_keywords
 from dipy.utils.logging import logger
 
@@ -64,7 +63,7 @@ class ScaleSpace:
 
         # The properties are saved in separate lists. Insert input image
         # properties at the first level of the scale space
-        self.images = [img.astype(floating)]
+        self.images = [img.astype(np.float32)]
         self.domain_shapes = [input_size.astype(np.int32)]
         if input_spacing is None:
             input_spacing = np.ones((self.dim,), dtype=np.int32)
@@ -111,7 +110,7 @@ class ScaleSpace:
                 filtered *= mask
 
             # Add current level to the scale space
-            self.images.append(filtered.astype(floating))
+            self.images.append(filtered.astype(np.float32))
             self.domain_shapes.append(output_size)
             self.spacings.append(output_spacing)
             self.scalings.append(scaling)
@@ -387,7 +386,7 @@ class IsotropicScaleSpace(ScaleSpace):
 
         # The properties are saved in separate lists. Insert input image
         # properties at the first level of the scale space
-        self.images = [img.astype(floating)]
+        self.images = [img.astype(np.float32)]
         self.domain_shapes = [input_size.astype(np.int32)]
         if input_spacing is None:
             input_spacing = np.ones((self.dim,), dtype=np.int32)
@@ -440,7 +439,7 @@ class IsotropicScaleSpace(ScaleSpace):
                 filtered *= mask
 
             # Add current level to the scale space
-            self.images.append(filtered.astype(floating))
+            self.images.append(filtered.astype(np.float32))
             self.domain_shapes.append(output_size)
             self.spacings.append(new_spacing)
             self.scalings.append(shrink_factors)

--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from dipy.align import crosscorr as cc, floating
+from dipy.align import crosscorr as cc
 from dipy.testing.decorators import set_random_number_generator
 
 
@@ -11,8 +11,8 @@ def test_cc_factors_2d():
     correlation factors against a direct (not optimized, but less error prone)
     implementation.
     """
-    a = np.array(range(20 * 20), dtype=floating).reshape(20, 20)
-    b = np.array(range(20 * 20)[::-1], dtype=floating).reshape(20, 20)
+    a = np.array(range(20 * 20), dtype=np.float32).reshape(20, 20)
+    b = np.array(range(20 * 20)[::-1], dtype=np.float32).reshape(20, 20)
     a /= a.max()
     b /= b.max()
     for radius in [0, 1, 3, 6]:
@@ -27,8 +27,8 @@ def test_cc_factors_3d():
     correlation factors against a direct (not optimized, but less error prone)
     implementation.
     """
-    a = np.array(range(20 * 20 * 20), dtype=floating).reshape(20, 20, 20)
-    b = np.array(range(20 * 20 * 20)[::-1], dtype=floating).reshape(20, 20, 20)
+    a = np.array(range(20 * 20 * 20), dtype=np.float32).reshape(20, 20, 20)
+    b = np.array(range(20 * 20 * 20)[::-1], dtype=np.float32).reshape(20, 20, 20)
     a /= a.max()
     b /= b.max()
     for radius in [0, 1, 3, 6]:
@@ -56,35 +56,35 @@ def test_compute_cc_steps_2d(rng):
     X[..., 1] = x_1[None, :] * _O
 
     # Compute the gradient fields of F and G
-    gradF = np.array(X - c_f, dtype=floating)
-    gradG = np.array(X - c_g, dtype=floating)
+    gradF = np.array(X - c_f, dtype=np.float32)
+    gradG = np.array(X - c_g, dtype=np.float32)
 
     sz = np.size(gradF)
     Fnoise = rng.random(sz).reshape(gradF.shape) * gradF.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     gradF += Fnoise
 
     sz = np.size(gradG)
     Gnoise = rng.random(sz).reshape(gradG.shape) * gradG.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     gradG += Gnoise
 
     sq_norm_grad_G = np.sum(gradG**2, -1)
 
-    F = np.array(0.5 * np.sum(gradF**2, -1), dtype=floating)
-    G = np.array(0.5 * sq_norm_grad_G, dtype=floating)
+    F = np.array(0.5 * np.sum(gradF**2, -1), dtype=np.float32)
+    G = np.array(0.5 * sq_norm_grad_G, dtype=np.float32)
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
     # precompute the cross correlation factors
     factors = cc.precompute_cc_factors_2d_test(F, G, radius)
-    factors = np.array(factors, dtype=floating)
+    factors = np.array(factors, dtype=np.float32)
 
     # test the forward step against the exact expression
     _I = factors[..., 0]
@@ -92,7 +92,7 @@ def test_compute_cc_steps_2d(rng):
     sfm = factors[..., 2]
     sff = factors[..., 3]
     smm = factors[..., 4]
-    expected = np.ndarray(shape=sh + (2,), dtype=floating)
+    expected = np.ndarray(shape=sh + (2,), dtype=np.float32)
     factor = (-2.0 * sfm / (sff * smm)) * (_J - (sfm / sff) * _I)
     expected[..., 0] = factor * gradF[..., 0]
     factor = (-2.0 * sfm / (sff * smm)) * (_J - (sfm / sff) * _I)
@@ -143,35 +143,35 @@ def test_compute_cc_steps_3d(rng):
     X[..., 2] = x_2[None, None, :] * _O
 
     # Compute the gradient fields of F and G
-    gradF = np.array(X - c_f, dtype=floating)
-    gradG = np.array(X - c_g, dtype=floating)
+    gradF = np.array(X - c_f, dtype=np.float32)
+    gradG = np.array(X - c_g, dtype=np.float32)
 
     sz = np.size(gradF)
     Fnoise = rng.random(sz).reshape(gradF.shape) * gradF.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     gradF += Fnoise
 
     sz = np.size(gradG)
     Gnoise = rng.random(sz).reshape(gradG.shape) * gradG.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     gradG += Gnoise
 
     sq_norm_grad_G = np.sum(gradG**2, -1)
 
-    F = np.array(0.5 * np.sum(gradF**2, -1), dtype=floating)
-    G = np.array(0.5 * sq_norm_grad_G, dtype=floating)
+    F = np.array(0.5 * np.sum(gradF**2, -1), dtype=np.float32)
+    G = np.array(0.5 * sq_norm_grad_G, dtype=np.float32)
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
     # precompute the cross correlation factors
     factors = cc.precompute_cc_factors_3d_test(F, G, radius)
-    factors = np.array(factors, dtype=floating)
+    factors = np.array(factors, dtype=np.float32)
 
     # test the forward step against the exact expression
     _I = factors[..., 0]
@@ -179,7 +179,7 @@ def test_compute_cc_steps_3d(rng):
     sfm = factors[..., 2]
     sff = factors[..., 3]
     smm = factors[..., 4]
-    expected = np.ndarray(shape=sh + (3,), dtype=floating)
+    expected = np.ndarray(shape=sh + (3,), dtype=np.float32)
     factor = (-2.0 * sfm / (sff * smm)) * (_J - (sfm / sff) * _I)
     expected[..., 0] = factor * gradF[..., 0]
     expected[..., 1] = factor * gradF[..., 1]

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -6,7 +6,7 @@ from numpy.testing import (
     assert_raises,
 )
 
-from dipy.align import expectmax as em, floating
+from dipy.align import expectmax as em
 from dipy.testing.decorators import set_random_number_generator
 
 
@@ -103,11 +103,11 @@ def test_compute_em_demons_step_2d(rng):
 
     # Now compute it using the implementation under test
 
-    actual = np.empty_like(expected, dtype=floating)
+    actual = np.empty_like(expected, dtype=np.float32)
     em.compute_em_demons_step_2d(
-        np.array(delta_field, dtype=floating),
-        np.array(sigma_i_sq, dtype=floating),
-        np.array(grad_G, dtype=floating),
+        np.array(delta_field, dtype=np.float32),
+        np.array(sigma_i_sq, dtype=np.float32),
+        np.array(grad_G, dtype=np.float32),
         sigma_x_sq,
         actual,
     )
@@ -251,11 +251,11 @@ def test_compute_em_demons_step_3d(rng):
     expected[random_labels >= 3, ...] *= (num / den)[..., None]
 
     # Now compute it using the implementation under test
-    actual = np.empty_like(expected, dtype=floating)
+    actual = np.empty_like(expected, dtype=np.float32)
     em.compute_em_demons_step_3d(
-        np.array(delta_field, dtype=floating),
-        np.array(sigma_i_sq, dtype=floating),
-        np.array(grad_G, dtype=floating),
+        np.array(delta_field, dtype=np.float32),
+        np.array(sigma_i_sq, dtype=np.float32),
+        np.array(grad_G, dtype=np.float32),
         sigma_x_sq,
         actual,
     )
@@ -331,8 +331,8 @@ def test_quantize_positive_2d(rng):
     noise_amplitude = np.min([delta / 4.0, min_positive / 4.0])
     sz = np.size(true_quantization)
     noise = rng.random(sz).reshape(img_shape) * noise_amplitude
-    noise = noise.astype(floating)
-    input_image = np.ndarray(img_shape, dtype=floating)
+    noise = noise.astype(np.float32)
+    input_image = np.ndarray(img_shape, dtype=np.float32)
     # assign intensities plus noise
     input_image[...] = true_levels[true_quantization] + noise
     # preserve original zeros
@@ -354,10 +354,12 @@ def test_quantize_positive_2d(rng):
     assert_raises(ValueError, em.quantize_positive_2d, input_image, 0)
     assert_raises(ValueError, em.quantize_positive_2d, input_image, 1)
 
-    out, levels, hist = em.quantize_positive_2d(np.zeros(img_shape, dtype=floating), 2)
+    out, levels, hist = em.quantize_positive_2d(
+        np.zeros(img_shape, dtype=np.float32), 2
+    )
     assert_equal(out, np.zeros(img_shape, dtype=np.int32))
 
-    out, levels, hist = em.quantize_positive_2d(np.ones(img_shape, dtype=floating), 2)
+    out, levels, hist = em.quantize_positive_2d(np.ones(img_shape, dtype=np.float32), 2)
     assert_equal(out, np.ones(img_shape, dtype=np.int32))
 
 
@@ -391,8 +393,8 @@ def test_quantize_positive_3d(rng):
     noise_amplitude = np.min([delta / 4.0, min_positive / 4.0])
     sz = np.size(true_quantization)
     noise = rng.random(sz).reshape(img_shape) * noise_amplitude
-    noise = noise.astype(floating)
-    input_image = np.ndarray(img_shape, dtype=floating)
+    noise = noise.astype(np.float32)
+    input_image = np.ndarray(img_shape, dtype=np.float32)
     # assign intensities plus noise
     input_image[...] = true_levels[true_quantization] + noise
     # preserve original zeros
@@ -414,10 +416,12 @@ def test_quantize_positive_3d(rng):
     assert_raises(ValueError, em.quantize_positive_3d, input_image, 0)
     assert_raises(ValueError, em.quantize_positive_3d, input_image, 1)
 
-    out, levels, hist = em.quantize_positive_3d(np.zeros(img_shape, dtype=floating), 2)
+    out, levels, hist = em.quantize_positive_3d(
+        np.zeros(img_shape, dtype=np.float32), 2
+    )
     assert_equal(out, np.zeros(img_shape, dtype=np.int32))
 
-    out, levels, hist = em.quantize_positive_3d(np.ones(img_shape, dtype=floating), 2)
+    out, levels, hist = em.quantize_positive_3d(np.ones(img_shape, dtype=np.float32), 2)
     assert_equal(out, np.ones(img_shape, dtype=np.int32))
 
 
@@ -432,7 +436,7 @@ def test_compute_masked_class_stats_2d(rng):
     labels[0, 0] = 1
 
     # Create random values
-    values = rng.standard_normal((shape[0], shape[1])).astype(floating)
+    values = rng.standard_normal((shape[0], shape[1])).astype(np.float32)
     values *= labels
     values += labels
 
@@ -459,7 +463,7 @@ def test_compute_masked_class_stats_3d(rng):
     labels[0, 0, 0] = 1
 
     # Create random values
-    values = rng.standard_normal((shape[0], shape[1], shape[2])).astype(floating)
+    values = rng.standard_normal((shape[0], shape[1], shape[2])).astype(np.float32)
     values *= labels
     values += labels
 

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -8,8 +8,6 @@ from numpy.testing import (
 )
 
 from dipy.align import (
-    VerbosityLevels,
-    floating,
     imwarp as imwarp,
     metrics as metrics,
     vector_fields as vfu,
@@ -19,6 +17,7 @@ from dipy.core.interpolation import interpolate_scalar_2d, interpolate_scalar_3d
 from dipy.data import get_fnames
 from dipy.testing.decorators import set_random_number_generator
 from dipy.tracking.streamline import deform_streamlines
+from dipy.utils import VerbosityLevels
 
 
 def test_mult_aff():
@@ -74,10 +73,10 @@ def test_diffeomorphic_map_2d(rng):
         np.array(codomain_shape, dtype=np.int32),
         codomain_grid2world,
     )
-    disp = np.array(disp, dtype=floating)
+    disp = np.array(disp, dtype=np.float32)
     assign = np.array(assign)
     # create a random image (with decimal digits) to warp
-    moving_image = np.ndarray(codomain_shape, dtype=floating)
+    moving_image = np.ndarray(codomain_shape, dtype=np.float32)
     ns = np.size(moving_image)
     moving_image[...] = rng.integers(0, 10, ns).reshape(codomain_shape)
     # set boundary values to zero so we don't test wrong interpolation due
@@ -106,7 +105,7 @@ def test_diffeomorphic_map_2d(rng):
     # Verify that the transform method accepts different image types (note that
     # the actual image contained integer values, we don't want to test
     # rounding)
-    for _type in [floating, np.float64, np.int64, np.int32]:
+    for _type in [np.float32, np.float64, np.int64, np.int32]:
         moving_image = moving_image.astype(_type)
 
         # warp using linear interpolation
@@ -141,7 +140,7 @@ def test_diffeomorphic_map_2d(rng):
         prealign=None,
     )
     diff_map.backward = disp
-    for _type in [floating, np.float64, np.int64, np.int32]:
+    for _type in [np.float32, np.float64, np.int64, np.int32]:
         moving_image = moving_image.astype(_type)
 
         # warp using linear interpolation
@@ -250,8 +249,8 @@ def test_diffeomorphic_map_simplification_2d():
         codomain_grid2world=C,
         prealign=P,
     )
-    diff_map.forward = np.array(d, dtype=floating)
-    diff_map.backward = np.array(dinv, dtype=floating)
+    diff_map.forward = np.array(d, dtype=np.float32)
+    diff_map.backward = np.array(dinv, dtype=np.float32)
     # Warp the circle to obtain the expected image
     expected = diff_map.transform(circle, interpolation="linear")
 
@@ -324,8 +323,8 @@ def test_diffeomorphic_map_simplification_3d():
         codomain_grid2world=C,
         prealign=P,
     )
-    diff_map.forward = np.array(d, dtype=floating)
-    diff_map.backward = np.array(dinv, dtype=floating)
+    diff_map.forward = np.array(d, dtype=np.float32)
+    diff_map.backward = np.array(dinv, dtype=np.float32)
     # Warp the sphere to obtain the expected image
     expected = diff_map.transform(sphere, interpolation="linear")
 
@@ -425,8 +424,8 @@ def test_ssd_2d_demons():
 
     moving = np.load(fname_moving)
     static = np.load(fname_static)
-    moving = np.array(moving, dtype=floating)
-    static = np.array(static, dtype=floating)
+    moving = np.array(moving, dtype=np.float32)
+    static = np.array(static, dtype=np.float32)
     moving = (moving - moving.min()) / (moving.max() - moving.min())
     static = (static - static.min()) / (static.max() - static.min())
     # Create the SSD metric
@@ -497,8 +496,8 @@ def test_ssd_2d_gauss_newton():
 
     moving = np.load(fname_moving)
     static = np.load(fname_static)
-    moving = np.array(moving, dtype=floating)
-    static = np.array(static, dtype=floating)
+    moving = np.array(moving, dtype=np.float32)
+    static = np.array(static, dtype=np.float32)
     moving = (moving - moving.min()) / (moving.max() - moving.min())
     static = (static - static.min()) / (static.max() - static.min())
     # Create the SSD metric
@@ -600,8 +599,8 @@ def get_warped_stacked_image(image, nslices, b, m):
     shape = image.shape
     # create a synthetic invertible map and warp the circle
     d, dinv = vfu.create_harmonic_fields_2d(shape[0], shape[1], b, m)
-    d = np.asarray(d, dtype=floating)
-    dinv = np.asarray(dinv, dtype=floating)
+    d = np.asarray(d, dtype=np.float32)
+    dinv = np.asarray(dinv, dtype=np.float32)
     mapping = DiffeomorphicMap(2, shape)
     mapping.forward, mapping.backward = d, dinv
     wimage = mapping.transform(image)
@@ -610,7 +609,7 @@ def get_warped_stacked_image(image, nslices, b, m):
         return image, wimage
 
     # normalize and form the 3d by piling slices
-    image = image.astype(floating)
+    image = image.astype(np.float32)
     image = (image - image.min()) / (image.max() - image.min())
     zero_slices = nslices // 3
     vol = np.zeros(shape=image.shape + (nslices,))
@@ -624,12 +623,12 @@ def get_warped_stacked_image(image, nslices, b, m):
 def get_synthetic_warped_circle(nslices):
     # get a subsampled circle
     fname_circle = get_fnames(name="reg_o")
-    circle = np.load(fname_circle)[::4, ::4].astype(floating)
+    circle = np.load(fname_circle)[::4, ::4].astype(np.float32)
 
     # create a synthetic invertible map and warp the circle
     d, dinv = vfu.create_harmonic_fields_2d(64, 64, 0.1, 4)
-    d = np.asarray(d, dtype=floating)
-    dinv = np.asarray(dinv, dtype=floating)
+    d = np.asarray(d, dtype=np.float32)
+    dinv = np.asarray(dinv, dtype=np.float32)
     mapping = DiffeomorphicMap(2, (64, 64))
     mapping.forward, mapping.backward = d, dinv
     wcircle = mapping.transform(circle)
@@ -639,14 +638,14 @@ def get_synthetic_warped_circle(nslices):
 
     # normalize and form the 3d by piling slices
     circle = (circle - circle.min()) / (circle.max() - circle.min())
-    circle_3d = np.ndarray(circle.shape + (nslices,), dtype=floating)
+    circle_3d = np.ndarray(circle.shape + (nslices,), dtype=np.float32)
     circle_3d[...] = circle[..., None]
     circle_3d[..., 0] = 0
     circle_3d[..., -1] = 0
 
     # do the same with the warped circle
     wcircle = (wcircle - wcircle.min()) / (wcircle.max() - wcircle.min())
-    wcircle_3d = np.ndarray(wcircle.shape + (nslices,), dtype=floating)
+    wcircle_3d = np.ndarray(wcircle.shape + (nslices,), dtype=np.float32)
     wcircle_3d[...] = wcircle[..., None]
     wcircle_3d[..., 0] = 0
     wcircle_3d[..., -1] = 0
@@ -1162,7 +1161,7 @@ def test_coordinate_mapping(rng):
             np.array(codomain_shape, dtype=np.int32),
             codomain_grid2world,
         )
-        disp = disp.astype(floating)
+        disp = disp.astype(np.float32)
         # Create a DiffeomorphicMap instance
         diff_map = imwarp.DiffeomorphicMap(
             dim,

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 from scipy import ndimage
 
-from dipy.align import floating
 from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
 from dipy.testing.decorators import set_random_number_generator
 
@@ -54,7 +53,7 @@ def test_EMMetric_image_dynamics(rng):
 
     target_shape = (10, 10)
     # create a random image
-    image = np.ndarray(target_shape, dtype=floating)
+    image = np.ndarray(target_shape, dtype=np.float32)
     image[...] = rng.integers(0, 10, np.size(image)).reshape(tuple(target_shape))
     # compute the expected binary mask
     expected = (image > 0).astype(np.int32)
@@ -119,14 +118,14 @@ def test_em_demons_step_2d():
     sigma_i_sq = (F - G) ** 2
     # Set the properties relevant to the demons methods
     metric.smooth = 3.0
-    metric.gradient_static = np.array(grad_F, dtype=floating)
-    metric.gradient_moving = np.array(grad_G, dtype=floating)
-    metric.static_image = np.array(F, dtype=floating)
-    metric.moving_image = np.array(G, dtype=floating)
-    metric.staticq_means_field = np.array(F, dtype=floating)
-    metric.staticq_sigma_sq_field = np.array(sigma_i_sq, dtype=floating)
-    metric.movingq_means_field = np.array(G, dtype=floating)
-    metric.movingq_sigma_sq_field = np.array(sigma_i_sq, dtype=floating)
+    metric.gradient_static = np.array(grad_F, dtype=np.float32)
+    metric.gradient_moving = np.array(grad_G, dtype=np.float32)
+    metric.static_image = np.array(F, dtype=np.float32)
+    metric.moving_image = np.array(G, dtype=np.float32)
+    metric.staticq_means_field = np.array(F, dtype=np.float32)
+    metric.staticq_sigma_sq_field = np.array(sigma_i_sq, dtype=np.float32)
+    metric.movingq_means_field = np.array(G, dtype=np.float32)
+    metric.movingq_sigma_sq_field = np.array(sigma_i_sq, dtype=np.float32)
 
     # compute the step using the implementation under test
     actual_forward = metric.compute_demons_step(forward_step=True)
@@ -213,14 +212,14 @@ def test_em_demons_step_3d():
     sigma_i_sq = (F - G) ** 2
     # Set the properties relevant to the demons methods
     metric.smooth = 3.0
-    metric.gradient_static = np.array(grad_F, dtype=floating)
-    metric.gradient_moving = np.array(grad_G, dtype=floating)
-    metric.static_image = np.array(F, dtype=floating)
-    metric.moving_image = np.array(G, dtype=floating)
-    metric.staticq_means_field = np.array(F, dtype=floating)
-    metric.staticq_sigma_sq_field = np.array(sigma_i_sq, dtype=floating)
-    metric.movingq_means_field = np.array(G, dtype=floating)
-    metric.movingq_sigma_sq_field = np.array(sigma_i_sq, dtype=floating)
+    metric.gradient_static = np.array(grad_F, dtype=np.float32)
+    metric.gradient_moving = np.array(grad_G, dtype=np.float32)
+    metric.static_image = np.array(F, dtype=np.float32)
+    metric.moving_image = np.array(G, dtype=np.float32)
+    metric.staticq_means_field = np.array(F, dtype=np.float32)
+    metric.staticq_sigma_sq_field = np.array(sigma_i_sq, dtype=np.float32)
+    metric.movingq_means_field = np.array(G, dtype=np.float32)
+    metric.movingq_sigma_sq_field = np.array(sigma_i_sq, dtype=np.float32)
 
     # compute the step using the implementation under test
     actual_forward = metric.compute_demons_step(forward_step=True)

--- a/dipy/align/tests/test_scalespace.py
+++ b/dipy/align/tests/test_scalespace.py
@@ -2,7 +2,6 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 import scipy as sp
 
-from dipy.align import floating
 from dipy.align.imwarp import get_direction_and_spacings
 from dipy.align.scalespace import IsotropicScaleSpace, ScaleSpace
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
@@ -73,7 +72,7 @@ def test_scale_space():
 def test_scale_space_exceptions(rng):
     target_shape = (32, 32)
     # create a random image
-    image = np.ndarray(target_shape, dtype=floating)
+    image = np.ndarray(target_shape, dtype=np.float32)
     ns = np.size(image)
     image[...] = rng.integers(0, 10, ns).reshape(tuple(target_shape))
     zeros = (image == 0).astype(np.int32)

--- a/dipy/align/tests/test_sumsqdiff.py
+++ b/dipy/align/tests/test_sumsqdiff.py
@@ -6,7 +6,7 @@ from numpy.testing import (
     assert_equal,
 )
 
-from dipy.align import floating, sumsqdiff as ssd
+from dipy.align import sumsqdiff as ssd
 from dipy.testing.decorators import set_random_number_generator
 
 
@@ -151,11 +151,11 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
     grad_G = X - c_g
 
     Fnoise = rng.random(np.size(grad_F)).reshape(grad_F.shape) * grad_F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     grad_F += Fnoise
 
     Gnoise = rng.random(np.size(grad_G)).reshape(grad_G.shape) * grad_G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     grad_G += Gnoise
 
     # The squared norm of grad_G
@@ -166,17 +166,17 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
     G = 0.5 * sq_norm_grad_G
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
-    delta_field = np.array(F - G, dtype=floating)
+    delta_field = np.array(F - G, dtype=np.float32)
 
     sigma_field = rng.standard_normal(delta_field.size).reshape(delta_field.shape)
-    sigma_field = sigma_field.astype(floating)
+    sigma_field = sigma_field.astype(np.float32)
 
     # Select some pixels to force sigma_field = infinite
     inf_sigma = rng.integers(0, 2, sh[0] * sh[1])
@@ -184,7 +184,7 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
     sigma_field[inf_sigma == 1] = np.inf
 
     # Select an initial displacement field
-    d = rng.standard_normal(grad_G.size).reshape(grad_G.shape).astype(floating)
+    d = rng.standard_normal(grad_G.size).reshape(grad_G.shape).astype(np.float32)
     lambda_param = 1.5
 
     # Implementation under test
@@ -232,7 +232,7 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
         actual = iut(
             delta_field,
             sigma_field,
-            grad_G.astype(floating),
+            grad_G.astype(np.float32),
             target,
             lambda_param,
             d,
@@ -240,13 +240,13 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
         )
         assert_allclose(actual, expected, rtol=rtol, atol=atol)
         # destroy previous result
-        actual = np.ndarray(actual.shape, dtype=floating)
+        actual = np.ndarray(actual.shape, dtype=np.float32)
 
         # Test residual field computation starting with residual is not None
         iut(
             delta_field,
             sigma_field,
-            grad_G.astype(floating),
+            grad_G.astype(np.float32),
             target,
             lambda_param,
             d,
@@ -263,7 +263,7 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
             iterate_residual_field_ssd_2d(
                 delta_field,
                 sigma_field,
-                grad_G.astype(floating),
+                grad_G.astype(np.float32),
                 residual,
                 lambda_param,
                 expected,
@@ -273,7 +273,7 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
             ssd.iterate_residual_displacement_field_ssd_2d(
                 delta_field,
                 sigma_field,
-                grad_G.astype(floating),
+                grad_G.astype(np.float32),
                 residual,
                 lambda_param,
                 actual,
@@ -306,11 +306,11 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
     grad_G = X - c_g
 
     Fnoise = rng.random(np.size(grad_F)).reshape(grad_F.shape) * grad_F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     grad_F += Fnoise
 
     Gnoise = rng.random(np.size(grad_G)).reshape(grad_G.shape) * grad_G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     grad_G += Gnoise
 
     # The squared norm of grad_G
@@ -321,17 +321,17 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
     G = 0.5 * sq_norm_grad_G
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
-    delta_field = np.array(F - G, dtype=floating)
+    delta_field = np.array(F - G, dtype=np.float32)
 
     sigma_field = rng.random(delta_field.size).reshape(delta_field.shape)
-    sigma_field = sigma_field.astype(floating)
+    sigma_field = sigma_field.astype(np.float32)
 
     # Select some pixels to force sigma_field = infinite
     inf_sigma = rng.integers(0, 2, sh[0] * sh[1] * sh[2])
@@ -339,7 +339,7 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
     sigma_field[inf_sigma == 1] = np.inf
 
     # Select an initial displacement field
-    d = rng.random(grad_G.size).reshape(grad_G.shape).astype(floating)
+    d = rng.random(grad_G.size).reshape(grad_G.shape).astype(np.float32)
     lambda_param = 1.5
 
     # Implementation under test
@@ -389,7 +389,7 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
         actual = iut(
             delta_field,
             sigma_field,
-            grad_G.astype(floating),
+            grad_G.astype(np.float32),
             target,
             lambda_param,
             d,
@@ -397,13 +397,13 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
         )
         assert_allclose(actual, expected, rtol=rtol, atol=atol)
         # destroy previous result
-        actual = np.ndarray(actual.shape, dtype=floating)
+        actual = np.ndarray(actual.shape, dtype=np.float32)
 
         # Test residual field computation starting with residual is not None
         iut(
             delta_field,
             sigma_field,
-            grad_G.astype(floating),
+            grad_G.astype(np.float32),
             target,
             lambda_param,
             d,
@@ -420,7 +420,7 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
             iterate_residual_field_ssd_3d(
                 delta_field,
                 sigma_field,
-                grad_G.astype(floating),
+                grad_G.astype(np.float32),
                 residual,
                 lambda_param,
                 expected,
@@ -430,7 +430,7 @@ def test_compute_residual_displacement_field_ssd_3d(rng):
             ssd.iterate_residual_displacement_field_ssd_3d(
                 delta_field,
                 sigma_field,
-                grad_G.astype(floating),
+                grad_G.astype(np.float32),
                 residual,
                 lambda_param,
                 actual,
@@ -547,7 +547,7 @@ def test_compute_energy_ssd_2d():
     # being optimized). This test case should be updated after
     # further investigation
     expected = ((F - G) ** 2).sum()
-    actual = ssd.compute_energy_ssd_2d(np.array(F - G, dtype=floating))
+    actual = ssd.compute_energy_ssd_2d(np.array(F - G, dtype=np.float32))
     assert_almost_equal(expected, actual)
 
 
@@ -582,7 +582,7 @@ def test_compute_energy_ssd_3d():
     # being optimized). This test case should be updated after
     # further investigating
     expected = ((F - G) ** 2).sum()
-    actual = ssd.compute_energy_ssd_3d(np.array(F - G, dtype=floating))
+    actual = ssd.compute_energy_ssd_3d(np.array(F - G, dtype=np.float32))
     assert_almost_equal(expected, actual)
 
 
@@ -621,11 +621,11 @@ def test_compute_ssd_demons_step_2d(rng):
     grad_G = X - c_g
 
     Fnoise = rng.random(np.size(grad_F)).reshape(grad_F.shape) * grad_F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     grad_F += Fnoise
 
     Gnoise = rng.random(np.size(grad_G)).reshape(grad_G.shape) * grad_G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     grad_G += Gnoise
 
     # The squared norm of grad_G to be used later
@@ -636,14 +636,14 @@ def test_compute_ssd_demons_step_2d(rng):
     G = 0.5 * sq_norm_grad_G
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
-    delta_field = np.array(G - F, dtype=floating)
+    delta_field = np.array(G - F, dtype=np.float32)
 
     # Select some pixels to force gradient = 0 and F=G
     random_labels = rng.integers(0, 2, sh[0] * sh[1])
@@ -672,10 +672,10 @@ def test_compute_ssd_demons_step_2d(rng):
         expected[random_labels == 0, ...] = 0
 
         # Now compute it using the implementation under test
-        actual = np.empty_like(expected, dtype=floating)
+        actual = np.empty_like(expected, dtype=np.float32)
 
         ssd.compute_ssd_demons_step_2d(
-            delta_field, np.array(grad_G, dtype=floating), sigma_x_sq, actual
+            delta_field, np.array(grad_G, dtype=np.float32), sigma_x_sq, actual
         )
 
         assert_array_almost_equal(actual, expected)
@@ -719,11 +719,11 @@ def test_compute_ssd_demons_step_3d(rng):
     grad_G = X - c_g
 
     Fnoise = rng.random(np.size(grad_F)).reshape(grad_F.shape) * grad_F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     grad_F += Fnoise
 
     Gnoise = rng.random(np.size(grad_G)).reshape(grad_G.shape) * grad_G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     grad_G += Gnoise
 
     # The squared norm of grad_G to be used later
@@ -734,14 +734,14 @@ def test_compute_ssd_demons_step_3d(rng):
     G = 0.5 * sq_norm_grad_G
 
     Fnoise = rng.random(np.size(F)).reshape(F.shape) * F.max() * 0.1
-    Fnoise = Fnoise.astype(floating)
+    Fnoise = Fnoise.astype(np.float32)
     F += Fnoise
 
     Gnoise = rng.random(np.size(G)).reshape(G.shape) * G.max() * 0.1
-    Gnoise = Gnoise.astype(floating)
+    Gnoise = Gnoise.astype(np.float32)
     G += Gnoise
 
-    delta_field = np.array(G - F, dtype=floating)
+    delta_field = np.array(G - F, dtype=np.float32)
 
     # Select some pixels to force gradient = 0 and F=G
     random_labels = rng.integers(0, 2, sh[0] * sh[1] * sh[2])
@@ -771,10 +771,10 @@ def test_compute_ssd_demons_step_3d(rng):
         expected[random_labels == 0, ...] = 0
 
         # Now compute it using the implementation under test
-        actual = np.empty_like(expected, dtype=floating)
+        actual = np.empty_like(expected, dtype=np.float32)
 
         ssd.compute_ssd_demons_step_3d(
-            delta_field, np.array(grad_G, dtype=floating), sigma_x_sq, actual
+            delta_field, np.array(grad_G, dtype=np.float32), sigma_x_sq, actual
         )
 
         assert_array_almost_equal(actual, expected)

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -9,7 +9,7 @@ from numpy.testing import (
 )
 from scipy.ndimage import map_coordinates
 
-from dipy.align import floating, imwarp, vector_fields as vfu
+from dipy.align import imwarp, vector_fields as vfu
 from dipy.align.parzenhist import sample_domain_regular
 from dipy.align.transforms import regtransforms
 from dipy.core import geometry
@@ -58,7 +58,7 @@ def test_random_displacement_field_2d(rng):
                 to_grid2world,
                 rng=rng,
             )
-            field = np.array(field, dtype=floating)
+            field = np.array(field, dtype=np.float32)
             assignment = np.array(assignment)
             # Verify the assignments are inside the requested region
             assert_equal(0, (assignment < 0).sum())
@@ -154,7 +154,7 @@ def test_random_displacement_field_3d(rng):
                 to_grid2world,
                 rng=rng,
             )
-            field = np.array(field, dtype=floating)
+            field = np.array(field, dtype=np.float32)
             assignment = np.array(assignment)
             # Verify the assignments are inside the requested region
             assert_equal(0, (assignment < 0).sum())
@@ -309,11 +309,11 @@ def test_warping_2d():
     # Create an image of a circle
     radius = 24
     circle = vfu.create_circle(nr, nc, radius)
-    circle = np.array(circle, dtype=floating)
+    circle = np.array(circle, dtype=np.float32)
 
     # Create a displacement field for warping
     d, dinv = vfu.create_harmonic_fields_2d(nr, nc, 0.2, 8)
-    d = np.asarray(d).astype(floating)
+    d = np.asarray(d).astype(np.float32)
 
     # Create grid coordinates
     x_0 = np.asarray(range(sh[0]))
@@ -356,7 +356,7 @@ def test_warping_2d():
             # transform
             dcopy = np.copy(d)
             vfu.reorient_vector_field_2d(dcopy, field_grid2world)
-            extended_dcopy = np.zeros((nr + 2, nc + 2, 2), dtype=floating)
+            extended_dcopy = np.zeros((nr + 2, nc + 2, 2), dtype=np.float32)
             extended_dcopy[1 : nr + 1, 1 : nc + 1, :] = dcopy
 
             # Compute the warping coordinates (see warp_2d documentation)
@@ -473,11 +473,11 @@ def test_warping_3d():
     # Create an image of a sphere
     radius = 24
     sphere = vfu.create_sphere(ns, nr, nc, radius)
-    sphere = np.array(sphere, dtype=floating)
+    sphere = np.array(sphere, dtype=np.float32)
 
     # Create a displacement field for warping
     d, dinv = vfu.create_harmonic_fields_3d(ns, nr, nc, 0.2, 8)
-    d = np.asarray(d).astype(floating)
+    d = np.asarray(d).astype(np.float32)
 
     # Create grid coordinates
     x_0 = np.asarray(range(sh[0]))
@@ -528,7 +528,7 @@ def test_warping_3d():
             dcopy = np.copy(d)
             vfu.reorient_vector_field_3d(dcopy, field_grid2world)
 
-            extended_dcopy = np.zeros((ns + 2, nr + 2, nc + 2, 3), dtype=floating)
+            extended_dcopy = np.zeros((ns + 2, nr + 2, nc + 2, 3), dtype=np.float32)
             extended_dcopy[1 : ns + 1, 1 : nr + 1, 1 : nc + 1, :] = dcopy
 
             # Compute the warping coordinates (see warp_2d documentation)
@@ -647,7 +647,7 @@ def test_affine_transforms_2d():
     # Create an image of a circle
     radius = 16
     circle = vfu.create_circle(codomain_shape[0], codomain_shape[1], radius)
-    circle = np.array(circle, dtype=floating)
+    circle = np.array(circle, dtype=np.float32)
 
     # Create grid coordinates
     x_0 = np.asarray(range(d_shape[0]))
@@ -733,7 +733,7 @@ def test_affine_transforms_3d():
     sphere = vfu.create_sphere(
         codomain_shape[0], codomain_shape[1], codomain_shape[2], radius
     )
-    sphere = np.array(sphere, dtype=floating)
+    sphere = np.array(sphere, dtype=np.float32)
 
     # Create grid coordinates
     x_0 = np.asarray(range(d_shape[0]))
@@ -841,7 +841,7 @@ def test_compose_vector_fields_2d(rng):
         target_grid2world,
         rng=rng,
     )
-    disp1 = np.array(disp1, dtype=floating)
+    disp1 = np.array(disp1, dtype=np.float32)
     assign1 = np.array(assign1)
 
     disp2, assign2 = vfu.create_random_displacement_2d(
@@ -851,11 +851,11 @@ def test_compose_vector_fields_2d(rng):
         target_grid2world,
         rng=rng,
     )
-    disp2 = np.array(disp2, dtype=floating)
+    disp2 = np.array(disp2, dtype=np.float32)
     assign2 = np.array(assign2)
 
     # create a random image (with decimal digits) to warp
-    moving_image = np.empty(tgt_sh, dtype=floating)
+    moving_image = np.empty(tgt_sh, dtype=np.float32)
     moving_image[...] = rng.integers(0, 10, np.size(moving_image)).reshape(
         tuple(tgt_sh)
     )
@@ -948,7 +948,7 @@ def test_compose_vector_fields_2d(rng):
     random_labels = rng.integers(0, 2, input_shape[0] * input_shape[1] * 2)
     random_labels = random_labels.reshape(input_shape + (2,))
     values = np.array([-1, tgt_sh[0]])
-    disp1 = (values[random_labels] - X).astype(floating)
+    disp1 = (values[random_labels] - X).astype(np.float32)
     composition, stats = vfu.compose_vector_fields_2d(
         disp1, disp2, None, None, 1.0, None
     )
@@ -1020,7 +1020,7 @@ def test_compose_vector_fields_3d(rng):
         target_grid2world,
         rng=rng,
     )
-    disp1 = np.array(disp1, dtype=floating)
+    disp1 = np.array(disp1, dtype=np.float32)
     assign1 = np.array(assign1)
 
     disp2, assign2 = vfu.create_random_displacement_3d(
@@ -1030,11 +1030,11 @@ def test_compose_vector_fields_3d(rng):
         target_grid2world,
         rng=rng,
     )
-    disp2 = np.array(disp2, dtype=floating)
+    disp2 = np.array(disp2, dtype=np.float32)
     assign2 = np.array(assign2)
 
     # create a random image (with decimal digits) to warp
-    moving_image = np.empty(tgt_sh, dtype=floating)
+    moving_image = np.empty(tgt_sh, dtype=np.float32)
     moving_image[...] = rng.integers(0, 10, np.size(moving_image)).reshape(
         tuple(tgt_sh)
     )
@@ -1133,7 +1133,7 @@ def test_compose_vector_fields_3d(rng):
     random_labels = rng.integers(0, 2, sz)
     random_labels = random_labels.reshape(input_shape + (3,))
     values = np.array([-1, tgt_sh[0]])
-    disp1 = (values[random_labels] - X).astype(floating)
+    disp1 = (values[random_labels] - X).astype(np.float32)
     composition, stats = vfu.compose_vector_fields_3d(
         disp1, disp2, None, None, 1.0, None
     )
@@ -1183,7 +1183,7 @@ def test_invert_vector_field_2d():
     trans_inv = np.linalg.inv(trans)
 
     d, _ = vfu.create_harmonic_fields_2d(nr, nc, 0.2, 8)
-    d = np.asarray(d).astype(floating)
+    d = np.asarray(d).astype(np.float32)
 
     for theta in [-1 * np.pi / 5.0, 0.0, np.pi / 5.0]:  # rotation angle
         for s in [0.5, 1.0, 2.0]:  # scale
@@ -1248,7 +1248,7 @@ def test_invert_vector_field_3d():
     trans_inv = np.linalg.inv(trans)
 
     d, _ = vfu.create_harmonic_fields_3d(ns, nr, nc, 0.2, 8)
-    d = np.asarray(d).astype(floating)
+    d = np.asarray(d).astype(np.float32)
 
     for theta in [-1 * np.pi / 5.0, 0.0, np.pi / 5.0]:  # rotation angle
         for s in [0.5, 1.0, 2.0]:  # scale
@@ -1308,7 +1308,7 @@ def test_resample_vector_field_2d():
     reduced_shape = np.array((32, 32), dtype=np.int32)
     factors = np.array([0.5, 0.5])
     d, dinv = vfu.create_harmonic_fields_2d(reduced_shape[0], reduced_shape[1], 0.3, 6)
-    d = np.array(d, dtype=floating)
+    d = np.array(d, dtype=np.float32)
 
     expanded = vfu.resample_displacement_field_2d(d, factors, domain_shape)
     subsampled = expanded[::2, ::2, :]
@@ -1327,7 +1327,7 @@ def test_resample_vector_field_3d():
     d, dinv = vfu.create_harmonic_fields_3d(
         reduced_shape[0], reduced_shape[1], reduced_shape[2], 0.3, 6
     )
-    d = np.array(d, dtype=floating)
+    d = np.array(d, dtype=np.float32)
 
     expanded = vfu.resample_displacement_field_3d(d, factors, domain_shape)
     subsampled = expanded[::2, ::2, ::2, :]
@@ -1343,7 +1343,7 @@ def test_downsample_scalar_field_2d(rng):
         nr = size - 1 if reduce_r else size
         for reduce_c in [True, False]:
             nc = size - 1 if reduce_c else size
-            image = np.empty((size, size), dtype=floating)
+            image = np.empty((size, size), dtype=np.float32)
             image[...] = rng.integers(0, 10, np.size(image)).reshape(sh)
 
             if reduce_r:
@@ -1375,7 +1375,7 @@ def test_downsample_displacement_field_2d(rng):
         nr = size - 1 if reduce_r else size
         for reduce_c in [True, False]:
             nc = size - 1 if reduce_c else size
-            field = np.empty((size, size, 2), dtype=floating)
+            field = np.empty((size, size, 2), dtype=np.float32)
             field[...] = rng.integers(0, 10, np.size(field)).reshape(sh)
 
             if reduce_r:
@@ -1409,7 +1409,7 @@ def test_downsample_scalar_field_3d(rng):
             nr = size - 1 if reduce_r else size
             for reduce_c in [True, False]:
                 nc = size - 1 if reduce_c else size
-                image = np.empty((size, size, size), dtype=floating)
+                image = np.empty((size, size, size), dtype=np.float32)
                 image[...] = rng.integers(0, 10, np.size(image)).reshape(sh)
 
                 if reduce_s:
@@ -1451,7 +1451,7 @@ def test_downsample_displacement_field_3d(rng):
             nr = size - 1 if reduce_r else size
             for reduce_c in [True, False]:
                 nc = size - 1 if reduce_c else size
-                field = np.empty((size, size, size, 3), dtype=floating)
+                field = np.empty((size, size, size, 3), dtype=np.float32)
                 field[...] = rng.integers(0, 10, np.size(field)).reshape(sh)
 
                 if reduce_s:
@@ -1486,10 +1486,10 @@ def test_downsample_displacement_field_3d(rng):
 def test_reorient_vector_field_2d():
     shape = (16, 16)
     d, dinv = vfu.create_harmonic_fields_2d(shape[0], shape[1], 0.2, 4)
-    d = np.array(d, dtype=floating)
+    d = np.array(d, dtype=np.float32)
 
     # the vector field rotated 90 degrees
-    expected = np.empty(shape=shape + (2,), dtype=floating)
+    expected = np.empty(shape=shape + (2,), dtype=np.float32)
     expected[..., 0] = -1 * d[..., 1]
     expected[..., 1] = d[..., 0]
 
@@ -1510,11 +1510,11 @@ def test_reorient_vector_field_2d():
 def test_reorient_vector_field_3d():
     sh = (16, 16, 16)
     d, dinv = vfu.create_harmonic_fields_3d(sh[0], sh[1], sh[2], 0.2, 4)
-    d = np.array(d, dtype=floating)
-    dinv = np.array(dinv, dtype=floating)
+    d = np.array(d, dtype=np.float32)
+    dinv = np.array(dinv, dtype=np.float32)
 
     # the vector field rotated 90 degrees around the last axis
-    expected = np.empty(shape=sh + (3,), dtype=floating)
+    expected = np.empty(shape=sh + (3,), dtype=np.float32)
     expected[..., 0] = -1 * d[..., 1]
     expected[..., 1] = d[..., 0]
     expected[..., 2] = d[..., 2]
@@ -1555,14 +1555,14 @@ def test_reorient_random_vector_fields(rng):
     ):
         size = [20, 30, 40][:n_dims] + [n_dims]
         arr = rng.normal(size=size)
-        arr_32 = arr.astype(floating)
+        arr_32 = arr.astype(np.float32)
         affine = from_matvec(rng.normal(size=(n_dims, n_dims)), np.zeros(n_dims))
         func(arr_32, affine)
         assert_almost_equal(arr_32, apply_affine(affine, arr), 6)
         # Reorient reorients without translation
         trans = np.arange(n_dims) + 2
         affine[:-1, -1] = trans
-        arr_32 = arr.astype(floating)
+        arr_32 = arr.astype(np.float32)
         func(arr_32, affine)
         assert_almost_equal(arr_32, apply_affine(affine, arr) - trans, 6)
 
@@ -1595,14 +1595,14 @@ def test_gradient_2d(rng):
     b = 5e-3
     c = 7e-3
     img = a * TX[..., 0] ** 2 + b * TX[..., 0] * TX[..., 1] + c * TX[..., 1] ** 2
-    img = img.astype(floating)
+    img = img.astype(np.float32)
     # img is an image sampled at X with grid-to-space transform T
 
     # Test sparse gradient: choose some sample points (in space)
     sample = sample_domain_regular(20, np.array(sh, dtype=np.int32), T, rng=rng)
     sample = np.array(sample)
     # Compute the analytical gradient at all points
-    expected = np.empty((sample.shape[0], 2), dtype=floating)
+    expected = np.empty((sample.shape[0], 2), dtype=np.float32)
     expected[..., 0] = 2 * a * sample[:, 0] + b * sample[:, 1]
     expected[..., 1] = 2 * c * sample[:, 1] + b * sample[:, 0]
     # Get the numerical gradient with the implementation under test
@@ -1624,7 +1624,7 @@ def test_gradient_2d(rng):
 
     # Test dense gradient
     # Compute the analytical gradient at all points
-    expected = np.empty(sh + (2,), dtype=floating)
+    expected = np.empty(sh + (2,), dtype=np.float32)
     expected[..., 0] = 2 * a * TX[..., 0] + b * TX[..., 1]
     expected[..., 1] = 2 * c * TX[..., 1] + b * TX[..., 0]
     # Get the numerical gradient with the implementation under test
@@ -1678,12 +1678,12 @@ def test_gradient_3d(rng):
         + f * TX[..., 1] * TX[..., 2]
     )
 
-    img = img.astype(floating)
+    img = img.astype(np.float32)
     # Test sparse gradient: choose some sample points (in space)
     sample = sample_domain_regular(100, np.array(shape, dtype=np.int32), T, rng=rng)
     sample = np.array(sample)
     # Compute the analytical gradient at all points
-    expected = np.empty((sample.shape[0], 3), dtype=floating)
+    expected = np.empty((sample.shape[0], 3), dtype=np.float32)
     expected[..., 0] = 2 * a * sample[:, 0] + d * sample[:, 1] + e * sample[:, 2]
     expected[..., 1] = 2 * b * sample[:, 1] + d * sample[:, 0] + f * sample[:, 2]
     expected[..., 2] = 2 * c * sample[:, 2] + e * sample[:, 0] + f * sample[:, 1]
@@ -1707,7 +1707,7 @@ def test_gradient_3d(rng):
 
     # Test dense gradient
     # Compute the analytical gradient at all points
-    expected = np.empty(shape + (3,), dtype=floating)
+    expected = np.empty(shape + (3,), dtype=np.float32)
     expected[..., 0] = 2 * a * TX[..., 0] + d * TX[..., 1] + e * TX[..., 2]
     expected[..., 1] = 2 * b * TX[..., 1] + d * TX[..., 0] + f * TX[..., 2]
     expected[..., 2] = 2 * c * TX[..., 2] + e * TX[..., 0] + f * TX[..., 1]

--- a/dipy/align/utils.py
+++ b/dipy/align/utils.py
@@ -1,0 +1,31 @@
+from enum import IntEnum
+
+import numpy as np
+
+FLOAT_DTYPE = np.float32
+
+
+class RegistrationStages(IntEnum):
+    """Callback stages for volumetric registration.
+
+    The stage value is passed to the callback function so it can react
+    accordingly.
+
+    INIT_START : optimizer initialization starts
+    INIT_END : optimizer initialization ends
+    OPT_START : optimization starts
+    OPT_END : optimization ends
+    SCALE_START : optimization at a new scale space resolution starts
+    SCALE_END : optimization at the current scale space resolution ends
+    ITER_START : a new iteration starts
+    ITER_END : the current iteration ends
+    """
+
+    INIT_START = 0
+    INIT_END = 1
+    OPT_START = 2
+    OPT_END = 3
+    SCALE_START = 4
+    SCALE_END = 5
+    ITER_START = 6
+    ITER_END = 7

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.testing as npt
 from scipy.ndimage import map_coordinates
 
-from dipy.align import floating
 from dipy.core.interpolation import (
     NearestNeighborInterpolator,
     OutsideImage,
@@ -70,10 +69,10 @@ def test_trilinear_interpolate(rng):
 def test_interpolate_scalar_2d(rng):
     sz = 64
     target_shape = (sz, sz)
-    image = np.empty(target_shape, dtype=floating)
+    image = np.empty(target_shape, dtype=np.float32)
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
 
-    extended_image = np.zeros((sz + 2, sz + 2), dtype=floating)
+    extended_image = np.zeros((sz + 2, sz + 2), dtype=np.float32)
     extended_image[1 : sz + 1, 1 : sz + 1] = image[...]
 
     # Select some coordinates inside the image to interpolate at
@@ -112,7 +111,7 @@ def test_interpolate_scalar_2d(rng):
 def test_interpolate_scalar_nn_2d(rng):
     sz = 64
     target_shape = (sz, sz)
-    image = np.empty(target_shape, dtype=floating)
+    image = np.empty(target_shape, dtype=np.float32)
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
     # Select some coordinates to interpolate at
     nsamples = 200
@@ -140,7 +139,7 @@ def test_interpolate_scalar_nn_2d(rng):
 def test_interpolate_scalar_nn_3d(rng):
     sz = 64
     target_shape = (sz, sz, sz)
-    image = np.empty(target_shape, dtype=floating)
+    image = np.empty(target_shape, dtype=np.float32)
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
     # Select some coordinates to interpolate at
     nsamples = 200
@@ -168,10 +167,10 @@ def test_interpolate_scalar_nn_3d(rng):
 def test_interpolate_scalar_3d(rng):
     sz = 64
     target_shape = (sz, sz, sz)
-    image = np.empty(target_shape, dtype=floating)
+    image = np.empty(target_shape, dtype=np.float32)
     image[...] = rng.integers(0, 10, np.size(image)).reshape(target_shape)
 
-    extended_image = np.zeros((sz + 2, sz + 2, sz + 2), dtype=floating)
+    extended_image = np.zeros((sz + 2, sz + 2, sz + 2), dtype=np.float32)
     extended_image[1 : sz + 1, 1 : sz + 1, 1 : sz + 1] = image[...]
 
     # Select some coordinates inside the image to interpolate at
@@ -212,10 +211,10 @@ def test_interpolate_scalar_3d(rng):
 def test_interpolate_vector_3d(rng):
     sz = 64
     target_shape = (sz, sz, sz)
-    field = np.empty(target_shape + (3,), dtype=floating)
+    field = np.empty(target_shape + (3,), dtype=np.float32)
     field[...] = rng.integers(0, 10, np.size(field)).reshape(target_shape + (3,))
 
-    extended_field = np.zeros((sz + 2, sz + 2, sz + 2, 3), dtype=floating)
+    extended_field = np.zeros((sz + 2, sz + 2, sz + 2, 3), dtype=np.float32)
     extended_field[1 : sz + 1, 1 : sz + 1, 1 : sz + 1] = field
     # Select some coordinates to interpolate at
     nsamples = 800
@@ -262,9 +261,9 @@ def test_interpolate_vector_3d(rng):
 def test_interpolate_vector_2d(rng):
     sz = 64
     target_shape = (sz, sz)
-    field = np.empty(target_shape + (2,), dtype=floating)
+    field = np.empty(target_shape + (2,), dtype=np.float32)
     field[...] = rng.integers(0, 10, np.size(field)).reshape(target_shape + (2,))
-    extended_field = np.zeros((sz + 2, sz + 2, 2), dtype=floating)
+    extended_field = np.zeros((sz + 2, sz + 2, 2), dtype=np.float32)
     extended_field[1 : sz + 1, 1 : sz + 1] = field
     # Select some coordinates to interpolate at
     nsamples = 200

--- a/dipy/utils/__init__.py
+++ b/dipy/utils/__init__.py
@@ -1,1 +1,4 @@
 # code support utilities for dipy
+from dipy.utils.logging import VerbosityLevels
+
+__all__ = ["VerbosityLevels"]

--- a/dipy/utils/logging.py
+++ b/dipy/utils/logging.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 import logging
 import os
 import sys
@@ -122,3 +123,19 @@ def configure_logger(
 
 # Provide a default logger for convenience
 logger = get_logger()
+
+
+class VerbosityLevels(IntEnum):
+    """Verbosity levels for dipy algorithms.
+
+    NONE : do not print anything
+    STATUS : print information about the current status of the algorithm
+    DIAGNOSE : print high level information of the components involved in the
+        registration that can be used to detect a failing component
+    DEBUG : print as much information as possible to isolate the cause of a bug
+    """
+
+    NONE = 0
+    STATUS = 1
+    DIAGNOSE = 2
+    DEBUG = 3

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,7 +32,6 @@ ignore = [
 ]
 
 [lint.extend-per-file-ignores]
-"dipy/align/__init__.py" = ["E402"]
 "dipy/reconst/*.py" = ["B026"]
 "dipy/viz/__init__.py" = ["F401"]
 "doc/examples/**" = ["E402"]


### PR DESCRIPTION
## Description

This pull request removes the legacy `floating`, `Bunch`, and `VerbosityLevels` constructs from `dipy.align`, replacing them with standard Python types and enums, and updates all usages to use `np.float32` and the new locations for enums. It also introduces deprecation warnings for backward compatibility and cleans up related imports and test code. The main themes are deprecation/removal of legacy constructs and standardization of floating-point type usage.

* Added `utils.py` to the build system so that new utility enums and helpers are included.

## Motivation and Context

These changes modernize the codebase, improve maintainability, and provide a clear migration path for users of the affected APIs.

## How Has This Been Tested?

run unittest

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
