### PR TITLE
BF: multi_voxel_fit leaks orchestration kwargs into per-voxel fit (#4053)

### DIFF
--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -3,7 +3,6 @@
 from functools import partial
 import inspect
 import multiprocessing
-import warnings
 
 import numpy as np
 from tqdm import tqdm
@@ -11,6 +10,7 @@ from tqdm import tqdm
 from dipy.core.ndindex import ndindex
 from dipy.reconst.base import ReconstFit
 from dipy.reconst.quick_squash import quick_squash as _squash
+from dipy.utils.logging import logger
 from dipy.utils.multiproc import determine_num_processes
 from dipy.utils.parallel import auto_ray_chunk_size, paramap
 
@@ -198,12 +198,11 @@ def multi_voxel_fit(
 
             dropped = [k for k in _drop_kwargs if k in kwargs]
             if dropped:
-                warnings.warn(
-                    f"multi_voxel_fit: {dropped} consumed for parallelization/"
-                    "orchestration; not forwarded to the per-voxel fit "
-                    "(it does not declare these keyword arguments).",
-                    UserWarning,
-                    stacklevel=2,
+                logger.debug(
+                    "multi_voxel_fit: %s consumed for parallelization/orchestration; "
+                    "not forwarded to the per-voxel fit (it does not declare these "
+                    "keyword arguments).",
+                    dropped,
                 )
             fit_kwargs = {k: v for k, v in kwargs.items() if k not in _drop_kwargs}
 

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,7 +1,9 @@
 """Tools to easily make multi voxel models"""
 
 from functools import partial
+import inspect
 import multiprocessing
+import warnings
 
 import numpy as np
 from tqdm import tqdm
@@ -11,6 +13,30 @@ from dipy.reconst.base import ReconstFit
 from dipy.reconst.quick_squash import quick_squash as _squash
 from dipy.utils.multiproc import determine_num_processes
 from dipy.utils.parallel import auto_ray_chunk_size, paramap
+
+# Keyword arguments that configure parallelization/orchestration for the
+# ``multi_voxel_fit`` decorator and :func:`dipy.utils.parallel.paramap`.  They
+# must not reach a per-voxel model fit unless that fit explicitly declares them
+# (see ``_accepts_kwarg``); otherwise they would raise ``TypeError`` in fits
+# that forward ``**kwargs`` to a strict solver (e.g. ``ls_fit_dki``).
+ORCHESTRATION_KWARGS = ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap")
+
+
+def _accepts_kwarg(func, name):
+    """Return True iff ``func`` declares ``name`` as an explicit parameter.
+
+    A parameter absorbed only by ``**kwargs`` does not count, so a reserved
+    orchestration key is forwarded solely to fits that name it explicitly
+    (e.g. ``MCSD.fit(self, data, verbose=True, **kwargs)``).
+    """
+    try:
+        param = inspect.signature(func).parameters.get(name)
+    except (TypeError, ValueError):
+        return False
+    return param is not None and param.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
 
 
 def _assemble_results(params_list, *, fit_class):
@@ -164,13 +190,35 @@ def multi_voxel_fit(
     """
 
     def decorator(single_voxel_fit):
+        # Reserved orchestration keys this fit does NOT declare explicitly are
+        # stripped before per-voxel dispatch; ones it declares (e.g. MCSD's
+        # ``verbose``) are forwarded.  Computed once per decorated function.
+        _drop_kwargs = tuple(
+            k for k in ORCHESTRATION_KWARGS if not _accepts_kwarg(single_voxel_fit, k)
+        )
+
         def new_fit(self, data, *, mask=None, **kwargs):
             """Fit method for every voxel in data"""
+
+            # Orchestration kwargs configure parallelization only; they must not
+            # leak into the per-voxel fit unless it declares them.  Warn so a
+            # dropped keyword argument is never silent, then strip for dispatch.
+            dropped = [k for k in _drop_kwargs if k in kwargs]
+            if dropped:
+                warnings.warn(
+                    f"multi_voxel_fit: {dropped} consumed for parallelization/"
+                    "orchestration; not forwarded to the per-voxel fit "
+                    "(it does not declare these keyword arguments).",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            # Per-voxel kwargs: orchestration keys removed, model kwargs kept.
+            fit_kwargs = {k: v for k, v in kwargs.items() if k not in _drop_kwargs}
 
             # If only one voxel just return a standard fit, passing through
             # the functions key-word arguments (no mask needed).
             if data.ndim == 1:
-                svf = single_voxel_fit(self, data, **kwargs)
+                svf = single_voxel_fit(self, data, **fit_kwargs)
                 # If fit method does not return extra, cannot return extra
                 if isinstance(svf, tuple):
                     svf, extra = svf
@@ -244,16 +292,12 @@ def multi_voxel_fit(
                     disable=not kwargs.get("verbose", False),
                 )
                 bar.set_description("Fitting (batched serial)")
-                fit_kwargs = {
-                    k: v
-                    for k, v in kwargs.items()
-                    if k not in ("engine", "n_jobs", "vox_per_chunk", "verbose")
-                }
+                chunk_kwargs = dict(fit_kwargs)
                 if use_raw:
-                    fit_kwargs["_raw"] = True
+                    chunk_kwargs["_raw"] = True
                 for start in range(0, n_vox, vox_per_chunk):
                     chunk = data_to_fit[start : start + vox_per_chunk]
-                    chunk_result = single_voxel_fit(self, chunk, **fit_kwargs)
+                    chunk_result = single_voxel_fit(self, chunk, **chunk_kwargs)
                     all_chunk_results.append(chunk_result)
                     bar.update(len(chunk))
                 bar.close()
@@ -276,10 +320,11 @@ def multi_voxel_fit(
                 )
                 for ijk in ndindex(data.shape[:-1]):
                     if mask[ijk]:
+                        voxel_kwargs = fit_kwargs
                         if weights_is_array:
-                            kwargs["weights"] = weights[ijk]
+                            voxel_kwargs = {**fit_kwargs, "weights": weights[ijk]}
 
-                        svf = single_voxel_fit(self, data[ijk], **kwargs)
+                        svf = single_voxel_fit(self, data[ijk], **voxel_kwargs)
 
                         # Not all fit methods return extra, handle this here
                         if isinstance(svf, tuple):
@@ -320,10 +365,10 @@ def multi_voxel_fit(
                 try:
                     fit_func = partial(single_voxel_fit, self)
 
-                    # Build per-chunk kwargs
+                    # Build per-chunk kwargs (orchestration keys already stripped)
                     kwargs_chunks = []
                     for ii in range(0, data_to_fit.shape[0], vox_per_chunk):
-                        kw = kwargs.copy()
+                        kw = dict(fit_kwargs)
                         if batched:
                             kw["_batched"] = True
                         if use_raw:

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -14,12 +14,11 @@ from dipy.reconst.quick_squash import quick_squash as _squash
 from dipy.utils.multiproc import determine_num_processes
 from dipy.utils.parallel import auto_ray_chunk_size, paramap
 
-# Keyword arguments that configure parallelization/orchestration for the
-# ``multi_voxel_fit`` decorator and :func:`dipy.utils.parallel.paramap`.  They
-# must not reach a per-voxel model fit unless that fit explicitly declares them
-# (see ``_accepts_kwarg``); otherwise they would raise ``TypeError`` in fits
-# that forward ``**kwargs`` to a strict solver (e.g. ``ls_fit_dki``).
 ORCHESTRATION_KWARGS = ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap")
+"""
+Keyword arguments that configure parallelization/orchestration for the ``multi_voxel_fit`` decorator
+and :func:`dipy.utils.parallel.paramap`.
+"""
 
 
 def _accepts_kwarg(func, name):
@@ -190,9 +189,6 @@ def multi_voxel_fit(
     """
 
     def decorator(single_voxel_fit):
-        # Reserved orchestration keys this fit does NOT declare explicitly are
-        # stripped before per-voxel dispatch; ones it declares (e.g. MCSD's
-        # ``verbose``) are forwarded.  Computed once per decorated function.
         _drop_kwargs = tuple(
             k for k in ORCHESTRATION_KWARGS if not _accepts_kwarg(single_voxel_fit, k)
         )
@@ -200,9 +196,6 @@ def multi_voxel_fit(
         def new_fit(self, data, *, mask=None, **kwargs):
             """Fit method for every voxel in data"""
 
-            # Orchestration kwargs configure parallelization only; they must not
-            # leak into the per-voxel fit unless it declares them.  Warn so a
-            # dropped keyword argument is never silent, then strip for dispatch.
             dropped = [k for k in _drop_kwargs if k in kwargs]
             if dropped:
                 warnings.warn(
@@ -212,7 +205,6 @@ def multi_voxel_fit(
                     UserWarning,
                     stacklevel=2,
                 )
-            # Per-voxel kwargs: orchestration keys removed, model kwargs kept.
             fit_kwargs = {k: v for k, v in kwargs.items() if k not in _drop_kwargs}
 
             # If only one voxel just return a standard fit, passing through

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -429,6 +429,18 @@ def test_multi_voxel_fit_logs_dropped_kwargs(caplog, dipy_log_propagate):
     assert "engine" in drop_logs[0] and "n_jobs" in drop_logs[0]
 
 
+@pytest.mark.parametrize("unintrospectable", [object(), 42, min])
+def test_accepts_kwarg_unintrospectable_callable(unintrospectable):
+    """Objects whose signature cannot be determined are not forwarded reserved keys.
+
+    When ``inspect.signature`` raises ``TypeError`` (non-callable) or
+    ``ValueError`` (signature-less builtin such as ``min``), ``_accepts_kwarg``
+    treats the object as *not* declaring the keyword, so reserved orchestration
+    keys are never forwarded to it.
+    """
+    assert mv._accepts_kwarg(unintrospectable, "verbose") is False
+
+
 def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
     """Orchestration kwargs are forwarded to ``paramap`` while the per-chunk
     kwargs are stripped. ``paramap`` is replaced by an in-process spy so the

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -1,16 +1,42 @@
 from functools import reduce
+import warnings
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 
+from dipy.core.gradients import gradient_table
 from dipy.core.sphere import unit_icosahedron
+from dipy.data import get_fnames
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
+from dipy.reconst.dki import DiffusionKurtosisModel
 from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
+from dipy.sims.voxel import multi_tensor_dki, single_tensor
 from dipy.testing.decorators import set_random_number_generator, warning_for_keywords
 from dipy.utils.optpkg import optional_package
 
 joblib, has_joblib, _ = optional_package("joblib")
 dask, has_dask, _ = optional_package("dask")
 ray, has_ray, _ = optional_package("ray")
+
+# Orchestration kwargs consumed by the ``multi_voxel_fit`` decorator / ``paramap``;
+# none of these may leak into a per-voxel model fit that does not declare them.
+ORCHESTRATION_KWARGS = ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap")
+
+# Engines available for parallel testing (mirrors dipy/utils/tests/test_parallel.py).
+# "serial" is included on purpose: the serial (non-batched) path leaks the same
+# orchestration kwargs when ``engine=`` is passed explicitly.
+PARALLEL_ENGINES = ["serial"]
+if has_joblib:
+    PARALLEL_ENGINES.append("joblib")
+if has_dask:
+    PARALLEL_ENGINES.append("dask")
+if has_ray:
+    PARALLEL_ENGINES.append("ray")
+
+# Engines that actually run work in a (potentially) parallel backend.
+NONSERIAL_ENGINES = [e for e in PARALLEL_ENGINES if e != "serial"]
 
 
 def test_squash():
@@ -154,6 +180,14 @@ def test_multi_voxel_fit(rng):
             # Make sure that an argument that is not passed is still
             # usable in the fitting procedure:
             assert kwarg_untouched
+            # Orchestration kwargs (engine, n_jobs, ...) configure parallelization
+            # only; they must never leak into the per-voxel fit (regression for
+            # dipy#4053). ``SillyModel.fit`` declares none of them, so the decorator
+            # must strip every one before dispatch.
+            leaked = [k for k in ORCHESTRATION_KWARGS if k in kwargs]
+            assert not leaked, (
+                f"orchestration kwargs leaked into per-voxel fit: {leaked}"
+            )
             return SillyFit(model, data)
 
         def predict(self, S0):
@@ -256,3 +290,216 @@ def test_multi_voxel_fit(rng):
     # Test indexing into a fit
     npt.assert_equal(type(fit[0, 0, 0]), SillyFit)
     npt.assert_equal(fit[:2, :2, :2].shape, (2, 2, 2))
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for dipy#4053: ``multi_voxel_fit`` must not leak the
+# orchestration kwargs (engine, n_jobs, vox_per_chunk, verbose, inflight_cap)
+# into the per-voxel model fit.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingFit:
+    """Minimal fit object that knows how to predict a constant signal."""
+
+    def __init__(self, model, data):
+        self.model = model
+        self.data = data
+
+    def predict(self, S0):
+        return np.ones(self.data.shape) * S0
+
+
+def _recording_model(received):
+    """A model whose per-voxel fit records the kwargs it actually receives.
+
+    ``fit_method`` is a legitimate, explicitly declared model kwarg used to
+    check that real model kwargs are *not* stripped.  Everything else lands in
+    ``**kwargs``, where any leaked orchestration kwarg would show up.
+    """
+
+    class RecordingModel:
+        @multi_voxel_fit
+        def fit(self, data, *, fit_method="LS", **kwargs):
+            received.append((fit_method, dict(kwargs)))
+            return _RecordingFit(self, data)
+
+    return RecordingModel()
+
+
+def _verbose_declaring_model(seen_verbose):
+    """A model whose per-voxel fit *declares* ``verbose`` (as MCSD does)."""
+
+    class VerboseModel:
+        @multi_voxel_fit
+        def fit(self, data, *, verbose=False, **kwargs):
+            seen_verbose.append(verbose)
+            # Keys this fit does NOT declare are still stripped:
+            assert "engine" not in kwargs
+            assert "n_jobs" not in kwargs
+            return _RecordingFit(self, data)
+
+    return VerboseModel()
+
+
+@set_random_number_generator()
+def test_multi_voxel_fit_no_orchestration_leak(rng):
+    """Orchestration kwargs never reach a per-voxel fit that doesn't declare them.
+
+    Covers the serial (explicit ``engine="serial"``) and every available
+    parallel path. A legitimate model kwarg (``fit_method``) and a per-voxel
+    ``weights`` array must still pass through.
+    """
+    n_vox, n_grad = 6, 8
+    data = rng.random((n_vox, n_grad))
+
+    for engine in PARALLEL_ENGINES:
+        received = []
+        model = _recording_model(received)
+        weights = rng.random((n_vox, n_grad))
+        with warnings.catch_warnings():
+            # warn-on-drop is asserted separately; silence it here
+            warnings.simplefilter("ignore")
+            model.fit(
+                data,
+                engine=engine,
+                n_jobs=1,
+                vox_per_chunk=2,
+                verbose=False,
+                fit_method="WLS",
+                weights=weights,
+            )
+
+        assert received, f"per-voxel fit was never called (engine={engine})"
+        for fit_method, received_kwargs in received:
+            # Legitimate, explicitly declared model kwarg survived:
+            npt.assert_equal(fit_method, "WLS")
+            # No orchestration kwarg leaked into the per-voxel fit:
+            for key in ORCHESTRATION_KWARGS:
+                assert key not in received_kwargs, (
+                    f"{key!r} leaked into the per-voxel fit (engine={engine})"
+                )
+            # A per-voxel model kwarg (weights) was forwarded and sliced:
+            assert "weights" in received_kwargs
+            assert isinstance(received_kwargs["weights"], np.ndarray)
+
+
+@set_random_number_generator()
+def test_multi_voxel_fit_forwards_declared_kwarg(rng):
+    """A reserved key the fit *declares* (e.g. ``verbose``, as in MCSD) is
+    forwarded — and is not warned about — while undeclared keys are stripped.
+    """
+    n_vox, n_grad = 6, 8
+    data = rng.random((n_vox, n_grad))
+
+    for engine in PARALLEL_ENGINES:
+        seen_verbose = []
+        model = _verbose_declaring_model(seen_verbose)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model.fit(data, engine=engine, n_jobs=1, verbose=True)
+
+        # The declared ``verbose`` reached every per-voxel fit:
+        assert seen_verbose and all(v is True for v in seen_verbose)
+        # ... and was not reported as a dropped kwarg:
+        assert not any("verbose" in str(w.message) for w in caught), (
+            "verbose was dropped/warned despite being declared by the fit"
+        )
+
+
+@set_random_number_generator()
+def test_multi_voxel_fit_warns_on_dropped_kwargs(rng):
+    """Dropping orchestration kwargs is never silent: a warning names them."""
+    data = rng.random((6, 8))
+    received = []
+    model = _recording_model(received)
+    with pytest.warns(UserWarning, match="engine"):
+        model.fit(data, engine="serial", n_jobs=1)
+
+
+# --- Real-model parity fixtures (built once) --------------------------------
+_GTAB_2S = _DKI_DATA = _DKI_REF = None
+_CSD_MODEL = _CSD_DATA = _CSD_REF = None
+
+
+def _unwrap(fit):
+    """Some decorated fits return ``(MultiVoxelFit, extra)``; take the fit."""
+    return fit[0] if isinstance(fit, tuple) else fit
+
+
+def setup_module():
+    """Build small, per-voxel-distinct datasets and serial-reference fits."""
+    global _GTAB_2S, _DKI_DATA, _DKI_REF
+    global _CSD_MODEL, _CSD_DATA, _CSD_REF
+
+    _, fbvals, fbvecs = get_fnames(name="small_64D")
+    bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
+
+    # Distinct per-voxel scaling so a chunk-ordering bug would surface.
+    scale = (1.0 + 0.02 * np.arange(6))[:, None]
+
+    # Two-shell table for DKI (multi-shell model).
+    bvals_2s = np.concatenate((bvals, bvals * 2))
+    bvecs_2s = np.concatenate((bvecs, bvecs))
+    _GTAB_2S = gradient_table(bvals_2s, bvecs=bvecs_2s)
+    mevals = np.array([[0.00099, 0, 0], [0.00226, 0.00087, 0.00087]])
+    signal, _, _ = multi_tensor_dki(
+        _GTAB_2S, mevals, S0=100, fractions=[50, 50], snr=None
+    )
+    _DKI_DATA = (signal[None, :] * scale).astype(float)
+    # Reference: default serial path (no engine kwarg -> no leak).
+    _DKI_REF = _unwrap(DiffusionKurtosisModel(_GTAB_2S).multi_fit(_DKI_DATA))
+
+    # Single-shell table for CSD.
+    gtab_1s = gradient_table(bvals, bvecs=bvecs)
+    response = (np.array([0.0015, 0.0003, 0.0003]), 100.0)
+    _CSD_MODEL = ConstrainedSphericalDeconvModel(gtab_1s, response)
+    csd_signal = single_tensor(
+        gtab_1s,
+        100.0,
+        evals=np.array([0.0015, 0.0003, 0.0003]),
+        evecs=np.eye(3),
+        snr=None,
+    )
+    _CSD_DATA = (csd_signal[None, :] * scale).astype(float)
+    _CSD_REF = _unwrap(_CSD_MODEL.fit(_CSD_DATA))
+
+
+@pytest.mark.skipif(not NONSERIAL_ENGINES, reason="no parallel engine installed")
+@pytest.mark.parametrize("engine", NONSERIAL_ENGINES)
+@pytest.mark.parametrize("vox_per_chunk", [1, 4, 100])  # ==1, <n_vox, >n_vox
+@pytest.mark.parametrize("n_jobs", [1, 2])
+def test_dki_multi_fit_parallel_matches_serial(engine, vox_per_chunk, n_jobs):
+    """DKI (single-voxel fit rejects ``engine``) parallel == serial, exactly."""
+    model = DiffusionKurtosisModel(_GTAB_2S)
+    got = _unwrap(
+        model.multi_fit(
+            _DKI_DATA, engine=engine, n_jobs=n_jobs, vox_per_chunk=vox_per_chunk
+        )
+    )
+    npt.assert_allclose(
+        np.asarray(got.model_params),
+        np.asarray(_DKI_REF.model_params),
+        rtol=1e-6,
+        atol=1e-8,
+    )
+    npt.assert_allclose(
+        np.asarray(got.kt), np.asarray(_DKI_REF.kt), rtol=1e-6, atol=1e-8
+    )
+
+
+@pytest.mark.skipif(not NONSERIAL_ENGINES, reason="no parallel engine installed")
+@pytest.mark.parametrize("engine", NONSERIAL_ENGINES)
+@pytest.mark.parametrize("vox_per_chunk", [1, 4, 100])
+def test_csd_fit_parallel_matches_serial(engine, vox_per_chunk):
+    """CSD parallel == serial (guards against regressions on the absorb path)."""
+    got = _unwrap(
+        _CSD_MODEL.fit(_CSD_DATA, engine=engine, n_jobs=1, vox_per_chunk=vox_per_chunk)
+    )
+    npt.assert_allclose(
+        np.asarray(got.shm_coeff),
+        np.asarray(_CSD_REF.shm_coeff),
+        rtol=1e-6,
+        atol=1e-8,
+    )

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -38,6 +38,14 @@ if has_ray:
 # Engines that actually run work in a (potentially) parallel backend.
 NONSERIAL_ENGINES = [e for e in PARALLEL_ENGINES if e != "serial"]
 
+# Engines that execute the per-voxel fit in the *calling* process, so a test can
+# observe what the fit received via shared in-memory state. "ray" always runs in
+# separate worker processes (worker-side state never reaches the parent), and
+# "serial"/joblib(n_jobs=1)/dask(threading) run in-process. Ray's per-chunk kwarg
+# stripping is covered instead by test_multi_voxel_fit_orchestration_reaches_paramap
+# (inspects the kwargs handed to paramap) and the real-engine parity tests.
+INPROCESS_ENGINES = [e for e in PARALLEL_ENGINES if e != "ray"]
+
 
 def test_squash():
     A = np.ones((3, 3), dtype=float)
@@ -346,14 +354,14 @@ def _verbose_declaring_model(seen_verbose):
 def test_multi_voxel_fit_no_orchestration_leak(rng):
     """Orchestration kwargs never reach a per-voxel fit that doesn't declare them.
 
-    Covers the serial (explicit ``engine="serial"``) and every available
-    parallel path. A legitimate model kwarg (``fit_method``) and a per-voxel
-    ``weights`` array must still pass through.
+    Covers the serial (explicit ``engine="serial"``) and the in-process parallel
+    paths (the recorder lives in the calling process). A legitimate model kwarg
+    (``fit_method``) and a per-voxel ``weights`` array must still pass through.
     """
     n_vox, n_grad = 6, 8
     data = rng.random((n_vox, n_grad))
 
-    for engine in PARALLEL_ENGINES:
+    for engine in INPROCESS_ENGINES:
         received = []
         model = _recording_model(received)
         weights = rng.random((n_vox, n_grad))
@@ -392,7 +400,7 @@ def test_multi_voxel_fit_forwards_declared_kwarg(rng):
     n_vox, n_grad = 6, 8
     data = rng.random((n_vox, n_grad))
 
-    for engine in PARALLEL_ENGINES:
+    for engine in INPROCESS_ENGINES:
         seen_verbose = []
         model = _verbose_declaring_model(seen_verbose)
 

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -1,4 +1,5 @@
 from functools import reduce
+import logging
 import warnings
 
 import numpy as np
@@ -17,6 +18,7 @@ from dipy.reconst.multi_voxel import (
     _squash,
     multi_voxel_fit,
 )
+from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.sims.voxel import multi_tensor_dki, single_tensor
 from dipy.testing.decorators import set_random_number_generator, warning_for_keywords
 from dipy.utils.optpkg import optional_package
@@ -293,6 +295,16 @@ def test_multi_voxel_fit(rng):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def dipy_log_propagate():
+    """Enable propagation on the dipy logger so pytest caplog can capture records."""
+    dipy_logger = logging.getLogger("dipy")
+    old = dipy_logger.propagate
+    dipy_logger.propagate = True
+    yield
+    dipy_logger.propagate = old
+
+
 class _RecordingFit:
     """Minimal fit object that knows how to predict a constant signal."""
 
@@ -351,18 +363,15 @@ def test_multi_voxel_fit_no_orchestration_leak(rng):
         received = []
         model = _recording_model(received)
         weights = rng.random((n_vox, n_grad))
-        with warnings.catch_warnings():
-            # warn-on-drop is asserted separately; silence it here
-            warnings.simplefilter("ignore")
-            model.fit(
-                data,
-                engine=engine,
-                n_jobs=1,
-                vox_per_chunk=2,
-                verbose=False,
-                fit_method="WLS",
-                weights=weights,
-            )
+        model.fit(
+            data,
+            engine=engine,
+            n_jobs=1,
+            vox_per_chunk=2,
+            verbose=False,
+            fit_method="WLS",
+            weights=weights,
+        )
 
         assert received, f"per-voxel fit was never called (engine={engine})"
         for fit_method, received_kwargs in received:
@@ -378,38 +387,45 @@ def test_multi_voxel_fit_no_orchestration_leak(rng):
             assert isinstance(received_kwargs["weights"], np.ndarray)
 
 
-@set_random_number_generator()
-def test_multi_voxel_fit_forwards_declared_kwarg(rng):
+def test_multi_voxel_fit_forwards_declared_kwarg(caplog, dipy_log_propagate):
     """A reserved key the fit *declares* (e.g. ``verbose``, as in MCSD) is
-    forwarded — and is not warned about — while undeclared keys are stripped.
+    forwarded to the per-voxel fit, while undeclared keys are stripped and traced.
     """
-    n_vox, n_grad = 6, 8
-    data = rng.random((n_vox, n_grad))
+    data = np.zeros((6, 8))
 
     for engine in INPROCESS_ENGINES:
         seen_verbose = []
         model = _verbose_declaring_model(seen_verbose)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="dipy"):
             model.fit(data, engine=engine, n_jobs=1, verbose=True)
 
         # The declared ``verbose`` reached every per-voxel fit:
         assert seen_verbose and all(v is True for v in seen_verbose)
-        # ... and was not reported as a dropped kwarg:
-        assert not any("verbose" in str(w.message) for w in caught), (
-            "verbose was dropped/warned despite being declared by the fit"
+        # The undeclared orchestration kwargs are traced as dropped ...
+        drop_logs = [
+            r.getMessage() for r in caplog.records if "consumed for" in r.getMessage()
+        ]
+        assert drop_logs, f"expected a debug trace for dropped kwargs (engine={engine})"
+        # ... but the declared ``verbose`` is not among them:
+        assert not any("verbose" in msg for msg in drop_logs), (
+            "verbose was reported as dropped despite being declared by the fit"
         )
 
 
-@set_random_number_generator()
-def test_multi_voxel_fit_warns_on_dropped_kwargs(rng):
-    """Dropping orchestration kwargs is never silent: a warning names them."""
-    data = rng.random((6, 8))
+def test_multi_voxel_fit_logs_dropped_kwargs(caplog, dipy_log_propagate):
+    """Dropping orchestration kwargs leaves a debug trace — it is never silent."""
+    data = np.zeros((6, 8))
     received = []
     model = _recording_model(received)
-    with pytest.warns(UserWarning, match="engine"):
+    with caplog.at_level(logging.DEBUG, logger="dipy"):
         model.fit(data, engine="serial", n_jobs=1)
+    drop_logs = [
+        r.getMessage() for r in caplog.records if "consumed for" in r.getMessage()
+    ]
+    assert drop_logs, "expected a debug trace naming the dropped orchestration kwargs"
+    assert "engine" in drop_logs[0] and "n_jobs" in drop_logs[0]
 
 
 def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
@@ -434,16 +450,14 @@ def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
     received = []
     model = _recording_model(received)
     data = np.zeros((6, 8))
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        model.fit(
-            data,
-            engine="joblib",
-            n_jobs=2,
-            vox_per_chunk=3,
-            verbose=False,
-            inflight_cap=4,
-        )
+    model.fit(
+        data,
+        engine="joblib",
+        n_jobs=2,
+        vox_per_chunk=3,
+        verbose=False,
+        inflight_cap=4,
+    )
 
     # Every orchestration kwarg was handed to paramap / the engine:
     for key in ORCHESTRATION_KWARGS:
@@ -490,7 +504,6 @@ def setup_module():
     # Single-shell table for CSD.
     gtab_1s = gradient_table(bvals, bvecs=bvecs)
     response = (np.array([0.0015, 0.0003, 0.0003]), 100.0)
-    _CSD_MODEL = ConstrainedSphericalDeconvModel(gtab_1s, response)
     csd_signal = single_tensor(
         gtab_1s,
         100.0,
@@ -499,7 +512,16 @@ def setup_module():
         snr=None,
     )
     _CSD_DATA = (csd_signal[None, :] * scale).astype(float)
-    _CSD_REF = _unwrap(_CSD_MODEL.fit(_CSD_DATA))
+    with warnings.catch_warnings():
+        # CSD uses the legacy descoteaux07 SH basis by default (unrelated to
+        # this PR); silence it so DIPY_WERRORS does not fail on it.
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        _CSD_MODEL = ConstrainedSphericalDeconvModel(gtab_1s, response)
+        _CSD_REF = _unwrap(_CSD_MODEL.fit(_CSD_DATA))
 
 
 @pytest.mark.skipif(not NONSERIAL_ENGINES, reason="no parallel engine installed")
@@ -530,9 +552,17 @@ def test_dki_multi_fit_parallel_matches_serial(engine, vox_per_chunk, n_jobs):
 @pytest.mark.parametrize("vox_per_chunk", [1, 4, 100])
 def test_csd_fit_parallel_matches_serial(engine, vox_per_chunk):
     """CSD parallel == serial (guards against regressions on the absorb path)."""
-    got = _unwrap(
-        _CSD_MODEL.fit(_CSD_DATA, engine=engine, n_jobs=1, vox_per_chunk=vox_per_chunk)
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        got = _unwrap(
+            _CSD_MODEL.fit(
+                _CSD_DATA, engine=engine, n_jobs=1, vox_per_chunk=vox_per_chunk
+            )
+        )
     npt.assert_allclose(
         np.asarray(got.shm_coeff),
         np.asarray(_CSD_REF.shm_coeff),

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -20,13 +20,6 @@ joblib, has_joblib, _ = optional_package("joblib")
 dask, has_dask, _ = optional_package("dask")
 ray, has_ray, _ = optional_package("ray")
 
-# Orchestration kwargs consumed by the ``multi_voxel_fit`` decorator / ``paramap``;
-# none of these may leak into a per-voxel model fit that does not declare them.
-ORCHESTRATION_KWARGS = ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap")
-
-# Engines available for parallel testing (mirrors dipy/utils/tests/test_parallel.py).
-# "serial" is included on purpose: the serial (non-batched) path leaks the same
-# orchestration kwargs when ``engine=`` is passed explicitly.
 PARALLEL_ENGINES = ["serial"]
 if has_joblib:
     PARALLEL_ENGINES.append("joblib")
@@ -35,15 +28,7 @@ if has_dask:
 if has_ray:
     PARALLEL_ENGINES.append("ray")
 
-# Engines that actually run work in a (potentially) parallel backend.
 NONSERIAL_ENGINES = [e for e in PARALLEL_ENGINES if e != "serial"]
-
-# Engines that execute the per-voxel fit in the *calling* process, so a test can
-# observe what the fit received via shared in-memory state. "ray" always runs in
-# separate worker processes (worker-side state never reaches the parent), and
-# "serial"/joblib(n_jobs=1)/dask(threading) run in-process. Ray's per-chunk kwarg
-# stripping is covered instead by test_multi_voxel_fit_orchestration_reaches_paramap
-# (inspects the kwargs handed to paramap) and the real-engine parity tests.
 INPROCESS_ENGINES = [e for e in PARALLEL_ENGINES if e != "ray"]
 
 
@@ -188,9 +173,7 @@ def test_multi_voxel_fit(rng):
             # Make sure that an argument that is not passed is still
             # usable in the fitting procedure:
             assert kwarg_untouched
-            # Orchestration kwargs (engine, n_jobs, ...) configure parallelization
-            # only; they must never leak into the per-voxel fit (regression for
-            # dipy#4053). ``SillyModel.fit`` declares none of them, so the decorator
+            # ``SillyModel.fit`` declares no orchestration flags, so the decorator
             # must strip every one before dispatch.
             leaked = [k for k in ORCHESTRATION_KWARGS if k in kwargs]
             assert not leaked, (
@@ -301,11 +284,8 @@ def test_multi_voxel_fit(rng):
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for dipy#4053: ``multi_voxel_fit`` must not leak the
-# orchestration kwargs (engine, n_jobs, vox_per_chunk, verbose, inflight_cap)
-# into the per-voxel model fit.
+# Regression tests for dipy#4053
 # ---------------------------------------------------------------------------
-
 
 class _RecordingFit:
     """Minimal fit object that knows how to predict a constant signal."""

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -11,7 +11,12 @@ from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dki import DiffusionKurtosisModel
-from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit, ORCHESTRATION_KWARGS
+from dipy.reconst.multi_voxel import (
+    ORCHESTRATION_KWARGS,
+    CallableArray,
+    _squash,
+    multi_voxel_fit,
+)
 from dipy.sims.voxel import multi_tensor_dki, single_tensor
 from dipy.testing.decorators import set_random_number_generator, warning_for_keywords
 from dipy.utils.optpkg import optional_package
@@ -287,6 +292,7 @@ def test_multi_voxel_fit(rng):
 # Regression tests for dipy#4053
 # ---------------------------------------------------------------------------
 
+
 class _RecordingFit:
     """Minimal fit object that knows how to predict a constant signal."""
 
@@ -430,10 +436,17 @@ def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
     data = np.zeros((6, 8))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        model.fit(data, engine="joblib", n_jobs=2, vox_per_chunk=3, verbose=False)
+        model.fit(
+            data,
+            engine="joblib",
+            n_jobs=2,
+            vox_per_chunk=3,
+            verbose=False,
+            inflight_cap=4,
+        )
 
-    # The orchestration kwargs were handed to paramap / the engine:
-    for key in ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap"):
+    # Every orchestration kwarg was handed to paramap / the engine:
+    for key in ORCHESTRATION_KWARGS:
         assert key in captured["parallel_kwargs"], f"{key} did not reach paramap"
     # ... but none of them leaked into the per-chunk (per-voxel) kwargs:
     for chunk_kwargs in captured["per_chunk_kwargs"]:

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -11,7 +11,7 @@ from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dki import DiffusionKurtosisModel
-from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit
+from dipy.reconst.multi_voxel import CallableArray, _squash, multi_voxel_fit, ORCHESTRATION_KWARGS
 from dipy.sims.voxel import multi_tensor_dki, single_tensor
 from dipy.testing.decorators import set_random_number_generator, warning_for_keywords
 from dipy.utils.optpkg import optional_package
@@ -453,7 +453,7 @@ def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
         model.fit(data, engine="joblib", n_jobs=2, vox_per_chunk=3, verbose=False)
 
     # The orchestration kwargs were handed to paramap / the engine:
-    for key in ("engine", "n_jobs", "vox_per_chunk", "verbose"):
+    for key in ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap"):
         assert key in captured["parallel_kwargs"], f"{key} did not reach paramap"
     # ... but none of them leaked into the per-chunk (per-voxel) kwargs:
     for chunk_kwargs in captured["per_chunk_kwargs"]:

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -12,6 +12,7 @@ from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dki import DiffusionKurtosisModel
+import dipy.reconst.multi_voxel as mv
 from dipy.reconst.multi_voxel import (
     ORCHESTRATION_KWARGS,
     CallableArray,
@@ -433,7 +434,6 @@ def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
     kwargs are stripped. ``paramap`` is replaced by an in-process spy so the
     routing is checked deterministically without spawning workers.
     """
-    import dipy.reconst.multi_voxel as mv
 
     captured = {}
 

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -418,6 +418,41 @@ def test_multi_voxel_fit_warns_on_dropped_kwargs(rng):
         model.fit(data, engine="serial", n_jobs=1)
 
 
+def test_multi_voxel_fit_orchestration_reaches_paramap(monkeypatch):
+    """Orchestration kwargs are forwarded to ``paramap`` while the per-chunk
+    kwargs are stripped. ``paramap`` is replaced by an in-process spy so the
+    routing is checked deterministically without spawning workers.
+    """
+    import dipy.reconst.multi_voxel as mv
+
+    captured = {}
+
+    def spy(func, in_list, *, func_args=None, func_kwargs=None, **kwargs):
+        captured["parallel_kwargs"] = kwargs
+        captured["per_chunk_kwargs"] = func_kwargs
+        func_args = func_args or []
+        if isinstance(func_kwargs, (list, tuple)):
+            return [func(x, *func_args, **fk) for x, fk in zip(in_list, func_kwargs)]
+        return [func(x, *func_args, **(func_kwargs or {})) for x in in_list]
+
+    monkeypatch.setattr(mv, "paramap", spy)
+
+    received = []
+    model = _recording_model(received)
+    data = np.zeros((6, 8))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model.fit(data, engine="joblib", n_jobs=2, vox_per_chunk=3, verbose=False)
+
+    # The orchestration kwargs were handed to paramap / the engine:
+    for key in ("engine", "n_jobs", "vox_per_chunk", "verbose"):
+        assert key in captured["parallel_kwargs"], f"{key} did not reach paramap"
+    # ... but none of them leaked into the per-chunk (per-voxel) kwargs:
+    for chunk_kwargs in captured["per_chunk_kwargs"]:
+        for key in ORCHESTRATION_KWARGS:
+            assert key not in chunk_kwargs
+
+
 # --- Real-model parity fixtures (built once) --------------------------------
 _GTAB_2S = _DKI_DATA = _DKI_REF = None
 _CSD_MODEL = _CSD_DATA = _CSD_REF = None


### PR DESCRIPTION
> [!WARNING]
> **Provenance.** This pull request was fundamentally produced by [Claude Code](https://claude.com/claude-code) Opus 4.8 [1m] under my supervision (@oesteban). I independently hit this bug first, then drove and reviewed the diagnosis, the test design, and every step of the workflow below.
>
> <details>
> <summary>Prompts and nudges that drove this work</summary>
>
>
> ## Initial prompt — executed in PLAN MODE
>
> ```
> You are working in a fork of dipy/dipy. Resolve dipy/dipy#4053 — a bug in DIPY's
> `@multi_voxel_fit` decorator — and harden its argument handling. READ ISSUE
> dipy/dipy#4053 FIRST (it contains the repro, root cause, permanent code links, and
> a related-work map). Work in PLAN MODE first; do not edit until I approve the plan.
> Then follow strict red-before-green TDD.
>
> ## The bug (full details in dipy/dipy#4053)
>
> `multi_voxel_fit` (dipy/reconst/multi_voxel.py) leaks orchestration kwargs
> (`engine`, `n_jobs`, `vox_per_chunk`, `verbose`, and on master also `inflight_cap`)
> into the per-voxel fit function when a parallel engine is used. The parallel
> branch builds per-chunk kwargs from a full `kwargs.copy()` without removing those
> keys, and `_parallel_fit_worker` forwards them straight into `single_voxel_fit`,
> which doesn't accept them -> TypeError. Every reconstruction model is affected;
> DKI is the easiest reproducer.
>
> Minimal repro (dipy 1.10.0; re-verify on the current checkout):
>
> \`\`\`python
> import numpy as np
> from dipy.core.gradients import gradient_table
> from dipy.reconst.dki import DiffusionKurtosisModel
> rng = np.random.default_rng(0)
> bvals = np.r_[0, np.full(15,1000), np.full(15,2000), np.full(15,3000)].astype(float)
> bvecs = np.zeros((46,3)); bvecs[1:] = rng.standard_normal((45,3))
> bvecs[1:] /= np.linalg.norm(bvecs[1:],axis=1,keepdims=True)
> gtab = gradient_table(bvals, bvecs=bvecs)
> data = rng.random((100, bvals.size))*100 + 100
> m = DiffusionKurtosisModel(gtab)
> m.multi_fit(data, engine="joblib", n_jobs=2)   # -> TypeError: ls_fit_dki() got an unexpected keyword argument 'engine'
> \`\`\`
>
> Reference points (verify line numbers against HEAD before trusting them):
> - 1.10.0 (4eb161f): worker forwards kwargs to single_voxel_fit
>   https://github.com/dipy/dipy/blob/4eb161f32d7cf6100a656372ea8c740800ec2cc6/dipy/reconst/multi_voxel.py#L15-L35
>   chunk kwargs built unstripped
>   https://github.com/dipy/dipy/blob/4eb161f32d7cf6100a656372ea8c740800ec2cc6/dipy/reconst/multi_voxel.py#L115-L125
> - master (d9e9e30): leak persists
>   https://github.com/dipy/dipy/blob/d9e9e30cedf89562b88cff120b0e69efb028d912/dipy/reconst/multi_voxel.py#L324-L344
>   https://github.com/dipy/dipy/blob/d9e9e30cedf89562b88cff120b0e69efb028d912/dipy/reconst/multi_voxel.py#L101-L113
> - Note: the master *batched-serial* path already strips these keys
>   (`if k not in ("engine","n_jobs","vox_per_chunk","verbose")`); the parallel
>   branch does not. Use that existing pattern as the reference fix.
>
> Origin (context only): nipreps/nifreeze#442, #142, #443.
>
> ## Phase 0 — Reproduce + plan (PLAN MODE)
> - Set up a dev install of this fork (editable) and confirm which `engine` backends
>   are actually installed (joblib always; dask/ray optional). Reproduce the bug on
>   the CURRENT code; capture the exact traceback and the real current line numbers.
> - Read `multi_voxel_fit`, `_parallel_fit_worker`, and `dipy.utils.parallel.paramap`
>   end to end. Map every kwarg: where it originates (model.fit/multi_fit call),
>   which are orchestration vs. per-voxel-model kwargs, and where each is consumed.
> - Produce a written plan: the minimal fix, the test strategy, and the audit scope.
>   Stop for my approval.
>
> ## Phase 1 — Tests FIRST, and prove they FAIL (red)
> - Write regression tests in the appropriate dipy test module BEFORE touching the
>   decorator. They must FAIL against the current (unpatched) code — run them and
>   paste the failing output.
> - Tests must be unequivocal and cover at least:
>   1. `model.fit`/`multi_fit` with `engine="joblib"` (and `engine="serial"`, and
>      `dask`/`ray` guarded by importorskip) raises NO error and returns fits whose
>      parameters are numerically equal (allclose) to the serial path, for >1 model
>      (DKI and at least one more, e.g. DTI/CSD) — pick models whose single-voxel
>      fit signature would reject `engine`/`n_jobs`.
>   2. A direct, white-box assertion that the orchestration keys never reach the
>      single-voxel fit: e.g. monkeypatch/wrap `single_voxel_fit` (or
>      `_parallel_fit_worker`) to record received kwargs and assert
>      `engine`/`n_jobs`/`vox_per_chunk`/`verbose`/`inflight_cap` are absent while a
>      legitimate model kwarg (e.g. a `weights` array or `fit_method`) is present.
>   3. Parametrize over `vox_per_chunk` boundaries (1, < n_vox, > n_vox) and a
>      single-CPU case so we don't reintroduce prior parallel regressions.
>
> ## Phase 2 — Patch (green), then audit side effects
> - Apply the minimal fix: strip the orchestration keys from the per-voxel kwargs
>   before dispatch (mirror the batched-serial path), NOT from the dict passed to
>   `paramap`. Re-run Phase 1 tests until green; run the full reconst test suite.
> - Because the fix deletes/ignores kwargs, explicitly verify NO side effects:
>   * The stripped keys are still delivered to `paramap` / the engine where they’re
>     needed (n_jobs, vox_per_chunk, engine selection, verbose, inflight_cap).
>   * No reconstruction model legitimately accepts a fit kwarg named `engine`,
>     `n_jobs`, `vox_per_chunk`, `verbose`, or `inflight_cap` (grep the reconst
>     package); if any does, resolve the collision deliberately, don’t silently drop.
>   * `weights`, `mask`, `fit_method`, and model-specific kwargs still pass through
>     intact on both serial and parallel paths (assert in tests).
>
> ## Phase 3 — Audit the decorator’s argument handling and report gaps
> My hypothesis: `multi_voxel_fit` is brittle about kwargs and does NOT let callers
> configure the underlying parallelization library. Audit and document:
> - Exactly which kwargs `multi_voxel_fit` forwards to `paramap`, vs. which `paramap`
>   (and the underlying joblib/dask/ray) actually accept (joblib backend, dask
>   scheduler/backend, ray num_cpus/num_gpus/object-store/init options, inflight_cap,
>   per-engine batch sizing). Show, with code links, where backend-specific options
>   are currently swallowed or impossible to set from `model.fit(...)`.
> - Propose a clean, collision-free routing scheme (e.g. an explicit `engine_kwargs`
>   dict, or a reserved prefix) so parallelization can be configured without mixing
>   into per-voxel model kwargs, and so adding engines doesn’t require editing a
>   hardcoded key list. Provide a short gap table (param -> supported? -> where lost).
> - Keep this as a written report + (optional) a follow-up issue draft; only
>   implement beyond the leak fix if I approve.
>
> ## Constraints
> - Follow DIPY’s contribution conventions (commit style, changelog/news fragment if
>   required, code style/linting). Keep the leak fix minimal and isolated from the
>   Phase 3 redesign. Don’t break the serial, batched, dask, or ray paths.
> - The PR must close the issue: include "Fixes dipy/dipy#4053" in the PR body, and
>   reference it in the news/changelog fragment if DIPY uses one.
> - Show me the failing test output (Phase 1) and the diff before committing or
>   opening a PR; push/PR only on my confirmation.
> ```
>
> ## Plan iterations
>
> The plan was authored and refined entirely in PLAN MODE. It was approved on the
> **4th submission to `ExitPlanMode`** — the first three were rejected with revision
> requests — and additionally went through **2 in-plan clarification rounds**
> (`AskUserQuestion`) plus the initial "where's my plan?" nudge. That is **6
> plan-shaping exchanges** before approval. The driving messages are reproduced
> verbatim under "Relevant later exchanges" below.
>
> ## Approved plan (verbatim)
>
> ```
> # Fix kwargs leak in `@multi_voxel_fit` (dipy/dipy#4053)
>
> ## Context
>
> `@multi_voxel_fit` (`dipy/reconst/multi_voxel.py`) is DIPY's decorator that turns a
> single-voxel model fit into a whole-volume fit and, since #2593/#3844, optionally
> parallelizes it via `dipy.utils.parallel.paramap`. The caller selects parallelism
> through **orchestration kwargs** mixed into the same `**kwargs` as model fit options:
> `engine`, `n_jobs`, `vox_per_chunk`, `verbose`, `inflight_cap`.
>
> **Bug:** in the parallel branch the per-voxel kwargs are built from an unstripped
> `kwargs.copy()` and `_parallel_fit_worker` forwards them straight into the
> single-voxel fit, which doesn't accept them → `TypeError` (e.g.
> `ls_fit_dki() got an unexpected keyword argument 'engine'`). This makes DIPY's own
> multi-voxel parallelization unusable from the public API for every real model
> (DKI, DTI, CSD, …). Surfaced while parallelizing DKI in NiFreeze (nipreps/nifreeze#442).
>
> **Confirmed at source (HEAD `d9e9e30`):**
> - Parallel branch builds chunk kwargs unstripped: `multi_voxel.py:324-333` (`kw = kwargs.copy()`).
> - Worker pops only `_sobj_*`, `_batched`, `weights` — not the orchestration keys: `multi_voxel.py:84-113`.
> - The **batched-serial** path already strips them correctly (`if k not in ("engine","n_jobs","vox_per_chunk","verbose")`): `multi_voxel.py:247-251` — this is the reference pattern. (Note: it omits `inflight_cap`.)
> - The **serial non-batched** path (`multi_voxel.py:267-294`, dispatch at `:282`) also passes full `kwargs`, so it leaks too whenever `engine=`/etc. are passed explicitly. The existing test masks this because its `SillyModel.fit` has `**kwargs` and swallows them; real models forward to helpers without `**kwargs`.
>
> Intended outcome: `model.fit/multi_fit(data, engine="joblib", n_jobs=...)` runs and
> returns fits numerically identical to the serial path, for every model — with the
> orchestration kwargs reaching `paramap`/the engine but never the per-voxel fit.
>
> ## Collision found + chosen resolution (signature-aware routing)
>
> `MCSD.fit(self, data, verbose=True, **kwargs)` — `dipy/reconst/mcsd.py:317-318` —
> declares `verbose` as a real model kwarg. It is the **only** decorated fit that collides
> with a reserved orchestration key. (No decorated fit declares `engine`, `n_jobs`,
> `vox_per_chunk`, or `inflight_cap`. `quantize_evecs` at `dti.py:2494` has `engine`/`n_jobs`
> but is **not** `@multi_voxel_fit`-decorated — irrelevant.)
>
> **Resolution (per user):** a reserved key must be *forwarded to a fit that explicitly
> declares it, ignored (stripped) for fits that don't, and never crash a strict helper.*
> Implement this by **introspecting the single-voxel fit's signature** rather than a blunt
> strip: forward each reserved key only when the fit names it as an explicit parameter.
> - MCSD declares `verbose` ⇒ it receives `verbose` (and `paramap` also gets it for its
>   progress bar — dual-routed, both honored).
> - DKI's `ls_fit_dki` / every other fit does **not** declare these ⇒ all reserved keys are
>   stripped from the per-voxel call ⇒ no `TypeError`.
>
> This generalizes to any future model and is the seed of the Phase 3 "more articulated way
> for models to declare the arguments their fit accepts" discussion (which I'll write up,
> not implement, unless approved).
>
> ## The fix (minimal, isolated)
>
> In `dipy/reconst/multi_voxel.py`:
>
> 1. Module-level constant + a tiny introspection helper:
>    \`\`\`python
>    import inspect
>    _ORCHESTRATION_KWARGS = ("engine", "n_jobs", "vox_per_chunk", "verbose", "inflight_cap")
>
>    def _accepts_kwarg(func, name):
>        """True iff `func` declares `name` as an explicit param (not via **kwargs)."""
>        try:
>            p = inspect.signature(func).parameters.get(name)
>        except (TypeError, ValueError):
>            return False
>        return p is not None and p.kind in (
>            inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
>    \`\`\`
> 2. Inside `decorator(single_voxel_fit)`, compute the drop set **once** (per decorated
>    function), so a key MCSD declares is preserved:
>    \`\`\`python
>    _drop_kwargs = tuple(
>        k for k in _ORCHESTRATION_KWARGS if not _accepts_kwarg(single_voxel_fit, k))
>    \`\`\`
> 3. **Warn on drop (transparency).** At the top of `new_fit`, when the caller actually
>    passed any key in `_drop_kwargs`, emit one informative `warnings.warn(...)` naming the
>    dropped keys, e.g.:
>    \`\`\`python
>    _dropped = [k for k in _drop_kwargs if k in kwargs]
>    if _dropped:
>        warnings.warn(
>            f"multi_voxel_fit: {_dropped} consumed for parallelization/orchestration; "
>            f"not forwarded to the per-voxel fit (it does not declare them).",
>            UserWarning, stacklevel=2)
>    \`\`\`
>    Python's default warning filter shows this once per call site, so no hot-path spam.
>    (Keys the fit *does* declare — MCSD's `verbose` — are forwarded and **not** warned.)
> 4. **Parallel branch** (`:324-333`): build per-chunk base from a stripped dict, not
>    `kwargs.copy()`: `base_kw = {k: v for k, v in kwargs.items() if k not in _drop_kwargs}`
>    then add `_batched`/`_raw`/`weights` as today. Leave `parallel_kwargs` (`:335-344`)
>    untouched — it still forwards orchestration keys to `paramap`.
> 5. **Serial non-batched path** (`:267-294`): compute `fit_kwargs = {k: v ... not in
>    _drop_kwargs}` once before the `ndindex` loop; inject per-voxel `weights` into a copy;
>    dispatch with it (mirrors batched-serial).
> 6. **Batched-serial path** (`:247-251`): replace the inline 4-key tuple with `_drop_kwargs`
>    (now also covers `inflight_cap`, and respects an explicitly-declared `verbose`).
>
> The signature introspection answers "which keys does this fit accept?"; the warning makes
> every drop visible/debuggable so the routing is never silent magic. (`warnings` is already
> imported-by-convention across DIPY; add the import if absent.)
>
> Strips orchestration keys from the **per-voxel** kwargs only, never from the dict passed
> to `paramap`. (Note: `warning_for_keywords`-wrapped fits — e.g. DKI — must still introspect
> correctly; verify the wrapper preserves the signature via `functools.wraps`/`__wrapped__`.
> Worst case a wrapped fit that declares a reserved key gets it stripped, but no such model
> exists today — MCSD is the only verbose-declaring fit and it is unwrapped.)
>
> ## TDD — tests first, prove red (Phase 1)
>
> Extend `dipy/reconst/tests/test_multi_voxel.py` (engine-guard pattern already present:
> `has_joblib/has_dask/has_ray` via `optional_package`, lines 11-13). **Reuse and extend the
> existing `SillyModel`** (lines 145-157) rather than adding a parallel bespoke model — its
> `**kwargs` currently masks the bug, so it's the natural place to exercise the protocol.
>
> 1. **Harden `SillyModel.fit` into a white-box leak check** — add an inline assertion in
>    its body that none of `engine/n_jobs/vox_per_chunk/verbose/inflight_cap` appear in the
>    received `**kwargs`. This immediately turns the EXISTING serial/joblib/dask/ray + mask
>    + sequence-kwarg coverage (lines 187-258) into a direct regression: **red** before the
>    patch (serial-explicit at line 200 and the parallel loop both leak `engine`/`verbose`),
>    **green** after. Because `SillyModel.fit` declares none of the reserved keys, `verbose`
>    is now dropped+warned, so the calls that pass `verbose=` must be wrapped in
>    `pytest.warns(UserWarning)` (and verbose still reaches `paramap` for the progress bar).
>    Also assert a `weights` array still reaches the fit and is sliced per voxel.
> 2. **Declared-key passthrough (introspection branch)** — add a small sibling model whose
>    `fit` **explicitly declares** `verbose` (mimicking MCSD `mcsd.py:318`): assert it
>    *receives* `verbose`, that `engine/n_jobs/…` are still stripped, and that **no** warning
>    fires (the declared key is forwarded, not dropped). Pair with an explicit
>    `pytest.warns(UserWarning)` assertion on `SillyModel` to lock warn-on-drop.
> 3. **Numeric parity** — real **decorated** models on small synthetic data (use
>    `dipy.sims.voxel.multi_tensor_dki`/`single_tensor` + `gradient_table`, per
>    `test_dki_micro.py`/`test_dti.py`). Primary: **DKI** (`DiffusionKurtosisModel.multi_fit`,
>    `dki.py:1973`) and **CSD** (`csdeconv.py:195/340`) — both `@multi_voxel_fit`-decorated
>    with single-voxel fits that reject `engine`. Fit `engine="serial"` vs `joblib`
>    (+ `dask`/`ray` guarded); assert `np.allclose` on `.model_params` (+ a derived metric,
>    e.g. DKI `.kt`, CSD `.shm_coeff`). DKI joblib raises the exact issue `TypeError` ⇒ red.
>    (DTI is the issue's secondary case — `TensorModel.fit` may not be `@multi_voxel_fit`-
>    decorated; confirm during execution and include only if it routes through the decorator,
>    else substitute another decorated model, e.g. IVIM/FWDTI.)
> 4. **Boundaries** — parametrize `vox_per_chunk` ∈ {1, < n_vox, ≥ n_vox} and `n_jobs=1`
>    (single-CPU) to guard against prior parallel regressions (e.g. 22f767b0).
>
> Run the new tests against unpatched code and **paste the failing output** before editing
> the decorator.
>
> ## Green + side-effect audit (Phase 2)
>
> - Apply the fix; iterate tests to green; run `pytest dipy/reconst/tests/test_multi_voxel.py
>   dipy/utils/tests/test_parallel.py` then the broader `pytest dipy/reconst/tests`.
> - Explicitly verify (assertions in tests where practical):
>   - Orchestration keys still reach `paramap`/engine (n_jobs, vox_per_chunk, engine,
>     verbose, inflight_cap) — `parallel_kwargs` unchanged.
>   - `weights`, `mask`, `fit_method`, model-specific kwargs still pass through on serial
>     **and** parallel paths.
>   - Only collision is MCSD `verbose`, handled as above; no silent drop of a real kwarg.
>
> ## Phase 3 — argument-handling audit (written report only; no code unless approved)
>
> Deliver a report (`doc/` note or a follow-up issue draft) covering:
> - Gap table: each backend option (joblib `backend`; dask `scheduler`/`backend`; ray
>   `num_cpus`/`num_gpus`/object-store/`init` opts; `inflight_cap`; per-engine batch
>   sizing) → reachable from `model.fit(...)` today? → where it's lost. Key finding from
>   source: the decorator forwards only `n_jobs/vox_per_chunk/engine/verbose/inflight_cap`
>   to `paramap` (`:335-344`); `backend` and all engine-specific `**kwargs` that `paramap`
>   accepts (`parallel.py:147-163`) are unreachable.
> - Proposal: a collision-free routing scheme — an explicit `engine_kwargs` dict (or a
>   reserved prefix) — so parallelization is configurable without polluting per-voxel
>   kwargs, and adding an engine doesn't require editing a hardcoded key list (e.g. derive
>   reserved keys by introspecting `paramap`'s signature). Kept separate from the leak fix.
>
> ## Delivery workflow — red-on-CI first, then green (explicit)
>
> The regression must be demonstrably red in CI before the fix lands, so the PR history
> itself proves the bug:
>
> 1. **Tests-only commit.** Write the Phase 1 tests; run them locally and **confirm they
>    FAIL** against unpatched code (paste output for review). Commit *only the tests*
>    (`TEST:` prefix). Show the diff; commit/push **only on confirmation**.
> 2. **Push + draft PR.** Push the tests-only branch; open a **draft** PR with body
>    "Fixes dipy/dipy#4053". Expect **CI/CD to go red** on this commit (the new tests fail
>    on unpatched code) — this is the intended, visible proof.
> 3. **Fix commit.** Implement the `multi_voxel.py` fix; run the tests locally until
>    **green** and run the broader reconst/parallel suites. Show the diff; commit
>    (`BF:` prefix) and push to the same PR **on confirmation**.
> 4. **Lift draft.** When CI/CD turns **green** on the fix commit, mark the PR
>    ready-for-review (lift the draft flag).
>
> (Two commits — tests then fix — kept separate and in that order. Phase 3 audit is a
> separate report/issue, not part of this PR unless approved.)
>
> ## Conventions / deliverables
>
> - Commit prefixes are enforced by `tools/hooks/commit-msg.py` — use `BF:` (fix) and
>   `TEST:` (tests); subject 15–78 chars, blank second line, no trailing period.
> - No towncrier/changelog fragments in this repo (release notes are generated under
>   `doc/release_notes/`). PR body must include **"Fixes dipy/dipy#4053"**.
> - Show failing test output (Phase 1) and the diff before any commit/push. Push/PR only
>   on explicit confirmation.
>
> ## Files
>
> - `dipy/reconst/multi_voxel.py` — the fix (constant + 3 paths).
> - `dipy/reconst/tests/test_multi_voxel.py` — regression tests.
> - (Phase 3) a new report file / issue draft — no source changes without approval.
>
> ## Verification
>
> 1. Build editable install first (Phase 0 — repo isn't built; `dipy.version` missing):
>    `pip install -e . --no-build-isolation` (or per `CONTRIBUTING.md`), then reproduce the
>    issue snippet to capture the real traceback on this checkout.
> 2. `pytest dipy/reconst/tests/test_multi_voxel.py -v` — red before, green after.
> 3. `pytest dipy/reconst/tests dipy/utils/tests/test_parallel.py` — no regressions.
> 4. Re-run the issue's DKI repro with `engine="joblib", n_jobs=2` — completes and matches
>    the serial fit.
> ```
>
> ## Relevant later exchanges (verbatim user messages; my actions summarized in brackets)
>
> ### 1. In-plan clarification round 1 — MCSD `verbose` collision + path scope
> [Answer to AskUserQuestion. The first answer reshaped the fix from a blunt strip into signature-aware routing; the second expanded scope to the serial path.]
>
> Q (MCSD verbose collision): "Add verbose to all fit methods, and make sure that it is ignored if the particular fit does not use it and will trip if defined, which bring the question of a more articulated way for Models to declare the arguments fit can take."
>
> Q (serial path scope): "Fix both paths (recommended)"
>
> ### 2. ExitPlanMode rejection 1 — red-on-CI-first delivery workflow
> [Added the explicit Delivery workflow section to the plan.]
>
> The plan should be clear that we will first commit the tests in a single commit. These tests will have been verified to break locally first. It will be committed and pushed, and we will create a draft PR. The CI/CD builds should now break in the PR. Next, the fix is built, the tests should go green locally and finally the fix is pushed to the PR. If CI/CD turns green, we lift the draft flag.
>
> ### 3. ExitPlanMode rejection 2 — "introspection is a bit obscure"
> [Led to AskUserQuestion on routing design.]
>
> The introspection into the fit signature is very interesting, but I'm a bit afraid the solution is a bit obscure. Please consider either (a) issue a warning when keyword arguments are dropped; or (b) take an explicit, white-list approach such that the Model declares the list of acceptable arguments in fit. Perhaps (a) is sufficient?
>
> ### 4. In-plan clarification round 2 — routing design
> [Answer to AskUserQuestion: keep introspection AND warn on drop. The plan's fix section gained the warn-on-drop step.]
>
> Keep the signature-introspection but issue a warning when dropping keywords
>
> ### 5. ExitPlanMode rejection 3 — reuse SillyModel
> [Reworked the Phase 1 test section to harden the existing SillyModel rather than add a parallel bespoke model.]
>
> SillyModel.fit is not touched by any tests? It looks like a missed opportunity to exercise the new protocol, isn't it?
>
> ### 6. Environment setup decision
> [Used micromamba to create a dedicated `dipy-dev` env (Python 3.12) for the editable build, since only system Python 3.9 was available.]
>
> use micromamba, create a new environment for dipy
>
> ### 7. Tests-only commit + draft PR confirmation, with PR-description requirements
> [Branched, committed tests-only (TEST:), pushed, opened draft PR #4054 with a WARNING provenance admonition and an expandable prompt/nudge log.]
>
> Yes, proceed as described (i.e., option (1)). That said, please make sure that the DRAFT PR's description is as brief as possible but as detailed as necessary. Include a WARNING admonition at the top declaring that this is fundamentally Claude Code's work with my supervision, and include an expandable description inside (see https://github.com/dipy/dipy/issues/4053 for reference) that tracks my initial prompt and subsequent nudges.
>
> </details>

Fixes #4053.

## What this PR does

`@multi_voxel_fit` (`dipy/reconst/multi_voxel.py`) leaks its orchestration kwargs — `engine`, `n_jobs`, `vox_per_chunk`, `verbose`, `inflight_cap` — into the per-voxel model fit, which doesn't accept them, so any parallel call raises e.g. `TypeError: ls_fit_dki() got an unexpected keyword argument 'engine'`. Full diagnosis and code links in #4053.

This PR follows strict TDD:

1. **Tests only commit (https://github.com/dipy/dipy/pull/4054/commits/aa7148bac9813a4e2587cb8e961ec6c04363cfcb).** New/extended regression tests in `dipy/reconst/tests/test_multi_voxel.py` that **fail on current `master`**. CI is expected to be **red** here to make the bug apparent.
2. **Patch (next commit(s)).** Strip the orchestration kwargs from the per-voxel kwargs on every dispatch path (parallel, serial-non-batched, batched-serial). The strip is **signature-aware**: a reserved key a fit *explicitly declares* (e.g. `MCSD.fit(..., verbose=True, ...)`) is forwarded; undeclared keys are stripped, and a `UserWarning` names anything dropped so the routing is never silent. The keys still reach `paramap`/the engine.

When CI is back to green, the draft flag will be lifted.

## Tests added

- **Hardened the existing `SillyModel`** so the current serial/joblib/dask/mask/sequence coverage now asserts that no orchestration kwarg reaches the per-voxel fit.
- **White-box:** no-leak across `serial` + every available engine (joblib/dask/ray), with `weights` and `fit_method` passthrough; declared-key (`verbose`) forwarding without a warning; warn-on-drop for undeclared keys.
- **Numeric parity:** DKI (`multi_fit`) and CSD give `parallel == serial` across `vox_per_chunk ∈ {1, <n, >n}` and `n_jobs ∈ {1, 2}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
