### PR TITLE
Fetcher GitHub release mirror

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -47,6 +47,10 @@ MIRRORABLE_HOSTS = [
     "stacks.stanford.edu",
 ]
 
+# Github release mirror: release tag == local dataset folder name, asset name
+# == local filename, so this reproduces `~/.dipy/<folder>/<file>` 1:1.
+GITHUB_MIRROR_BASE = "https://github.com/dipy/dipy_datatest/releases/download"
+
 boto3, has_boto3, _ = optional_package("boto3")
 
 HEADER_LIST = [
@@ -203,6 +207,26 @@ def _get_mirror_url(original_url):
     return None
 
 
+def _get_github_mirror_url(fname):
+    """Github Release mirror URL derived from the local destination path.
+
+    Release tag == parent folder name; asset name == local filename, so a
+    release that mirrors `~/.dipy/<folder>/<file>` needs no per-file mapping.
+
+    Parameters
+    ----------
+    fname : str or Path
+        The local destination path the file is being downloaded to.
+
+    Returns
+    -------
+    str
+        Github release mirror URL for this file.
+    """
+    fname = Path(fname)
+    return f"{GITHUB_MIRROR_BASE}/{fname.parent.name}/{fname.name}"
+
+
 def _get_file_data(
     fname, url, *, use_headers=False, timeout=60, max_retries=5, stored_md5=None
 ):
@@ -229,8 +253,16 @@ def _get_file_data(
         If download fails after all retry attempts.
 
     """
-    # Check if mirror is available for this URL
+    # Build the ordered list of URLs to cycle through on retries: the
+    # original source, the workshop.dipy.org mirror (if applicable), and the
+    # github release mirror (if a release exists for this file).
+    candidates = [url]
     mirror_url = _get_mirror_url(url)
+    if mirror_url:
+        candidates.append(mirror_url)
+    github_url = _get_github_mirror_url(fname)
+    if github_url not in candidates:
+        candidates.append(github_url)
 
     is_figshare = "figshare.com" in url
     is_zenodo = "zenodo.org" in url
@@ -243,16 +275,12 @@ def _get_file_data(
 
     last_exception = None
     for attempt in range(max_retries):
-        # Alternate between original URL and mirror on retries
-        if mirror_url and attempt > 0:
-            # Use mirror on odd attempts, original on even attempts
-            current_url = mirror_url if attempt % 2 == 1 else url
-            if current_url == mirror_url:
-                logger.info(f"Trying mirror server: {mirror_url}")
-            else:
+        current_url = candidates[attempt % len(candidates)]
+        if attempt > 0:
+            if current_url == url:
                 logger.info(f"Retrying original URL: {url}")
-        else:
-            current_url = url
+            else:
+                logger.info(f"Trying fallback source: {current_url}")
 
         req = current_url
         if use_headers:

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -322,8 +322,8 @@ def test_get_mirror_url_no_double_slash():
     assert "//" not in path_part
 
 
-def test_get_github_mirror_url_derived_from_local_path():
-    fname = Path("/home/user/.dipy/histo_resdnn_weights/resdnn_weights_mri_2018.h5")
+def test_get_github_mirror_url_derived_from_local_path(tmp_path):
+    fname = tmp_path / "histo_resdnn_weights" / "resdnn_weights_mri_2018.h5"
     result = _get_github_mirror_url(fname)
     assert (
         result
@@ -331,8 +331,9 @@ def test_get_github_mirror_url_derived_from_local_path():
     )
 
 
-def test_get_github_mirror_url_accepts_str():
-    result = _get_github_mirror_url("/tmp/synb0/weights1.h5")
+def test_get_github_mirror_url_accepts_str(tmp_path):
+    fname = tmp_path / "synb0" / "weights1.h5"
+    result = _get_github_mirror_url(str(fname))
     assert result == f"{GITHUB_MIRROR_BASE}/synb0/weights1.h5"
 
 

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -13,10 +13,12 @@ from dipy.data import SPHERE_FILES
 import dipy.data.fetcher as fetcher
 from dipy.data.fetcher import (
     DIPY_MIRROR_URL,
+    GITHUB_MIRROR_BASE,
     MIRRORABLE_HOSTS,
     FetcherError,
     _already_there_msg,
     _get_file_md5,
+    _get_github_mirror_url,
     _get_mirror_url,
     _make_fetcher,
     check_md5,
@@ -318,6 +320,20 @@ def test_get_mirror_url_no_double_slash():
     result = _get_mirror_url("https://zenodo.org/record/999/files/f.nii.gz")
     path_part = result.split(DIPY_MIRROR_URL, 1)[-1]
     assert "//" not in path_part
+
+
+def test_get_github_mirror_url_derived_from_local_path():
+    fname = Path("/home/user/.dipy/histo_resdnn_weights/resdnn_weights_mri_2018.h5")
+    result = _get_github_mirror_url(fname)
+    assert (
+        result
+        == f"{GITHUB_MIRROR_BASE}/histo_resdnn_weights/resdnn_weights_mri_2018.h5"
+    )
+
+
+def test_get_github_mirror_url_accepts_str():
+    result = _get_github_mirror_url("/tmp/synb0/weights1.h5")
+    assert result == f"{GITHUB_MIRROR_BASE}/synb0/weights1.h5"
 
 
 def test_already_there_msg_str(tmp_path):


### PR DESCRIPTION
## Description

Figshare/zenodo sources intermittently 403 (rate limiting). Add a third fallback tier derived purely from the local destination path (release tag = dataset folder, asset = local filename), so no per-fetcher URL mapping is needed. Mirrors hosted in dipy/dipy_datatest.


## Motivation and Context

Due to rate limiting in figshare or zenodo, CIs are failing regurlarly and it is hard to detect PR issues due to that?

## How Has This Been Tested?

locally

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
