### PR TITLE
BF: Fix MSVC C4244 npy_intp conversion warnings in dipy/segment

### DIFF
--- a/dipy/io/tests/test_stateful_surface.py
+++ b/dipy/io/tests/test_stateful_surface.py
@@ -11,6 +11,7 @@ from dipy.data import get_fnames
 from dipy.io.stateful_surface import StatefulSurface
 from dipy.io.surface import load_surface, save_surface
 from dipy.io.utils import Origin, Space, recursive_compare
+from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
 vtk, have_vtk, setup_module = optional_package(
@@ -217,7 +218,8 @@ def test_equality():
     npt.assert_(sfs_1 == sfs_2)
 
 
-def test_random_space_transformations():
+@set_random_number_generator(0)
+def test_random_space_transformations(rng):
     sfs = load_surface(
         FILEPATH_DIX["naf_lh.pial"], FILEPATH_DIX["naf_mni_masked.nii.gz"]
     )
@@ -229,15 +231,15 @@ def test_random_space_transformations():
 
     # Apply 100 random transformations
     for _ in range(100):
-        space = np.random.choice(SPACES, 1, replace=False)
-        origin = np.random.choice(ORIGINS, 1, replace=False)
+        space = rng.choice(SPACES)
+        origin = rng.choice(ORIGINS)
         sfs.to_space(space)
         sfs.to_origin(origin)
 
     # Return to initial space and compare
     sfs.to_rasmm()
     sfs.to_center()
-    npt.assert_almost_equal(initial_vertices, sfs.vertices, decimal=5)
+    npt.assert_array_almost_equal(initial_vertices, sfs.vertices, decimal=5)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -235,7 +235,7 @@ cdef class CenterOfMassFeature(CythonFeature):
         return shape
 
     cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) noexcept nogil:
-        cdef int N = datum.shape[0], D = datum.shape[1]
+        cdef cnp.npy_intp N = datum.shape[0], D = datum.shape[1]
         cdef cnp.npy_intp i, d
 
         for d in range(D):
@@ -246,7 +246,7 @@ cdef class CenterOfMassFeature(CythonFeature):
                 out[0, d] += datum[i, d]
 
         for d in range(D):
-            out[0, d] /= N
+            out[0, d] /= <float>N
 
 
 cdef class MidpointFeature(CythonFeature):

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -281,9 +281,9 @@ cdef class AveragePointwiseEuclideanMetric(SumPointwiseEuclideanMetric):
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
     cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) except -1 nogil:
-        cdef int N = features1.shape[0]
+        cdef cnp.npy_intp N = features1.shape[0]
         cdef double dist = SumPointwiseEuclideanMetric.c_dist(self, features1, features2)
-        return dist / N
+        return dist / <double>N
 
 
 cdef class MinimumAverageDirectFlipMetric(AveragePointwiseEuclideanMetric):


### PR DESCRIPTION
## Description

Change cdef int N/D declarations to cnp.npy_intp in featurespeed.pyx and metricspeed.pyx to eliminate implicit npy_intp-to-int conversion warnings when reading datum.shape[] and features1.shape[]. Add explicit <float>/<double> casts at the division sites to prevent new warnings on the subsequent arithmetic.

These changes improve code robustness and maintain consistency. It should help for https://github.com/dipy/dipy/issues/2376

PR 5/6

## Motivation and Context

improving and trying to reach https://github.com/dipy/dipy/issues/2588

## How Has This Been Tested?

unitest

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
