### PR TITLE
NF: Parallelize motion correction

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -8,6 +8,7 @@ streamlines.
 
 import collections.abc
 from functools import partial
+import multiprocessing as mp
 import numbers
 from pathlib import Path
 import re
@@ -41,6 +42,7 @@ from dipy.testing.decorators import warning_for_keywords
 from dipy.tracking.streamline import set_number_of_points
 from dipy.tracking.utils import transform_tracking_output
 from dipy.utils.logging import logger
+from dipy.utils.multiproc import determine_num_processes
 
 __all__ = [
     "syn_registration",
@@ -667,6 +669,71 @@ _METHOD_DICT = {  # mapping from str key -> (callable, class) tuple
 }
 
 
+_REGISTER_CTX = {}
+
+
+def _init_register_worker(
+    ref,
+    series_affine,
+    ref_affine,
+    pipeline,
+    static_mask,
+    level_iters,
+    optimizer_options,
+):
+    """Initialize the per-worker context for the parallel branch of
+    :func:`register_series`.
+
+    Runs once per worker process (the ``initializer`` of the pool), storing the
+    arguments that are constant across all volumes so :func:`_register_one_volume`
+    can reuse them without re-pickling them per task.
+    """
+    _REGISTER_CTX.update(
+        ref=ref,
+        series_affine=series_affine,
+        ref_affine=ref_affine,
+        pipeline=pipeline,
+        static_mask=static_mask,
+        level_iters=level_iters,
+        optimizer_options=optimizer_options,
+    )
+
+
+def _register_one_volume(args):
+    """Register a single moving volume to the static reference.
+
+    Module-level worker for the parallel branch of :func:`register_series`
+    (must be importable/picklable for the ``spawn`` start method). The constant
+    arguments come from the worker context set up by
+    :func:`_init_register_worker`; only the per-volume payload is passed in.
+
+    Parameters
+    ----------
+    args : tuple
+        ``(index, moving)`` -- the volume index and the 3D volume to register.
+
+    Returns
+    -------
+    index, transformed, reg_affine : int, ndarray, ndarray
+        The volume index (used to scatter the result back into place), the
+        registered 3D volume, and its associated 4x4 affine.
+    """
+    index, moving = args
+    ctx = _REGISTER_CTX
+    logger.info(f"Registering volume {index} of the series...")
+    transformed, reg_affine = affine_registration(
+        moving,
+        ctx["ref"],
+        moving_affine=ctx["series_affine"],
+        static_affine=ctx["ref_affine"],
+        pipeline=ctx["pipeline"],
+        static_mask=ctx["static_mask"],
+        level_iters=ctx["level_iters"],
+        optimizer_options=ctx["optimizer_options"],
+    )
+    return index, transformed, reg_affine
+
+
 @warning_for_keywords()
 def register_series(
     series,
@@ -678,6 +745,7 @@ def register_series(
     static_mask=None,
     level_iters=None,
     optimizer_options=None,
+    num_processes=1,
 ):
     """Register a series to a reference image.
 
@@ -714,6 +782,12 @@ def register_series(
         Options to be passed to the optimizer. See `scipy.optimize.minimize`
         documentation for details.
 
+    num_processes : int, optional
+        Split the registration of the series volumes across a pool of child
+        processes. Default is 1. If < 0 the maximal number of cores minus
+        ``num_processes + 1`` is used (enter -1 to use as many cores as
+        possible). 0 raises an error.
+
     Returns
     -------
     xformed, affines : 4D array with transformed data and a (4,4,n) array
@@ -739,16 +813,24 @@ def register_series(
                 " or the index of one or more volumes",
             )
 
+    num_processes = determine_num_processes(num_processes)
+
     xformed = np.zeros(series.shape)
     affines = np.zeros((4, 4, series.shape[-1]))
+
+    to_register = []
     for ii in range(series.shape[-1]):
-        logger.info(f"Registering volume {ii} of the series...")
         this_moving = series[..., ii]
         if isinstance(ref_as_idx, numbers.Number) and ii == ref_as_idx:
             # This is the reference! No need to move and the xform is I(4):
             xformed[..., ii] = this_moving
             affines[..., ii] = np.eye(4)
         else:
+            to_register.append((ii, this_moving))
+
+    if num_processes == 1:
+        for ii, this_moving in to_register:
+            logger.info(f"Registering volume {ii} of the series...")
             transformed, reg_affine = affine_registration(
                 this_moving,
                 ref,
@@ -761,6 +843,29 @@ def register_series(
             )
             xformed[..., ii] = transformed
             affines[..., ii] = reg_affine
+    else:
+        logger.info(
+            f"Registering {len(to_register)} volumes of the series "
+            f"using {num_processes} processes..."
+        )
+        with mp.get_context("spawn").Pool(
+            num_processes,
+            initializer=_init_register_worker,
+            initargs=(
+                ref,
+                series_affine,
+                ref_affine,
+                pipeline,
+                static_mask,
+                level_iters,
+                optimizer_options,
+            ),
+        ) as pool:
+            for ii, transformed, reg_affine in pool.imap_unordered(
+                _register_one_volume, to_register
+            ):
+                xformed[..., ii] = transformed
+                affines[..., ii] = reg_affine
 
     return xformed, affines
 
@@ -776,6 +881,7 @@ def register_dwi_series(
     static_mask=None,
     level_iters=None,
     optimizer_options=None,
+    num_processes=1,
 ):
     """Register a DWI series to the mean of the B0 images in that series.
 
@@ -817,6 +923,12 @@ def register_dwi_series(
         Options to be passed to the optimizer. See `scipy.optimize.minimize`
         documentation for details.
 
+    num_processes : int, optional
+        Split the registration of the series volumes across a pool of child
+        processes. Default is 1. If < 0 the maximal number of cores minus
+        ``num_processes + 1`` is used (enter -1 to use as many cores as
+        possible). 0 raises an error.
+
     Returns
     -------
     xform_img, affine_array: a Nifti1Image containing the registered data and
@@ -852,6 +964,7 @@ def register_dwi_series(
             static_mask=static_mask,
             level_iters=level_iters,
             optimizer_options=optimizer_options,
+            num_processes=num_processes,
         )
         ref_data = np.mean(trans_b0, -1, keepdims=True)
     else:
@@ -871,6 +984,7 @@ def register_dwi_series(
         static_mask=static_mask,
         level_iters=level_iters,
         optimizer_options=optimizer_options,
+        num_processes=num_processes,
     )
     # Cut out the part pertaining to that first volume:
     affines = affines[..., 1:]

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -313,6 +313,33 @@ def test_register_dwi_series_and_motion_correction():
         npt.assert_array_equal(reg_affines, reg_affines_2)
 
 
+def test_register_dwi_series_parallel():
+    # Parallel (num_processes > 1) registration must match the serial result,
+    # since the per-volume registrations are independent.
+    fdata, fbval, fbvec = dpd.get_fnames(name="small_64D")
+    with TemporaryDirectory() as tmpdir:
+        # Use an abbreviated data-set:
+        img = nib.load(fdata)
+        data = img.get_fdata()[..., :10]
+        bvals = np.loadtxt(fbval)
+        bvecs = np.loadtxt(fbvec)
+        np.savetxt(Path(tmpdir) / "bvals.txt", bvals[:10])
+        np.savetxt(Path(tmpdir) / "bvecs.txt", bvecs[:10])
+        gtab = dpg.gradient_table(
+            Path(tmpdir) / "bvals.txt", bvecs=Path(tmpdir) / "bvecs.txt"
+        )
+
+        reg_img, reg_affines = motion_correction(
+            data, gtab, affine=img.affine, num_processes=1
+        )
+        reg_img_par, reg_affines_par = motion_correction(
+            data, gtab, affine=img.affine, num_processes=2
+        )
+
+        npt.assert_array_almost_equal(reg_img.get_fdata(), reg_img_par.get_fdata())
+        npt.assert_array_almost_equal(reg_affines, reg_affines_par)
+
+
 @set_random_number_generator()
 def test_streamline_registration(rng):
     sl1 = [

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -966,6 +966,7 @@ class MotionCorrectionFlow(Workflow):
         b0_threshold=50,
         bvecs_tol=0.01,
         level_iters=(1000, 500, 100),
+        num_processes=1,
         out_dir="",
         out_moved="moved.nii.gz",
         out_affine="affine.txt",
@@ -989,6 +990,11 @@ class MotionCorrectionFlow(Workflow):
             b-vectors are unit vectors
         level_iters : variable int, optional
             The number of iterations at each level of the Gaussian pyramid.
+        num_processes : int, optional
+            Split the registration of the series volumes across a pool of
+            child processes. Default is 1. If < 0 the maximal number of cores
+            minus ``num_processes + 1`` is used (enter -1 to use as many cores
+            as possible). 0 raises an error.
         out_dir : string or Path, optional
             Directory to save the transformed image and the affine matrix.
         out_moved : string, optional
@@ -1027,7 +1033,11 @@ class MotionCorrectionFlow(Workflow):
             )
 
             reg_img, reg_affines = motion_correction(
-                data=data, gtab=gtab, affine=affine, level_iters=level_iters
+                data=data,
+                gtab=gtab,
+                affine=affine,
+                level_iters=level_iters,
+                num_processes=num_processes,
             )
 
             # Saving the corrected image file


### PR DESCRIPTION
  ## Description

  Add a `num_processes` option to `register_series`, `register_dwi_series`, and `motion_correction` (and expose it on the `MotionCorrectionFlow` workflow) to register the volumes of a series in parallel across a pool of worker processes.
  The per-volume registrations are independent, so they are fanned out with a `multiprocessing` `spawn` pool. Default is `1` (serial), so existing behavior is unchanged.

  The constant arguments (static reference volume, affines, pipeline, mask, optimizer options) are shipped to each worker **once** via a pool initializer rather than being re-pickled with every volume, and the reference-volume special-case is handled in a single shared loop used by both the serial and parallel paths.

  ## Motivation and Context

  Motion correction of a DWI series registers each volume to the reference independently and sequentially, which is slow for large series. Since the per-volume registrations don't depend on one another, they can run concurrently. Adding `num_processes` lets users trade cores for wall-clock time, with no change to the result. The `spawn` start method is used (rather than mutating the global start method via `set_start_method`) so the pool is self-contained and safe on macOS/Windows.

  ## How Has This Been Tested?

  Added `test_register_dwi_series_parallel`, which runs `motion_correction` with `num_processes=1` and `num_processes=2` on an abbreviated dataset and asserts the registered data and affines match (the parallel path must reproduce the serial result).

  ```bash
  conda run -n dipy_test python -m pytest \
    dipy/align/tests/test_api.py::test_register_dwi_series_parallel \
    dipy/align/tests/test_api.py::test_register_series \
    dipy/align/tests/test_api.py::test_register_dwi_series_and_motion_correction \
    dipy/align/tests/test_api.py::test_register_dwi_series_multi_b0 \
    dipy/align/tests/test_api.py::test_register_dwi_to_template
  ```

  All new and existing register_series / register_dwi_series / motion_correction tests pass locally.

  Checklist

  - [x] I have read the CONTRIBUTING guidelines.
  - [x] My code follows the DIPY coding style.
  - [x] I have added tests that cover my changes (if applicable).
  - [x] All new and existing tests pass locally.
  - [x] I have updated the documentation accordingly (if applicable).

  Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Maintenance / CI / Infrastructure