### PR TITLE
RF: Added fixes

### DIFF
--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -335,25 +335,33 @@ def test_patch2self_small_data_edge_cases(rng):
 def test_patch2self_v3_preserves_out_dtype_and_precision_invariance(rng):
     shape = (10, 10, 6, 13)
     base = 30.0 + 2.0 * rng.standard_normal(shape)
-    bvals = np.repeat(1000.0, shape[-1])  # all DWI
+    bvals = np.repeat(1000.0, shape[-1])
 
     data32 = base.astype(np.float32)
     data64 = base.astype(np.float64)
 
-    den32 = p2s.patch2self(data32, bvals, model="ridge", alpha=1.0, version=3)
-    den64 = p2s.patch2self(data64, bvals, model="ridge", alpha=1.0, version=3)
+    state = np.random.get_state()
+    try:
+        np.random.seed(2025)
+        den32 = p2s.patch2self(
+            data32, bvals, model="ridge", alpha=1.0, version=3
+        )
 
-    # Out dtype should follow input dtype by default
+        np.random.seed(2025)
+        den64 = p2s.patch2self(
+            data64, bvals, model="ridge", alpha=1.0, version=3
+        )
+    finally:
+        np.random.set_state(state)
+
     assert_equal(den32.dtype, np.float32)
     assert_equal(den64.dtype, np.float64)
 
-    # Compare per-volume statistics (mean and std across spatial dims)
     m32 = den32.reshape(-1, shape[-1]).mean(axis=0)
     m64 = den64.reshape(-1, shape[-1]).mean(axis=0)
     s32 = den32.reshape(-1, shape[-1]).std(axis=0)
     s64 = den64.reshape(-1, shape[-1]).std(axis=0)
 
-    # Allow small-to-moderate diffs due to dtype & randomized count-sketch
     assert_allclose(m32, m64, rtol=2e-2, atol=1.25)
     assert_allclose(s32, s64, rtol=1e-1, atol=1.0)
 

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -343,14 +343,10 @@ def test_patch2self_v3_preserves_out_dtype_and_precision_invariance(rng):
     state = np.random.get_state()
     try:
         np.random.seed(2025)
-        den32 = p2s.patch2self(
-            data32, bvals, model="ridge", alpha=1.0, version=3
-        )
+        den32 = p2s.patch2self(data32, bvals, model="ridge", alpha=1.0, version=3)
 
         np.random.seed(2025)
-        den64 = p2s.patch2self(
-            data64, bvals, model="ridge", alpha=1.0, version=3
-        )
+        den64 = p2s.patch2self(data64, bvals, model="ridge", alpha=1.0, version=3)
     finally:
         np.random.set_state(state)
 


### PR DESCRIPTION
This PR fixes issue mentioned in #4041. The issue was due to the way sketching is done in v3. Sketching is random, so when there were two calls being done and the random state not being set to a specific value, caused the error.

