### PR TITLE
BF: fix flaky test_csd_xval by using rng kwarg in kfold_xval

### DIFF
--- a/dipy/reconst/cross_validation.py
+++ b/dipy/reconst/cross_validation.py
@@ -99,7 +99,7 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
     .. footbibliography::
 
     """
-    _ = model_kwargs.pop("rng", np.random.default_rng())
+    rng = model_kwargs.pop("rng", np.random.default_rng())
 
     # This should always be there, if the model inherits from
     # dipy.reconst.base.ReconstModel:
@@ -118,7 +118,7 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
     n_in_fold = data_b.shape[-1] / folds
     prediction = np.zeros(data.shape)
     # We are going to leave out some randomly chosen samples in each iteration:
-    order = np.random.permutation(data_b.shape[-1])
+    order = rng.permutation(data_b.shape[-1])
 
     nz_bval = gtab.bvals[~gtab.b0s_mask]
     nz_bvec = gtab.bvecs[~gtab.b0s_mask]


### PR DESCRIPTION
## Summary
- `kfold_xval` popped the `rng` kwarg but discarded it (`_ = model_kwargs.pop("rng", ...)`), then drew fold order from the unseeded global `np.random.permutation`.
- `test_csd_xval` passes a fixed seed via `rng=rng`, but that seed never reached the fold split — the resulting COD landed on either side of a rounding boundary (97 vs 98) depending on unrelated global numpy RNG state, causing intermittent CI failures like https://github.com/dipy/dipy/actions/runs/28965371175/job/85947055674?pr=4079#step:12:4514
- Fix: actually use the popped `rng` for `order = rng.permutation(...)`.

## Test plan
- [x] `pytest dipy/reconst/tests/test_cross_validation.py -q` passes repeatedly (ran 3x)
- [x] confirmed deterministic regardless of global numpy RNG state polluted by other tests