### PR TITLE
Update CCMetric energy after backward step

### DIFF
--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -340,7 +340,7 @@ class CCMetric(SimilarityMetric):
         Computes the update displacement field to be used for registration of
         the static image towards the moving image
         """
-        displacement, energy = self.compute_backward_step(
+        displacement, self.energy = self.compute_backward_step(
             self.gradient_moving, self.factors, self.radius
         )
         displacement = np.array(displacement)

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -1,7 +1,12 @@
 import itertools
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_raises,
+)
 from scipy import ndimage
 
 from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
@@ -45,6 +50,83 @@ def test_exceptions():
     # expected to pass for any dimension == 2*radius + 1.
     metric = init_metric((9, 9), 4)
     metric.initialize_iteration()
+
+
+def setup_metric(metric, static, moving):
+    r"""Initialize a metric with a simple pair of images for one iteration."""
+    metric.set_static_image(static, None, np.ones(metric.dim), None)
+    metric.set_moving_image(moving, None, np.ones(metric.dim), None)
+    metric.initialize_iteration()
+    return metric
+
+
+def cc_energy_from_factors(factors, radius):
+    r"""Compute CC energy as implemented in ``crosscorr.pyx`` step functions.
+
+    This replicates the local NCC energy accumulation used by
+    ``compute_cc_forward_step_2d`` and ``compute_cc_backward_step_2d``
+    """
+    energy = 0
+    factors = np.asarray(factors)
+    for r in range(radius, factors.shape[0] - radius):
+        for c in range(radius, factors.shape[1] - radius):
+            sfm = factors[r, c, 2]
+            sff = factors[r, c, 3]
+            smm = factors[r, c, 4]
+            if sff == 0 or smm == 0:
+                continue
+            local_correlation = 0
+            if sff * smm > 1e-5:
+                local_correlation = sfm * sfm / (sff * smm)
+            if local_correlation < 1:
+                energy -= local_correlation
+    return energy
+
+
+@set_random_number_generator(7181309)
+def test_cc_metric_energy_matches_local_cross_correlation(rng):
+    r"""Verify that CCMetric reports the local cross-correlation energy.
+
+    The forward and backward CC steps both should store the same scalar data
+    energy for the initialized image pair.
+    """
+    static = rng.random((5, 5)).astype(np.float32)
+    moving = rng.random((5, 5)).astype(np.float32)
+    radius = 1
+
+    metric = setup_metric(CCMetric(2, radius=radius, sigma_diff=0), static, moving)
+    expected = cc_energy_from_factors(metric.factors, radius)
+    metric.compute_forward()
+    assert_almost_equal(metric.get_energy(), expected)
+    metric.free_iteration()
+
+    metric = setup_metric(CCMetric(2, radius=radius, sigma_diff=0), static, moving)
+    expected = cc_energy_from_factors(metric.factors, radius)
+    metric.compute_backward()
+    assert_almost_equal(metric.get_energy(), expected)
+    metric.free_iteration()
+
+
+@set_random_number_generator(7181309)
+def test_ssd_metric_energy_matches_squared_difference(rng):
+    r"""Verify that SSDMetric reports the sum of squared differences energy.
+
+    The forward and backward SSD steps both should store the same
+    squared-difference energy for the initialized image pair.
+    """
+    static = rng.random((5, 5)).astype(np.float32)
+    moving = rng.random((5, 5)).astype(np.float32)
+    expected = np.sum((static - moving) ** 2)
+
+    metric = setup_metric(SSDMetric(2, smooth=0), static, moving)
+    metric.compute_forward()
+    assert_almost_equal(metric.get_energy(), expected)
+    metric.free_iteration()
+
+    metric = setup_metric(SSDMetric(2, smooth=0), static, moving)
+    metric.compute_backward()
+    assert_almost_equal(metric.get_energy(), expected)
+    metric.free_iteration()
 
 
 @set_random_number_generator(7181309)

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -53,15 +53,14 @@ def test_exceptions():
 
 
 def setup_metric(metric, static, moving):
-    r"""Initialize a metric with a simple pair of images for one iteration."""
+    """Initialize a metric with a simple pair of images for one iteration."""
     metric.set_static_image(static, None, np.ones(metric.dim), None)
     metric.set_moving_image(moving, None, np.ones(metric.dim), None)
     metric.initialize_iteration()
-    return metric
 
 
 def cc_energy_from_factors(factors, radius):
-    r"""Compute CC energy as implemented in ``crosscorr.pyx`` step functions.
+    """Compute CC energy as implemented in ``crosscorr.pyx`` step functions.
 
     This replicates the local NCC energy accumulation used by
     ``compute_cc_forward_step_2d`` and ``compute_cc_backward_step_2d``
@@ -85,7 +84,7 @@ def cc_energy_from_factors(factors, radius):
 
 @set_random_number_generator(7181309)
 def test_cc_metric_energy_matches_local_cross_correlation(rng):
-    r"""Verify that CCMetric reports the local cross-correlation energy.
+    """Verify that CCMetric reports the local cross-correlation energy.
 
     The forward and backward CC steps both should store the same scalar data
     energy for the initialized image pair.
@@ -94,13 +93,15 @@ def test_cc_metric_energy_matches_local_cross_correlation(rng):
     moving = rng.random((5, 5)).astype(np.float32)
     radius = 1
 
-    metric = setup_metric(CCMetric(2, radius=radius, sigma_diff=0), static, moving)
+    metric = CCMetric(2, radius=radius, sigma_diff=0)
+    setup_metric(metric, static, moving)
     expected = cc_energy_from_factors(metric.factors, radius)
     metric.compute_forward()
     assert_almost_equal(metric.get_energy(), expected)
     metric.free_iteration()
 
-    metric = setup_metric(CCMetric(2, radius=radius, sigma_diff=0), static, moving)
+    metric = CCMetric(2, radius=radius, sigma_diff=0)
+    setup_metric(metric, static, moving)
     expected = cc_energy_from_factors(metric.factors, radius)
     metric.compute_backward()
     assert_almost_equal(metric.get_energy(), expected)
@@ -109,7 +110,7 @@ def test_cc_metric_energy_matches_local_cross_correlation(rng):
 
 @set_random_number_generator(7181309)
 def test_ssd_metric_energy_matches_squared_difference(rng):
-    r"""Verify that SSDMetric reports the sum of squared differences energy.
+    """Verify that SSDMetric reports the sum of squared differences energy.
 
     The forward and backward SSD steps both should store the same
     squared-difference energy for the initialized image pair.
@@ -118,12 +119,14 @@ def test_ssd_metric_energy_matches_squared_difference(rng):
     moving = rng.random((5, 5)).astype(np.float32)
     expected = np.sum((static - moving) ** 2)
 
-    metric = setup_metric(SSDMetric(2, smooth=0), static, moving)
+    metric = SSDMetric(2, smooth=0)
+    setup_metric(metric, static, moving)
     metric.compute_forward()
     assert_almost_equal(metric.get_energy(), expected)
     metric.free_iteration()
 
-    metric = setup_metric(SSDMetric(2, smooth=0), static, moving)
+    metric = SSDMetric(2, smooth=0)
+    setup_metric(metric, static, moving)
     metric.compute_backward()
     assert_almost_equal(metric.get_energy(), expected)
     metric.free_iteration()


### PR DESCRIPTION
## Description

`CCMetric.compute_backward()` computed the backward CC energy but did not store it in `self.energy`, unlike `CCMetric.compute_forward()` and the other metric implementations. This PR updates `compute_backward()` to store the computed energy in `self.energy`.

It also adds tests for `CCMetric` and `SSDMetric` to verify that `get_energy()` reports the expected energy after both forward and backward metric steps.

## Motivation and Context

This issue appears to be silent in the standard SyN registration workflow and is not expected to change registration results.

In `SymmetricDiffeomorphicRegistration`, `metric.compute_forward()` is called before `metric.compute_backward()`, so `self.energy` is already initialized before `metric.get_energy()` is called. For `CCMetric`, the forward and backward steps compute different displacement fields, but both evaluate the same cross-correlation energy for the same image pair on the same grid. As a result, the stale forward energy matches the backward energy in the current SyN+CC optimization path.

However, `compute_backward()` should still update `self.energy` for consistency with the metric API and with the other metric implementations. Without this fix, direct use of `CCMetric.compute_backward()` or custom optimization code using the metric interface outside `SymmetricDiffeomorphicRegistration` could observe an unset or stale value from `get_energy()`.

## How Has This Been Tested?

Two tests were added under `dipy/align/tests/test_metrics.py`.

The tests initialize `CCMetric` and `SSDMetric` on randomly generated static and moving images, then run forward and backward steps independently. After each step, they verify that `metric.get_energy()` reports the expected energy:

- For `CCMetric`, the expected value is computed from the local cross-correlation factors, matching the energy accumulation used by `compute_cc_forward_step_2d()` and `compute_cc_backward_step_2d()`.
- For `SSDMetric`, the expected value is the sum of squared differences between the static and moving images.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure