### PR TITLE
ENH: Fill mask holes in synthseg

### DIFF
--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -16,6 +16,7 @@ from dipy.segment.clustering import QuickBundles, qbx_and_merge
 from dipy.segment.fss import FastStreamlineSearch, nearest_from_matrix_col
 from dipy.segment.mask import median_otsu
 from dipy.segment.tissue import TissueClassifierHMRF, dam_classifier
+from dipy.segment.utils import remove_holes_and_islands
 from dipy.tracking import Streamlines
 from dipy.utils.deprecator import deprecated_params
 from dipy.utils.logging import logger
@@ -669,7 +670,7 @@ class BrainMaskFlow(Workflow):
             'median_otsu' method.
         finalize_mask : bool, optional
             Whether to remove potential holes or islands. Useful for solving
-            minor errors. Used only for 'median_otsu' method.
+            minor errors. Used for 'median_otsu' and 'synthseg' methods.
         save_masked : bool, optional
             Save the masked volume in addition to the mask.
         use_cuda : bool, optional
@@ -786,6 +787,8 @@ class BrainMaskFlow(Workflow):
                     )
                 vol = data[..., 0] if data.ndim == 4 else data
                 _, _, mask_volume = synthseg_model.predict(vol, affine)
+                if finalize_mask:
+                    mask_volume = remove_holes_and_islands(mask_volume).astype(np.int32)
                 mask_for_apply = (
                     mask_volume[..., np.newaxis] if data.ndim == 4 else mask_volume
                 )


### PR DESCRIPTION
## Description

This pull request improves the robustness of mask generation in the `synthseg` segmentation workflow by ensuring that output masks are free of holes and isolated regions ("islands"). It does so by applying a new utility function, `remove_holes_and_islands`, to masks produced by the `synthseg` model and updating the workflow to support this for both `median_otsu` and `synthseg` methods. 

## Motivation and Context

holes has been reported in synthseg masks

## How Has This Been Tested?

Added a new test, `test_mask_no_holes`, to verify that masks produced by `synthseg` do not contain holes, increasing confidence in mask integrity.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
