### PR TITLE
NF: expose FORCE prior ranges in the CLI and autoscale the ODI grid

### DIFF
--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -13,6 +13,10 @@ from dipy.reconst._force_search import search_inner_product as _cython_search
 from dipy.reconst.base import ReconstFit, ReconstModel
 from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.shm import sf_to_sh
+from dipy.sims._force_core import (
+    DEFAULT_THREE_FIBER_MIN_ANGLE,
+    DEFAULT_TWO_FIBER_MIN_ANGLE,
+)
 from dipy.sims.force import (
     DEFAULT_NUM_ODI_VALUES,
     DEFAULT_ODI_RANGE,
@@ -197,8 +201,29 @@ def _odi_grid_matches(entry, odi_range, num_odi_values):
     return int(entry_num) == int(num_odi_values)
 
 
+def _min_angles_match(entry, min_crossing_angles):
+    """Check whether a registry *entry*'s crossing angles match the request.
+
+    Entries written before this became part of the cache key are read as
+    using the defaults.
+    """
+    entry_angles = (
+        entry.get("two_fiber_min_angle", DEFAULT_TWO_FIBER_MIN_ANGLE),
+        entry.get("three_fiber_min_angle", DEFAULT_THREE_FIBER_MIN_ANGLE),
+    )
+    return all(
+        np.isclose(a, b) for a, b in zip(entry_angles, min_crossing_angles, strict=True)
+    )
+
+
 def _find_cached_simulation(
-    cache_dir, gtab, diffusivity_config, num_simulations, odi_range, num_odi_values
+    cache_dir,
+    gtab,
+    diffusivity_config,
+    num_simulations,
+    odi_range,
+    num_odi_values,
+    min_crossing_angles,
 ):
     """Search the registry for a simulation matching the given parameters.
 
@@ -216,6 +241,8 @@ def _find_cached_simulation(
         ``(min, max)`` orientation-dispersion-index range.
     num_odi_values : int
         Resolved number of ODI grid points.
+    min_crossing_angles : tuple
+        ``(two_fiber_min_angle, three_fiber_min_angle)`` in degrees.
 
     Returns
     -------
@@ -232,6 +259,8 @@ def _find_cached_simulation(
             continue
         if not _odi_grid_matches(entry, odi_range, num_odi_values):
             continue
+        if not _min_angles_match(entry, min_crossing_angles):
+            continue
         candidate = cache_dir / entry["filename"]
         if candidate.exists():
             return str(candidate)
@@ -246,6 +275,7 @@ def _register_cached_simulation(
     filename,
     odi_range,
     num_odi_values,
+    min_crossing_angles,
 ):
     """Add a new entry to the cache registry.
 
@@ -265,6 +295,8 @@ def _register_cached_simulation(
         ``(min, max)`` orientation-dispersion-index range.
     num_odi_values : int
         Resolved number of ODI grid points.
+    min_crossing_angles : tuple
+        ``(two_fiber_min_angle, three_fiber_min_angle)`` in degrees.
     """
 
     # Convert numpy types to plain Python for JSON serialisation
@@ -288,6 +320,8 @@ def _register_cached_simulation(
         "num_simulations": int(num_simulations),
         "odi_range": [float(odi_range[0]), float(odi_range[1])],
         "num_odi_values": int(num_odi_values),
+        "two_fiber_min_angle": float(min_crossing_angles[0]),
+        "three_fiber_min_angle": float(min_crossing_angles[1]),
         "filename": filename,
     }
 
@@ -758,6 +792,8 @@ class FORCEModel(ReconstModel):
         tortuosity=False,
         odi_range=DEFAULT_ODI_RANGE,
         num_odi_values=None,
+        two_fiber_min_angle=DEFAULT_TWO_FIBER_MIN_ANGLE,
+        three_fiber_min_angle=DEFAULT_THREE_FIBER_MIN_ANGLE,
         diffusivity_config=None,
         compute_dti=True,
         compute_dki=False,
@@ -769,8 +805,9 @@ class FORCEModel(ReconstModel):
         When ``output_path`` is ``None`` and ``use_cache`` is ``True``,
         simulations are cached in ``~/.dipy/force_simulations/`` (or
         ``$DIPY_HOME``). A registry file (``cache_registry.json``) keeps
-        track of the bvals, bvecs, diffusivity configuration and number of
-        simulations for each cached file. If a cached simulation that matches
+        track of the bvals, bvecs, diffusivity configuration, ODI grid,
+        minimum crossing angles and number of simulations for each cached
+        file. If a cached simulation that matches
         the current gradient table (within tolerance) and diffusivity
         configuration already exists, it is loaded from disk and generation
         is skipped.
@@ -797,6 +834,13 @@ class FORCEModel(ReconstModel):
             Number of points in the ODI sampling grid. When ``None`` (default),
             the grid is autoscaled from ``odi_range`` so its sampling density
             matches the default grid.
+        two_fiber_min_angle : float, optional
+            Minimum crossing angle for two-fiber simulations, in degrees. The
+            library never contains crossings below this angle, so the fit
+            cannot report them either. Use ``0`` to allow any crossing.
+        three_fiber_min_angle : float, optional
+            Minimum pairwise crossing angle for three-fiber simulations, in
+            degrees.
         diffusivity_config : dict, optional
             Custom diffusivity ranges.
         compute_dti : bool, optional
@@ -846,6 +890,7 @@ class FORCEModel(ReconstModel):
         # key and the generated library agree on it.
         resolved_odi_range = (float(odi_range[0]), float(odi_range[1]))
         resolved_num_odi = resolve_num_odi_values(resolved_odi_range, num_odi_values)
+        min_crossing_angles = (float(two_fiber_min_angle), float(three_fiber_min_angle))
 
         # --- Cache logic when no explicit output_path is given ----------
         if output_path is None and use_cache:
@@ -857,6 +902,7 @@ class FORCEModel(ReconstModel):
                 num_simulations,
                 resolved_odi_range,
                 resolved_num_odi,
+                min_crossing_angles,
             )
             if cached is not None:
                 if verbose:
@@ -874,6 +920,8 @@ class FORCEModel(ReconstModel):
             tortuosity=tortuosity,
             odi_range=resolved_odi_range,
             num_odi_values=resolved_num_odi,
+            two_fiber_min_angle=two_fiber_min_angle,
+            three_fiber_min_angle=three_fiber_min_angle,
             diffusivity_config=diffusivity_config,
             compute_dti=compute_dti,
             compute_dki=compute_dki,
@@ -906,6 +954,7 @@ class FORCEModel(ReconstModel):
                 filename,
                 resolved_odi_range,
                 resolved_num_odi,
+                min_crossing_angles,
             )
             if verbose:
                 print(f"[FORCE] Cached simulations to {cache_dir / filename}")

--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -14,9 +14,12 @@ from dipy.reconst.base import ReconstFit, ReconstModel
 from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.shm import sf_to_sh
 from dipy.sims.force import (
+    DEFAULT_NUM_ODI_VALUES,
+    DEFAULT_ODI_RANGE,
     generate_force_simulations,
     get_default_diffusivity_config,
     load_force_simulations,
+    resolve_num_odi_values,
     save_force_simulations,
 )
 from dipy.utils.logging import logger
@@ -174,7 +177,29 @@ def _locked_registry_update(cache_dir, update_fn):
                 fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
 
-def _find_cached_simulation(cache_dir, gtab, diffusivity_config, num_simulations):
+def _odi_grid_matches(entry, odi_range, num_odi_values):
+    """Check whether a registry *entry*'s ODI grid matches the request.
+
+    Legacy entries written before the ODI grid was part of the cache key are
+    treated as having been generated with the historical defaults
+    (``DEFAULT_ODI_RANGE`` / ``DEFAULT_NUM_ODI_VALUES``), so existing caches
+    keep matching default-grid requests.
+    """
+    entry_range = entry.get("odi_range", list(DEFAULT_ODI_RANGE))
+    entry_num = entry.get("num_odi_values", DEFAULT_NUM_ODI_VALUES)
+    if len(entry_range) != 2:
+        return False
+    if not (
+        np.isclose(entry_range[0], odi_range[0])
+        and np.isclose(entry_range[1], odi_range[1])
+    ):
+        return False
+    return int(entry_num) == int(num_odi_values)
+
+
+def _find_cached_simulation(
+    cache_dir, gtab, diffusivity_config, num_simulations, odi_range, num_odi_values
+):
     """Search the registry for a simulation matching the given parameters.
 
     Parameters
@@ -187,6 +212,10 @@ def _find_cached_simulation(cache_dir, gtab, diffusivity_config, num_simulations
         Diffusivity ranges used for generation.
     num_simulations : int
         Number of simulations requested.
+    odi_range : tuple
+        ``(min, max)`` orientation-dispersion-index range.
+    num_odi_values : int
+        Resolved number of ODI grid points.
 
     Returns
     -------
@@ -201,6 +230,8 @@ def _find_cached_simulation(cache_dir, gtab, diffusivity_config, num_simulations
             continue
         if not _diffusivity_matches(entry["diffusivity_config"], diffusivity_config):
             continue
+        if not _odi_grid_matches(entry, odi_range, num_odi_values):
+            continue
         candidate = cache_dir / entry["filename"]
         if candidate.exists():
             return str(candidate)
@@ -208,7 +239,13 @@ def _find_cached_simulation(cache_dir, gtab, diffusivity_config, num_simulations
 
 
 def _register_cached_simulation(
-    cache_dir, gtab, diffusivity_config, num_simulations, filename
+    cache_dir,
+    gtab,
+    diffusivity_config,
+    num_simulations,
+    filename,
+    odi_range,
+    num_odi_values,
 ):
     """Add a new entry to the cache registry.
 
@@ -224,6 +261,10 @@ def _register_cached_simulation(
         Number of simulations.
     filename : str
         Filename of the saved ``.npz`` inside *cache_dir*.
+    odi_range : tuple
+        ``(min, max)`` orientation-dispersion-index range.
+    num_odi_values : int
+        Resolved number of ODI grid points.
     """
 
     # Convert numpy types to plain Python for JSON serialisation
@@ -245,6 +286,8 @@ def _register_cached_simulation(
         "bvecs": np.asarray(gtab.bvecs, dtype=np.float64).tolist(),
         "diffusivity_config": config_json,
         "num_simulations": int(num_simulations),
+        "odi_range": [float(odi_range[0]), float(odi_range[1])],
+        "num_odi_values": int(num_odi_values),
         "filename": filename,
     }
 
@@ -713,7 +756,8 @@ class FORCEModel(ReconstModel):
         num_cpus=1,
         wm_threshold=0.5,
         tortuosity=False,
-        odi_range=(0.01, 0.3),
+        odi_range=DEFAULT_ODI_RANGE,
+        num_odi_values=None,
         diffusivity_config=None,
         compute_dti=True,
         compute_dki=False,
@@ -749,6 +793,10 @@ class FORCEModel(ReconstModel):
             Use tortuosity constraint for perpendicular diffusivity.
         odi_range : tuple, optional
             (min, max) orientation dispersion index range.
+        num_odi_values : int or None, optional
+            Number of points in the ODI sampling grid. When ``None`` (default),
+            the grid is autoscaled from ``odi_range`` so its sampling density
+            matches the default grid.
         diffusivity_config : dict, optional
             Custom diffusivity ranges.
         compute_dti : bool, optional
@@ -794,6 +842,11 @@ class FORCEModel(ReconstModel):
             else get_default_diffusivity_config()
         )
 
+        # Resolve the ODI grid that will actually be used, so both the cache
+        # key and the generated library agree on it.
+        resolved_odi_range = (float(odi_range[0]), float(odi_range[1]))
+        resolved_num_odi = resolve_num_odi_values(resolved_odi_range, num_odi_values)
+
         # --- Cache logic when no explicit output_path is given ----------
         if output_path is None and use_cache:
             cache_dir = _get_force_cache_dir()
@@ -802,6 +855,8 @@ class FORCEModel(ReconstModel):
                 self.gtab,
                 resolved_config,
                 num_simulations,
+                resolved_odi_range,
+                resolved_num_odi,
             )
             if cached is not None:
                 if verbose:
@@ -817,7 +872,8 @@ class FORCEModel(ReconstModel):
             num_cpus=num_cpus,
             wm_threshold=wm_threshold,
             tortuosity=tortuosity,
-            odi_range=odi_range,
+            odi_range=resolved_odi_range,
+            num_odi_values=resolved_num_odi,
             diffusivity_config=diffusivity_config,
             compute_dti=compute_dti,
             compute_dki=compute_dki,
@@ -848,6 +904,8 @@ class FORCEModel(ReconstModel):
                 resolved_config,
                 num_simulations,
                 filename,
+                resolved_odi_range,
+                resolved_num_odi,
             )
             if verbose:
                 print(f"[FORCE] Cached simulations to {cache_dir / filename}")

--- a/dipy/reconst/tests/test_force.py
+++ b/dipy/reconst/tests/test_force.py
@@ -389,3 +389,38 @@ def test_force_cache_keys_on_odi_grid(tmp_path, monkeypatch):
     gen(num_odi_values=5)
     assert ((0.01, 0.3), 5) in entries()
     assert len(entries()) == 3
+
+
+def test_cache_registry_separates_min_crossing_angles(tmp_path, monkeypatch):
+    """Libraries built with different crossing-angle limits get separate cache slots."""
+    from dipy.core.gradients import gradient_table
+
+    monkeypatch.setenv("DIPY_HOME", str(tmp_path))
+
+    dirs = np.array(
+        [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]],
+        dtype=float,
+    )
+    bvals = np.array([0.0] + [1000.0] * 6 + [2000.0] * 6)
+    bvecs = np.vstack(([[0.0, 0.0, 0.0]], dirs, dirs))
+    gtab = gradient_table(bvals, bvecs=bvecs)
+
+    strict = FORCEModel(gtab)
+    strict.generate(num_simulations=60, num_cpus=1, verbose=False)
+
+    relaxed = FORCEModel(gtab)
+    relaxed.generate(
+        num_simulations=60, num_cpus=1, two_fiber_min_angle=0.0, verbose=False
+    )
+
+    cache_dir = tmp_path / "force_simulations"
+    assert len(list(cache_dir.glob("force_sim_*.npz"))) == 2
+
+    # The relaxed request must not be served the strict library, and a repeat
+    # of the relaxed request must reuse the one just written.
+    again = FORCEModel(gtab)
+    again.generate(
+        num_simulations=60, num_cpus=1, two_fiber_min_angle=0.0, verbose=False
+    )
+    assert len(list(cache_dir.glob("force_sim_*.npz"))) == 2
+    npt.assert_array_equal(again.simulations["signals"], relaxed.simulations["signals"])

--- a/dipy/reconst/tests/test_force.py
+++ b/dipy/reconst/tests/test_force.py
@@ -1,6 +1,7 @@
 """Tests for FORCE reconstruction module."""
 
 from concurrent.futures import ThreadPoolExecutor
+import json
 import types
 
 import numpy as np
@@ -10,9 +11,12 @@ from numpy.testing import assert_almost_equal, assert_array_less
 from dipy.core.gradients import gradient_table
 from dipy.data import default_sphere
 from dipy.reconst.force import (
+    DEFAULT_NUM_ODI_VALUES,
+    DEFAULT_ODI_RANGE,
     FORCEModel,
     SignalIndex,
     _fwhm_kde_batch,
+    _odi_grid_matches,
     _weighted_percentile,
     compute_microstructure_uncertainty_ambiguity,
     compute_uncertainty_ambiguity,
@@ -20,6 +24,22 @@ from dipy.reconst.force import (
     normalize_signals,
     softmax_stable,
 )
+
+
+def _make_gtab(shells):
+    """Minimal GradientTable: two b0s + 6 directions per non-zero shell."""
+    from dipy.core.gradients import gradient_table
+
+    dirs = np.array(
+        [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]],
+        dtype=float,
+    )
+    bvals = [0, 0]
+    bvecs = [[0, 0, 0], [0, 0, 0]]
+    for b in shells:
+        bvals.extend([b] * 6)
+        bvecs.extend(dirs.tolist())
+    return gradient_table(np.array(bvals, dtype=float), bvecs=np.array(bvecs))
 
 
 def test_normalize_signals():
@@ -313,3 +333,59 @@ def test_micro_postprocessing_serial_inside_ray_worker(monkeypatch):
                 np.asarray(getattr(threaded, f"{metric}_{param}")),
                 np.asarray(getattr(serial, f"{metric}_{param}")),
             )
+
+
+def test_odi_grid_matches_legacy_and_exact():
+    """Cache matching on the ODI grid, incl. legacy (keyless) entries."""
+    # A legacy entry (written before the ODI grid was part of the key) is
+    # treated as the historical default grid.
+    legacy = {"num_simulations": 100}
+    assert _odi_grid_matches(legacy, DEFAULT_ODI_RANGE, DEFAULT_NUM_ODI_VALUES)
+    assert not _odi_grid_matches(legacy, (0.01, 0.6), 19)
+    assert not _odi_grid_matches(legacy, DEFAULT_ODI_RANGE, 5)
+
+    # A modern entry matches only its exact range and grid.
+    entry = {"odi_range": [0.01, 0.6], "num_odi_values": 19}
+    assert _odi_grid_matches(entry, (0.01, 0.6), 19)
+    assert not _odi_grid_matches(entry, (0.01, 0.6), 10)  # same range, diff grid
+    assert not _odi_grid_matches(entry, (0.01, 0.3), 19)  # diff range, same grid
+
+
+def _registry(dipy_home):
+    path = dipy_home / "force_simulations" / "cache_registry.json"
+    return json.load(open(path)) if path.exists() else []
+
+
+def test_force_cache_keys_on_odi_grid(tmp_path, monkeypatch):
+    """The simulation cache is keyed on odi_range and the resolved grid."""
+    monkeypatch.setenv("DIPY_HOME", str(tmp_path))
+    gtab = _make_gtab([1000])
+
+    def gen(**kwargs):
+        FORCEModel(gtab).generate(
+            num_simulations=60, num_cpus=1, verbose=False, **kwargs
+        )
+
+    def entries():
+        return [
+            (tuple(e["odi_range"]), e["num_odi_values"]) for e in _registry(tmp_path)
+        ]
+
+    # 1. default range -> one entry recorded at the autoscaled grid (10).
+    gen()
+    assert entries() == [((0.01, 0.3), DEFAULT_NUM_ODI_VALUES)]
+
+    # 2. a wider range is a distinct library (autoscaled grid 19), not a hit.
+    gen(odi_range=(0.01, 0.6))
+    assert len(entries()) == 2
+    assert ((0.01, 0.6), 19) in entries()
+
+    # 3. re-running the default params hits the cache (no new entry).
+    n_before = len(entries())
+    gen()
+    assert len(entries()) == n_before
+
+    # 4. an explicit grid at the default range is again distinct.
+    gen(num_odi_values=5)
+    assert ((0.01, 0.3), 5) in entries()
+    assert len(entries()) == 3

--- a/dipy/sims/_force_core.pyx
+++ b/dipy/sims/_force_core.pyx
@@ -26,6 +26,10 @@ cdef double GM_D_MIN = 0.7e-3
 cdef double GM_D_MAX = 1.2e-3
 cdef double CSF_D = 3.0e-3
 
+# Minimum angular separation (degrees) between simulated fiber populations.
+DEFAULT_TWO_FIBER_MIN_ANGLE = 30.0
+DEFAULT_THREE_FIBER_MIN_ANGLE = 60.0
+
 
 def set_diffusivity_ranges(
     wm_d_par_range=(2.0e-3, 3.0e-3),
@@ -322,7 +326,8 @@ cpdef tuple generate_two_fibers(
     cnp.ndarray[DTYPE_t, ndim=1] bvals,
     cnp.ndarray[DTYPE_t, ndim=2] bvecs,
     object multi_tensor_func,
-    bint tortuosity
+    bint tortuosity,
+    double min_crossing_angle=DEFAULT_TWO_FIBER_MIN_ANGLE
 ):
     """
     Generate diffusion signal for two crossing fiber populations.
@@ -345,6 +350,8 @@ cpdef tuple generate_two_fibers(
         Function to compute multi-tensor signal.
     tortuosity : bool
         Whether to use tortuosity constraint.
+    min_crossing_angle : float, optional
+        Minimum separation between the two fibers, in degrees.
 
     Returns
     -------
@@ -386,15 +393,17 @@ cpdef tuple generate_two_fibers(
     index = np.random.randint(0, n_dirs, 2)
     _angle_tries = 0
     while not is_angle_valid(
-        angle_between(target_sphere[index[0]], target_sphere[index[1]])
+        angle_between(target_sphere[index[0]], target_sphere[index[1]]),
+        threshold=min_crossing_angle
     ):
         index = np.random.randint(0, n_dirs, 2)
         _angle_tries += 1
         if _angle_tries >= _MAX_ANGLE_TRIES:
             raise RuntimeError(
-                "Could not find two fiber directions with sufficient angular "
-                "separation after %d attempts. Consider using a finer sphere."
-                % _MAX_ANGLE_TRIES
+                "Could not find two fiber directions separated by at least "
+                f"{min_crossing_angle:g} degrees after {_MAX_ANGLE_TRIES} "
+                "attempts. Consider using a finer sphere or a smaller "
+                "min_crossing_angle."
             )
 
     idx0 = int(index[0])
@@ -454,7 +463,8 @@ cpdef tuple generate_three_fibers(
     cnp.ndarray[DTYPE_t, ndim=1] bvals,
     cnp.ndarray[DTYPE_t, ndim=2] bvecs,
     object multi_tensor_func,
-    bint tortuosity
+    bint tortuosity,
+    double min_crossing_angle=DEFAULT_THREE_FIBER_MIN_ANGLE
 ):
     """
     Generate diffusion signal for three crossing fiber populations.
@@ -477,6 +487,8 @@ cpdef tuple generate_three_fibers(
         Function to compute multi-tensor signal.
     tortuosity : bool
         Whether to use tortuosity constraint.
+    min_crossing_angle : float, optional
+        Minimum pairwise separation between the three fibers, in degrees.
 
     Returns
     -------
@@ -521,24 +533,25 @@ cpdef tuple generate_three_fibers(
     while (
         not is_angle_valid(
             angle_between(target_sphere[index[0]], target_sphere[index[1]]),
-            threshold=60
+            threshold=min_crossing_angle
         )
         or not is_angle_valid(
             angle_between(target_sphere[index[0]], target_sphere[index[2]]),
-            threshold=60
+            threshold=min_crossing_angle
         )
         or not is_angle_valid(
             angle_between(target_sphere[index[1]], target_sphere[index[2]]),
-            threshold=60
+            threshold=min_crossing_angle
         )
     ):
         index = np.random.randint(0, n_dirs, 3)
         _angle_tries += 1
         if _angle_tries >= _MAX_ANGLE_TRIES:
             raise RuntimeError(
-                "Could not find three fiber directions with sufficient angular "
-                "separation after %d attempts. Consider using a finer sphere."
-                % _MAX_ANGLE_TRIES
+                "Could not find three fiber directions pairwise separated "
+                f"by at least {min_crossing_angle:g} degrees after "
+                f"{_MAX_ANGLE_TRIES} attempts. Consider using a finer sphere "
+                "or a smaller min_crossing_angle."
             )
 
     idx0 = int(index[0])
@@ -598,7 +611,9 @@ cpdef tuple create_wm_signal(
     cnp.ndarray[DTYPE_t, ndim=1] bvals,
     cnp.ndarray[DTYPE_t, ndim=2] bvecs,
     object multi_tensor_func,
-    bint tortuosity
+    bint tortuosity,
+    double two_fiber_min_angle=DEFAULT_TWO_FIBER_MIN_ANGLE,
+    double three_fiber_min_angle=DEFAULT_THREE_FIBER_MIN_ANGLE
 ):
     """
     Create white matter signal with specified number of fibers.
@@ -623,6 +638,10 @@ cpdef tuple create_wm_signal(
         Function to compute multi-tensor signal.
     tortuosity : bool
         Whether to use tortuosity constraint.
+    two_fiber_min_angle : float, optional
+        Minimum separation for two-fiber configurations, in degrees.
+    three_fiber_min_angle : float, optional
+        Minimum pairwise separation for three-fiber configurations, in degrees.
 
     Returns
     -------
@@ -637,12 +656,14 @@ cpdef tuple create_wm_signal(
     elif num_fib == 2:
         return generate_two_fibers(
             target_sphere, evecs, bingham_sf, odi_list,
-            bvals, bvecs, multi_tensor_func, tortuosity
+            bvals, bvecs, multi_tensor_func, tortuosity,
+            two_fiber_min_angle
         )
     elif num_fib == 3:
         return generate_three_fibers(
             target_sphere, evecs, bingham_sf, odi_list,
-            bvals, bvecs, multi_tensor_func, tortuosity
+            bvals, bvecs, multi_tensor_func, tortuosity,
+            three_fiber_min_angle
         )
     else:
         raise ValueError("num_fib must be 1, 2 or 3")
@@ -739,7 +760,9 @@ cpdef tuple create_mixed_signal(
     cnp.ndarray[DTYPE_t, ndim=2] bvecs,
     object multi_tensor_func,
     double wm_threshold,
-    bint tortuosity
+    bint tortuosity,
+    double two_fiber_min_angle=DEFAULT_TWO_FIBER_MIN_ANGLE,
+    double three_fiber_min_angle=DEFAULT_THREE_FIBER_MIN_ANGLE
 ):
     """
     Create mixed WM/GM/CSF tissue signal.
@@ -767,6 +790,10 @@ cpdef tuple create_mixed_signal(
         Minimum WM fraction to include fiber labels.
     tortuosity : bool
         Whether to use tortuosity constraint.
+    two_fiber_min_angle : float, optional
+        Minimum separation for two-fiber configurations, in degrees.
+    three_fiber_min_angle : float, optional
+        Minimum pairwise separation for three-fiber configurations, in degrees.
 
     Returns
     -------
@@ -805,6 +832,8 @@ cpdef tuple create_mixed_signal(
         bvecs,
         multi_tensor_func,
         tortuosity,
+        two_fiber_min_angle,
+        three_fiber_min_angle,
     )
     wm_signal = wm_result[0]
     wm_label = wm_result[1]

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -26,6 +26,10 @@ import numpy as np
 
 from dipy.data import default_sphere
 from dipy.reconst.bingham import _single_bingham_to_sf as bingham_to_sf
+from dipy.sims._force_core import (
+    DEFAULT_THREE_FIBER_MIN_ANGLE,
+    DEFAULT_TWO_FIBER_MIN_ANGLE,
+)
 from dipy.sims.voxel import all_tensor_evecs
 from dipy.utils.logging import logger
 from dipy.utils.multiproc import determine_num_processes
@@ -185,6 +189,7 @@ def _generate_batch_worker(
     tort,
     memmap_info,
     diffusivity_cfg,
+    min_crossing_angles,
 ):
     """Worker function for parallel batch generation.
 
@@ -310,7 +315,17 @@ def _generate_batch_worker(
     for i in range(batch_size):
         idx = start_idx + i
         res = create_mixed_signal(
-            sphere, evecs, bingham, odi, bval, bvec, multi_tensor, wm_thresh, tort
+            sphere,
+            evecs,
+            bingham,
+            odi,
+            bval,
+            bvec,
+            multi_tensor,
+            wm_thresh,
+            tort,
+            min_crossing_angles[0],
+            min_crossing_angles[1],
         )
         (
             signals_mm[idx],
@@ -419,6 +434,8 @@ def generate_force_simulations(
     tortuosity=False,
     odi_range=DEFAULT_ODI_RANGE,
     num_odi_values=None,
+    two_fiber_min_angle=DEFAULT_TWO_FIBER_MIN_ANGLE,
+    three_fiber_min_angle=DEFAULT_THREE_FIBER_MIN_ANGLE,
     diffusivity_config=None,
     dtype=np.float32,
     compute_dti=True,
@@ -457,6 +474,12 @@ def generate_force_simulations(
         Number of ODI values in the sampling grid. When ``None`` (default),
         the grid is autoscaled from ``odi_range`` to keep the sampling density
         constant (see :func:`resolve_num_odi_values`).
+    two_fiber_min_angle : float, optional
+        Minimum crossing angle for two-fiber simulations, in degrees. Crossings
+        below this angle are never simulated. Use ``0`` to allow any crossing.
+    three_fiber_min_angle : float, optional
+        Minimum pairwise crossing angle for three-fiber simulations, in
+        degrees.
     diffusivity_config : dict, optional
         Custom diffusivity ranges.
     dtype : dtype, optional
@@ -497,6 +520,14 @@ def generate_force_simulations(
         }
 
     set_diffusivity_ranges(**diffusivity_config)
+
+    for name, angle in (
+        ("two_fiber_min_angle", two_fiber_min_angle),
+        ("three_fiber_min_angle", three_fiber_min_angle),
+    ):
+        if not 0 <= angle < 90:
+            raise ValueError(f"{name} must be in [0, 90) degrees, got {angle}")
+    min_crossing_angles = (float(two_fiber_min_angle), float(three_fiber_min_angle))
 
     # Setup sphere and ODI values
     sphere = default_sphere
@@ -663,6 +694,7 @@ def generate_force_simulations(
                 tortuosity,
                 memmap_info,
                 diffusivity_config,
+                min_crossing_angles,
             )
             pbar.update(batch_done)
     elif sys.platform == "win32":
@@ -686,6 +718,7 @@ def generate_force_simulations(
                         tortuosity,
                         memmap_info,
                         diffusivity_config,
+                        min_crossing_angles,
                     ): (start_idx, bs)
                     for start_idx, bs in batch_specs
                 }
@@ -713,6 +746,7 @@ def generate_force_simulations(
                     tortuosity,
                     memmap_info,
                     diffusivity_config,
+                    min_crossing_angles,
                 )
                 pbar.update(batch_done)
     else:
@@ -739,6 +773,7 @@ def generate_force_simulations(
                     tortuosity,
                     memmap_info,
                     diffusivity_config,
+                    min_crossing_angles,
                 ): (start_idx, bs)
                 for start_idx, bs in batch_specs
             }

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -30,6 +30,42 @@ from dipy.sims.voxel import all_tensor_evecs
 from dipy.utils.logging import logger
 from dipy.utils.multiproc import determine_num_processes
 
+# Reference ODI sampling grid. The library samples orientation-dispersion
+# values from ``linspace(*odi_range, num_odi_values)``; these constants define
+# the default grid and its density, which ``resolve_num_odi_values`` uses to
+# autoscale the number of grid points to any custom ``odi_range``.
+DEFAULT_ODI_RANGE = (0.01, 0.3)
+DEFAULT_NUM_ODI_VALUES = 10
+
+
+def resolve_num_odi_values(odi_range, num_odi_values=None):
+    """Resolve the number of ODI grid points, autoscaling when unset.
+
+    Parameters
+    ----------
+    odi_range : tuple
+        ``(min, max)`` orientation-dispersion-index range.
+    num_odi_values : int or None, optional
+        Explicit number of grid points. When ``None``, the grid is autoscaled
+        so its spacing matches the default grid
+        (``DEFAULT_NUM_ODI_VALUES`` points across ``DEFAULT_ODI_RANGE``),
+        keeping sampling density constant as ``odi_range`` widens or narrows.
+
+    Returns
+    -------
+    n : int
+        Number of ODI grid points (always >= 2).
+    """
+    if num_odi_values is not None:
+        n = int(num_odi_values)
+        if n < 2:
+            raise ValueError(f"num_odi_values must be >= 2; got {n}.")
+        return n
+    lo, hi = float(odi_range[0]), float(odi_range[1])
+    default_lo, default_hi = DEFAULT_ODI_RANGE
+    spacing = (default_hi - default_lo) / (DEFAULT_NUM_ODI_VALUES - 1)
+    return max(2, int(round((hi - lo) / spacing)) + 1)
+
 
 def dispersion_lut(target_sphere, odi_list):
     """Generate spherical functions for all directions and ODI values.
@@ -381,8 +417,8 @@ def generate_force_simulations(
     batch_size=1000,
     wm_threshold=0.5,
     tortuosity=False,
-    odi_range=(0.01, 0.3),
-    num_odi_values=10,
+    odi_range=DEFAULT_ODI_RANGE,
+    num_odi_values=None,
     diffusivity_config=None,
     dtype=np.float32,
     compute_dti=True,
@@ -417,8 +453,10 @@ def generate_force_simulations(
         Use tortuosity constraint for perpendicular diffusivity.
     odi_range : tuple, optional
         (min, max) orientation dispersion index range.
-    num_odi_values : int, optional
-        Number of ODI values to sample.
+    num_odi_values : int or None, optional
+        Number of ODI values in the sampling grid. When ``None`` (default),
+        the grid is autoscaled from ``odi_range`` to keep the sampling density
+        constant (see :func:`resolve_num_odi_values`).
     diffusivity_config : dict, optional
         Custom diffusivity ranges.
     dtype : dtype, optional
@@ -474,9 +512,15 @@ def generate_force_simulations(
         [all_tensor_evecs(tuple(point)) for point in target_sphere],
         dtype=np.float64,
     )
+    num_odi_values = resolve_num_odi_values(odi_range, num_odi_values)
     odi_list = np.linspace(odi_range[0], odi_range[1], num_odi_values).astype(
         np.float64
     )
+    if verbose:
+        logger.info(
+            f"ODI sampling grid: {num_odi_values} values over "
+            f"[{odi_range[0]:.3g}, {odi_range[1]:.3g}]"
+        )
     dispersion_sf = dispersion_lut(target_sphere, odi_list)
 
     label_dtype = np.uint8

--- a/dipy/sims/tests/test_force.py
+++ b/dipy/sims/tests/test_force.py
@@ -289,3 +289,77 @@ def test_generate_force_simulations_honors_odi_grid():
             num_odi_values=1,
             verbose=False,
         )
+
+
+def _library_crossing_angles(sims, num_fibers):
+    """Antipodal-symmetric angles between the labelled fibers of *num_fibers* voxels."""
+    from dipy.data import default_sphere
+
+    vertices = default_sphere.vertices
+    angles = []
+    for labels in sims["labels"][sims["num_fibers"] == num_fibers]:
+        dirs = vertices[np.flatnonzero(labels == 1)]
+        for i in range(len(dirs)):
+            for j in range(i + 1, len(dirs)):
+                cos = np.clip(np.dot(dirs[i], dirs[j]), -1.0, 1.0)
+                angles.append(np.rad2deg(np.arccos(abs(cos))))
+    return np.asarray(angles)
+
+
+def test_generate_force_simulations_default_min_crossing_angles(monkeypatch):
+    """By default the library holds no crossing below 30 (two) or 60 (three) degrees."""
+    from dipy.sims.force import generate_force_simulations
+
+    monkeypatch.setattr(
+        "dipy.sims.force.init_worker", lambda *a, **k: np.random.seed(0)
+    )
+    gtab = _make_gtab([1000, 2000])
+    sims = generate_force_simulations(
+        gtab, num_simulations=300, batch_size=100, num_cpus=1, verbose=False
+    )
+
+    two = _library_crossing_angles(sims, 2)
+    three = _library_crossing_angles(sims, 3)
+    assert two.size and three.size
+    assert two.min() >= 30.0
+    assert three.min() >= 60.0
+
+
+def test_generate_force_simulations_relaxed_min_crossing_angles(monkeypatch):
+    """Lowering the limits lets shallow crossings into the library."""
+    from dipy.sims.force import generate_force_simulations
+
+    monkeypatch.setattr(
+        "dipy.sims.force.init_worker", lambda *a, **k: np.random.seed(0)
+    )
+    gtab = _make_gtab([1000, 2000])
+    sims = generate_force_simulations(
+        gtab,
+        num_simulations=300,
+        batch_size=100,
+        num_cpus=1,
+        two_fiber_min_angle=0.0,
+        three_fiber_min_angle=0.0,
+        verbose=False,
+    )
+
+    two = _library_crossing_angles(sims, 2)
+    three = _library_crossing_angles(sims, 3)
+    assert two.size and three.size
+    assert two.min() < 30.0
+    assert three.min() < 60.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"two_fiber_min_angle": 90.0}, {"three_fiber_min_angle": -1.0}],
+)
+def test_generate_force_simulations_invalid_min_crossing_angle(kwargs):
+    """Angles outside [0, 90) degrees are rejected."""
+    from dipy.sims.force import generate_force_simulations
+
+    gtab = _make_gtab([1000])
+    with pytest.raises(ValueError, match="must be in .0, 90. degrees"):
+        generate_force_simulations(
+            gtab, num_simulations=10, batch_size=10, num_cpus=1, verbose=False, **kwargs
+        )

--- a/dipy/sims/tests/test_force.py
+++ b/dipy/sims/tests/test_force.py
@@ -4,8 +4,11 @@ import numpy as np
 import pytest
 
 from dipy.sims.force import (
+    DEFAULT_NUM_ODI_VALUES,
+    DEFAULT_ODI_RANGE,
     dispersion_lut,
     get_default_diffusivity_config,
+    resolve_num_odi_values,
     smallest_shell_bval,
     validate_diffusivity_config,
 )
@@ -242,3 +245,47 @@ def test_generate_force_simulations_no_dti_no_dki():
             assert np.all(sims[key] == 0), f"'{key}' should be zero when DTI disabled"
         else:
             assert key not in sims, f"DKI key '{key}' should be absent"
+
+
+def test_resolve_num_odi_values_autoscale():
+    """None autoscales the ODI grid to keep sampling density constant."""
+    # Default range resolves to the historical fixed grid (backward compatible).
+    assert resolve_num_odi_values(DEFAULT_ODI_RANGE, None) == DEFAULT_NUM_ODI_VALUES
+
+    # Doubling the span roughly doubles the number of grid points.
+    assert resolve_num_odi_values((0.01, 0.6), None) == 19
+
+    # Narrower span -> fewer points; wider -> more.
+    n_narrow = resolve_num_odi_values((0.05, 0.15), None)
+    n_wide = resolve_num_odi_values((0.01, 0.9), None)
+    assert n_narrow < DEFAULT_NUM_ODI_VALUES < n_wide
+
+    # A degenerate (zero-width) range still yields a valid grid (>= 2).
+    assert resolve_num_odi_values((0.2, 0.2), None) == 2
+
+
+def test_resolve_num_odi_values_explicit_and_invalid():
+    """An explicit count is passed through; counts < 2 are rejected."""
+    # Explicit value is honored regardless of the range.
+    assert resolve_num_odi_values((0.01, 0.9), 7) == 7
+    assert resolve_num_odi_values(DEFAULT_ODI_RANGE, 3) == 3
+
+    for bad in (1, 0, -5):
+        with pytest.raises(ValueError, match="must be >= 2"):
+            resolve_num_odi_values(DEFAULT_ODI_RANGE, bad)
+
+
+def test_generate_force_simulations_honors_odi_grid():
+    """A resolve error for num_odi_values < 2 propagates through generation."""
+    from dipy.sims.force import generate_force_simulations
+
+    gtab = _make_gtab([1000])
+    with pytest.raises(ValueError, match="must be >= 2"):
+        generate_force_simulations(
+            gtab,
+            num_simulations=10,
+            batch_size=10,
+            num_cpus=1,
+            num_odi_values=1,
+            verbose=False,
+        )

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -3460,6 +3460,14 @@ class ReconstForceFlow(Workflow):
         posterior_beta=2000.0,
         compute_odf=False,
         num_simulations=500000,
+        wm_threshold=0.5,
+        tortuosity=False,
+        odi_range=None,
+        num_odi_values=None,
+        wm_d_par_range=None,
+        wm_d_perp_range=None,
+        gm_d_iso_range=None,
+        csf_d=None,
         num_cpus=-1,
         use_cache=True,
         compute_kurtosis=False,
@@ -3526,6 +3534,35 @@ class ReconstForceFlow(Workflow):
             Compute posterior ODF maps.
         num_simulations : int, optional
             Number of simulated voxels for the simulation library.
+        wm_threshold : float, optional
+            Minimum white-matter signal fraction for a simulated voxel to be
+            assigned fiber-orientation labels when building the library.
+        tortuosity : bool, optional
+            Constrain the white-matter perpendicular diffusivity through the
+            tortuosity model instead of sampling ``wm_d_perp_range``
+            independently.
+        odi_range : variable float, optional
+            Two values ``min max`` giving the orientation-dispersion-index
+            prior range sampled when building the simulation library. If not
+            set, the FORCE default ``0.01 0.3`` is used.
+        num_odi_values : int, optional
+            Number of points in the ODI sampling grid. If not set, the grid is
+            autoscaled from ``odi_range`` so its sampling density matches the
+            default grid (10 points across ``0.01 0.3``).
+        wm_d_par_range : variable float, optional
+            Two values ``min max`` (in mm^2/s) for the white-matter parallel
+            (axial) diffusivity prior. If not set, defaults to
+            ``0.002 0.003``.
+        wm_d_perp_range : variable float, optional
+            Two values ``min max`` (in mm^2/s) for the white-matter
+            perpendicular (radial) diffusivity prior. Ignored when
+            ``tortuosity`` is set. If not set, defaults to ``0.0003 0.0015``.
+        gm_d_iso_range : variable float, optional
+            Two values ``min max`` (in mm^2/s) for the gray-matter isotropic
+            diffusivity prior. If not set, defaults to ``0.0007 0.0012``.
+        csf_d : float, optional
+            Fixed CSF isotropic diffusivity in mm^2/s. If not set, defaults to
+            ``0.003``.
         num_cpus : int, optional
             Number of CPU cores for simulation generation. Use -1 to use
             all available cores.
@@ -3600,10 +3637,49 @@ class ReconstForceFlow(Workflow):
 
         """
         from dipy.reconst.force import MICRO_PARAMS, FORCEModel
+        from dipy.sims.force import get_default_diffusivity_config
         from dipy.utils.optpkg import optional_package
 
         use_posterior = not use_exact
         save_metrics = save_metrics or []
+
+        # Assemble the simulation-library prior overrides. Any range left
+        # unset falls back to the FORCE defaults (see
+        # ``get_default_diffusivity_config``), so the defaults are unchanged
+        # unless the user explicitly passes one of these options.
+        def _as_range(name, value):
+            values = tuple(float(v) for v in value)
+            if len(values) != 2:
+                raise ValueError(
+                    f"'{name}' expects exactly two values (min max); "
+                    f"got {len(values)}: {value}."
+                )
+            if values[0] > values[1]:
+                raise ValueError(
+                    f"'{name}' min ({values[0]}) must not exceed max ({values[1]})."
+                )
+            return values
+
+        diffusivity_overrides = {
+            "wm_d_par_range": wm_d_par_range,
+            "wm_d_perp_range": wm_d_perp_range,
+            "gm_d_iso_range": gm_d_iso_range,
+            "csf_d": csf_d,
+        }
+        if any(v is not None for v in diffusivity_overrides.values()):
+            diffusivity_config = get_default_diffusivity_config()
+            for key, value in diffusivity_overrides.items():
+                if value is None:
+                    continue
+                diffusivity_config[key] = (
+                    float(value) if key == "csf_d" else _as_range(key, value)
+                )
+        else:
+            diffusivity_config = None
+
+        gen_range_kwargs = {}
+        if odi_range is not None:
+            gen_range_kwargs["odi_range"] = _as_range("odi_range", odi_range)
 
         if engine == "ray":
             _, has_ray, _ = optional_package("ray")
@@ -3673,7 +3749,12 @@ class ReconstForceFlow(Workflow):
                 num_cpus=num_cpus,
                 use_cache=use_cache,
                 compute_dki=compute_kurtosis,
+                wm_threshold=wm_threshold,
+                tortuosity=tortuosity,
+                num_odi_values=num_odi_values,
+                diffusivity_config=diffusivity_config,
                 verbose=verbose,
+                **gen_range_kwargs,
             )
 
             logger.info("Fitting FORCE model...")

--- a/dipy/workflows/tests/test_reconst.py
+++ b/dipy/workflows/tests/test_reconst.py
@@ -599,3 +599,117 @@ def test_reconst_force_ray_fallback(monkeypatch, tmp_path):
 
     out_path = flow.last_generated_outputs["out_fa"]
     assert os.path.exists(out_path)
+
+
+def _patch_generate_capture(monkeypatch, fake_sims):
+    """Patch generate to record its kwargs and inject fake_sims."""
+    captured = {}
+
+    def _fake_generate(self, **kwargs):
+        captured.update(kwargs)
+        self.simulations = fake_sims
+        self._prepare_library()
+        return self
+
+    monkeypatch.setattr("dipy.reconst.force.FORCEModel.generate", _fake_generate)
+    return captured
+
+
+def test_reconst_force_prior_range_options(monkeypatch, tmp_path):
+    """CLI prior-range options are assembled and threaded into generate()."""
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones(volume.shape[:3], dtype=np.uint8)
+    mask_path = tmp_path / "mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
+
+    bvals, _ = read_bvals_bvecs(bval_path, bvec_path)
+    captured = _patch_generate_capture(monkeypatch, _make_fake_simulations(len(bvals)))
+
+    flow = ReconstForceFlow()
+    flow.run(
+        str(data_path),
+        str(bval_path),
+        str(bvec_path),
+        str(mask_path),
+        n_neighbors=5,
+        engine="serial",
+        odi_range=[0.01, 0.6],
+        num_odi_values=8,
+        wm_d_par_range=[0.0021, 0.0029],
+        csf_d=0.0028,
+        tortuosity=True,
+        save_metrics=["fa"],
+        out_dir=str(tmp_path),
+    )
+
+    # ODI grid options are threaded through verbatim.
+    npt.assert_allclose(captured["odi_range"], (0.01, 0.6))
+    assert captured["num_odi_values"] == 8
+    assert captured["tortuosity"] is True
+
+    # diffusivity_config: overridden keys applied, unset keys keep defaults.
+    cfg = captured["diffusivity_config"]
+    npt.assert_allclose(cfg["wm_d_par_range"], (0.0021, 0.0029))
+    npt.assert_allclose(cfg["csf_d"], 0.0028)
+    npt.assert_allclose(cfg["wm_d_perp_range"], (0.3e-3, 1.5e-3))  # default kept
+    npt.assert_allclose(cfg["gm_d_iso_range"], (0.7e-3, 1.2e-3))  # default kept
+
+
+def test_reconst_force_defaults_leave_priors_unset(monkeypatch, tmp_path):
+    """With no range options, generate() receives defaults (config=None)."""
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones(volume.shape[:3], dtype=np.uint8)
+    mask_path = tmp_path / "mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
+
+    bvals, _ = read_bvals_bvecs(bval_path, bvec_path)
+    captured = _patch_generate_capture(monkeypatch, _make_fake_simulations(len(bvals)))
+
+    flow = ReconstForceFlow()
+    flow.run(
+        str(data_path),
+        str(bval_path),
+        str(bvec_path),
+        str(mask_path),
+        n_neighbors=5,
+        save_metrics=["fa"],
+        out_dir=str(tmp_path),
+    )
+
+    # No overrides -> no explicit config or odi_range forwarded.
+    assert captured["diffusivity_config"] is None
+    assert captured["num_odi_values"] is None
+    assert "odi_range" not in captured
+
+
+def test_reconst_force_invalid_range_options(monkeypatch, tmp_path):
+    """Malformed range options raise a clear ValueError before fitting."""
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask_path = tmp_path / "mask.nii.gz"
+    save_nifti(mask_path, np.ones(volume.shape[:3], dtype=np.uint8), affine)
+
+    _patch_generate(monkeypatch, _make_fake_simulations(len(volume)))
+    flow = ReconstForceFlow()
+
+    with pytest.raises(ValueError, match="exactly two values"):
+        flow.run(
+            str(data_path),
+            str(bval_path),
+            str(bvec_path),
+            str(mask_path),
+            odi_range=[0.1],  # only one value
+            out_dir=str(tmp_path),
+        )
+
+    with pytest.raises(ValueError, match="must not exceed max"):
+        flow.run(
+            str(data_path),
+            str(bval_path),
+            str(bvec_path),
+            str(mask_path),
+            wm_d_par_range=[0.003, 0.002],  # min > max
+            out_dir=str(tmp_path),
+        )


### PR DESCRIPTION


## Description

dipy_fit_force and FORCEModel.generate previously exposed only the number of simulations, hiding the priors that define the simulation library. This gives control over those priors while keeping the defaults unchanged:

- Workflow (dipy_fit_force): new options wm_threshold, tortuosity, odi_range, num_odi_values, wm_d_par_range, wm_d_perp_range, gm_d_iso_range and csf_d, assembled into a diffusivity_config with validation. Ranges left unset keep the FORCE defaults.
- Autoscale the ODI sampling grid: num_odi_values now defaults to None and is resolved from odi_range to keep the sampling density constant (resolve_num_odi_values); the default range still yields 10 points.
- Cache correctness: the simulation cache now keys on odi_range and the resolved grid, so changing them no longer returns a stale library. Legacy cache entries are read as the historical default grid.

Adds unit and integration tests for the autoscaling, the cache keying (including legacy entries), and the new workflow options.


## Motivation and Context

Closes #3974 

## How Has This Been Tested?

Existing and added test cases pass

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [X] I have added tests that cover my changes (if applicable).
- [X] All new and existing tests pass locally.
- [X] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
