### PR TITLE
NF: integrate lanczos in reslice

### DIFF
--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -14,6 +14,139 @@ def _affine_transform(kwargs):
         return affine_transform(**kwargs)
 
 
+def _lanczos_kernel(values, num_lobes):
+    """Lanczos kernel: sinc(x) * sinc(x/a) for |x| < a, else 0.
+
+    Parameters
+    ----------
+    values : array-like
+        Input values.
+    num_lobes : int
+        Kernel support half-width. Values where ``|x| >= num_lobes`` are
+        set to 0 regardless of position in the array. Typically 2 or 3.
+
+    Returns
+    -------
+    result : ndarray
+        Kernel values at values.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    mask = np.abs(values) < num_lobes
+    return np.where(mask, np.sinc(values) * np.sinc(values / num_lobes), 0.0)
+
+
+def _lanczos_resample_1d_axis0(
+    data, scale, out_size, *, num_lobes=2, mode="constant", cval=0
+):
+    """Apply 1D Lanczos resampling along axis 0 of an N-dimensional array.
+
+    Parameters
+    ----------
+    data : ndarray, shape (in_size, ...)
+        Input array. Must be float64.
+    scale : float
+        Ratio new_zoom / old_zoom for this axis.
+    out_size : int
+        Number of output samples along axis 0.
+    num_lobes : int, optional
+        Lanczos kernel lobes (2 or 3).
+    mode : str, optional
+        Boundary mode: 'constant', 'nearest', 'reflect', or 'wrap'.
+    cval : float, optional
+        Fill value for mode='constant'.
+
+    Returns
+    -------
+    out : ndarray, shape (out_size, ...), float64
+        Resampled array.
+    """
+    valid_modes = ("constant", "nearest", "reflect", "wrap")
+    if mode not in valid_modes:
+        raise ValueError(f"Invalid mode {mode!r}. Valid modes: {valid_modes}")
+
+    in_size = data.shape[0]
+    extra_dims = data.ndim - 1
+    bc_shape = (-1,) + (1,) * extra_dims
+
+    out_idx = np.arange(out_size, dtype=np.float64)
+    in_coords = out_idx * scale
+    floor_coords = np.floor(in_coords).astype(np.intp)
+
+    result = np.zeros((out_size,) + data.shape[1:], dtype=np.float64)
+    weight_sum = np.zeros(out_size, dtype=np.float64)
+
+    for delta in range(-(num_lobes - 1), num_lobes + 1):
+        neigh = floor_coords + delta
+        w = _lanczos_kernel(in_coords - neigh, num_lobes)
+
+        if mode == "wrap":
+            sample = data[np.mod(neigh, in_size)]
+        elif mode == "reflect":
+            period = 2 * (in_size - 1) if in_size > 1 else 1
+            idx = np.mod(neigh, period)
+            idx = np.where(idx >= in_size, period - idx, idx)
+            sample = data[idx]
+        else:
+            sample = data[np.clip(neigh, 0, in_size - 1)]
+            if mode == "constant":
+                invalid = (neigh < 0) | (neigh >= in_size)
+                if invalid.any():
+                    sample = sample.copy()
+                    sample[invalid] = float(cval)
+
+        result += w.reshape(bc_shape) * sample
+        weight_sum += w
+
+    nonzero = (np.abs(weight_sum) > 1e-10).reshape(bc_shape)
+    weight_sum_bc = weight_sum.reshape(bc_shape)
+    fill = float(cval) if mode == "constant" else 0.0
+    return np.where(nonzero, result / np.where(nonzero, weight_sum_bc, 1.0), fill)
+
+
+def _lanczos_resample_3d(
+    data, scale, output_shape, *, num_lobes=2, mode="constant", cval=0
+):
+    """Resample a 3D volume using separable Lanczos interpolation.
+
+    Applies 1D Lanczos resampling along each spatial axis in sequence.
+    Separability of the Lanczos kernel makes this equivalent to the full
+    3D tensor-product kernel at a fraction of the cost.
+
+    Parameters
+    ----------
+    data : ndarray, shape (I, J, K)
+        Input 3D volume.
+    scale : ndarray, shape (3,)
+        Scaling factors per axis (new_zooms / zooms).
+    output_shape : tuple of int
+        Shape of the output volume.
+    num_lobes : int, optional
+        Lanczos kernel lobes (2 or 3).
+    mode : str, optional
+        Boundary mode: 'constant', 'nearest', 'reflect', or 'wrap'.
+    cval : float, optional
+        Fill value for mode='constant'.
+
+    Returns
+    -------
+    out : ndarray, shape output_shape, dtype matches data.dtype
+        Resampled volume.
+    """
+    vol = data.astype(np.float64)
+    for axis in range(3):
+        vol = np.moveaxis(vol, axis, 0)
+        vol = _lanczos_resample_1d_axis0(
+            vol,
+            scale[axis],
+            output_shape[axis],
+            num_lobes=num_lobes,
+            mode=mode,
+            cval=cval,
+        )
+        vol = np.moveaxis(vol, 0, axis)
+    return vol.astype(data.dtype)
+
+
 @warning_for_keywords()
 def reslice(
     data,
@@ -39,10 +172,11 @@ def reslice(
         voxel size for (i,j,k) dimensions
     new_zooms : tuple, shape (3,)
         new voxel size for (i,j,k) after resampling
-    order : int, from 0 to 5
-        order of interpolation for resampling/reslicing,
-        0 nearest interpolation, 1 trilinear etc..
-        if you don't want any smoothing 0 is the option you need.
+    order : int or str
+        Interpolation order. Integer 0–5 selects spline order via scipy
+        (0 nearest, 1 trilinear, …). String values ``'lanczos'`` or
+        ``'lanczos2'`` select a 2-lobe Lanczos kernel; ``'lanczos3'``
+        selects a 3-lobe Lanczos kernel.
     mode : string ('constant', 'nearest', 'reflect' or 'wrap')
         Points outside the boundaries of the input are filled according
         to the given mode.
@@ -53,7 +187,8 @@ def reslice(
         Split the calculation to a pool of children processes. This only
         applies to 4D `data` arrays. Default is 1. If < 0 the maximal number
         of cores minus ``num_processes + 1`` is used (enter -1 to use as many
-        cores as possible). 0 raises an error.
+        cores as possible). 0 raises an error. Ignored when order is
+        ``'lanczos'``, ``'lanczos2'``, or ``'lanczos3'``.
     new_shape : tuple, shape (3,), optional
         Sets the shape the image should take after affine transformation.
         If None, it is calculated through the affine matrix and current shape.
@@ -87,6 +222,28 @@ def reslice(
     """
     num_processes = determine_num_processes(num_processes)
 
+    lanczos_lobes = None
+    if isinstance(order, str):
+        if order in ("lanczos", "lanczos2"):
+            lanczos_lobes = 2
+        elif order == "lanczos3":
+            lanczos_lobes = 3
+        else:
+            raise ValueError(
+                f"Unknown interpolation order {order!r}. "
+                "Valid string values: 'lanczos', 'lanczos2', 'lanczos3'."
+            )
+    elif not (0 <= order <= 5):
+        raise ValueError(f"order must be 0-5, got {order!r}.")
+
+    _valid_modes_lanczos = ("constant", "nearest", "reflect", "wrap")
+    _valid_modes_scipy = ("constant", "nearest", "reflect", "mirror", "wrap")
+    _valid_modes = (
+        _valid_modes_lanczos if lanczos_lobes is not None else _valid_modes_scipy
+    )
+    if mode not in _valid_modes:
+        raise ValueError(f"Invalid mode {mode!r}. Valid modes: {_valid_modes}")
+
     # We are suppressing warnings emitted by scipy >= 0.18,
     # described in https://github.com/dipy/dipy/issues/1107.
     # These warnings are not relevant to us, as long as our offset
@@ -95,40 +252,67 @@ def reslice(
         warnings.filterwarnings("ignore", message=".*scipy.*18.*", category=UserWarning)
         new_zooms = np.array(new_zooms, dtype="f8")
         zooms = np.array(zooms, dtype="f8")
-        R = new_zooms / zooms
+        scale = new_zooms / zooms
         if new_shape is None:
             new_shape = zooms / new_zooms * np.array(data.shape[:3])
             new_shape = tuple(np.round(new_shape).astype("i8"))
-        kwargs = {
-            "matrix": R,
-            "output_shape": new_shape,
-            "order": order,
-            "mode": mode,
-            "cval": cval,
-        }
-        if data.ndim == 3:
-            data2 = affine_transform(input=data, **kwargs)
-        elif data.ndim == 4:
-            data2 = np.zeros(new_shape + (data.shape[-1],), data.dtype)
-            if num_processes == 1:
-                for i in range(data.shape[-1]):
-                    affine_transform(input=data[..., i], output=data2[..., i], **kwargs)
-            else:
-                params = []
-                for i in range(data.shape[-1]):
-                    _kwargs = {"input": data[..., i]}
-                    _kwargs.update(kwargs)
-                    params.append(_kwargs)
-                mp.set_start_method("spawn", force=True)
-                pool = mp.Pool(num_processes)
-                for i, res in enumerate(pool.imap(_affine_transform, params)):
-                    data2[..., i] = res
-                pool.close()
-        else:
+
+        if data.ndim not in (3, 4):
             raise ValueError(
                 f"dimension of data should be 3 or 4 but you provided {data.ndim}"
             )
-        Rx = np.eye(4)
-        Rx[:3, :3] = np.diag(R)
-        affine2 = np.dot(affine, Rx)
+
+        if lanczos_lobes is not None:
+            if data.ndim == 3:
+                data2 = _lanczos_resample_3d(
+                    data,
+                    scale,
+                    new_shape,
+                    num_lobes=lanczos_lobes,
+                    mode=mode,
+                    cval=cval,
+                )
+            else:
+                data2 = np.zeros(new_shape + (data.shape[-1],), data.dtype)
+                for vol_idx in range(data.shape[-1]):
+                    data2[..., vol_idx] = _lanczos_resample_3d(
+                        data[..., vol_idx],
+                        scale,
+                        new_shape,
+                        num_lobes=lanczos_lobes,
+                        mode=mode,
+                        cval=cval,
+                    )
+        else:
+            kwargs = {
+                "matrix": scale,
+                "output_shape": new_shape,
+                "order": order,
+                "mode": mode,
+                "cval": cval,
+            }
+            if data.ndim == 3:
+                data2 = affine_transform(input=data, **kwargs)
+            else:
+                data2 = np.zeros(new_shape + (data.shape[-1],), data.dtype)
+                if num_processes == 1:
+                    for i in range(data.shape[-1]):
+                        affine_transform(
+                            input=data[..., i], output=data2[..., i], **kwargs
+                        )
+                else:
+                    params = []
+                    for i in range(data.shape[-1]):
+                        _kwargs = {"input": data[..., i]}
+                        _kwargs.update(kwargs)
+                        params.append(_kwargs)
+                    mp.set_start_method("spawn", force=True)
+                    pool = mp.Pool(num_processes)
+                    for i, res in enumerate(pool.imap(_affine_transform, params)):
+                        data2[..., i] = res
+                    pool.close()
+
+        affine_scale = np.eye(4)
+        affine_scale[:3, :3] = np.diag(scale)
+        affine2 = np.dot(affine, affine_scale)
     return (data2, affine2)

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import numpy as np
 from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
-from dipy.align.reslice import reslice
+from dipy.align.reslice import _lanczos_kernel, reslice
 from dipy.data import get_fnames
 from dipy.denoise.noise_estimate import estimate_sigma
 from dipy.io.image import load_nifti
@@ -64,4 +64,56 @@ def test_resample():
     # test invalid volume dimension
     assert_raises(
         ValueError, reslice, np.zeros((4, 4, 4, 4, 1)), affine, zooms, new_zooms
+    )
+
+
+def test_lanczos_kernel():
+    assert_almost_equal(_lanczos_kernel(0.0, 2), 1.0)
+    assert_equal(_lanczos_kernel(3.0, 2), 0.0)
+    assert_equal(_lanczos_kernel(-3.0, 2), 0.0)
+    vals = np.linspace(-1.9, 1.9, 20)
+    assert_almost_equal(_lanczos_kernel(vals, 2), _lanczos_kernel(-vals, 2))
+
+
+def test_reslice_lanczos():
+    fimg, _, _ = get_fnames(name="small_25")
+    data, affine, zooms = load_nifti(fimg, return_voxsize=True)
+
+    new_zooms = (1.0, 1.0, 1.0)
+
+    data_l2, affine_l2 = reslice(
+        data[..., 0], affine, zooms, new_zooms, order="lanczos2"
+    )
+    data_l, affine_l = reslice(data[..., 0], affine, zooms, new_zooms, order="lanczos")
+    assert_almost_equal(data_l2, data_l)
+    assert_almost_equal(affine_l2, affine_l)
+
+    data_lin, _ = reslice(data[..., 0], affine, zooms, new_zooms, order=1)
+    assert_equal(data_l2.shape, data_lin.shape)
+
+    data_l3, _ = reslice(data[..., 0], affine, zooms, new_zooms, order="lanczos3")
+    assert_equal(data_l3.shape, data_lin.shape)
+
+    data2_4d, _ = reslice(data, affine, zooms, new_zooms, order="lanczos2")
+    assert_equal(data2_4d.shape[:3], data_l2.shape[:3])
+    assert_equal(data2_4d.shape[-1], data.shape[-1])
+
+    assert_almost_equal(affine_l2, affine_l)
+
+    assert_raises(
+        ValueError, reslice, data[..., 0], affine, zooms, new_zooms, order="bad"
+    )
+    assert_raises(ValueError, reslice, data[..., 0], affine, zooms, new_zooms, order=6)
+    assert_raises(
+        ValueError, reslice, data[..., 0], affine, zooms, new_zooms, mode="invalid"
+    )
+    assert_raises(
+        ValueError,
+        reslice,
+        data[..., 0],
+        affine,
+        zooms,
+        new_zooms,
+        order="lanczos2",
+        mode="mirror",
     )

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -89,11 +89,14 @@ class ResliceFlow(Workflow):
             new_vox = voxel_sorted[1] + (voxel_sorted[2] - voxel_sorted[1]) * vox_factor
             where voxel_sorted are the original voxel dimensions sorted in
             ascending order. The calculated value is applied isotropically
-            to all three dimensions.
-        order : int, optional
-            order of interpolation, from 0 to 5, for resampling/reslicing,
-            0 nearest interpolation, 1 trilinear etc.. if you don't want any
-            smoothing 0 is the option you need.
+            to all three dimensions. If the auto-calculated value is strictly
+            greater than 2.0mm, it is halved repeatedly until it falls below
+            2.0mm (e.g. 2.5 → 1.25mm, 5.0 → 1.25mm).
+        order : str, optional
+            Interpolation order. Integer values 0–5 select spline order via
+            scipy (0 nearest, 1 trilinear, …). String values ``'lanczos'`` or
+            ``'lanczos2'`` select a 2-lobe Lanczos kernel; ``'lanczos3'``
+            selects a 3-lobe Lanczos kernel. Use 0 to avoid smoothing.
         mode : string, optional
             Points outside the boundaries of the input are filled according
             to the given mode 'constant', 'nearest', 'reflect' or 'wrap'.
@@ -119,6 +122,9 @@ class ResliceFlow(Workflow):
 
         """
 
+        if isinstance(order, str) and order.lstrip("-").isdigit():
+            order = int(order)
+
         io_it = self.get_io_iterator()
         corrected_outputs = list(self.flat_outputs)
 
@@ -134,6 +140,15 @@ class ResliceFlow(Workflow):
                 calculated_vox_size = (
                     smax_vox_size + (max_vox_size - smax_vox_size) * vox_factor
                 )
+                if calculated_vox_size > 2.0:
+                    divisor = 2
+                    while calculated_vox_size / divisor >= 2.0:
+                        divisor *= 2
+                    calculated_vox_size /= divisor
+                    logger.warning(
+                        f"Auto-calculated voxel size > 2.0mm. "
+                        f"Divided by {divisor} → {calculated_vox_size:.4f}mm."
+                    )
                 new_vox_size_to_use = [calculated_vox_size] * 3
                 logger.warning(
                     f"new_vox_size not provided. Automatically calculated as "

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -175,6 +175,55 @@ def test_reslice_skip_returns_original_path(caplog):
         npt.assert_equal(resliced.shape, data.shape)
 
 
+def test_reslice_auto_scale_guard(caplog, tmp_path):
+    """Auto-calculated voxel size > 2.0mm gets halved to [1.0, 2.0)."""
+    affine = np.eye(4)
+
+    for orig_zooms, expected_divisor in [(2.5, 2), (5.0, 4), (3.9, 2)]:
+        data = np.random.rand(10, 10, 10).astype(np.float32)
+        img = nib.Nifti1Image(data, affine)
+        img.header.set_zooms([orig_zooms, orig_zooms, orig_zooms])
+        in_path = tmp_path / f"vol_{orig_zooms}.nii.gz"
+        nib.save(img, str(in_path))
+
+        with caplog.at_level(logging.WARNING, logger="dipy"):
+            caplog.clear()
+            out_dir = tmp_path / f"out_{orig_zooms}"
+            out_dir.mkdir()
+            ResliceFlow().run(str(in_path), out_dir=str(out_dir))
+
+        expected_vox = orig_zooms / expected_divisor
+        warning_messages = " ".join(
+            r.message for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert f"Divided by {expected_divisor}" in warning_messages, (
+            f"Expected divisor {expected_divisor} for {orig_zooms}mm. Messages: {warning_messages}"
+        )
+        assert f"{expected_vox:.4f}" in warning_messages, (
+            f"Expected {expected_vox:.4f}mm in warning. Messages: {warning_messages}"
+        )
+
+
+def test_reslice_auto_scale_guard_no_trigger(caplog, tmp_path):
+    """Auto-calculated voxel size <= 2.0mm is not modified."""
+    affine = np.eye(4)
+    data = np.random.rand(10, 10, 10).astype(np.float32)
+    img = nib.Nifti1Image(data, affine)
+    img.header.set_zooms([2.0, 2.0, 2.0])
+    in_path = tmp_path / "vol_2mm.nii.gz"
+    nib.save(img, str(in_path))
+
+    with caplog.at_level(logging.WARNING, logger="dipy"):
+        ResliceFlow().run(str(in_path), out_dir=str(tmp_path / "out"))
+
+    warning_messages = " ".join(
+        r.message for r in caplog.records if r.levelname == "WARNING"
+    )
+    assert "Divided by" not in warning_messages, (
+        f"Should not trigger auto-scale at 2.0mm. Messages: {warning_messages}"
+    )
+
+
 def test_slr_flow(caplog):
     with TemporaryDirectory() as out_dir:
         data_path = get_fnames(name="fornix")


### PR DESCRIPTION
## Description

This pull request introduces support for Lanczos interpolation in the `reslice` function,  It also improves the workflow for automatically determining voxel sizes, ensuring that auto-calculated voxel sizes greater than 2.0mm are reduced to fall below this threshold. Comprehensive tests are added for these new features and behaviors.

## Motivation and Context

Lanczos interpolation allow higher-quality image resampling with options for 2- or 3-lobe kernels and give similar performance to trilinear or cubic interpolation

## How Has This Been Tested?

* Added tests in `dipy/align/tests/test_reslice.py` for the new Lanczos kernel and reslicing options, including shape and value checks, and error handling for invalid interpolation orders. [[1]](diffhunk://#diff-3f051a2fec8e269eb78701332f1318e1832d8a5a9dcf51cb5b621ea384e436f1L5-R5) [[2]](diffhunk://#diff-3f051a2fec8e269eb78701332f1318e1832d8a5a9dcf51cb5b621ea384e436f1R68-R105)
* Added tests in `dipy/workflows/tests/test_align.py` to verify the new voxel size auto-scaling logic, ensuring that warnings are correctly emitted and the voxel size is properly adjusted or left unchanged as appropriate.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
