### PR TITLE
NF: dipy_auto pipeline workflow

### DIFF
--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1755,6 +1755,7 @@ class AutoFlow(Workflow):
             )
             return
 
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = os.path.abspath(out_dir) or os.getcwd()
 
         if list_pipelines:

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1747,6 +1747,11 @@ class AutoFlow(Workflow):
         out_report : str, optional
             Path to the report file.
         """
+
+        if list_pipelines:
+            logger.info(templates.list_pipelines_with_descriptions())
+            return
+
         out_dir = os.path.abspath(out_dir) or os.getcwd()
 
         if list_pipelines:

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1704,11 +1704,14 @@ def _serve_html_report(report_path):
             logger.info("Server stopped.")
 
 
+# =============================================================================
+# AutoFlow Workflow
+# =============================================================================
 # TODO:
-# - handle maskfile, check binary, % of white voxels.
+# - Done: handle maskfile, check binary, % of white voxels.
 # - Add opposite phase encoding (AP/PA)
-# - ~~handle incorrect --start name.~~
-# - Create dipy_brain_mask workflow and add to pipelines
+# - Done: handle incorrect --start name.
+# - Done: Create dipy_brain_mask workflow and add to pipelines
 #   (SynthSeg, median_otsu, PUMBA, EVAC+)
 # - Create dipy_denoise
 # - dipy cluster qbx

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1749,7 +1749,10 @@ class AutoFlow(Workflow):
         """
 
         if list_pipelines:
-            logger.info(templates.list_pipelines_with_descriptions())
+            current_log_level = logger.getEffectiveLevel()
+            logger.info(
+                templates.list_pipelines_with_descriptions(log_level=current_log_level)
+            )
             return
 
         out_dir = os.path.abspath(out_dir) or os.getcwd()

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1660,6 +1660,60 @@ def _serve_html_report(report_path):
 # - dipy cluster qbx
 
 
+def _serve_html_report(report_path):
+    """Serve an HTML pipeline report via a local HTTP server and open it.
+
+    Starts a ``http.server`` rooted at the report's directory, opens the
+    default browser, and blocks until the user presses Ctrl+C.
+
+    Parameters
+    ----------
+    report_path : str or Path
+        Path to the HTML report file (e.g., ``pipeline_report.html``).
+    """
+    import functools
+    import http.server
+    import socket
+    import socketserver
+    import webbrowser
+
+    report_path = Path(report_path).resolve()
+    report_dir = str(report_path.parent)
+    report_name = report_path.name
+
+    port = 8000
+    while True:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                break
+            except OSError:
+                port += 1
+
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=report_dir
+    )
+    url = f"http://localhost:{port}/{report_name}"
+    logger.info(f"Serving report at: {url}")
+    logger.info("Press Ctrl+C to stop the server.")
+    webbrowser.open(url)
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            logger.info("Server stopped.")
+
+
+# TODO:
+# - handle maskfile, check binary, % of white voxels.
+# - Add opposite phase encoding (AP/PA)
+# - handle incorrect --start name.
+# - Create dipy_brain_mask workflow and add to pipelines
+#   (SynthSeg, median_otsu, PUMBA, EVAC+)
+# - Create dipy_denoise
+# - dipy cluster qbx
+
+
 class AutoFlow(Workflow):
     """Automatic pipeline execution workflow with semantic DAG-based wiring.
 
@@ -1754,6 +1808,38 @@ class AutoFlow(Workflow):
                 templates.list_pipelines_with_descriptions(log_level=current_log_level)
             )
             return
+
+        # =====================================================================
+        # Detect file types from input_files
+        # =====================================================================
+
+        config_file = None
+        dwi_file = None
+        bvals_file = None
+        bvecs_file = None
+
+        for f in input_files:
+            p = Path(f)
+            name_lower = p.name.lower()
+            full_suffix = "".join(p.suffixes).lower()
+
+            if re.match(r".*report.*\.html$", name_lower):
+                logger.info(
+                    f"HTML report detected: {f}. "
+                    "Ignoring all other inputs and opening report."
+                )
+                _serve_html_report(f)
+                return
+            elif full_suffix == ".toml":
+                config_file = f
+            elif full_suffix in (".nii.gz", ".nii"):
+                dwi_file = f
+            elif p.suffix.lower() in (".bval", ".bvals"):
+                bvals_file = f
+            elif p.suffix.lower() in (".bvec", ".bvecs"):
+                bvecs_file = f
+            else:
+                logger.warning(f"Unrecognized file type, ignoring: {f}")
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = os.path.abspath(out_dir) or os.getcwd()

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1707,7 +1707,7 @@ def _serve_html_report(report_path):
 # TODO:
 # - handle maskfile, check binary, % of white voxels.
 # - Add opposite phase encoding (AP/PA)
-# - handle incorrect --start name.
+# - ~~handle incorrect --start name.~~
 # - Create dipy_brain_mask workflow and add to pipelines
 #   (SynthSeg, median_otsu, PUMBA, EVAC+)
 # - Create dipy_denoise

--- a/dipy/workflows/combined_workflow.py
+++ b/dipy/workflows/combined_workflow.py
@@ -1747,6 +1747,7 @@ class AutoFlow(Workflow):
         out_report : str, optional
             Path to the report file.
         """
+        out_dir = os.path.abspath(out_dir) or os.getcwd()
 
         if list_pipelines:
             current_log_level = logger.getEffectiveLevel()

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -62,6 +62,7 @@ from dipy.reconst.shm import (
     QballModel,
     anisotropic_power,
     normalize_data,
+    order_from_ncoef,
     smooth_pinv,
     sph_harm_lookup,
 )
@@ -1206,11 +1207,29 @@ class ReconstCSDFlow(Workflow):
 
             n_params = ((sh_order_max + 1) * (sh_order_max + 2)) / 2
             if data.shape[-1] < n_params:
-                raise ValueError(
-                    f"You need at least {n_params} unique DWI volumes to "
-                    f"compute fiber odfs. You currently have: {data.shape[-1]}"
-                    " DWI volumes."
+                logger.warning(
+                    f"sh_order_max={sh_order_max} requires at least "
+                    f"{int(n_params)} DWI volumes, but only "
+                    f"{data.shape[-1]} are available. Searching for the best "
+                    "sh_order_max that can be used with the current data..."
                 )
+                best_order = order_from_ncoef(data.shape[-1])
+                if best_order % 2 != 0:
+                    best_order -= 1
+                while (
+                    best_order >= 2
+                    and ((best_order + 1) * (best_order + 2)) / 2 > data.shape[-1]
+                ):
+                    best_order -= 2
+                if best_order < 2:
+                    logger.error(
+                        f"Not enough DWI volumes ({data.shape[-1]}) to compute "
+                        "fiber ODFs. A minimum of 6 unique DWI volumes "
+                        "(sh_order_max=2) is required."
+                    )
+                    return sys.exit(1)
+                sh_order_max = best_order
+                logger.warning(f"sh_order_max automatically set to {sh_order_max}.")
 
             model_args = {"gtab": gtab, "sh_order_max": sh_order_max}
             if not use_msmt:

--- a/dipy/workflows/report.py
+++ b/dipy/workflows/report.py
@@ -579,6 +579,27 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             background: #fff;
         }}
 
+        .stage-badge {{
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 0.8em;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+            vertical-align: middle;
+            margin-left: 10px;
+        }}
+        .badge-restart {{
+            background: #e8f4fd;
+            color: #2471a3;
+            border: 1px solid #aed6f1;
+        }}
+        .badge-user-mask {{
+            background: #eafaf1;
+            color: #1e8449;
+            border: 1px solid #a9dfbf;
+        }}
+
         @media print {{
             .topbar, .sidebar {{ display: none; }}
             .main-content {{ margin-left: 0; }}

--- a/dipy/workflows/report.py
+++ b/dipy/workflows/report.py
@@ -579,25 +579,45 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             background: #fff;
         }}
 
+        /* ── Badges ──────────────────────────────────────────── */
         .stage-badge {{
             display: inline-block;
-            padding: 4px 10px;
+            padding: 2px 9px;
             border-radius: 12px;
-            font-size: 0.8em;
+            font-size: 11px;
             font-weight: 600;
-            letter-spacing: 0.3px;
+            letter-spacing: 0.2px;
             vertical-align: middle;
-            margin-left: 10px;
+            margin-left: 8px;
         }}
         .badge-restart {{
-            background: #e8f4fd;
-            color: #2471a3;
-            border: 1px solid #aed6f1;
+            background: #eff6ff;
+            color: #1d4ed8;
+            border: 1px solid #bfdbfe;
         }}
         .badge-user-mask {{
-            background: #eafaf1;
-            color: #1e8449;
-            border: 1px solid #a9dfbf;
+            background: #f0fdf4;
+            color: #166534;
+            border: 1px solid #bbf7d0;
+        }}
+
+        /* ── Profile charts ──────────────────────────────────── */
+        .profile-charts-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 20px;
+            margin: 16px 0;
+        }}
+        .profile-chart-container {{
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 16px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        }}
+        .profile-chart-container canvas {{
+            height: 240px !important;
+            background: #fff;
         }}
 
         @media print {{

--- a/dipy/workflows/templates.py
+++ b/dipy/workflows/templates.py
@@ -409,7 +409,7 @@ bvectors_files = "${io.bvecs}"
 [[pipeline]]
 name = "bias_correction"
 cli = "dipy_correct_biasfield"
-input_files = "${motion_correction.out_moved}"
+input_files = "${gibbs.out_unring}"
 bval = "${io.bvals}"
 bvec = "${io.bvecs}"
 method = "auto"

--- a/dipy/workflows/templates.py
+++ b/dipy/workflows/templates.py
@@ -390,6 +390,38 @@ input_files = "${bias_correction.out_corrected}"
 bval_files = "${io.bvals}"
 verbose = true
 
+[[pipeline]]
+name = "gibbs"
+cli = "dipy_gibbs_ringing"
+input_files = "${brain_mask.out_masked}"
+slice_axis = 2
+num_processes = -1
+
+# Step 3: Motion correction
+[[pipeline]]
+name = "motion_correction"
+cli = "dipy_correct_motion"
+input_files = "${gibbs.out_unring}"
+bvalues_files = "${io.bvals}"
+bvectors_files = "${io.bvecs}"
+
+# Step 4: Bias field correction (using median_otsu on b0)
+[[pipeline]]
+name = "bias_correction"
+cli = "dipy_correct_biasfield"
+input_files = "${motion_correction.out_moved}"
+bval = "${io.bvals}"
+bvec = "${io.bvecs}"
+method = "b0"
+
+# Step 5: Denoising with Patch2Self
+[[pipeline]]
+name = "denoise"
+cli = "dipy_denoise_patch2self"
+input_files = "${bias_correction.out_corrected}"
+bvalues_files = "${io.bvals}"
+verbose = true
+
 # Multiple reconstructions
 [[pipeline]]
 name = "dti_fit"
@@ -411,6 +443,7 @@ bvectors_files = "${io.bvecs}"
 mask_files = "${brain_mask.out_mask}"
 extract_pam_values = true
 out_dir = "${io.out_dir}/csd"
+
 
 # Tractography
 [[pipeline]]

--- a/dipy/workflows/templates.py
+++ b/dipy/workflows/templates.py
@@ -412,7 +412,7 @@ cli = "dipy_correct_biasfield"
 input_files = "${motion_correction.out_moved}"
 bval = "${io.bvals}"
 bvec = "${io.bvecs}"
-method = "b0"
+method = "auto"
 
 # Step 5: Denoising with Patch2Self
 [[pipeline]]

--- a/dipy/workflows/templates.py
+++ b/dipy/workflows/templates.py
@@ -419,7 +419,7 @@ method = "b0"
 name = "denoise"
 cli = "dipy_denoise_patch2self"
 input_files = "${bias_correction.out_corrected}"
-bvalues_files = "${io.bvals}"
+bval_files = "${io.bvals}"
 verbose = true
 
 # Multiple reconstructions

--- a/dipy/workflows/templates.py
+++ b/dipy/workflows/templates.py
@@ -349,6 +349,7 @@ bundle_atlas_dir = ""
 name = "reslice"
 cli = "dipy_reslice"
 input_files = "${io.dwi}"
+order = "lanczos2"
 
 [[pipeline]]
 name = "b0_extraction"
@@ -364,6 +365,7 @@ input_files = "${reslice.out_resliced}"
 bvalues_files = ["${io.bvals}"]
 median_radius = 2
 numpass = 5
+finalize_mask = true
 save_masked = true
 
 [[pipeline]]
@@ -372,38 +374,6 @@ cli = "dipy_gibbs_ringing"
 input_files = "${brain_mask.out_masked}"
 slice_axis = 2
 num_processes = -1
-
-# Step 4: Bias field correction (using median_otsu on b0)
-[[pipeline]]
-name = "bias_correction"
-cli = "dipy_correct_biasfield"
-input_files = "${gibbs.out_unring}"
-bval = "${io.bvals}"
-bvec = "${io.bvecs}"
-method = "auto"
-
-# Step 5: Denoising with Patch2Self
-[[pipeline]]
-name = "denoise"
-cli = "dipy_denoise_patch2self"
-input_files = "${bias_correction.out_corrected}"
-bval_files = "${io.bvals}"
-verbose = true
-
-[[pipeline]]
-name = "gibbs"
-cli = "dipy_gibbs_ringing"
-input_files = "${brain_mask.out_masked}"
-slice_axis = 2
-num_processes = -1
-
-# Step 3: Motion correction
-[[pipeline]]
-name = "motion_correction"
-cli = "dipy_correct_motion"
-input_files = "${gibbs.out_unring}"
-bvalues_files = "${io.bvals}"
-bvectors_files = "${io.bvecs}"
 
 # Step 4: Bias field correction (using median_otsu on b0)
 [[pipeline]]
@@ -435,22 +405,22 @@ extract_pam_values = true
 out_dir = "${io.out_dir}/dti"
 
 [[pipeline]]
-name = "csd_fit"
-cli = "dipy_fit_csd"
+name = "force_fit"
+cli = "dipy_fit_force"
 input_files = "${denoise.out_denoised}"
 bvalues_files = "${io.bvals}"
 bvectors_files = "${io.bvecs}"
 mask_files = "${brain_mask.out_mask}"
-extract_pam_values = true
-out_dir = "${io.out_dir}/csd"
-
+compute_kurtosis = true
+engine = "ray"
+out_dir = "${io.out_dir}/force"
 
 # Tractography
 [[pipeline]]
 name = "tracking"
 cli = "dipy_track"
-pam_files = "${csd_fit.out_pam}"
-stopping_files = "${dti_fit.out_fa}"
+pam_files = "${force_fit.out_pam}"
+stopping_files = "${force_fit.out_fa}"
 seeding_files = "${brain_mask.out_mask}"
 seed_density = 2
 
@@ -492,10 +462,10 @@ out_dir = "${io.out_dir}/buan_profiles"
 """
 
 # =============================================================================
-# Full Pipeline - Complete analysis
+# Full Pipeline with Motion Correction - Complete analysis
 # =============================================================================
 
-FULL_PIPELINE = """
+FULL_PIPELINE_WITH_MOTION = """
 [General]
 name = "full_pipeline_with_motion"
 description = "Full pipeline: preprocessing + reconstruction + tracking + SLR + bundles"
@@ -517,6 +487,7 @@ bundle_atlas_dir = ""
 name = "reslice"
 cli = "dipy_reslice"
 input_files = "${io.dwi}"
+order = "lanczos2"
 
 [[pipeline]]
 name = "b0_extraction"
@@ -532,6 +503,7 @@ input_files = "${reslice.out_resliced}"
 bvalues_files = ["${io.bvals}"]
 median_radius = 2
 numpass = 5
+finalize_mask = true
 save_masked = true
 
 [[pipeline]]
@@ -553,9 +525,10 @@ bvectors_files = "${io.bvecs}"
 [[pipeline]]
 name = "bias_correction"
 cli = "dipy_correct_biasfield"
-input_files = "${gibbs.out_unring}"
+input_files = "${motion_correction.out_moved}"
 bval = "${io.bvals}"
 bvec = "${io.bvecs}"
+mask = "${brain_mask.out_mask}"
 method = "auto"
 
 # Step 5: Denoising with Patch2Self
@@ -579,6 +552,17 @@ extract_pam_values = true
 out_dir = "${io.out_dir}/dti"
 
 [[pipeline]]
+name = "force_fit"
+cli = "dipy_fit_force"
+input_files = "${denoise.out_denoised}"
+bvalues_files = "${io.bvals}"
+bvectors_files = "${io.bvecs}"
+mask_files = "${brain_mask.out_mask}"
+compute_kurtosis = true
+engine = "ray"
+out_dir = "${io.out_dir}/force"
+
+[[pipeline]]
 name = "csd_fit"
 cli = "dipy_fit_csd"
 input_files = "${denoise.out_denoised}"
@@ -592,8 +576,8 @@ out_dir = "${io.out_dir}/csd"
 [[pipeline]]
 name = "tracking"
 cli = "dipy_track"
-pam_files = "${csd_fit.out_pam}"
-stopping_files = "${dti_fit.out_fa}"
+pam_files = "${force_fit.out_pam}"
+stopping_files = "${force_fit.out_fa}"
 seeding_files = "${brain_mask.out_mask}"
 seed_density = 2
 
@@ -950,6 +934,13 @@ PREDEFINED_PIPELINES = {
             "Full pipeline: preprocessing + reconstruction + tracking + SLR + bundles"
         ),
         "config": FULL_PIPELINE,
+    },
+    "full_with_motion": {
+        "description": (
+            "Full pipeline with motion correction: preprocessing + reconstruction"
+            " + tracking + SLR + bundles"
+        ),
+        "config": FULL_PIPELINE_WITH_MOTION,
     },
     "comprehensive": {
         "description": "Complete: preprocessing + 6 methods + tracking + SLR + bundles",


### PR DESCRIPTION
## Summary

- Adds `dipy_auto` workflow for automated diffusion MRI pipeline execution
- Semantic DAG-based pipeline specification via TOML `[[pipeline]]` sections
- Interactive mode, predefined pipeline templates, HTML report generation
- Replaces #3955 with clean history (14 commits on top of workshop26)

## Changes

- `dipy/workflows/combined_workflow.py`: AutoFlow workflow, semantic pipeline execution, DAG wiring
- `dipy/workflows/templates.py`: Predefined pipeline templates (denoise, DTI, tractography, full)
- `dipy/workflows/report.py`: HTML report generation with mosaic viewers
- `dipy/workflows/interactive.py`: Interactive pipeline builder
- `dipy/workflows/reconst.py`: FORCE workflow integration

## Test plan

- [ ] `dipy_auto --list-pipelines`
- [ ] `dipy_auto --pipeline_type dti_only <dwi> <bvals> <bvecs>`
- [ ] `dipy_auto --dry-run` mode
- [ ] HTML report generation and serving