### PR TITLE
RF: unify forward and backward CC steps

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -1,6 +1,8 @@
 """ Utility functions used by the Cross Correlation (CC) metric """
 
 import numpy as np
+from dipy.utils.deprecator import deprecate_with_version
+
 from dipy.align.fused_types cimport floating
 cimport cython
 cimport numpy as cnp
@@ -421,6 +423,32 @@ def compute_cc_step_3d(floating[:, :, :, :] gradient,
     return np.asarray(out), energy
 
 
+@deprecate_with_version(
+    "compute_cc_forward_step_3d is deprecated. "
+    "Use compute_cc_step_3d with forward_step=True instead.",
+    since="1.13",
+    until="2.0",
+)
+def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
+                               floating[:, :, :, :] factors,
+                               cnp.npy_intp radius):
+    """Deprecated. Use :func:`compute_cc_step_3d` with ``forward_step=True``."""
+    return compute_cc_step_3d(grad_static, factors, radius, True)
+
+
+@deprecate_with_version(
+    "compute_cc_backward_step_3d is deprecated. "
+    "Use compute_cc_step_3d with forward_step=False instead.",
+    since="1.13",
+    until="2.0",
+)
+def compute_cc_backward_step_3d(floating[:, :, :, :] grad_moving,
+                                floating[:, :, :, :] factors,
+                                cnp.npy_intp radius):
+    """Deprecated. Use :func:`compute_cc_step_3d` with ``forward_step=False``."""
+    return compute_cc_step_3d(grad_moving, factors, radius, False)
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -665,3 +693,29 @@ def compute_cc_step_2d(floating[:, :, :] gradient,
                 out[r, c, 0] -= temp * gradient[r, c, 0]
                 out[r, c, 1] -= temp * gradient[r, c, 1]
     return np.asarray(out), energy
+
+
+@deprecate_with_version(
+    "compute_cc_forward_step_2d is deprecated. "
+    "Use compute_cc_step_2d with forward_step=True instead.",
+    since="1.13",
+    until="2.0",
+)
+def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
+                               floating[:, :, :] factors,
+                               cnp.npy_intp radius):
+    """Deprecated. Use :func:`compute_cc_step_2d` with ``forward_step=True``."""
+    return compute_cc_step_2d(grad_static, factors, radius, True)
+
+
+@deprecate_with_version(
+    "compute_cc_backward_step_2d is deprecated. "
+    "Use compute_cc_step_2d with forward_step=False instead.",
+    since="1.13",
+    until="2.0",
+)
+def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
+                                floating[:, :, :] factors,
+                                cnp.npy_intp radius):
+    """Deprecated. Use :func:`compute_cc_step_2d` with ``forward_step=False``."""
+    return compute_cc_step_2d(grad_moving, factors, radius, False)

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -345,20 +345,21 @@ def precompute_cc_factors_3d_test(floating[:, :, :] static,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
-                               floating[:, :, :, :] factors,
-                               cnp.npy_intp radius):
-    """Gradient of the CC Metric w.r.t. the forward transformation.
+def compute_cc_step_3d(floating[:, :, :, :] gradient,
+                       floating[:, :, :, :] factors,
+                       cnp.npy_intp radius,
+                       bint forward_step):
+    """Gradient of the 3D CC metric for one SyN step.
 
-    Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) :footcite:p:`Avants2008` w.r.t. the displacement
-    associated to the moving volume ('forward' step) as in
+    Computes either the forward or backward gradient of the Cross Correlation
+    metric for symmetric registration (SyN) :footcite:p:`Avants2008`, as in
     :footcite:t:`Avants2009`.
 
     Parameters
     ----------
-    grad_static : array, shape (S, R, C, 3)
-        the gradient of the static volume
+    gradient : array, shape (S, R, C, 3)
+        the gradient of the static volume for a forward step, or the gradient
+        of the moving volume for a backward step
     factors : array, shape (S, R, C, 5)
         the precomputed cross correlation terms obtained via
         precompute_cc_factors_3d
@@ -366,12 +367,15 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
         the radius of the neighborhood used for the CC metric when
         computing the factors. The returned vector field will be
         zero along a boundary of width radius voxels.
+    forward_step : bool
+        if True, compute the forward step. Otherwise, compute the backward
+        step.
 
     Returns
     -------
     out : array, shape (S, R, C, 3)
         the gradient of the cross correlation metric with respect to the
-        displacement associated to the moving volume
+        selected displacement
     energy : the cross correlation energy (data term) at this iteration
 
     References
@@ -379,14 +383,14 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
     .. footbibliography::
     """
     cdef:
-        cnp.npy_intp ns = grad_static.shape[0]
-        cnp.npy_intp nr = grad_static.shape[1]
-        cnp.npy_intp nc = grad_static.shape[2]
+        cnp.npy_intp ns = gradient.shape[0]
+        cnp.npy_intp nr = gradient.shape[1]
+        cnp.npy_intp nc = gradient.shape[2]
         double energy = 0
         cnp.npy_intp s, r, c
         double Ii, Ji, sfm, sff, smm, localCorrelation, temp
         floating[:, :, :, :] out =\
-            np.zeros((ns, nr, nc, 3), dtype=np.asarray(grad_static).dtype)
+            np.zeros((ns, nr, nc, 3), dtype=np.asarray(gradient).dtype)
     with nogil:
         for s in range(radius, ns-radius):
             for r in range(radius, nr-radius):
@@ -403,80 +407,17 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
                         localCorrelation = sfm * sfm / (sff * smm)
                     if localCorrelation < 1:  # avoid bad values...
                         energy -= localCorrelation
-                    temp = 2.0 * sfm / (sff * smm) * (Ji - sfm / sff * Ii)
-                    out[s, r, c, 0] -= temp * grad_static[s, r, c, 0]
-                    out[s, r, c, 1] -= temp * grad_static[s, r, c, 1]
-                    out[s, r, c, 2] -= temp * grad_static[s, r, c, 2]
-    return np.asarray(out), energy
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-def compute_cc_backward_step_3d(floating[:, :, :, :] grad_moving,
-                                floating[:, :, :, :] factors,
-                                cnp.npy_intp radius):
-    """Gradient of the CC Metric w.r.t. the backward transformation.
-
-    Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) :footcite:p:`Avants2008`. w.r.t. the displacement
-    associated to the static volume ('backward' step) as in
-    :footcite:t:`Avants2009`.
-
-    Parameters
-    ----------
-    grad_moving : array, shape (S, R, C, 3)
-        the gradient of the moving volume
-    factors : array, shape (S, R, C, 5)
-        the precomputed cross correlation terms obtained via
-        precompute_cc_factors_3d
-    radius : int
-        the radius of the neighborhood used for the CC metric when
-        computing the factors. The returned vector field will be
-        zero along a boundary of width radius voxels.
-
-    Returns
-    -------
-    out : array, shape (S, R, C, 3)
-        the gradient of the cross correlation metric with respect to the
-        displacement associated to the static volume
-    energy : the cross correlation energy (data term) at this iteration
-
-    References
-    ----------
-    .. footbibliography::
-    """
-    ftype = np.asarray(grad_moving).dtype
-    cdef:
-        cnp.npy_intp ns = grad_moving.shape[0]
-        cnp.npy_intp nr = grad_moving.shape[1]
-        cnp.npy_intp nc = grad_moving.shape[2]
-        cnp.npy_intp s, r, c
-        double energy = 0
-        double Ii, Ji, sfm, sff, smm, localCorrelation, temp
-        floating[:, :, :, :] out = np.zeros((ns, nr, nc, 3), dtype=ftype)
-
-    with nogil:
-
-        for s in range(radius, ns-radius):
-            for r in range(radius, nr-radius):
-                for c in range(radius, nc-radius):
-                    Ii = factors[s, r, c, 0]
-                    Ji = factors[s, r, c, 1]
-                    sfm = factors[s, r, c, 2]
-                    sff = factors[s, r, c, 3]
-                    smm = factors[s, r, c, 4]
-                    if sff == 0.0 or smm == 0.0:
-                        continue
-                    localCorrelation = 0
-                    if sff * smm > 1e-5:
-                        localCorrelation = sfm * sfm / (sff * smm)
-                    if localCorrelation < 1:  # avoid bad values...
-                        energy -= localCorrelation
-                    temp = 2.0 * sfm / (sff * smm) * (Ii - sfm / smm * Ji)
-                    out[s, r, c, 0] -= temp * grad_moving[s, r, c, 0]
-                    out[s, r, c, 1] -= temp * grad_moving[s, r, c, 1]
-                    out[s, r, c, 2] -= temp * grad_moving[s, r, c, 2]
+                    if forward_step:
+                        temp = 2.0 * sfm / (sff * smm) * (
+                            Ji - sfm / sff * Ii
+                        )
+                    else:
+                        temp = 2.0 * sfm / (sff * smm) * (
+                            Ii - sfm / smm * Ji
+                        )
+                    out[s, r, c, 0] -= temp * gradient[s, r, c, 0]
+                    out[s, r, c, 1] -= temp * gradient[s, r, c, 1]
+                    out[s, r, c, 2] -= temp * gradient[s, r, c, 2]
     return np.asarray(out), energy
 
 
@@ -652,50 +593,51 @@ def precompute_cc_factors_2d_test(floating[:, :] static, floating[:, :] moving,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
-                               floating[:, :, :] factors,
-                               cnp.npy_intp radius):
-    """Gradient of the CC Metric w.r.t. the forward transformation.
+def compute_cc_step_2d(floating[:, :, :] gradient,
+                       floating[:, :, :] factors,
+                       cnp.npy_intp radius,
+                       bint forward_step):
+    """Gradient of the 2D CC metric for one SyN step.
 
-    Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) :footcite:p:`Avants2008` w.r.t. the displacement
-    associated to the moving image ('backward' step) as in
+    Computes either the forward or backward gradient of the Cross Correlation
+    metric for symmetric registration (SyN) :footcite:p:`Avants2008`, as in
     :footcite:t:`Avants2009`.
 
     Parameters
     ----------
-    grad_static : array, shape (R, C, 2)
-        the gradient of the static image
+    gradient : array, shape (R, C, 2)
+        the gradient of the static image for a forward step, or the gradient
+        of the moving image for a backward step
     factors : array, shape (R, C, 5)
         the precomputed cross correlation terms obtained via
         precompute_cc_factors_2d
+    radius : int
+        the radius of the neighborhood used for the CC metric when
+        computing the factors. The returned vector field will be
+        zero along a boundary of width radius pixels.
+    forward_step : bool
+        if True, compute the forward step. Otherwise, compute the backward
+        step.
 
     Returns
     -------
     out : array, shape (R, C, 2)
         the gradient of the cross correlation metric with respect to the
-        displacement associated to the moving image
+        selected displacement
     energy : the cross correlation energy (data term) at this iteration
-
-    Notes
-    -----
-    Currently, the gradient of the static image is not being used, but some
-    authors suggest that symmetrizing the gradient by including both, the
-    moving and static gradients may improve the registration quality. We are
-    leaving this parameter as a placeholder for future investigation
 
     References
     ----------
     .. footbibliography::
     """
     cdef:
-        cnp.npy_intp nr = grad_static.shape[0]
-        cnp.npy_intp nc = grad_static.shape[1]
+        cnp.npy_intp nr = gradient.shape[0]
+        cnp.npy_intp nc = gradient.shape[1]
         double energy = 0
         cnp.npy_intp r, c
         double Ii, Ji, sfm, sff, smm, localCorrelation, temp
         floating[:, :, :] out = np.zeros((nr, nc, 2),
-                                         dtype=np.asarray(grad_static).dtype)
+                                         dtype=np.asarray(gradient).dtype)
     with nogil:
 
         for r in range(radius, nr-radius):
@@ -712,70 +654,14 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
                     localCorrelation = sfm * sfm / (sff * smm)
                 if localCorrelation < 1:  # avoid bad values...
                     energy -= localCorrelation
-                temp = 2.0 * sfm / (sff * smm) * (Ji - sfm / sff * Ii)
-                out[r, c, 0] -= temp * grad_static[r, c, 0]
-                out[r, c, 1] -= temp * grad_static[r, c, 1]
-    return np.asarray(out), energy
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
-                                floating[:, :, :] factors,
-                                cnp.npy_intp radius):
-    """Gradient of the CC Metric w.r.t. the backward transformation.
-
-    Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) :footcite:p:`Avants2008` w.r.t. the displacement
-    associated to the static image ('forward' step) as in
-    :footcite:t:`Avants2009`.
-
-    Parameters
-    ----------
-    grad_moving : array, shape (R, C, 2)
-        the gradient of the moving image
-    factors : array, shape (R, C, 5)
-        the precomputed cross correlation terms obtained via
-        precompute_cc_factors_2d
-
-    Returns
-    -------
-    out : array, shape (R, C, 2)
-        the gradient of the cross correlation metric with respect to the
-        displacement associated to the static image
-    energy : the cross correlation energy (data term) at this iteration
-
-    References
-    ----------
-    .. footbibliography::
-    """
-    ftype = np.asarray(grad_moving).dtype
-    cdef:
-        cnp.npy_intp nr = grad_moving.shape[0]
-        cnp.npy_intp nc = grad_moving.shape[1]
-        cnp.npy_intp r, c
-        double energy = 0
-        double Ii, Ji, sfm, sff, smm, localCorrelation, temp
-        floating[:, :, :] out = np.zeros((nr, nc, 2), dtype=ftype)
-
-    with nogil:
-
-        for r in range(radius, nr-radius):
-            for c in range(radius, nc-radius):
-                Ii = factors[r, c, 0]
-                Ji = factors[r, c, 1]
-                sfm = factors[r, c, 2]
-                sff = factors[r, c, 3]
-                smm = factors[r, c, 4]
-                if sff == 0.0 or smm == 0.0:
-                    continue
-                localCorrelation = 0
-                if sff * smm > 1e-5:
-                    localCorrelation = sfm * sfm / (sff * smm)
-                if localCorrelation < 1:  # avoid bad values...
-                    energy -= localCorrelation
-                temp = 2.0 * sfm / (sff * smm) * (Ii - sfm / smm * Ji)
-                out[r, c, 0] -= temp * grad_moving[r, c, 0]
-                out[r, c, 1] -= temp * grad_moving[r, c, 1]
+                if forward_step:
+                    temp = 2.0 * sfm / (sff * smm) * (
+                        Ji - sfm / sff * Ii
+                    )
+                else:
+                    temp = 2.0 * sfm / (sff * smm) * (
+                        Ii - sfm / smm * Ji
+                    )
+                out[r, c, 0] -= temp * gradient[r, c, 0]
+                out[r, c, 1] -= temp * gradient[r, c, 1]
     return np.asarray(out), energy

--- a/dipy/align/metrics.py
+++ b/dipy/align/metrics.py
@@ -241,13 +241,11 @@ class CCMetric(SimilarityMetric):
         """
         if self.dim == 2:
             self.precompute_factors = cc.precompute_cc_factors_2d
-            self.compute_forward_step = cc.compute_cc_forward_step_2d
-            self.compute_backward_step = cc.compute_cc_backward_step_2d
+            self.compute_step = cc.compute_cc_step_2d
             self.reorient_vector_field = vfu.reorient_vector_field_2d
         elif self.dim == 3:
             self.precompute_factors = cc.precompute_cc_factors_3d
-            self.compute_forward_step = cc.compute_cc_forward_step_3d
-            self.compute_backward_step = cc.compute_cc_backward_step_3d
+            self.compute_step = cc.compute_cc_step_3d
             self.reorient_vector_field = vfu.reorient_vector_field_3d
         else:
             raise ValueError(f"CC Metric not defined for dim. {self.dim}")
@@ -324,8 +322,8 @@ class CCMetric(SimilarityMetric):
         Computes the update displacement field to be used for registration of
         the moving image towards the static image
         """
-        displacement, self.energy = self.compute_forward_step(
-            self.gradient_static, self.factors, self.radius
+        displacement, self.energy = self.compute_step(
+            self.gradient_static, self.factors, self.radius, forward_step=True
         )
         displacement = np.array(displacement)
         for i in range(self.dim):
@@ -340,8 +338,8 @@ class CCMetric(SimilarityMetric):
         Computes the update displacement field to be used for registration of
         the static image towards the moving image
         """
-        displacement, self.energy = self.compute_backward_step(
-            self.gradient_moving, self.factors, self.radius
+        displacement, self.energy = self.compute_step(
+            self.gradient_moving, self.factors, self.radius, forward_step=False
         )
         displacement = np.array(displacement)
         for i in range(self.dim):

--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -97,14 +97,16 @@ def test_compute_cc_steps_2d(rng):
     expected[..., 0] = factor * gradF[..., 0]
     factor = (-2.0 * sfm / (sff * smm)) * (_J - (sfm / sff) * _I)
     expected[..., 1] = factor * gradF[..., 1]
-    actual, energy = cc.compute_cc_forward_step_2d(gradF, factors, 0)
+    actual, energy = cc.compute_cc_step_2d(gradF, factors, 0, forward_step=True)
     assert_array_almost_equal(actual, expected)
     for radius in range(1, 5):
         expected[:radius, ...] = 0
         expected[:, :radius, ...] = 0
         expected[-radius::, ...] = 0
         expected[:, -radius::, ...] = 0
-        actual, energy = cc.compute_cc_forward_step_2d(gradF, factors, radius)
+        actual, energy = cc.compute_cc_step_2d(
+            gradF, factors, radius, forward_step=True
+        )
         assert_array_almost_equal(actual, expected)
 
     # test the backward step against the exact expression
@@ -112,14 +114,16 @@ def test_compute_cc_steps_2d(rng):
     expected[..., 0] = factor * gradG[..., 0]
     factor = (-2.0 * sfm / (sff * smm)) * (_I - (sfm / smm) * _J)
     expected[..., 1] = factor * gradG[..., 1]
-    actual, energy = cc.compute_cc_backward_step_2d(gradG, factors, 0)
+    actual, energy = cc.compute_cc_step_2d(gradG, factors, 0, forward_step=False)
     assert_array_almost_equal(actual, expected)
     for radius in range(1, 5):
         expected[:radius, ...] = 0
         expected[:, :radius, ...] = 0
         expected[-radius::, ...] = 0
         expected[:, -radius::, ...] = 0
-        actual, energy = cc.compute_cc_backward_step_2d(gradG, factors, radius)
+        actual, energy = cc.compute_cc_step_2d(
+            gradG, factors, radius, forward_step=False
+        )
         assert_array_almost_equal(actual, expected)
 
 
@@ -184,7 +188,7 @@ def test_compute_cc_steps_3d(rng):
     expected[..., 0] = factor * gradF[..., 0]
     expected[..., 1] = factor * gradF[..., 1]
     expected[..., 2] = factor * gradF[..., 2]
-    actual, energy = cc.compute_cc_forward_step_3d(gradF, factors, 0)
+    actual, energy = cc.compute_cc_step_3d(gradF, factors, 0, forward_step=True)
     assert_array_almost_equal(actual, expected)
     for radius in range(1, 5):
         expected[:radius, ...] = 0
@@ -193,7 +197,9 @@ def test_compute_cc_steps_3d(rng):
         expected[-radius::, ...] = 0
         expected[:, -radius::, ...] = 0
         expected[:, :, -radius::, ...] = 0
-        actual, energy = cc.compute_cc_forward_step_3d(gradF, factors, radius)
+        actual, energy = cc.compute_cc_step_3d(
+            gradF, factors, radius, forward_step=True
+        )
         assert_array_almost_equal(actual, expected)
 
     # test the backward step against the exact expression
@@ -201,7 +207,7 @@ def test_compute_cc_steps_3d(rng):
     expected[..., 0] = factor * gradG[..., 0]
     expected[..., 1] = factor * gradG[..., 1]
     expected[..., 2] = factor * gradG[..., 2]
-    actual, energy = cc.compute_cc_backward_step_3d(gradG, factors, 0)
+    actual, energy = cc.compute_cc_step_3d(gradG, factors, 0, forward_step=False)
     assert_array_almost_equal(actual, expected)
     for radius in range(1, 5):
         expected[:radius, ...] = 0
@@ -210,5 +216,7 @@ def test_compute_cc_steps_3d(rng):
         expected[-radius::, ...] = 0
         expected[:, -radius::, ...] = 0
         expected[:, :, -radius::, ...] = 0
-        actual, energy = cc.compute_cc_backward_step_3d(gradG, factors, radius)
+        actual, energy = cc.compute_cc_step_3d(
+            gradG, factors, radius, forward_step=False
+        )
         assert_array_almost_equal(actual, expected)

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -63,7 +63,7 @@ def cc_energy_from_factors(factors, radius):
     """Compute CC energy as implemented in ``crosscorr.pyx`` step functions.
 
     This replicates the local NCC energy accumulation used by
-    ``compute_cc_forward_step_2d`` and ``compute_cc_backward_step_2d``
+    ``compute_cc_step_2d``.
     """
     energy = 0
     factors = np.asarray(factors)


### PR DESCRIPTION
## Description

This PR consolidates the existing forward and backward SyN Cross-Correlation steps into two shared functions:

- `compute_cc_step_2d`
- `compute_cc_step_3d`

The direction is selected explicitly through the `forward_step` argument. `CCMetric` and the corresponding tests have been updated to use the new functions.

## Motivation and Context

This follows the code-simplification discussions at #4078.

While investigating the duplicated code between the affine CC implementation and the existing SyN backward steps, I noticed that the SyN forward and backward implementations were themselves largely duplicated. Their allocation, voxel loops, validity checks, energy calculation, and output operation were identical. Only the derivative factor selected for `temp` differed.

This PR removes that pre-existing duplication without changing the numerical behavior. It also provides a cleaner base on which the CC-for-affine branch can later be rebased and further simplified.

For backward compatibility, since the four existing functions are directly callable, I could keep them as thin wrappers around `compute_cc_step_2d/3d`, with `forward_step` fixed to the corresponding direction, and mark them as deprecated for removal in a future release. All internal call sites would still use the new shared functions directly. I initially omitted these wrappers because the functions appear to be low-level implementation details, but I can add them if we consider them part of the supported API.

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md)](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [[DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html)](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure