### PR TITLE
BF: Fix MSVC C4244 warnings in dipy/align

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -260,7 +260,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
                         firstc = _int_max(0, cc - radius)
                         lastc = _int_min(nc - 1, cc + radius)
                         sidec = (lastc - firstc + 1)
-                        cnt = sides*sider*sidec
+                        cnt = <double>sides * <double>sider * <double>sidec
                         Imean = temp[sss, rr, cc, SI] / cnt
                         Jmean = temp[sss, rr, cc, SJ] / cnt
                         IJprods = (temp[sss, rr, cc, SIJ] -

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -652,10 +652,10 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
         if total_sum > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= valid_points
+                    joint[i, j] /= <double>valid_points
 
             for i in range(nbins):
-                smarginal[i] /= valid_points
+                smarginal[i] /= <double>valid_points
 
             for j in range(nbins):
                 mmarginal[j] = 0
@@ -746,7 +746,7 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
                     joint[i, j] /= total_sum
 
             for i in range(nbins):
-                smarginal[i] /= valid_points
+                smarginal[i] /= <double>valid_points
 
             for j in range(nbins):
                 mmarginal[j] = 0
@@ -822,7 +822,7 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
                     joint[i, j] /= total_sum
 
             for i in range(nbins):
-                smarginal[i] /= valid_points
+                smarginal[i] /= <double>valid_points
 
             for j in range(nbins):
                 mmarginal[j] = 0
@@ -907,8 +907,8 @@ cdef _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
                     continue
 
                 valid_points += 1
-                x[0] = _apply_affine_2d_x0(i, j, 1, grid2world)
-                x[1] = _apply_affine_2d_x1(i, j, 1, grid2world)
+                x[0] = _apply_affine_2d_x0(<double>i, <double>j, 1, grid2world)
+                x[1] = _apply_affine_2d_x1(<double>i, <double>j, 1, grid2world)
 
                 if constant_jacobian == 0:
                     constant_jacobian = transform._jacobian(theta, x, J)
@@ -929,7 +929,7 @@ cdef _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
                         grad_pdf[r, c + offset, k] -= val * prod[k]
                     spline_arg += 1.0
 
-        norm_factor = valid_points * mdelta
+        norm_factor = <double>valid_points * mdelta
         if norm_factor > 0:
             for i in range(nbins):
                 for j in range(nbins):
@@ -1018,9 +1018,9 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                     if mmask is not None and mmask[k, i, j] == 0:
                         continue
                     valid_points += 1
-                    x[0] = _apply_affine_3d_x0(k, i, j, 1, grid2world)
-                    x[1] = _apply_affine_3d_x1(k, i, j, 1, grid2world)
-                    x[2] = _apply_affine_3d_x2(k, i, j, 1, grid2world)
+                    x[0] = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, grid2world)
+                    x[1] = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, grid2world)
+                    x[2] = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, grid2world)
 
                     if constant_jacobian == 0:
                         constant_jacobian = transform._jacobian(theta, x, J)
@@ -1042,7 +1042,7 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                             grad_pdf[r, c + offset, l] -= val * prod[l]
                         spline_arg += 1.0
 
-        norm_factor = valid_points * mdelta
+        norm_factor = <double>valid_points * mdelta
         if norm_factor > 0:
             for i in range(nbins):
                 for j in range(nbins):
@@ -1132,7 +1132,7 @@ cdef _joint_pdf_gradient_sparse_2d(double[:] theta, Transform transform,
                     grad_pdf[r, c + offset, j] -= val * prod[j]
                 spline_arg += 1.0
 
-        norm_factor = valid_points * mdelta
+        norm_factor = <double>valid_points * mdelta
         if norm_factor > 0:
             for i in range(nbins):
                 for j in range(nbins):
@@ -1224,7 +1224,7 @@ cdef _joint_pdf_gradient_sparse_3d(double[:] theta, Transform transform,
                     grad_pdf[r, c + offset, j] -= val * prod[j]
                 spline_arg += 1.0
 
-        norm_factor = valid_points * mdelta
+        norm_factor = <double>valid_points * mdelta
         if norm_factor > 0:
             for i in range(nbins):
                 for j in range(nbins):


### PR DESCRIPTION
## Description

Add explicit Cython casts to silence MSVC C4244 warnings caused by implicit npy_intp-to-double conversions in parzenhist.pyx and crosscorr.pyx: cast loop indices before _apply_affine_*d_x* calls, valid_points before division/multiplication, and sides/sider/sidec before the cnt product.


These changes improve code robustness and maintain consistency in how coordinates are handled throughout the vector field and image transformation pipeline. It should help for https://github.com/dipy/dipy/issues/2376

PR 2/6


## Motivation and Context

improving and trying to reach https://github.com/dipy/dipy/issues/2588

## How Has This Been Tested?

via unit test

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
