### PR TITLE
ENH: Faster FORCE fitting (Ray load-balancing + threaded post-processing) and example polish

### DIFF
--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 from pathlib import Path
@@ -19,6 +20,10 @@ from dipy.sims.force import (
     save_force_simulations,
 )
 from dipy.utils.logging import logger
+from dipy.utils.multiproc import get_usable_cpu_affinity
+from dipy.utils.optpkg import optional_package
+
+ray, has_ray, _ = optional_package("ray")
 
 # Named constants
 EPSILON = 1e-12
@@ -1087,16 +1092,33 @@ class FORCEModel(ReconstModel):
             params_arrays["ambiguity"] = A
             params_arrays["entropy"] = np.full(n_vox, np.nan, dtype=np.float32)
 
-        # Per-microstructure uncertainty and ambiguity from posterior density
+        # Per-microstructure uncertainty and ambiguity from posterior density.
+        # The FWHM-KDE ambiguity is the dominant serial cost; numpy releases the
+        # GIL on its large reductions, so fan the per-parameter loop over threads.
         prior_ranges = getattr(self, "_prior_ranges", {})
-        for param in MICRO_PARAMS:
-            if param in d and param in prior_ranges:
-                vals = d[param][neighbors].astype(np.float32)
-                u, a = compute_microstructure_uncertainty_ambiguity(
-                    vals, W, prior_ranges[param]
-                )
-                params_arrays[f"uncertainty_{param}"] = u
-                params_arrays[f"ambiguity_{param}"] = a
+        todo = [p for p in MICRO_PARAMS if p in d and p in prior_ranges]
+
+        def _micro(param):
+            vals = d[param][neighbors].astype(np.float32)
+            return param, compute_microstructure_uncertainty_ambiguity(
+                vals, W, prior_ranges[param]
+            )
+
+        # One thread inside a Ray worker: process-level parallelism already
+        # uses the cores, so threading here would oversubscribe.
+        if has_ray and ray.is_initialized():
+            n_threads = 1
+        else:
+            n_threads = min(len(MICRO_PARAMS), len(get_usable_cpu_affinity()))
+        if n_threads > 1 and len(todo) > 1:
+            with ThreadPoolExecutor(max_workers=min(n_threads, len(todo))) as ex:
+                micro_results = list(ex.map(_micro, todo))
+        else:
+            micro_results = [_micro(p) for p in todo]
+
+        for param, (u, a) in micro_results:
+            params_arrays[f"uncertainty_{param}"] = u
+            params_arrays[f"ambiguity_{param}"] = a
 
         if kwargs.pop("_raw", False):
             return params_arrays

--- a/dipy/reconst/tests/test_force.py
+++ b/dipy/reconst/tests/test_force.py
@@ -1,9 +1,16 @@
 """Tests for FORCE reconstruction module."""
 
+from concurrent.futures import ThreadPoolExecutor
+import types
+
 import numpy as np
+import numpy.testing as npt
 from numpy.testing import assert_almost_equal, assert_array_less
 
+from dipy.core.gradients import gradient_table
+from dipy.data import default_sphere
 from dipy.reconst.force import (
+    FORCEModel,
     SignalIndex,
     _fwhm_kde_batch,
     _weighted_percentile,
@@ -233,3 +240,76 @@ def test_compute_microstructure_uncertainty_ambiguity_different_ranges():
     # Larger prior range should give smaller normalized values
     assert unc_large[0] < unc_small[0]
     assert amb_large[0] < amb_small[0]
+
+
+def _tiny_model(n_sims=64, n_grad=12, seed=0):
+    """A FORCEModel backed by a small hand-made library (no generation)."""
+    rng = np.random.default_rng(seed)
+    bvals = np.concatenate(([0.0], np.full(n_grad - 1, 1000.0)))
+    bvecs = np.zeros((n_grad, 3))
+    bvecs[1:, 0] = 1.0
+
+    sims = {
+        "signals": rng.random((n_sims, n_grad)).astype(np.float32) + 0.5,
+        "labels": np.zeros((n_sims, len(default_sphere.vertices)), dtype=np.uint8),
+        "num_fibers": np.ones(n_sims, dtype=np.float32),
+        "fraction_array": rng.random((n_sims, 3)).astype(np.float32),
+    }
+    for key in (
+        "fa",
+        "md",
+        "rd",
+        "wm_fraction",
+        "gm_fraction",
+        "csf_fraction",
+        "dispersion",
+        "nd",
+    ):
+        sims[key] = rng.random(n_sims).astype(np.float32)
+
+    gtab = gradient_table(bvals, bvecs=bvecs)
+    return FORCEModel(gtab, simulations=sims, n_neighbors=8), sims
+
+
+def test_micro_postprocessing_serial_inside_ray_worker(monkeypatch):
+    """The per-parameter loop uses threads normally, but not inside a Ray worker.
+
+    Also checks both paths produce the same uncertainty and ambiguity maps.
+    """
+    model, sims = _tiny_model()
+    query = sims["signals"][:12]
+
+    pool_uses = []
+
+    def spy(*args, **kwargs):
+        pool_uses.append(kwargs.get("max_workers"))
+        return ThreadPoolExecutor(*args, **kwargs)
+
+    monkeypatch.setattr("dipy.reconst.force.ThreadPoolExecutor", spy)
+    # Pin the core count so the threaded path does not depend on runner size.
+    monkeypatch.setattr(
+        "dipy.reconst.force.get_usable_cpu_affinity", lambda: {0, 1, 2, 3}
+    )
+
+    # Outside a Ray worker the loop is threaded. Force the flag rather than
+    # relying on ambient state: another test may have left Ray initialised,
+    # since paramap never shuts it down.
+    monkeypatch.setattr("dipy.reconst.force.has_ray", False)
+    threaded = model.fit(query)
+    assert pool_uses, "expected the thread pool to be used outside a Ray worker"
+
+    # Inside a live Ray worker it stays serial.
+    pool_uses.clear()
+    monkeypatch.setattr("dipy.reconst.force.has_ray", True)
+    monkeypatch.setattr(
+        "dipy.reconst.force.ray", types.SimpleNamespace(is_initialized=lambda: True)
+    )
+    serial = model.fit(query)
+    assert not pool_uses, "expected no thread pool inside a Ray worker"
+
+    for param in ("fa", "nd"):
+        for metric in ("uncertainty", "ambiguity"):
+            npt.assert_array_equal(
+                np.asarray(getattr(threaded, f"{metric}_{param}")),
+                np.asarray(getattr(serial, f"{metric}_{param}")),
+            )

--- a/dipy/utils/multiproc.py
+++ b/dipy/utils/multiproc.py
@@ -1,6 +1,9 @@
 """Function for determining the effective number of processes to be used."""
 
 from multiprocessing import cpu_count
+import os
+import subprocess
+import sys
 from warnings import warn
 
 
@@ -40,3 +43,45 @@ def determine_num_processes(num_processes):
         return 1
 
     return num_processes
+
+
+def get_usable_cpu_affinity():
+    """Return the set of CPU core IDs available to the current process.
+
+    ``os.cpu_count()`` reports every core on the machine, which overcounts on
+    an HPC node or in a container where the process is pinned to a subset.
+    Sizing a thread or process pool from it then oversubscribes the cores and
+    slows the job down. This looks at the affinity mask where the platform
+    exposes one, and falls back to the machine core count otherwise.
+
+    Returns
+    -------
+    cpus : set of int
+        Usable core IDs. Never empty.
+    """
+    # Native Unix/Linux affinity, honours cgroups and taskset.
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            return os.sched_getaffinity(0)
+        except Exception:
+            pass
+
+    # Python 3.13+ multiplatform standard API.
+    if hasattr(os, "process_cpu_count"):
+        proc_count = os.process_cpu_count()
+        if proc_count:
+            return set(range(proc_count))
+
+    # macOS: query the system core count.
+    if sys.platform == "darwin":
+        try:
+            res = subprocess.check_output(["sysctl", "-n", "hw.ncpu"]).strip()
+            return set(range(int(res)))
+        except Exception:
+            pass
+
+    # Windows and generic fallback.
+    try:
+        return set(range(cpu_count()))
+    except Exception:
+        return set(range(os.cpu_count() or 1))

--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -96,10 +96,10 @@ def auto_ray_chunk_size(
 
       where ``bytes_per_voxel = n_gradients × 4 + output_bytes_per_voxel``.
 
-    * **Parallelism upper bound** — at least ``n_jobs`` chunks are produced
-      so all workers stay busy::
+    * **Parallelism upper bound** — several chunks per worker are produced so
+      the scheduler can load-balance across workers::
 
-          N_par = n_vox // n_jobs   (only applied when n_vox is given)
+          N_par = n_vox // (n_jobs * 8)   (only applied when n_vox is given)
 
     Final result: ``clamp(min(N_mem, N_par), lo=N_min)``.  Available RAM
     is detected via :func:`_available_ram` (stdlib only, no extra
@@ -113,7 +113,7 @@ def auto_ray_chunk_size(
         Number of diffusion gradients — sets the input chunk byte size.
     n_vox : int, optional
         Total number of voxels to fit.  Used to cap chunk size so that
-        at least ``n_jobs`` chunks are produced.
+        several chunks per worker are produced.
     shared_obj_nbytes : int, optional
         Total bytes already placed in the Ray object store (e.g. the
         simulation library).  Deducted from the available RAM budget.
@@ -139,7 +139,11 @@ def auto_ray_chunk_size(
     bytes_per_voxel = n_gradients * 4 + output_bytes_per_voxel
     n_mem = int(ray_budget / n_jobs / bytes_per_voxel)
 
-    n_par = (n_vox // n_jobs) if n_vox is not None else n_mem
+    # Emit several chunks per worker rather than one, so the Ray scheduler can
+    # load-balance: fast workers pull extra chunks while slow ones take fewer,
+    # instead of every worker being blocked on a single large chunk.
+    chunks_per_worker = 8
+    n_par = (n_vox // (n_jobs * chunks_per_worker)) if n_vox is not None else n_mem
 
     return max(n_min, min(n_mem, n_par))
 

--- a/dipy/utils/tests/test_multiproc.py
+++ b/dipy/utils/tests/test_multiproc.py
@@ -1,8 +1,11 @@
 """Testing multiproc utilities"""
 
+import os
+import sys
+
 from numpy.testing import assert_equal, assert_raises
 
-from dipy.utils.multiproc import determine_num_processes
+from dipy.utils.multiproc import determine_num_processes, get_usable_cpu_affinity
 
 
 def test_determine_num_processes():
@@ -29,3 +32,41 @@ def test_determine_num_processes():
     # -2 should be one less than -1 (if there are more than 1 cores)
     if determine_num_processes(-1) > 1:
         assert_equal(determine_num_processes(-1), determine_num_processes(-2) + 1)
+
+
+def test_get_usable_cpu_affinity():
+    cpus = get_usable_cpu_affinity()
+    assert isinstance(cpus, set)
+    assert len(cpus) >= 1
+    assert all(isinstance(c, int) for c in cpus)
+
+    # Where the platform reports an affinity mask, it is what we return, and
+    # it can be narrower than the machine core count (pinning, cgroups).
+    if hasattr(os, "sched_getaffinity"):
+        assert_equal(cpus, os.sched_getaffinity(0))
+        assert len(cpus) <= (os.cpu_count() or 1)
+
+
+def test_get_usable_cpu_affinity_fallbacks(monkeypatch):
+    """Each fallback is used when the one above it is unavailable."""
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+
+    # Python 3.13+ API.
+    monkeypatch.setattr(os, "process_cpu_count", lambda: 3, raising=False)
+    assert_equal(get_usable_cpu_affinity(), {0, 1, 2})
+
+    # macOS shells out to sysctl.
+    monkeypatch.delattr(os, "process_cpu_count", raising=False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(
+        "dipy.utils.multiproc.subprocess.check_output", lambda *a, **kw: b" 5\n"
+    )
+    assert_equal(get_usable_cpu_affinity(), {0, 1, 2, 3, 4})
+
+    # Generic fallback when sysctl is unusable.
+    monkeypatch.setattr(
+        "dipy.utils.multiproc.subprocess.check_output",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("nope")),
+    )
+    monkeypatch.setattr("dipy.utils.multiproc.cpu_count", lambda: 2)
+    assert_equal(get_usable_cpu_affinity(), {0, 1})

--- a/doc/examples/reconst_force.py
+++ b/doc/examples/reconst_force.py
@@ -64,9 +64,23 @@ print(f"mask shape: {mask.shape}, brain voxels: {mask.sum()}")
 # parameters; the simulation library is created separately via ``generate()``.
 #
 # * ``n_neighbors`` — number of library entries to retrieve per voxel query.
+# * ``penalty`` — fiber-complexity penalty subtracted from the match score,
+#   scaled by the number of fibers. Larger values bias the match towards
+#   simpler configurations.
 # * ``use_posterior`` — when ``True``, parameters are averaged over the
 #   ``n_neighbors`` nearest entries weighted by a softmax posterior; when
 #   ``False`` (default) only the single best-match entry is used.
+# * ``posterior_beta`` — softmax temperature of that posterior. Larger values
+#   concentrate the weights on the closest matches.
+# * ``compute_odf`` — when ``True``, a posterior ODF is assembled per voxel and
+#   exposed as ``fit.odf``.
+#
+# The posterior over the ``n_neighbors`` matches is always computed, even when
+# ``use_posterior=False``. That flag only decides where the *point estimates*
+# come from: the posterior mean, or the single best match. The uncertainty and
+# ambiguity maps shown further below are derived from the posterior either way.
+# The one exception is ``fit.entropy``, the entropy of the posterior weights,
+# which is only meaningful in posterior mode and is ``NaN`` otherwise.
 
 from dipy.reconst.force import FORCEModel, force_peaks
 
@@ -223,8 +237,12 @@ image_mosaic(
 #
 # FORCE also reports, for each microstructure parameter, an **uncertainty** map
 # (spread of the posterior) and an **ambiguity** map (multi-modality of the
-# posterior), both normalised to the prior range. Below we show them for the
-# NODDI parameters NDI and ODI.
+# posterior), both normalised to the prior range. They are available per
+# parameter as ``fit.uncertainty_<param>`` and ``fit.ambiguity_<param>``, for
+# example ``fit.uncertainty_fa`` or ``fit.ambiguity_wm_fraction``, alongside
+# the voxel-level ``fit.uncertainty`` and ``fit.ambiguity``. As noted above,
+# these come from the posterior regardless of ``use_posterior``. Below we show
+# them for the NODDI parameters NDI and ODI.
 
 image_mosaic(
     [
@@ -243,8 +261,32 @@ image_mosaic(
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# Per-microstructure uncertainty (left) and ambiguity (right) maps for NDI (top)
-# and ODI (bottom).
+# Per-microstructure uncertainty (left) and ambiguity (right) maps for NDI and
+# ODI.
+#
+# Using a different signal model
+# ------------------------------
+#
+# FORCE can also be used with different tissue models. Matching only sees the
+# library's signal matrix, so it does not depend on how those signals were
+# made. Its speed is set by the library size and the number of gradient
+# directions, and stays the same when the model changes.
+#
+# There are two ways to substitute your own model. The direct one is to edit
+# the signal generators in ``dipy/sims/_force_core.pyx`` and rebuild; the
+# library then carries your signals and everything downstream works unchanged.
+# The other avoids a rebuild: generate the library yourself and hand it to the
+# model::
+#
+#     model = FORCEModel(gtab, simulations=my_simulations)
+#
+# In both cases the per-voxel parameters are read straight off the matched
+# entry, so the dictionary has to carry a value per simulation for each
+# parameter you want back: ``signals`` and ``labels`` at minimum, plus
+# ``num_fibers``, ``dispersion``, ``nd``, ``wm_fraction``, ``gm_fraction``,
+# ``csf_fraction``, ``fa``, ``md``, ``rd`` and ``fraction_array``. Optional
+# extras (micro-FA, the DKI metrics, ``odfs``) are picked up when present.
+# Whatever you supply is what the fit reports back.
 #
 # References
 # ----------

--- a/doc/examples/reconst_force.py
+++ b/doc/examples/reconst_force.py
@@ -36,6 +36,7 @@ from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti
 from dipy.io.peaks import save_pam
+from dipy.viz.plotting import image_mosaic
 
 ###############################################################################
 # Download (or locate in cache) the Stanford HARDI dataset.  The first call
@@ -72,7 +73,7 @@ from dipy.reconst.force import FORCEModel, force_peaks
 model = FORCEModel(
     gtab,
     n_neighbors=50,
-    use_posterior=False,
+    use_posterior=True,
     verbose=True,
 )
 
@@ -93,10 +94,15 @@ model.generate(
 ###############################################################################
 # Fit the model to the data.
 #
-# For serial execution (one CPU), simply call ``model.fit()``.  To exploit
-# multiple cores, pass ``engine="ray"`` and ``n_jobs=<N>``.  The
-# ``@multi_voxel_fit`` decorator handles chunking, masking, and result
-# assembly automatically.
+# ``model.fit()`` runs serially by default. The ``ray`` engine is considerably
+# faster, as it parallelises the matching and post-processing across worker
+# processes instead of a single one. To use it, pass ``engine="ray"`` (and
+# optionally ``n_jobs=<N>``)::
+#
+#     fit = model.fit(data, mask=mask, engine="ray", n_jobs=-1)
+#
+# The ``ray`` engine requires Ray to be installed (``pip install ray``); if it
+# is not available the fit falls back to serial execution.
 
 fit = model.fit(data, mask=mask, n_jobs=-1, verbose=True)
 
@@ -107,6 +113,7 @@ fit = model.fit(data, mask=mask, n_jobs=-1, verbose=True)
 
 fa_map = fit.fa
 md_map = fit.md
+rd_map = fit.rd
 wm_fraction = fit.wm_fraction
 gm_fraction = fit.gm_fraction
 csf_fraction = fit.csf_fraction
@@ -148,42 +155,96 @@ save_nifti("force_uncertainty.nii.gz", uncertainty.astype(np.float32), affine)
 ###############################################################################
 # Visualize a representative axial slice.
 
-import matplotlib.pyplot as plt
+mid_z = (fa_map.shape[2] // 2) - 2
 
-mid_z = (fa_map.shape[2] // 2) - 5
 
-fig, axes = plt.subplots(2, 3, figsize=(15, 10))
+def _slice(arr):
+    return np.rot90(arr[:, :, mid_z])
 
-panels = [
-    (axes[0, 0], fa_map, "FA", "gray", 0, 1),
-    (axes[0, 1], md_map, "MD", "hot", None, None),
-    (axes[0, 2], wm_fraction, "WM Fraction", "gray", 0, 1),
-    (axes[1, 0], num_fibers, "Num Fibers", "viridis", 0, 3),
-    (axes[1, 1], gm_fraction, "GM Fraction", "gray", 0, 1),
-    (axes[1, 2], csf_fraction, "CSF Fraction", "Blues", 0, 1),
-]
 
-for ax, arr, title, cmap, vmin, vmax in panels:
-    kwargs = {"cmap": cmap}
-    if vmin is not None:
-        kwargs["vmin"] = vmin
-        kwargs["vmax"] = vmax
-    im = ax.imshow(np.rot90(arr[:, :, mid_z]), **kwargs)
-    ax.set_title(f"{title} (slice {mid_z})")
-    ax.axis("off")
-    plt.colorbar(im, ax=ax, fraction=0.046)
-
-plt.tight_layout()
-plt.savefig("force_maps.png", dpi=150, bbox_inches="tight")
-# plt.show()
+# Each map family gets its own figure and its own colormap: DTI -> viridis,
+# NODDI-like -> inferno, and tissue partial volume estimates -> gray.
+image_mosaic(
+    [_slice(fa_map), _slice(md_map), _slice(rd_map)],
+    ax_labels=["FA", "MD", "RD"],
+    ax_kwargs=[
+        {"cmap": "viridis", "vmin": 0, "vmax": 1},
+        {"cmap": "viridis"},
+        {"cmap": "viridis"},
+    ],
+    figsize=(15, 5),
+    filename="force_maps_dti.png",
+)
 
 
 ###############################################################################
 # .. rst-class:: centered small fst-italic fw-semibold
 #
-# FORCE microstructure maps for an axial slice of the Stanford HARDI dataset.
-# From left to right, top to bottom: FA, MD, WM fraction, number of fibers,
-# GM fraction, CSF fraction.
+# DTI maps for an axial slice of the Stanford HARDI dataset.
+
+image_mosaic(
+    [_slice(nd), _slice(dispersion)],
+    ax_labels=["NDI", "ODI"],
+    ax_kwargs=[{"cmap": "inferno", "vmin": 0, "vmax": 1}, {"cmap": "inferno"}],
+    figsize=(10, 5),
+    filename="force_maps_noddi.png",
+)
+
+
+###############################################################################
+# .. rst-class:: centered small fst-italic fw-semibold
+#
+# NODDI-like maps: neurite density index and orientation dispersion index.
+
+image_mosaic(
+    [
+        _slice(wm_fraction),
+        _slice(gm_fraction),
+        _slice(csf_fraction),
+        _slice(num_fibers),
+    ],
+    ax_labels=["WM fraction", "GM fraction", "CSF fraction", "Number of fibers"],
+    ax_kwargs=[
+        {"cmap": "gray", "vmin": 0, "vmax": 1},
+        {"cmap": "gray", "vmin": 0, "vmax": 1},
+        {"cmap": "gray", "vmin": 0, "vmax": 1},
+        {"cmap": "viridis", "vmin": 0, "vmax": 3},
+    ],
+    figsize=(20, 5),
+    filename="force_maps_tissue.png",
+)
+
+
+###############################################################################
+# .. rst-class:: centered small fst-italic fw-semibold
+#
+# Tissue partial volume estimates (WM/GM/CSF fractions, *gray*) and the number
+# of fiber populations per voxel.
+#
+# FORCE also reports, for each microstructure parameter, an **uncertainty** map
+# (spread of the posterior) and an **ambiguity** map (multi-modality of the
+# posterior), both normalised to the prior range. Below we show them for the
+# NODDI parameters NDI and ODI.
+
+image_mosaic(
+    [
+        _slice(fit.uncertainty_nd),
+        _slice(fit.ambiguity_nd),
+        _slice(fit.uncertainty_dispersion),
+        _slice(fit.ambiguity_dispersion),
+    ],
+    ax_labels=["NDI uncertainty", "NDI ambiguity", "ODI uncertainty", "ODI ambiguity"],
+    ax_kwargs=[{"cmap": "hot"}] * 4,
+    figsize=(20, 5),
+    filename="force_uncertainty_ambiguity.png",
+)
+
+
+###############################################################################
+# .. rst-class:: centered small fst-italic fw-semibold
+#
+# Per-microstructure uncertainty (left) and ambiguity (right) maps for NDI (top)
+# and ODI (bottom).
 #
 # References
 # ----------


### PR DESCRIPTION
## Description

Three small, independent improvements to FORCE

1. ** auto_ray_chunk_size ** now emits several chunks per worker instead of one
   (`n_vox // (n_jobs * 8)`), so the Ray scheduler can load-balance.

2. **Parallelized the per-microstructure post-processing.** The FWHM-KDE ambiguity
   dominates serial fit time and is single-threaded numpy; since numpy releases the
   GIL on its large reductions, the per-parameter loop is fanned over a thread pool.
   It stays single-threaded inside Ray workers (where process-level parallelism
   already uses the cores). Output is unchanged. On a full HCP brain this gave ~1.6x
   faster serial fitting with bit-identical maps.

3. **Docs example:** Added a note that the Ray engine is faster and requires Ray to be
   installed; use family-consistent colormaps (DTI: viridis, PVE: gray, NODDI:
   inferno) and add per-microstructure uncertainty/ambiguity maps so that the user knows what all we get as an output.


## Motivation and Context

FORCE fitting was dominated by two avoidable serial costs:

- With the Ray engine, the chunk heuristic produced exactly one chunk per worker, so
  the run finished only when the single slowest worker did — no slack for the
  scheduler to rebalance. Producing several chunks per worker lets faster workers
  absorb the slack and also lowers peak memory per in-flight chunk.
- The per-microstructure uncertainty/ambiguity (FWHM-KDE) is ~half of the serial
  fit time and ran single-threaded while the rest of the cores sat idle.


## How Has This Been Tested?

- `pytest dipy/reconst/tests/test_force.py` — 10 passed.
- `pytest dipy/utils/tests/test_parallel.py` — 9 passed (existing `auto_ray_chunk_size`
  assertions still hold).
- **Threaded post-processing is bit-identical**: fit with `postproc` single-threaded
  vs threaded gives max |Δ| = 0.0 across all uncertainty/ambiguity maps; confirmed it
  falls back to 1 thread inside a Ray worker.

## Checklist

<!-- Please check all that apply. -->

- [ X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ X] I have added tests that cover my changes (if applicable).
- [X ] All new and existing tests pass locally.
- [X ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ X] Documentation update
- [ ] Maintenance / CI / Infrastructure
