### PR TITLE
CI: disable some CI's on fork. 

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
         cd doc
         make -C . html-no-examples SPHINXOPTS="-W --keep-going"
     - name: Deploy dev docs to docs.dipy.org
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'dipy/dipy'
       env:
         DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
       run: |

--- a/.github/workflows/first_interaction.yml
+++ b/.github/workflows/first_interaction.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'dipy/dipy'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'dipy/dipy'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Description

This pull request makes minor updates to the GitHub Actions workflow configuration files to ensure that certain jobs only run on the main `dipy/dipy` repository, and not on forks or other repositories. This helps prevent unnecessary or unintended workflow executions.

## Motivation and Context

some Jobs works only on master and will fail on a fork

## How Has This Been Tested?

locally

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
