### PR TITLE
OPT: avoid redundant Parzen spline-bin evaluation

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -66,9 +66,22 @@ class ParzenJointHistogram:
         # than one bin, we need to add extra bins to both sides of the
         # histogram to account for the contributions of the minimum and maximum
         # intensities. Padding is the number of extra bins used at each side
-        # of the histogram (a total of [2 * padding] extra bins). Since the
-        # support of the cubic spline is 5 bins (the center plus 2 bins at each
-        # side) we need a padding of 2, in the case of cubic splines.
+        # of the histogram (a total of [2 * padding] extra bins).
+        #
+        # The cubic B-spline kernel has radius 2: a sample can only affect
+        # histogram bins whose centers are less than 2 bins away from the
+        # sample's continuous bin position.
+        #
+        # Here, c is the integer bin immediately to the left of the sample
+        # position cn. Therefore, for an in-range sample, the bin c - 2 is
+        # already at distance >= 2 from cn and receives zero weight. The first
+        # possibly nonzero bin is c - 1, and the last one is c + 2.
+        #
+        # More generally, with padding = 2, the nonzero moving-bin offsets are:
+        #
+        #     1 - padding, ..., padding
+        #
+        # which gives -1, 0, 1, 2.
         self.padding = 2
         self.setup_called = False
 
@@ -641,10 +654,10 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
                 r = _bin_index(rn, nbins, padding)
                 cn = _bin_normalize(moving[i, j], mmin, mdelta)
                 c = _bin_index(cn, nbins, padding)
-                spline_arg = (c - 2) - cn
+                spline_arg = (c - padding + 1) - cn
 
                 smarginal[r] += 1
-                for offset in range(-2, 3):
+                for offset in range(1 - padding, padding + 1):
                     val = _cubic_spline(spline_arg)
                     joint[r, c + offset] += val
                     total_sum += val
@@ -731,10 +744,10 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
                     r = _bin_index(rn, nbins, padding)
                     cn = _bin_normalize(moving[k, i, j], mmin, mdelta)
                     c = _bin_index(cn, nbins, padding)
-                    spline_arg = (c - 2) - cn
+                    spline_arg = (c - padding + 1) - cn
 
                     smarginal[r] += 1
-                    for offset in range(-2, 3):
+                    for offset in range(1 - padding, padding + 1):
                         val = _cubic_spline(spline_arg)
                         joint[r, c + offset] += val
                         total_sum += val
@@ -807,10 +820,10 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
             r = _bin_index(rn, nbins, padding)
             cn = _bin_normalize(mval[i], mmin, mdelta)
             c = _bin_index(cn, nbins, padding)
-            spline_arg = (c - 2) - cn
+            spline_arg = (c - padding + 1) - cn
 
             smarginal[r] += 1
-            for offset in range(-2, 3):
+            for offset in range(1 - padding, padding + 1):
                 val = _cubic_spline(spline_arg)
                 joint[r, c + offset] += val
                 total_sum += val
@@ -921,9 +934,9 @@ cdef _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
                 r = _bin_index(rn, nbins, padding)
                 cn = _bin_normalize(moving[i, j], mmin, mdelta)
                 c = _bin_index(cn, nbins, padding)
-                spline_arg = (c - 2) - cn
+                spline_arg = (c - padding + 1) - cn
 
-                for offset in range(-2, 3):
+                for offset in range(1 - padding, padding + 1):
                     val = _cubic_spline_derivative(spline_arg)
                     for k in range(n):
                         grad_pdf[r, c + offset, k] -= val * prod[k]
@@ -1034,9 +1047,9 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                     r = _bin_index(rn, nbins, padding)
                     cn = _bin_normalize(moving[k, i, j], mmin, mdelta)
                     c = _bin_index(cn, nbins, padding)
-                    spline_arg = (c - 2) - cn
+                    spline_arg = (c - padding + 1) - cn
 
-                    for offset in range(-2, 3):
+                    for offset in range(1 - padding, padding + 1):
                         val = _cubic_spline_derivative(spline_arg)
                         for l in range(n):
                             grad_pdf[r, c + offset, l] -= val * prod[l]
@@ -1101,7 +1114,7 @@ cdef _joint_pdf_gradient_sparse_2d(double[:] theta, Transform transform,
         cnp.npy_intp m = sval.shape[0]
         cnp.npy_intp offset
         int constant_jacobian = 0
-        cnp.npy_intp i, j, r, c, valid_points
+        cnp.npy_intp i, j, k, r, c, valid_points
         double rn, cn
         double val, spline_arg, norm_factor
         double[:, :] J = np.empty(shape=(2, n), dtype=np.float64)
@@ -1124,9 +1137,9 @@ cdef _joint_pdf_gradient_sparse_2d(double[:] theta, Transform transform,
             r = _bin_index(rn, nbins, padding)
             cn = _bin_normalize(mval[i], mmin, mdelta)
             c = _bin_index(cn, nbins, padding)
-            spline_arg = (c - 2) - cn
+            spline_arg = (c - padding + 1) - cn
 
-            for offset in range(-2, 3):
+            for offset in range(1 - padding, padding + 1):
                 val = _cubic_spline_derivative(spline_arg)
                 for j in range(n):
                     grad_pdf[r, c + offset, j] -= val * prod[j]
@@ -1216,9 +1229,9 @@ cdef _joint_pdf_gradient_sparse_3d(double[:] theta, Transform transform,
             r = _bin_index(rn, nbins, padding)
             cn = _bin_normalize(mval[i], mmin, mdelta)
             c = _bin_index(cn, nbins, padding)
-            spline_arg = (c - 2) - cn
+            spline_arg = (c - padding + 1) - cn
 
-            for offset in range(-2, 3):
+            for offset in range(1 - padding, padding + 1):
                 val = _cubic_spline_derivative(spline_arg)
                 for j in range(n):
                     grad_pdf[r, c + offset, j] -= val * prod[j]


### PR DESCRIPTION
## Description

This PR updates the Parzen joint histogram implementation used for mutual information by removing a redundant cubic B-spline bin evaluation.

For each sample, the current implementation evaluates moving-bin offsets `[-2, -1, 0, 1, 2]`. However, the weight assigned to each neighboring bin is computed by `_cubic_spline(q - cn)`, where `q` is the neighboring bin index and `cn` is the sample's continuous bin position. The `_cubic_spline()` function returns zero when `|q - cn| >= 2`. Since `c = floor(cn)` for in-range samples, the left-most evaluated bin `q = c - 2` is always at distance greater than or equal to `2` from `cn`, so it always receives zero weight. The implementation now iterates only over the effective nonzero support:

`range(1 - padding, padding + 1)`

which corresponds to offsets `[-1, 0, 1, 2]` when `padding = 2`.

This also removes hardcoded `2` values from the Parzen histogram loops and reuses the existing `padding` variable consistently.

## Motivation and Context

The previous code used `padding = 2`, but the histogram update loops still hardcoded the cubic B-spline radius manually through expressions such as `spline_arg = (c - 2) - cn` and `for offset in range(-2, 3)`.

This made the code less clear and caused one unnecessary spline evaluation per sample in both PDF and gradient computations.

This PR keeps the mathematical behavior unchanged for the effective support while avoiding redundant computation and making the relation between `padding` and the offset loop clearer.

## How Has This Been Tested?

I tested this by instrumenting the original implementation with debug counters in the dense 3D PDF and gradient paths. In a real MI run, the left-most offset was checked across 80,560 samples per evaluation, and its contribution was always exactly zero for both the PDF and gradient computations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure