### PR TITLE
RF: Centralize shared Cython DEFs

### DIFF
--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -2,6 +2,7 @@
 
 import itertools
 import numpy as np
+from libc.limits cimport INT_MAX
 
 from dipy.segment.cythonutils cimport Data2D, shape2tuple
 from dipy.segment.metricspeed cimport Metric
@@ -16,10 +17,7 @@ cdef extern from "stdlib.h" nogil:
     void *memset(void *ptr, int value, size_t num)
 
 
-DTYPE = np.float32
-DEF BIGGEST_DOUBLE = 1.7976931348623157e+308  # np.finfo('f8').max
-DEF BIGGEST_FLOAT = 3.402823e+38  # < FLT_MAX (3.4028235e+38); avoids double-to-float overflow
-DEF BIGGEST_INT = 2147483647  # np.iinfo('i4').max
+cimport dipy.utils.constants as consts
 
 
 def clusters_centroid2clustermap_centroid(ClustersCentroid clusters_list):
@@ -63,7 +61,7 @@ def peek(iterable):
 
 
 def quickbundles(streamlines, Metric metric, double threshold,
-                 long max_nb_clusters=BIGGEST_INT, ordering=None):
+                 long max_nb_clusters=INT_MAX, ordering=None):
     """ Clusters streamlines using QuickBundles.
 
     See :footcite:p:`Garyfallidis2012a` for further details about the method.
@@ -92,7 +90,7 @@ def quickbundles(streamlines, Metric metric, double threshold,
     .. footbibliography::
     """
     # Threshold of np.inf is not supported, set it to 'biggest_double'
-    threshold = min(threshold, BIGGEST_DOUBLE)
+    threshold = min(threshold, consts.BIGGEST_DOUBLE)
     # Threshold of -np.inf is not supported, set it to 0
     threshold = max(threshold, 0)
     if ordering is None:
@@ -103,13 +101,13 @@ def quickbundles(streamlines, Metric metric, double threshold,
     if first_idx is None or len(streamlines) == 0:
         return ClusterMapCentroid()
 
-    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(DTYPE)))
+    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32)))
     cdef QuickBundles qb = QuickBundles(features_shape, metric, threshold, max_nb_clusters)
     cdef int idx
     for idx in ordering:
         streamline = streamlines[idx]
-        if not streamline.flags.writeable or streamline.dtype != DTYPE:
-            streamline = streamline.astype(DTYPE)
+        if not streamline.flags.writeable or streamline.dtype != np.float32:
+            streamline = streamline.astype(np.float32)
         cluster_id = qb.assignment_step(streamline, idx)
         # The update step is performed right after the assignment step instead
         # of after all streamlines have been assigned like k-means algorithm.
@@ -155,14 +153,14 @@ def quickbundlesx(streamlines, Metric metric, thresholds, ordering=None):
     if first_idx is None or len(streamlines) == 0:
         return ClusterMapCentroid()
 
-    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(DTYPE)))
+    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32)))
     cdef QuickBundlesX qbx = QuickBundlesX(features_shape, thresholds, metric)
     cdef int idx
 
     for idx in ordering:
         streamline = streamlines[idx]
-        if not streamline.flags.writeable or streamline.dtype != DTYPE:
-            streamline = streamline.astype(DTYPE)
+        if not streamline.flags.writeable or streamline.dtype != np.float32:
+            streamline = streamline.astype(np.float32)
 
         qbx.insert(streamline, idx)
 

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -2,6 +2,7 @@
 
 import numpy as np
 cimport numpy as cnp
+from libc.limits cimport INT_MAX
 
 from dipy.segment.clustering import ClusterCentroid, ClusterMapCentroid
 from dipy.segment.clustering import TreeCluster, TreeClusterMap
@@ -22,12 +23,7 @@ cdef extern from "stdlib.h" nogil:
     void *realloc(void *ptr, size_t elsize)
     void *memset(void *ptr, int value, size_t num)
 
-DTYPE = np.float32
-DEF BIGGEST_DOUBLE = 1.7976931348623157e+308  # np.finfo('f8').max
-DEF BIGGEST_INT = 2147483647  # np.iinfo('i4').max
-DEF BIGGEST_FLOAT = 3.402823e+38  # < FLT_MAX (3.4028235e+38); avoids double-to-float overflow
-DEF SMALLEST_FLOAT = -3.402823e+38  # > -FLT_MAX; avoids double-to-float overflow
-
+cimport dipy.utils.constants as consts
 
 cdef print_node(CentroidNode* node, prepend=""):
     if node == NULL:
@@ -67,8 +63,8 @@ cdef void aabb_creation(Data2D streamline, float* aabb) noexcept nogil:
         float max_[3]
 
     for d in range(D):
-        min_[d] = <float>BIGGEST_FLOAT
-        max_[d] = <float>SMALLEST_FLOAT
+        min_[d] = <float>consts.BIGGEST_FLOAT
+        max_[d] = <float>consts.SMALLEST_FLOAT
         for n in range(N):
 
             if max_[d] < streamline[n, d]:
@@ -108,9 +104,9 @@ cdef CentroidNode* create_empty_node(Shape centroid_shape, float threshold) nogi
     node.aabb[0] = 0
     node.aabb[1] = 0
     node.aabb[2] = 0
-    node.aabb[3] = <float>BIGGEST_FLOAT
-    node.aabb[4] = <float>BIGGEST_FLOAT
-    node.aabb[5] = <float>BIGGEST_FLOAT
+    node.aabb[3] = <float>consts.BIGGEST_FLOAT
+    node.aabb[4] = <float>consts.BIGGEST_FLOAT
+    node.aabb[5] = <float>consts.BIGGEST_FLOAT
     node.threshold = threshold
     node.indices = NULL
     node.size = 0
@@ -212,7 +208,7 @@ cdef class QuickBundlesX:
             return
 
         nearest_cluster.id = -1
-        nearest_cluster.dist = BIGGEST_DOUBLE
+        nearest_cluster.dist = consts.BIGGEST_DOUBLE
         nearest_cluster.flip = 0
 
         for k in range(node.nb_children):
@@ -492,14 +488,14 @@ cdef class ClustersCentroid(Clusters):
 
 cdef class QuickBundles:
     def __init__(QuickBundles self, features_shape, Metric metric, double threshold,
-                 int max_nb_clusters=BIGGEST_INT):
+                 int max_nb_clusters=INT_MAX):
         self.metric = metric
         self.features_shape = tuple2shape(features_shape)
         self.threshold = threshold
         self.max_nb_clusters = max_nb_clusters
         self.clusters = ClustersCentroid(features_shape)
-        self.features = np.empty(features_shape, dtype=DTYPE)
-        self.features_flip = np.empty(features_shape, dtype=DTYPE)
+        self.features = np.empty(features_shape, dtype=np.float32)
+        self.features_flip = np.empty(features_shape, dtype=np.float32)
 
         self.stats.nb_mdf_calls = 0
         self.stats.nb_aabb_calls = 0
@@ -524,7 +520,7 @@ cdef class QuickBundles:
             float aabb[6]
 
         nearest_cluster.id = -1
-        nearest_cluster.dist = BIGGEST_DOUBLE
+        nearest_cluster.dist = consts.BIGGEST_DOUBLE
         nearest_cluster.flip = 0
 
         for k in range(self.clusters.c_size()):

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -26,8 +26,7 @@ cdef extern from "dpy_math.h" nogil:
 #@cython.boundscheck(False)
 #@cython.wraparound(False)
 
-DEF biggest_double = 1.79769e+308 #np.finfo('f8').max
-DEF biggest_float = 3.402823e+38  # < FLT_MAX (3.4028235e+38); avoids double-to-float overflow
+cimport dipy.utils.constants as consts
 
 cdef inline cnp.ndarray[cnp.float32_t, ndim=1] as_float_3vec(object vec):
     """ Utility function to convert object to 3D float vector """
@@ -1672,7 +1671,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
                     flip[k]=1
                 alld[k]=d[0]
 
-            m_d = <float>biggest_float
+            m_d = <float>consts.BIGGEST_FLOAT
             #find minimum distance and index
             for k from 0<=k<lenC:
                 if alld[k] < m_d:

--- a/dipy/utils/constants.pxd
+++ b/dipy/utils/constants.pxd
@@ -1,0 +1,9 @@
+cdef extern from *:
+    """
+    #define __Pyx_BIGGEST_DOUBLE 1.7976931348623157e+308  /* np.finfo('f8').max */
+    #define __Pyx_BIGGEST_FLOAT 3.402823e+38f  /* < FLT_MAX (3.4028235e+38); avoids double-to-float overflow */
+    #define __Pyx_SMALLEST_FLOAT (-3.402823e+38f)  /* > -FLT_MAX; avoids double-to-float overflow */
+    """
+    const double BIGGEST_DOUBLE "__Pyx_BIGGEST_DOUBLE"
+    const float BIGGEST_FLOAT "__Pyx_BIGGEST_FLOAT"
+    const float SMALLEST_FLOAT "__Pyx_SMALLEST_FLOAT"

--- a/dipy/utils/meson.build
+++ b/dipy/utils/meson.build
@@ -4,6 +4,7 @@ cython_sources = [
   ]
 
 cython_headers = [
+  'constants.pxd',
   'fast_numpy.pxd',
   'omp.pxd',
   ]


### PR DESCRIPTION
## Description

Move shared compile-time constants into a common Cython module and import them where needed to remove duplicate definitions and keep values consistent.

## Motivation and Context

We should not be duplicating constant definitions.

## How Has This Been Tested?

GitHub actions will test changes.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [X] I have updated the documentation accordingly (if applicable).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure

Follow-up to PR #4070.