### PR TITLE
RF: simplify Parzen PDF normalization

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -636,10 +636,9 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp i, j, r, c
         double rn, cn
-        double val, spline_arg, total_sum
+        double val, spline_arg
 
     joint[...] = 0
-    total_sum = 0
     valid_points = 0
     with nogil:
         smarginal[:] = 0
@@ -660,9 +659,8 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
                 for offset in range(1 - padding, padding + 1):
                     val = _cubic_spline(spline_arg)
                     joint[r, c + offset] += val
-                    total_sum += val
                     spline_arg += 1.0
-        if total_sum > 0:
+        if valid_points > 0:
             for i in range(nbins):
                 for j in range(nbins):
                     joint[i, j] /= <double>valid_points
@@ -725,10 +723,9 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp k, i, j, r, c
         double rn, cn
-        double val, spline_arg, total_sum
+        double val, spline_arg
 
     joint[...] = 0
-    total_sum = 0
     with nogil:
         valid_points = 0
         smarginal[:] = 0
@@ -750,13 +747,12 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
                     for offset in range(1 - padding, padding + 1):
                         val = _cubic_spline(spline_arg)
                         joint[r, c + offset] += val
-                        total_sum += val
                         spline_arg += 1.0
 
-        if total_sum > 0:
+        if valid_points > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= total_sum
+                    joint[i, j] /= <double>valid_points
 
             for i in range(nbins):
                 smarginal[i] /= <double>valid_points
@@ -806,10 +802,9 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
         cnp.npy_intp offset, valid_points
         cnp.npy_intp i, r, c
         double rn, cn
-        double val, spline_arg, total_sum
+        double val, spline_arg
 
     joint[...] = 0
-    total_sum = 0
 
     with nogil:
         valid_points = 0
@@ -826,13 +821,12 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
             for offset in range(1 - padding, padding + 1):
                 val = _cubic_spline(spline_arg)
                 joint[r, c + offset] += val
-                total_sum += val
                 spline_arg += 1.0
 
-        if total_sum > 0:
+        if valid_points > 0:
             for i in range(nbins):
                 for j in range(nbins):
-                    joint[i, j] /= total_sum
+                    joint[i, j] /= <double>valid_points
 
             for i in range(nbins):
                 smarginal[i] /= <double>valid_points


### PR DESCRIPTION
## Description

Following what we discussed at #4067, this PR simplifies and makes the Parzen PDF normalization consistent across dense 2D, dense 3D, and sparse sampling. All implementations now normalize using `valid_points` and the redundant `total_sum` accumulation has been removed.

## Motivation and Context

During registration, the moving image is resampled on the static-image grid. If the current transformation maps a static-grid position outside the moving image, there is no real moving intensity to interpolate, so the resampler returns an artificial zero.

If the images are not normalized and zero lies outside the moving-image intensity range, this artificial value can fall outside the support of the histogram. It may then contribute little or no B-spline weight to the joint PDF. However, the sample is still included in `valid_points`, and its static intensity is still added to the static marginal. For example, if 100 samples are counted but only 50 contribute joint weight, normalization by `valid_points` gives:

```text
joint.sum() = 50 / 100 = 0.5
```

The previous `total_sum` normalization used in 3D and sparse sampling forced the joint PDF to sum to one in this situation, but the static marginal was still normalized using `valid_points`. Therefore:

```python
smarginal != joint.sum(axis=1)
```

During the standard `AffineRegistration` workflow, however, the input images are normalized to `[0, 1]`. Zero is consequently inside the histogram range, including the artificial zeros introduced outside the moving-image domain. Each counted sample then contributes a total B-spline weight of one, so:

```text
total_sum ≈ valid_points
```

Under this assumption, removing `total_sum` preserves the expected numerical behaviour while making dense 2D, dense 3D, sparse sampling, and the PDF gradients use the same normalization.

The only problem remaining is that if the metric is used directly,  without `AffineRegistration` performing normalization, the failure I described remains possible. Actually, even in standard normalization, although it maybe isn't that important, artificial zeros sampled outside the moving image are still treated as real image intensities. I think this is mostly okey, since usually 0 intensity corresponds to background though. 

A complete fix would require detecting positions outside the moving-image domain and excluding those samples from the joint PDF, marginals, and gradient. That would require a bigger PR. The scope of this one is mainly to allow a sooner merge of #4067, but it could be done in the future.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
