### PR TITLE
BF: Fix MSVC C4244 npy_intp conversion warnings in dipy/tracking

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -342,7 +342,7 @@ def cut_plane(tracks, ref):
                             hit_ptr[1] = hit[1]
                             hit_ptr[2] = hit[2]
                             hit_ptr[3] = rcd
-                            hit_ptr[4] = t_no
+                            hit_ptr[4] = <float>t_no
                             hit_no += 1
         # convert hits list to hits array
         n_hits = hit_no
@@ -667,10 +667,10 @@ cdef inline cnp.float32_t czhang(cnp.npy_intp t1_len,
         cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0, dist_val = 0
     for t1_pi from 0<= t1_pi < t1_len:
         mean_t1t2+=min_t1t2[t1_pi]
-    mean_t1t2=mean_t1t2/t1_len
+    mean_t1t2=mean_t1t2/<cnp.float32_t>t1_len
     for t2_pi from 0<= t2_pi < t2_len:
         mean_t2t1+=min_t2t1[t2_pi]
-    mean_t2t1=mean_t2t1/t2_len
+    mean_t2t1=mean_t2t1/<cnp.float32_t>t2_len
     if metric_type == 0:
         dist_val=(mean_t2t1+mean_t1t2)/2.0
     elif metric_type == 1:
@@ -798,10 +798,10 @@ def mam_distances(xyz1,xyz2,metric='all'):
         cnp.float32_t mean_t2t1 = 0, mean_t1t2 = 0
     for t1_pi from 0<= t1_pi < t1_len:
         mean_t1t2+=min_t1t2[t1_pi]
-    mean_t1t2=mean_t1t2/t1_len
+    mean_t1t2=mean_t1t2/<cnp.float32_t>t1_len
     for t2_pi from 0<= t2_pi < t2_len:
         mean_t2t1+=min_t2t1[t2_pi]
-    mean_t2t1=mean_t2t1/t2_len
+    mean_t2t1=mean_t2t1/<cnp.float32_t>t2_len
     if metric=='all':
         return ((mean_t2t1+mean_t1t2)/2.0,
                 np.min((mean_t2t1,mean_t1t2)),


### PR DESCRIPTION
## Description

Add explicit Cython casts in distances.pyx to silence MSVC C4244 warnings: cast t1_len and t2_len to float32_t before division of float32 accumulators, and cast t_no to float before storing into a float pointer slot.

These changes improve code robustness and maintain consistency. It should help for https://github.com/dipy/dipy/issues/2376

PR 6/6

## Motivation and Context

improving and trying to reach https://github.com/dipy/dipy/issues/2588

## How Has This Been Tested?

unitest

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
