### PR TITLE
OPT: multi-threading 2D and 3D image warping

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1188,6 +1188,12 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
         if len(level_iters) == 0:
             raise ValueError("The iterations list cannot be empty")
 
+        if num_threads is not None:
+            if not isinstance(num_threads, int):
+                raise TypeError("num_threads must be an int or None")
+            if num_threads < 1:
+                raise ValueError("num_threads must be a positive integer or None")
+
         self.set_level_iters(level_iters)
         self.step_length = step_length
         self.ss_sigma_factor = ss_sigma_factor

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -342,6 +342,7 @@ class DiffeomorphicMap:
         image_world2grid=None,
         out_shape=None,
         out_grid2world=None,
+        num_threads=None,
     ):
         """Warps an image in the forward direction
 
@@ -366,6 +367,9 @@ class DiffeomorphicMap:
             the number of slices, rows, and columns of the desired warped image
         out_grid2world : the transformation bringing voxel coordinates of the
             warped image to physical space
+        num_threads : int or None, optional
+            Number of OpenMP threads used for image warping. If None, use
+            DIPY's default thread count.
 
         Returns
         -------
@@ -454,6 +458,7 @@ class DiffeomorphicMap:
             affine_idx_out=affine_idx_out,
             affine_disp=affine_disp,
             out_shape=out_shape,
+            num_threads=num_threads,
         )
         return warped
 
@@ -466,6 +471,7 @@ class DiffeomorphicMap:
         image_world2grid=None,
         out_shape=None,
         out_grid2world=None,
+        num_threads=None,
     ):
         """Warps an image in the backward direction
 
@@ -490,6 +496,9 @@ class DiffeomorphicMap:
             the number of slices, rows and columns of the desired warped image
         out_grid2world : the transformation bringing voxel coordinates of the
             warped image to physical space
+        num_threads : int or None, optional
+            Number of OpenMP threads used for image warping. If None, use
+            DIPY's default thread count.
 
         Returns
         -------
@@ -577,6 +586,7 @@ class DiffeomorphicMap:
             affine_idx_out=affine_idx_out,
             affine_disp=affine_disp,
             out_shape=out_shape,
+            num_threads=num_threads,
         )
 
         return warped
@@ -590,6 +600,7 @@ class DiffeomorphicMap:
         image_world2grid=None,
         out_shape=None,
         out_grid2world=None,
+        num_threads=None,
     ):
         """Warps an image in the forward direction
 
@@ -613,6 +624,9 @@ class DiffeomorphicMap:
             the number of slices, rows and columns of the desired warped image
         out_grid2world : the transformation bringing voxel coordinates of the
             warped image to physical space
+        num_threads : int or None, optional
+            Number of OpenMP threads used for image warping. If None, use
+            DIPY's default thread count.
 
         Returns
         -------
@@ -633,6 +647,7 @@ class DiffeomorphicMap:
                 image_world2grid=image_world2grid,
                 out_shape=out_shape,
                 out_grid2world=out_grid2world,
+                num_threads=num_threads,
             )
         else:
             warped = self._warp_forward(
@@ -641,6 +656,7 @@ class DiffeomorphicMap:
                 image_world2grid=image_world2grid,
                 out_shape=out_shape,
                 out_grid2world=out_grid2world,
+                num_threads=num_threads,
             )
         return np.asarray(warped)
 
@@ -653,6 +669,7 @@ class DiffeomorphicMap:
         image_world2grid=None,
         out_shape=None,
         out_grid2world=None,
+        num_threads=None,
     ):
         """Warps an image in the backward direction
 
@@ -676,6 +693,9 @@ class DiffeomorphicMap:
             the number of slices, rows, and columns of the desired warped image
         out_grid2world : the transformation bringing voxel coordinates of the
             warped image to physical space
+        num_threads : int or None, optional
+            Number of OpenMP threads used for image warping. If None, use
+            DIPY's default thread count.
 
         Returns
         -------
@@ -694,6 +714,7 @@ class DiffeomorphicMap:
                 image_world2grid=image_world2grid,
                 out_shape=out_shape,
                 out_grid2world=out_grid2world,
+                num_threads=num_threads,
             )
         else:
             warped = self._warp_backward(
@@ -702,6 +723,7 @@ class DiffeomorphicMap:
                 image_world2grid=image_world2grid,
                 out_shape=out_shape,
                 out_grid2world=out_grid2world,
+                num_threads=num_threads,
             )
         return np.asarray(warped)
 
@@ -1502,6 +1524,7 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
             image_world2grid=None,
             out_shape=current_disp_shape,
             out_grid2world=current_disp_grid2world,
+            num_threads=self.num_threads,
         )
         wmoving = self.moving_to_ref.transform_inverse(
             current_moving,
@@ -1509,6 +1532,7 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
             image_world2grid=None,
             out_shape=current_disp_shape,
             out_grid2world=current_disp_grid2world,
+            num_threads=self.num_threads,
         )
         # Pass both images to the metric. Now both images are sampled on the
         # reference grid (equal to the static image's grid) and the direction

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1199,9 +1199,12 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
             to be called after each iteration (this optimizer will call this
             function passing self as parameter)
         num_threads : int or None, optional
-            Number of OpenMP threads used for displacement-field composition
-            and inversion. The effective number of threads is resolved when
-            each threaded operation is called.
+            Number of OpenMP threads used for displacement-field composition,
+            inversion, and image warping. If None, use DIPY's default OpenMP
+            thread count. This respects OMP_NUM_THREADS when set; otherwise,
+            all available threads are used. Negative values follow
+            ``dipy.utils.omp.determine_num_threads`` (``-1`` uses all
+            available cores).
         """
         super().__init__(metric=metric)
         if level_iters is None:
@@ -1213,8 +1216,8 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
         if num_threads is not None:
             if not isinstance(num_threads, int):
                 raise TypeError("num_threads must be an int or None")
-            if num_threads < 1:
-                raise ValueError("num_threads must be a positive integer or None")
+            if num_threads == 0:
+                raise ValueError("num_threads cannot be 0")
 
         self.set_level_iters(level_iters)
         self.step_length = step_length

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -407,6 +407,19 @@ def test_optimizer_exceptions():
     assert_raises(
         ValueError, imwarp.SymmetricDiffeomorphicRegistration, metric, level_iters=[]
     )
+    assert_raises(
+        TypeError,
+        imwarp.SymmetricDiffeomorphicRegistration,
+        metric,
+        num_threads=1.5,
+    )
+    assert_raises(
+        ValueError,
+        imwarp.SymmetricDiffeomorphicRegistration,
+        metric,
+        num_threads=0,
+    )
+
     optimizer = imwarp.SymmetricDiffeomorphicRegistration(metric, level_iters=None)
     # Verify the default iterations list
     assert_array_equal(optimizer.level_iters, [100, 100, 25])

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -353,6 +353,50 @@ def test_diffeomorphic_map_simplification_3d():
     assert_array_almost_equal(warped, expected)
 
 
+@set_random_number_generator(1234)
+def test_diffeomorphic_map_warp_threading(rng):
+    """Threaded map warping matches one-thread map warping."""
+    cases = (
+        (2, (32, 29)),
+        (3, (16, 15, 14)),
+    )
+
+    for dim, shape in cases:
+        image = rng.random(shape).astype(np.float32)
+        forward = rng.normal(scale=0.25, size=shape + (dim,)).astype(np.float32)
+        backward = rng.normal(scale=0.25, size=shape + (dim,)).astype(np.float32)
+        grid2world = np.eye(dim + 1)
+
+        diff_map = DiffeomorphicMap(
+            dim=dim,
+            disp_shape=shape,
+            disp_grid2world=grid2world,
+            domain_shape=shape,
+            domain_grid2world=grid2world,
+            codomain_shape=shape,
+            codomain_grid2world=grid2world,
+        )
+        diff_map.forward = forward
+        diff_map.backward = backward
+
+        for interpolation in ("linear", "nearest"):
+            serial = diff_map.transform(
+                image, interpolation=interpolation, num_threads=1
+            )
+            threaded = diff_map.transform(
+                image, interpolation=interpolation, num_threads=2
+            )
+            assert_array_equal(threaded, serial)
+
+            serial = diff_map.transform_inverse(
+                image, interpolation=interpolation, num_threads=1
+            )
+            threaded = diff_map.transform_inverse(
+                image, interpolation=interpolation, num_threads=2
+            )
+            assert_array_equal(threaded, serial)
+
+
 def test_optimizer_exceptions():
     r"""Test exceptions from SyN"""
     # An arbitrary valid metric

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -635,6 +635,42 @@ def test_warping_3d():
     )
 
 
+@set_random_number_generator(1234)
+def test_warping_threading(rng):
+    """Threaded warping matches one-thread warping."""
+    cases = (
+        (vfu.warp_2d, vfu.warp_2d_nn, (32, 29), 2),
+        (vfu.warp_3d, vfu.warp_3d_nn, (16, 15, 14), 3),
+    )
+
+    for warp, warp_nn, shape, dim in cases:
+        affine = np.eye(dim + 1)
+        out_shape = np.asarray(shape, dtype=np.int32)
+
+        for dtype in (np.float32, np.float64):
+            image = rng.random(shape).astype(dtype)
+            displacement = rng.normal(scale=0.25, size=shape + (dim,)).astype(dtype)
+
+            serial = warp(
+                image, displacement, affine, affine, affine, out_shape, num_threads=1
+            )
+            threaded = warp(
+                image, displacement, affine, affine, affine, out_shape, num_threads=2
+            )
+
+            assert_array_equal(threaded, serial)
+
+            labels = rng.integers(0, 8, size=shape, dtype=np.int32)
+            serial = warp_nn(
+                labels, displacement, affine, affine, affine, out_shape, num_threads=1
+            )
+            threaded = warp_nn(
+                labels, displacement, affine, affine, affine, out_shape, num_threads=2
+            )
+
+            assert_array_equal(threaded, serial)
+
+
 def test_affine_transforms_2d():
     r"""
     Tests 2D affine transform functions against scipy implementation

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -1416,11 +1416,106 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
     return np.asarray(out)
 
 
+cdef void _warp_3d_slice(floating[:, :, :] volume,
+                         floating[:, :, :, :] d1,
+                         double[:, :] affine_idx_in,
+                         double[:, :] affine_idx_out,
+                         double[:, :] affine_disp,
+                         cnp.npy_intp k,
+                         cnp.npy_intp nrows,
+                         cnp.npy_intp ncols,
+                         floating[:, :, :] warped) noexcept nogil:
+    r"""Warp one slice of a 3D volume using trilinear interpolation.
+
+    This performs the inner two loops of :func:`warp_3d` for one output
+    slice. It was added so the outer slice loop can run with ``prange`` while
+    the temporary interpolation vector remains local to each worker.
+
+    Parameters
+    ----------
+    volume : array, shape (S, R, C)
+        the input volume to be transformed
+    d1 : array, shape (S', R', C', 3)
+        the displacement field driving the transformation
+    affine_idx_in : array, shape (4, 4)
+        the matrix A in eq. (1) above
+    affine_idx_out : array, shape (4, 4)
+        the matrix B in eq. (1) above
+    affine_disp : array, shape (4, 4)
+        the matrix C in eq. (1) above
+    k : int
+        Index of the output slice to compute.
+    nrows : int
+        Number of rows in the output slice.
+    ncols : int
+        Number of columns in the output slice.
+    warped : array, shape (S'', R'', C'')
+        Output buffer receiving the warped slice.
+
+    Returns
+    -------
+    warped : array, shape (S'', R'', C'')
+        On output, slice ``k`` contains the transformed volume values.
+    """
+    cdef:
+        cnp.npy_intp i, j
+        int inside
+        double dkk, dii, djj, dk, di, dj
+        floating tmp[3]
+
+    for i in range(nrows):
+        for j in range(ncols):
+            if affine_idx_in is None:
+                dkk = d1[k, i, j, 0]
+                dii = d1[k, i, j, 1]
+                djj = d1[k, i, j, 2]
+            else:
+                dk = _apply_affine_3d_x0(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                di = _apply_affine_3d_x1(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                dj = _apply_affine_3d_x2(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                inside = _interpolate_vector_3d[floating](d1, dk, di,
+                                                          dj, &tmp[0])
+                dkk = tmp[0]
+                dii = tmp[1]
+                djj = tmp[2]
+
+            if affine_disp is not None:
+                dk = _apply_affine_3d_x0(
+                    dkk, dii, djj, 0, affine_disp)
+                di = _apply_affine_3d_x1(
+                    dkk, dii, djj, 0, affine_disp)
+                dj = _apply_affine_3d_x2(
+                    dkk, dii, djj, 0, affine_disp)
+            else:
+                dk = dkk
+                di = dii
+                dj = djj
+
+            if affine_idx_out is not None:
+                dkk = dk + _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+                dii = di + _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+                djj = dj + _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+            else:
+                dkk = dk + <double>k
+                dii = di + <double>i
+                djj = dj + <double>j
+
+            inside = _interpolate_scalar_3d[floating](
+                volume, dkk, dii, djj, &warped[k, i, j])
+
+
 def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
             double[:, :] affine_idx_in=None,
             double[:, :] affine_idx_out=None,
             double[:, :] affine_disp=None,
-            int[:] out_shape=None):
+            int[:] out_shape=None,
+            num_threads=None):
     r"""Warps a 3D volume using trilinear interpolation
 
     Deforms the input volume under the given transformation. The warped volume
@@ -1446,6 +1541,9 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
         the matrix C in eq. (1) above
     out_shape : array, shape (3,)
         the number of slices, rows and columns of the sampling grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
 
     Returns
     -------
@@ -1471,12 +1569,8 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
         cnp.npy_intp nslices = volume.shape[0]
         cnp.npy_intp nrows = volume.shape[1]
         cnp.npy_intp ncols = volume.shape[2]
-        cnp.npy_intp nsVol = volume.shape[0]
-        cnp.npy_intp nrVol = volume.shape[1]
-        cnp.npy_intp ncVol = volume.shape[2]
-        cnp.npy_intp i, j, k
-        int inside
-        double dkk, dii, djj, dk, di, dj
+        cnp.npy_intp k
+        int threads_to_use
 
     if not is_valid_affine(affine_idx_in, 3):
         raise ValueError("Invalid inner index multiplication matrix")
@@ -1496,57 +1590,16 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
 
     cdef floating[:, :, :] warped = np.zeros(shape=(nslices, nrows, ncols),
                                              dtype=np.asarray(volume).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
+
+    threads_to_use = determine_num_threads(num_threads)
 
     with nogil:
-
-        for k in range(nslices):
-            for i in range(nrows):
-                for j in range(ncols):
-                    if affine_idx_in is None:
-                        dkk = d1[k, i, j, 0]
-                        dii = d1[k, i, j, 1]
-                        djj = d1[k, i, j, 2]
-                    else:
-                        dk = _apply_affine_3d_x0(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        di = _apply_affine_3d_x1(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        dj = _apply_affine_3d_x2(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        inside = _interpolate_vector_3d[floating](d1, dk, di,
-                                                                  dj, &tmp[0])
-                        dkk = tmp[0]
-                        dii = tmp[1]
-                        djj = tmp[2]
-
-                    if affine_disp is not None:
-                        dk = _apply_affine_3d_x0(
-                            dkk, dii, djj, 0, affine_disp)
-                        di = _apply_affine_3d_x1(
-                            dkk, dii, djj, 0, affine_disp)
-                        dj = _apply_affine_3d_x2(
-                            dkk, dii, djj, 0, affine_disp)
-                    else:
-                        dk = dkk
-                        di = dii
-                        dj = djj
-
-                    if affine_idx_out is not None:
-                        dkk = dk + _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                        dii = di + _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                        djj = dj + _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                    else:
-                        dkk = dk + <double>k
-                        dii = di + <double>i
-                        djj = dj + <double>j
-
-                    inside = _interpolate_scalar_3d[floating](volume, dkk,
-                                                              dii, djj,
-                                                              &warped[k, i, j])
+        for k in prange(
+            nslices, schedule="static", num_threads=threads_to_use
+        ):
+            _warp_3d_slice[floating](
+                volume, d1, affine_idx_in, affine_idx_out, affine_disp,
+                k, nrows, ncols, warped)
     return np.asarray(warped)
 
 
@@ -1616,11 +1669,107 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
     return np.asarray(out)
 
 
+cdef void _warp_3d_nn_slice(number[:, :, :] volume,
+                            floating[:, :, :, :] d1,
+                            double[:, :] affine_idx_in,
+                            double[:, :] affine_idx_out,
+                            double[:, :] affine_disp,
+                            cnp.npy_intp k,
+                            cnp.npy_intp nrows,
+                            cnp.npy_intp ncols,
+                            number[:, :, :] warped) noexcept nogil:
+    r"""Warp one slice of a 3D volume using nearest-neighbor interpolation.
+
+    This performs the inner two loops of :func:`warp_3d_nn` for one output
+    slice. It was added so the outer slice loop can run with ``prange`` while
+    the temporary interpolation vector remains local to each worker.
+
+    Parameters
+    ----------
+    volume : array, shape (S, R, C)
+        the input volume to be transformed
+    d1 : array, shape (S', R', C', 3)
+        the displacement field driving the transformation
+    affine_idx_in : array, shape (4, 4)
+        the matrix A in eq. (1) above
+    affine_idx_out : array, shape (4, 4)
+        the matrix B in eq. (1) above
+    affine_disp : array, shape (4, 4)
+        the matrix C in eq. (1) above
+    k : int
+        Index of the output slice to compute.
+    nrows : int
+        Number of rows in the output slice.
+    ncols : int
+        Number of columns in the output slice.
+    warped : array, shape (S'', R'', C'')
+        Output buffer receiving the warped slice.
+
+    Returns
+    -------
+    warped : array, shape (S'', R'', C'')
+        On output, slice ``k`` contains the transformed volume values.
+    """
+    cdef:
+        cnp.npy_intp i, j
+        int inside
+        double dkk, dii, djj, dk, di, dj
+        floating tmp[3]
+
+    for i in range(nrows):
+        for j in range(ncols):
+            if affine_idx_in is None:
+                dkk = d1[k, i, j, 0]
+                dii = d1[k, i, j, 1]
+                djj = d1[k, i, j, 2]
+            else:
+                dk = _apply_affine_3d_x0(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                di = _apply_affine_3d_x1(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                dj = _apply_affine_3d_x2(
+                    <double>k, <double>i, <double>j, 1, affine_idx_in)
+                inside = _interpolate_vector_3d[floating](d1, dk, di,
+                                                          dj, &tmp[0])
+                dkk = tmp[0]
+                dii = tmp[1]
+                djj = tmp[2]
+
+            if affine_disp is not None:
+                dk = _apply_affine_3d_x0(
+                    dkk, dii, djj, 0, affine_disp)
+                di = _apply_affine_3d_x1(
+                    dkk, dii, djj, 0, affine_disp)
+                dj = _apply_affine_3d_x2(
+                    dkk, dii, djj, 0, affine_disp)
+            else:
+                dk = dkk
+                di = dii
+                dj = djj
+
+            if affine_idx_out is not None:
+                dkk = dk + _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+                dii = di + _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+                djj = dj + _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1,
+                                               affine_idx_out)
+            else:
+                dkk = dk + <double>k
+                dii = di + <double>i
+                djj = dj + <double>j
+
+            # Interpolate the input volume at the resulting location
+            inside = _interpolate_scalar_nn_3d[number](
+                volume, dkk, dii, djj, &warped[k, i, j])
+
+
 def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
                double[:, :] affine_idx_in=None,
                double[:, :] affine_idx_out=None,
                double[:, :] affine_disp=None,
-               int[:] out_shape=None):
+               int[:] out_shape=None,
+               num_threads=None):
     r"""Warps a 3D volume using using nearest-neighbor interpolation
 
     Deforms the input volume under the given transformation. The warped volume
@@ -1646,6 +1795,9 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
         the matrix C in eq. (1) above
     out_shape : array, shape (3,)
         the number of slices, rows and columns of the sampling grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
 
     Returns
     -------
@@ -1671,12 +1823,8 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
         cnp.npy_intp nslices = volume.shape[0]
         cnp.npy_intp nrows = volume.shape[1]
         cnp.npy_intp ncols = volume.shape[2]
-        cnp.npy_intp nsVol = volume.shape[0]
-        cnp.npy_intp nrVol = volume.shape[1]
-        cnp.npy_intp ncVol = volume.shape[2]
-        cnp.npy_intp i, j, k
-        int inside
-        double dkk, dii, djj, dk, di, dj
+        cnp.npy_intp k
+        int threads_to_use
 
     if not is_valid_affine(affine_idx_in, 3):
         raise ValueError("Invalid inner index multiplication matrix")
@@ -1696,56 +1844,16 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
 
     cdef number[:, :, :] warped = np.zeros(shape=(nslices, nrows, ncols),
                                            dtype=np.asarray(volume).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(3,), dtype = np.asarray(d1).dtype)
+
+    threads_to_use = determine_num_threads(num_threads)
 
     with nogil:
-
-        for k in range(nslices):
-            for i in range(nrows):
-                for j in range(ncols):
-                    if affine_idx_in is None:
-                        dkk = d1[k, i, j, 0]
-                        dii = d1[k, i, j, 1]
-                        djj = d1[k, i, j, 2]
-                    else:
-                        dk = _apply_affine_3d_x0(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        di = _apply_affine_3d_x1(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        dj = _apply_affine_3d_x2(
-                            <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        inside = _interpolate_vector_3d[floating](d1, dk, di,
-                                                                  dj, &tmp[0])
-                        dkk = tmp[0]
-                        dii = tmp[1]
-                        djj = tmp[2]
-
-                    if affine_disp is not None:
-                        dk = _apply_affine_3d_x0(
-                            dkk, dii, djj, 0, affine_disp)
-                        di = _apply_affine_3d_x1(
-                            dkk, dii, djj, 0, affine_disp)
-                        dj = _apply_affine_3d_x2(
-                            dkk, dii, djj, 0, affine_disp)
-                    else:
-                        dk = dkk
-                        di = dii
-                        dj = djj
-
-                    if affine_idx_out is not None:
-                        dkk = dk + _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                        dii = di + _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                        djj = dj + _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1,
-                                                       affine_idx_out)
-                    else:
-                        dkk = dk + <double>k
-                        dii = di + <double>i
-                        djj = dj + <double>j
-
-                    inside = _interpolate_scalar_nn_3d[number](volume,
-                                        dkk, dii, djj, &warped[k, i, j])
+        for k in prange(
+            nslices, schedule="static", num_threads=threads_to_use
+        ):
+            _warp_3d_nn_slice[number, floating](
+                volume, d1, affine_idx_in, affine_idx_out, affine_disp,
+                k, nrows, ncols, warped)
     return np.asarray(warped)
 
 
@@ -1814,11 +1922,88 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
     return np.asarray(out)
 
 
+cdef void _warp_2d_row(floating[:, :] image,
+                       floating[:, :, :] d1,
+                       double[:, :] affine_idx_in,
+                       double[:, :] affine_idx_out,
+                       double[:, :] affine_disp,
+                       cnp.npy_intp i,
+                       cnp.npy_intp ncols,
+                       floating[:, :] warped) noexcept nogil:
+    r"""Warp one row of a 2D image using bilinear interpolation.
+
+    This performs the inner loop of :func:`warp_2d` for one output row. It was
+    added so the outer row loop can run with ``prange`` while the temporary
+    interpolation vector remains local to each worker.
+
+    Parameters
+    ----------
+    image : array, shape (R, C)
+        the input image to be transformed
+    d1 : array, shape (R', C', 2)
+        the displacement field driving the transformation
+    affine_idx_in : array, shape (3, 3)
+        the matrix A in eq. (1) above
+    affine_idx_out : array, shape (3, 3)
+        the matrix B in eq. (1) above
+    affine_disp : array, shape (3, 3)
+        the matrix C in eq. (1) above
+    i : int
+        Index of the output row to compute.
+    ncols : int
+        Number of columns in the output row.
+    warped : array, shape (R'', C'')
+        Output buffer receiving the warped row.
+
+    Returns
+    -------
+    warped : array, shape (R'', C'')
+        On output, row ``i`` contains the transformed image values.
+    """
+    cdef:
+        cnp.npy_intp j
+        double di, dj, dii, djj
+        floating tmp[2]
+
+    for j in range(ncols):
+        if affine_idx_in is None:
+            dii = d1[i, j, 0]
+            djj = d1[i, j, 1]
+        else:
+            di = _apply_affine_2d_x0(
+                <double>i, <double>j, 1, affine_idx_in)
+            dj = _apply_affine_2d_x1(
+                <double>i, <double>j, 1, affine_idx_in)
+            _interpolate_vector_2d[floating](d1, di, dj, &tmp[0])
+            dii = tmp[0]
+            djj = tmp[1]
+
+        if affine_disp is not None:
+            di = _apply_affine_2d_x0(
+                dii, djj, 0, affine_disp)
+            dj = _apply_affine_2d_x1(
+                dii, djj, 0, affine_disp)
+        else:
+            di = dii
+            dj = djj
+
+        if affine_idx_out is not None:
+            dii = di + _apply_affine_2d_x0(<double>i, <double>j, 1, affine_idx_out)
+            djj = dj + _apply_affine_2d_x1(<double>i, <double>j, 1, affine_idx_out)
+        else:
+            dii = di + <double>i
+            djj = dj + <double>j
+
+        _interpolate_scalar_2d[floating](image, dii, djj,
+                                         &warped[i, j])
+
+
 def warp_2d(floating[:, :] image, floating[:, :, :] d1,
             double[:, :] affine_idx_in=None,
             double[:, :] affine_idx_out=None,
             double[:, :] affine_disp=None,
-            int[:] out_shape=None):
+            int[:] out_shape=None,
+            num_threads=None):
     r"""Warps a 2D image using bilinear interpolation
 
     Deforms the input image under the given transformation. The warped image
@@ -1844,6 +2029,9 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
         the matrix C in eq. (1) above
     out_shape : array, shape (2,)
         the number of rows and columns of the sampling grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
 
     Returns
     -------
@@ -1868,10 +2056,8 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
     cdef:
         cnp.npy_intp nrows = image.shape[0]
         cnp.npy_intp ncols = image.shape[1]
-        cnp.npy_intp nrVol = image.shape[0]
-        cnp.npy_intp ncVol = image.shape[1]
-        cnp.npy_intp i, j, ii, jj
-        double di, dj, dii, djj
+        cnp.npy_intp i
+        int threads_to_use
 
     if not is_valid_affine(affine_idx_in, 2):
         raise ValueError("Invalid inner index multiplication matrix")
@@ -1888,46 +2074,16 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
         ncols = d1.shape[1]
     cdef floating[:, :] warped = np.zeros(shape=(nrows, ncols),
                                           dtype=np.asarray(image).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(2,), dtype=np.asarray(d1).dtype)
+
+    threads_to_use = determine_num_threads(num_threads)
 
     with nogil:
-
-        for i in range(nrows):
-            for j in range(ncols):
-                # Apply inner index pre-multiplication
-                if affine_idx_in is None:
-                    dii = d1[i, j, 0]
-                    djj = d1[i, j, 1]
-                else:
-                    di = _apply_affine_2d_x0(
-                        <double>i, <double>j, 1, affine_idx_in)
-                    dj = _apply_affine_2d_x1(
-                        <double>i, <double>j, 1, affine_idx_in)
-                    _interpolate_vector_2d[floating](d1, di, dj, &tmp[0])
-                    dii = tmp[0]
-                    djj = tmp[1]
-
-                # Apply displacement multiplication
-                if affine_disp is not None:
-                    di = _apply_affine_2d_x0(
-                        dii, djj, 0, affine_disp)
-                    dj = _apply_affine_2d_x1(
-                        dii, djj, 0, affine_disp)
-                else:
-                    di = dii
-                    dj = djj
-
-                # Apply outer index multiplication and add the displacements
-                if affine_idx_out is not None:
-                    dii = di + _apply_affine_2d_x0(<double>i, <double>j, 1, affine_idx_out)
-                    djj = dj + _apply_affine_2d_x1(<double>i, <double>j, 1, affine_idx_out)
-                else:
-                    dii = di + <double>i
-                    djj = dj + <double>j
-
-                # Interpolate the input image at the resulting location
-                _interpolate_scalar_2d[floating](image, dii, djj,
-                                                 &warped[i, j])
+        for i in prange(
+            nrows, schedule="static", num_threads=threads_to_use
+        ):
+            _warp_2d_row[floating](
+                image, d1, affine_idx_in, affine_idx_out, affine_disp,
+                i, ncols, warped)
     return np.asarray(warped)
 
 
@@ -1991,11 +2147,88 @@ def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
     return np.asarray(out)
 
 
+cdef void _warp_2d_nn_row(number[:, :] image,
+                          floating[:, :, :] d1,
+                          double[:, :] affine_idx_in,
+                          double[:, :] affine_idx_out,
+                          double[:, :] affine_disp,
+                          cnp.npy_intp i,
+                          cnp.npy_intp ncols,
+                          number[:, :] warped) noexcept nogil:
+    r"""Warp one row of a 2D image using nearest-neighbor interpolation.
+
+    This performs the inner loop of :func:`warp_2d_nn` for one output row. It
+    was added so the outer row loop can run with ``prange`` while the temporary
+    interpolation vector remains local to each worker.
+
+    Parameters
+    ----------
+    image : array, shape (R, C)
+        the input image to be transformed
+    d1 : array, shape (R', C', 2)
+        the displacement field driving the transformation
+    affine_idx_in : array, shape (3, 3)
+        the matrix A in eq. (1) above
+    affine_idx_out : array, shape (3, 3)
+        the matrix B in eq. (1) above
+    affine_disp : array, shape (3, 3)
+        the matrix C in eq. (1) above
+    i : int
+        Index of the output row to compute.
+    ncols : int
+        Number of columns in the output row.
+    warped : array, shape (R'', C'')
+        Output buffer receiving the warped row.
+
+    Returns
+    -------
+    warped : array, shape (R'', C'')
+        On output, row ``i`` contains the transformed image values.
+    """
+    cdef:
+        cnp.npy_intp j
+        double di, dj, dii, djj
+        floating tmp[2]
+
+    for j in range(ncols):
+        if affine_idx_in is None:
+            dii = d1[i, j, 0]
+            djj = d1[i, j, 1]
+        else:
+            di = _apply_affine_2d_x0(
+                <double>i, <double>j, 1, affine_idx_in)
+            dj = _apply_affine_2d_x1(
+                <double>i, <double>j, 1, affine_idx_in)
+            _interpolate_vector_2d[floating](d1, di, dj, &tmp[0])
+            dii = tmp[0]
+            djj = tmp[1]
+
+        if affine_disp is not None:
+            di = _apply_affine_2d_x0(
+                dii, djj, 0, affine_disp)
+            dj = _apply_affine_2d_x1(
+                dii, djj, 0, affine_disp)
+        else:
+            di = dii
+            dj = djj
+
+        if affine_idx_out is not None:
+            dii = di + _apply_affine_2d_x0(<double>i, <double>j, 1, affine_idx_out)
+            djj = dj + _apply_affine_2d_x1(<double>i, <double>j, 1, affine_idx_out)
+        else:
+            dii = di + <double>i
+            djj = dj + <double>j
+
+        _interpolate_scalar_nn_2d[number](image, dii, djj,
+                                          &warped[i, j])
+
+
 def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
                double[:, :] affine_idx_in=None,
                double[:, :] affine_idx_out=None,
                double[:, :] affine_disp=None,
-               int[:] out_shape=None):
+               int[:] out_shape=None,
+               num_threads=None):
     r"""Warps a 2D image using nearest neighbor interpolation
 
     Deforms the input image under the given transformation. The warped image
@@ -2021,6 +2254,9 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
         the matrix C in eq. (1) above
     out_shape : array, shape (2,)
         the number of rows and columns of the sampling grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
 
     Returns
     -------
@@ -2045,10 +2281,8 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
     cdef:
         cnp.npy_intp nrows = image.shape[0]
         cnp.npy_intp ncols = image.shape[1]
-        cnp.npy_intp nrVol = image.shape[0]
-        cnp.npy_intp ncVol = image.shape[1]
-        cnp.npy_intp i, j, ii, jj
-        double di, dj, dii, djj
+        cnp.npy_intp i
+        int threads_to_use
 
     if not is_valid_affine(affine_idx_in, 2):
         raise ValueError("Invalid inner index multiplication matrix")
@@ -2065,46 +2299,16 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
         ncols = d1.shape[1]
     cdef number[:, :] warped = np.zeros(shape=(nrows, ncols),
                                         dtype=np.asarray(image).dtype)
-    cdef floating[:] tmp = np.zeros(shape=(2,), dtype=np.asarray(d1).dtype)
+
+    threads_to_use = determine_num_threads(num_threads)
 
     with nogil:
-
-        for i in range(nrows):
-            for j in range(ncols):
-                # Apply inner index pre-multiplication
-                if affine_idx_in is None:
-                    dii = d1[i, j, 0]
-                    djj = d1[i, j, 1]
-                else:
-                    di = _apply_affine_2d_x0(
-                        <double>i, <double>j, 1, affine_idx_in)
-                    dj = _apply_affine_2d_x1(
-                        <double>i, <double>j, 1, affine_idx_in)
-                    _interpolate_vector_2d[floating](d1, di, dj, &tmp[0])
-                    dii = tmp[0]
-                    djj = tmp[1]
-
-                # Apply displacement multiplication
-                if affine_disp is not None:
-                    di = _apply_affine_2d_x0(
-                        dii, djj, 0, affine_disp)
-                    dj = _apply_affine_2d_x1(
-                        dii, djj, 0, affine_disp)
-                else:
-                    di = dii
-                    dj = djj
-
-                # Apply outer index multiplication and add the displacements
-                if affine_idx_out is not None:
-                    dii = di + _apply_affine_2d_x0(<double>i, <double>j, 1, affine_idx_out)
-                    djj = dj + _apply_affine_2d_x1(<double>i, <double>j, 1, affine_idx_out)
-                else:
-                    dii = di + <double>i
-                    djj = dj + <double>j
-
-                # Interpolate the input image at the resulting location
-                _interpolate_scalar_nn_2d[number](image, dii, djj,
-                                                  &warped[i, j])
+        for i in prange(
+            nrows, schedule="static", num_threads=threads_to_use
+        ):
+            _warp_2d_nn_row[number, floating](
+                image, d1, affine_idx_in, affine_idx_out, affine_disp,
+                i, ncols, warped)
     return np.asarray(warped)
 
 

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -71,6 +71,12 @@ cdef void _merge_composition_stats(double[:, :] partial_stats,
         if max_norm_sq < partial_stats[tid, 3]:
             max_norm_sq = partial_stats[tid, 3]
 
+    if count == 0:
+        stats[0] = 0
+        stats[1] = 0
+        stats[2] = 0
+        return
+
     mean_norm_sq = sum_norm_sq / count
     stats[0] = sqrt(max_norm_sq)
     stats[1] = sqrt(mean_norm_sq)
@@ -206,6 +212,7 @@ def compose_vector_fields_2d(floating[:, :, :] d1, floating[:, :, :] d2,
                              double[:, :] premult_disp,
                              double time_scaling,
                              floating[:, :, :] comp,
+                             *,
                              num_threads=None):
     r"""Computes the composition of two 2D displacement fields
 
@@ -428,6 +435,7 @@ def compose_vector_fields_3d(floating[:, :, :, :] d1, floating[:, :, :, :] d2,
                              double[:, :] premult_disp,
                              double time_scaling,
                              floating[:, :, :, :] comp,
+                             *,
                              num_threads=None):
     r"""Computes the composition of two 3D displacement fields
 
@@ -521,6 +529,7 @@ def invert_vector_field_fixed_point_2d(floating[:, :, :] d,
                                        double[:] spacing,
                                        int max_iter, double tolerance,
                                        floating[:, :, :] start=None,
+                                       *,
                                        num_threads=None):
     r"""Computes the inverse of a 2D displacement fields
 
@@ -637,6 +646,7 @@ def invert_vector_field_fixed_point_3d(floating[:, :, :, :] d,
                                        double[:] spacing,
                                        int max_iter, double tol,
                                        floating[:, :, :, :] start=None,
+                                       *,
                                        num_threads=None):
     r"""Computes the inverse of a 3D displacement fields
 
@@ -1515,6 +1525,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
             double[:, :] affine_idx_out=None,
             double[:, :] affine_disp=None,
             int[:] out_shape=None,
+            *,
             num_threads=None):
     r"""Warps a 3D volume using trilinear interpolation
 
@@ -1769,6 +1780,7 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
                double[:, :] affine_idx_out=None,
                double[:, :] affine_disp=None,
                int[:] out_shape=None,
+               *,
                num_threads=None):
     r"""Warps a 3D volume using using nearest-neighbor interpolation
 
@@ -2003,6 +2015,7 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
             double[:, :] affine_idx_out=None,
             double[:, :] affine_disp=None,
             int[:] out_shape=None,
+            *,
             num_threads=None):
     r"""Warps a 2D image using bilinear interpolation
 
@@ -2228,6 +2241,7 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
                double[:, :] affine_idx_out=None,
                double[:, :] affine_disp=None,
                int[:] out_shape=None,
+               *,
                num_threads=None):
     r"""Warps a 2D image using nearest neighbor interpolation
 


### PR DESCRIPTION
## Description

This PR adds OpenMP parallelization to DIPY's 2D and 3D image-warping kernels.

It is an extension of [dipy/dipy#4073](https://github.com/dipy/dipy/pull/4073), which introduces the shared `num_threads` configuration for SyN and parallelizes displacement-field composition and fixed-point inversion.

The outer row or slice loops of `warp_2d`, `warp_2d_nn`, `warp_3d`, and `warp_3d_nn` now use Cython's `prange`. Dedicated row and slice helpers provide thread-local interpolation buffers while preserving the operation order of the original implementations.

An optional `num_threads` parameter is exposed through the low-level warping functions and `DiffeomorphicMap.transform()` / `transform_inverse()`. `SymmetricDiffeomorphicRegistration` forwards its configured thread count to the image warps performed during each optimization iteration.

Both linear and nearest-neighbor interpolation are supported. Existing calls remain compatible because `num_threads=None` uses DIPY's default OpenMP thread count.

## Motivation and Context

SyN repeatedly warps the static and moving images into a common reference space during optimization. These warps evaluate every output pixel or voxel independently, but the existing implementations process them serially.

Parallelizing the independent outer rows or slices reduces this metric-independent part of the registration runtime. Thread-local temporary vectors are used because the original interpolation buffer could not safely be shared between OpenMP workers.

This PR is built directly on [dipy/dipy#4073](https://github.com/dipy/dipy/pull/4073). PR #4073 parallelizes the displacement-field composition used by fixed-point inversion and propagates `num_threads` through `SymmetricDiffeomorphicRegistration`. This PR reuses that thread configuration, forwards it to the image warps performed during each SyN iteration, and parallelizes the underlying 2D and 3D warping kernels.

This work directly follows the approach originally proposed in [dipy/dipy#1613](https://github.com/dipy/dipy/pull/1613). That earlier PR investigated multithreading the 3D registration path by:

- Parallelizing 3D vector-field composition.
- Parallelizing `warp_3d` and `warp_3d_nn`.
- Extracting per-slice helpers with local interpolation buffers.
- Introducing a `num_threads` option and propagating it through SyN.

Together, #4073 and this PR revisit that proposal against DIPY's modern codebase: #4073 implements the composition and fixed-point inversion portion, while this PR implements the image-warping portion.

## How Has This Been Tested?

Tests were added to verify that serial and threaded warping produce identical results. They cover the 2D and 3D implementations, linear and nearest-neighbor interpolation, and the forward and inverse `DiffeomorphicMap` paths.

A single end-to-end SyN experiment was also run on real 3D data, comparing one-thread and four-thread execution, and with the current state of the codebase.

Results:

| Revision and mode | Time | NCC |
|---|---:|---:|
| DIPY branch, one thread | 101.249 s | 0.95741 |
| DIPY branch, four threads | 76.864 s | 0.95741 |
| DIPY `master` | 110.465 s | 0.95741 |

The four-thread branch run achieved a **1.32x speed-up** over its one-thread execution, with identical NCC.

The branch is stacked on #4073, so the serial-to-threaded timing measures the combined threaded SyN path from #4073 and this PR. The experiment produced identical NCC values in every case.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
