### PR TITLE
BF: Fix MSVC C4244 npy_intp conversion warnings in dipy/reconst

### DIFF
--- a/dipy/reconst/_force_search.pyx
+++ b/dipy/reconst/_force_search.pyx
@@ -86,9 +86,9 @@ cdef void compute_distances_blas(
 
     Computes: distances_out[i, j] = queries[i, :] . database[j, :]
     """
-    cdef int nd = database.shape[0]
-    cdef int nq = queries.shape[0]
-    cdef int d = queries.shape[1]
+    cdef int nd = <int>database.shape[0]
+    cdef int nq = <int>queries.shape[0]
+    cdef int d = <int>queries.shape[1]
 
     cdef float alpha = 1.0
     cdef float beta = 0.0
@@ -252,9 +252,9 @@ def search_inner_product(
     indices : int64 array (n_queries, k)
         Indices of nearest neighbors
     """
-    cdef int n_queries = queries.shape[0]
-    cdef int n_database = database.shape[0]
-    cdef int d = queries.shape[1]
+    cdef cnp.npy_intp n_queries = queries.shape[0]
+    cdef cnp.npy_intp n_database = database.shape[0]
+    cdef cnp.npy_intp d = queries.shape[1]
 
     if queries.shape[1] != database.shape[1]:
         raise ValueError(
@@ -311,7 +311,7 @@ def inner_product_single(
     float
         Inner product
     """
-    cdef int d = x.shape[0]
+    cdef cnp.npy_intp d = x.shape[0]
 
     if x.shape[0] != y.shape[0]:
         raise ValueError(f"Dimension mismatch: {x.shape[0]} != {y.shape[0]}")
@@ -342,7 +342,7 @@ def l2sqr_single(
     float
         Squared L2 distance
     """
-    cdef int d = x.shape[0]
+    cdef cnp.npy_intp d = x.shape[0]
 
     if x.shape[0] != y.shape[0]:
         raise ValueError(f"Dimension mismatch: {x.shape[0]} != {y.shape[0]}")

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -140,7 +140,7 @@ def remove_similar_vertices(
     if vertices.shape[1] != 3:
         raise ValueError('Vertices should be 2D with second dim length 3')
 
-    cdef int n = vertices.shape[0]
+    cdef cnp.npy_intp n = vertices.shape[0]
     if n >= 2**16:
         raise ValueError("Too many vertices")
 


### PR DESCRIPTION
## Description

Add explicit <int> casts in _force_search.pyx where shape values are passed to BLAS (which expects int*), and change remaining shape assignments to cnp.npy_intp in _force_search.pyx and recspeed.pyx to eliminate implicit npy_intp-to-int conversion warnings.

These changes improve code robustness and maintain consistency. It should help for https://github.com/dipy/dipy/issues/2376

PR 4/6

## Motivation and Context

improving and trying to reach https://github.com/dipy/dipy/issues/2588

## How Has This Been Tested?

unitest

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
