### PR TITLE
Flexible input for synthseg

### DIFF
--- a/dipy/nn/tests/test_synthseg.py
+++ b/dipy/nn/tests/test_synthseg.py
@@ -66,6 +66,35 @@ def test_default_weights_batch():
 
 
 @pytest.mark.skipif(not have_torch, reason="Requires Torch")
+def test_input_shapes(monkeypatch):
+    synthseg_model = synthseg.SynthSeg()
+
+    def mock_predict(img):
+        prediction = np.zeros(
+            (img.shape[0], 33) + tuple(img.shape[2:]), dtype=np.float32
+        )
+        prediction[:, 0] = 1
+        return prediction
+
+    monkeypatch.setattr(synthseg_model, "_SynthSeg__predict", mock_predict)
+
+    shape_cases = [
+        ((17, 25, 31), (32, 32, 32)),
+        ((32, 48, 64), (32, 64, 64)),
+        ((34, 47, 65), (64, 64, 64)),
+    ]
+    for shape, model_shape in shape_cases:
+        input_arr = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+        labels, _, mask = synthseg_model.predict(input_arr, np.eye(4))
+        npt.assert_equal(labels.shape, shape)
+        npt.assert_equal(mask.shape, shape)
+
+        probabilities = synthseg_model.predict(input_arr, np.eye(4), return_prob=True)
+        npt.assert_equal(probabilities.shape, model_shape + (33,))
+
+
+@pytest.mark.skipif(not have_torch, reason="Requires Torch")
 def test_T1_error():
     T1 = np.ones((3, 32, 32, 32))
     synthseg_model = synthseg.SynthSeg()

--- a/dipy/nn/tests/test_utils.py
+++ b/dipy/nn/tests/test_utils.py
@@ -2,7 +2,13 @@ import warnings
 
 import numpy as np
 
-from dipy.nn.utils import normalize, recover_img, transform_img, unnormalize
+from dipy.nn.utils import (
+    get_padded_shape,
+    normalize,
+    recover_img,
+    transform_img,
+    unnormalize,
+)
 from dipy.testing.decorators import set_random_number_generator
 
 
@@ -34,3 +40,18 @@ def test_transform(rng=None):
         )
         temp2 = recover_img(temp2, params)
     np.testing.assert_almost_equal(np.array(temp.shape), np.array(temp2.shape))
+
+
+def test_get_padded_shape():
+    cases = [
+        ((32, 64, 96), 32, (32, 64, 96)),
+        ((33, 65, 95), 32, (64, 96, 96)),
+        ((1, 31, 32), 32, (32, 32, 32)),
+        ((5, 10), 4, (8, 12)),
+    ]
+
+    for shape, multiple, expected_shape in cases:
+        np.testing.assert_equal(get_padded_shape(shape, multiple), expected_shape)
+
+    for multiple in [0, -1]:
+        np.testing.assert_raises(ValueError, get_padded_shape, (32, 32, 32), multiple)

--- a/dipy/nn/torch/synthseg.py
+++ b/dipy/nn/torch/synthseg.py
@@ -638,8 +638,8 @@ class SynthSeg:
         if batch_size is None:
             batch_size = 1
 
-        transformed_images = []
-        params_list = []
+        transformed_images = [None] * len(T1)
+        params_list = [None] * len(T1)
 
         # Resample the data to 1 mm isotropic resolution.
         ori_shape = T1.shape[1:]
@@ -650,8 +650,8 @@ class SynthSeg:
                 target_voxsize=(1.0, 1.0, 1.0),
                 order=3,
             )
-            transformed_images.append(t_img)
-            params_list.append(params)
+            transformed_images[i] = t_img
+            params_list[i] = params
 
         # Pad all images to a common shape compatible with SynthSeg.
         max_shape = np.max([img.shape for img in transformed_images], axis=0)

--- a/dipy/nn/torch/synthseg.py
+++ b/dipy/nn/torch/synthseg.py
@@ -22,7 +22,9 @@ from scipy.ndimage import gaussian_filter
 
 from dipy.data import get_fnames
 from dipy.nn.utils import (
+    get_padded_shape,
     normalize,
+    pad_crop,
     recover_img,
     set_logger_level,
     transform_img,
@@ -596,7 +598,8 @@ class SynthSeg:
             has a batch dimension.
         return_prob : bool, optional
             Whether to return the probability map instead of a
-            label map. Useful for testing.
+            label map. Probability maps remain in the 1 mm isotropic model
+            space, padded to dimensions divisible by 32. Useful for testing.
 
         Returns
         -------
@@ -635,25 +638,36 @@ class SynthSeg:
         if batch_size is None:
             batch_size = 1
 
-        input_data = np.zeros((len(T1), 192, 192, 192))
+        transformed_images = []
         params_list = []
 
-        # Normalize the data.
+        # Resample the data to 1 mm isotropic resolution.
         ori_shape = T1.shape[1:]
         for i, T1_img in enumerate(T1):
             t_img, params = transform_img(
                 T1_img,
                 affine[i],
                 target_voxsize=(1.0, 1.0, 1.0),
-                final_size=(192, 192, 192),
                 order=3,
             )
+            transformed_images.append(t_img)
+            params_list.append(params)
+
+        # Pad all images to a common shape compatible with SynthSeg.
+        max_shape = np.max([img.shape for img in transformed_images], axis=0)
+        model_shape = get_padded_shape(max_shape, multiple=32)
+        input_data = np.zeros((len(T1),) + model_shape, dtype=np.float32)
+
+        for i, t_img in enumerate(transformed_images):
+            t_img, pad_vs, crop_vs = pad_crop(t_img, model_shape)
             min_v, max_v = np.percentile(t_img, (0.5, 99.5))
             t_img = normalize(t_img, min_v=min_v, max_v=max_v, new_min=0, new_max=1)
             input_data[i] = t_img
-            params_list.append(params)
+            params_list[i]["pad_value"] = pad_vs
+            params_list[i]["crop_value"] = crop_vs
+
         # Prediction stage
-        prediction = np.zeros((len(T1), 192, 192, 192, 33), dtype=np.float32)
+        prediction = np.zeros((len(T1),) + model_shape + (33,), dtype=np.float32)
         for batch_idx in range(batch_size, len(T1) + 1, batch_size):
             batch = input_data[batch_idx - batch_size : batch_idx]
             batch_start = batch_idx - batch_size
@@ -696,7 +710,7 @@ class SynthSeg:
             prediction[-remainder:] /= 2
 
         if return_prob:
-            labels = np.zeros((len(T1),) + (192, 192, 192, 33)).astype(np.float32)
+            labels = np.zeros((len(T1),) + model_shape + (33,), dtype=np.float32)
         else:
             labels = np.zeros((len(T1),) + ori_shape).astype(np.int32)
             masks = np.zeros((len(T1),) + ori_shape)

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from scipy.ndimage import affine_transform, map_coordinates
 
@@ -296,9 +298,7 @@ def get_padded_shape(shape, multiple):
     if multiple <= 0:
         raise ValueError("multiple must be greater than zero")
 
-    shape = np.asarray(shape, dtype=int)
-    padded_shape = ((shape + multiple - 1) // multiple) * multiple
-    return tuple(int(value) for value in padded_shape)
+    return tuple(math.ceil(int(dim) / multiple) * multiple for dim in shape)
 
 
 def pad_crop(image, target_shape):

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -277,6 +277,30 @@ def recover_img(image, params, *, order=3):
     return recovered
 
 
+def get_padded_shape(shape, multiple):
+    """Round each dimension of a shape up to a given multiple.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        Input shape.
+    multiple : int
+        Value that every output dimension must be divisible by.
+
+    Returns
+    -------
+    tuple of int
+        Smallest shape greater than or equal to ``shape`` for which every
+        dimension is divisible by ``multiple``.
+    """
+    if multiple <= 0:
+        raise ValueError("multiple must be greater than zero")
+
+    shape = np.asarray(shape, dtype=int)
+    padded_shape = ((shape + multiple - 1) // multiple) * multiple
+    return tuple(int(value) for value in padded_shape)
+
+
 def pad_crop(image, target_shape):
     """
     Function to figure out pad and crop range

--- a/dipy/nn/utils.py
+++ b/dipy/nn/utils.py
@@ -280,7 +280,8 @@ def recover_img(image, params, *, order=3):
 
 
 def get_padded_shape(shape, multiple):
-    """Round each dimension of a shape up to a given multiple.
+    """Return the smallest shape greater than or equal to ``shape`` whose
+    dimensions are divisible by ``multiple``.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

This PR updates `SynthSeg.predict` to support flexible input sizes instead of forcing every image to a fixed `192 x 192 x 192` model space.

The preprocessing pipeline now resamples input images to 1 mm isotropic resolution, computes the required model input shape dynamically, and pads the data to the smallest shape whose dimensions are divisible by 32. The predicted labels and masks are still recovered back to the original input image space, preserving the existing output behavior for standard predictions.

This PR also adds a small utility function, `get_padded_shape`, to compute the padded model-compatible shape in a reusable and readable way.

## Motivation and Context

Currently, `SynthSeg.predict` always passes `final_size=(192, 192, 192)` during preprocessing. This makes the model input shape fixed, meaning that larger images can be cropped during preprocessing, potentially reducing the field of view available to the model. While using the current interface, I have witnessed several cases where the output predictions were cropped and did not cover the full anatomy.

This behavior is also more restrictive than what is required by the original [SynthSeg implementation](https://github.com/BBillot/SynthSeg). The official SynthSeg documentation states that, when using the optional crop argument, the crop size must be divisible by 32, but it does not require a fixed `192 x 192 x 192` input size. In fact, by default, SynthSeg processes the whole image, and cropping is only an optional mechanism for faster analysis or fitting the image into GPU memory.

This change therefore removes the hard-coded `192 x 192 x 192` assumption and instead adapts the model input size to the input image after resampling. The new behavior keeps the full resampled field of view, while still ensuring that the final model-space shape is compatible with the network architecture by padding each dimension to a multiple of 32.

## How Has This Been Tested?

I tested this by running `SynthSeg.predict` on multiple T1-weighted samples from the OASIS-2 dataset and comparing the outputs obtained from the current `master` branch against the outputs obtained from this PR branch.

I visually inspected the predicted SynthSeg labels and masks from both branches. Across many OASIS-2 samples, I observed the same behavior: the flexible-input branch preserves a larger field of view when the resampled image does not naturally fit within the fixed `192 x 192 x 192` space, while the final recovered labels and masks remain aligned with the original input image space.

A representative visual comparison is shown below:

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/86579277-5b5d-4180-8b87-39db56a09757" width="360"><br>
      <sub><b>Master</b>: fixed <code>192 x 192 x 192</code> preprocessing</sub>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/df1fd1f1-b4f5-41f9-9bd5-1af6bd96fd33" width="360"><br>
      <sub><b>This PR</b>: flexible multiple-of-32 preprocessing</sub>
    </td>
  </tr>
</table>

The images were taken manually in Slicer, so small mismatches may just come from slightly different screenshot positioning.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
