### PR TITLE
BF: pin checkout ref in backport workflow to merge commit

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,7 @@ jobs:
       # potentially divergent maintenance branches.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Create backport pull requests


### PR DESCRIPTION
## Summary
- `Backport` workflow (pull_request_target) failed for merged fork PRs: actions/checkout refuses to run without an explicit ref, since default resolution can't rule out checking out untrusted fork code with base-repo secrets.
- Pin `ref` to `github.event.pull_request.merge_commit_sha`, which is already part of base repo history once the PR is merged.

Fixes failure seen in https://github.com/dipy/dipy/actions/runs/28962881509/job/85938566969

## Test plan
- [ ] Merge a fork PR with a `backport-maint/x.y.z` label and confirm the Backport workflow succeeds.