### PR TITLE
MNT: wrap itertools.product in list() for pytest 10 compatibility

### DIFF
--- a/dipy/io/tests/test_stateful_surface.py
+++ b/dipy/io/tests/test_stateful_surface.py
@@ -241,7 +241,7 @@ def test_random_space_transformations():
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
-@pytest.mark.parametrize("space, origin", itertools.product(SPACES, ORIGINS))
+@pytest.mark.parametrize("space, origin", list(itertools.product(SPACES, ORIGINS)))
 def test_space_origin_gold_standard(space, origin):
     fname = FILEPATH_DIX[f"gs_mesh_{space.value.lower()}_{origin.value.lower()}.ply"]
     sfs = load_surface(

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -65,7 +65,7 @@ def test_direct_trx_loading():
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
-@pytest.mark.parametrize("ext, space", itertools.product(EXTENSIONS, SPACES))
+@pytest.mark.parametrize("ext, space", list(itertools.product(EXTENSIONS, SPACES)))
 def test_space_gold_standard(ext, space):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
     from_space = Space.LPSMM if ext in ["vtk", "fib"] else Space.RASMM


### PR DESCRIPTION
## Description

pytest 10 deprecates passing non-Collection iterables to parametrize. Wrap itertools.product() calls in list() in test_stateful_surface.py and test_stateful_tractogram.py.

## Motivation and Context

fix those new release coming from pytest new release
```
../venv/lib/python3.13/site-packages/_pytest/python.py:124
  /Users/runner/work/dipy/dipy/venv/lib/python3.13/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: io/tests/test_stateful_surface.py::test_space_origin_gold_standard, argvalues type: product
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

../venv/lib/python3.13/site-packages/_pytest/python.py:124
  /Users/runner/work/dipy/dipy/venv/lib/python3.13/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: io/tests/test_stateful_tractogram.py::test_space_gold_standard, argvalues type: product
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)
```

## How Has This Been Tested?

unitest

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
