### PR TITLE
BF: fix dead code paths and a shadowed argument found 

### DIFF
--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -1557,10 +1557,10 @@ def force_peaks(fitted_object, *, mask=None, sh_order=8):
         ):
             v_max = np.max(odf, axis=-1, keepdims=True)
             v_min = np.min(odf, axis=-1, keepdims=True)
-            mask = v_max > 1.0
+            norm_mask = v_max > 1.0
             denom = (v_max - v_min) + 1e-12
             normalized_odf = (odf - v_min) / denom
-            odf = np.where(mask, normalized_odf, odf)
+            odf = np.where(norm_mask, normalized_odf, odf)
             res_sh = sf_to_sh(odf, default_sphere, sh_order=sh_order)
     peaks = PeaksAndMetrics()
     peaks.peak_dirs = res_dirs

--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 
 from dipy.core.gradients import unique_bvals_tolerance
-from dipy.direction.peaks import PeaksAndMetrics
+from dipy.direction.peaks import PeaksAndMetrics, _pam_from_attrs
 from dipy.reconst._force_search import search_inner_product as _cython_search
 from dipy.reconst.base import ReconstFit, ReconstModel
 from dipy.reconst.multi_voxel import multi_voxel_fit
@@ -1562,11 +1562,15 @@ def force_peaks(fitted_object, *, mask=None, sh_order=8):
             normalized_odf = (odf - v_min) / denom
             odf = np.where(norm_mask, normalized_odf, odf)
             res_sh = sf_to_sh(odf, default_sphere, sh_order=sh_order)
-    peaks = PeaksAndMetrics()
-    peaks.peak_dirs = res_dirs
-    peaks.peak_values = res_vals
-    peaks.peak_indices = res_inds
-    peaks.shm_coeff = res_sh
-    peaks.sphere = default_sphere
-
-    return peaks
+    return _pam_from_attrs(
+        PeaksAndMetrics,
+        default_sphere,
+        res_inds,
+        res_vals,
+        res_dirs,
+        None,
+        None,
+        res_sh,
+        None,
+        None,
+    )

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -269,7 +269,7 @@ def patch_maximum(vertices, odf, pole, width):
         logger.info(
             f"empty cone around pole {np.array_str(pole)} with with width {width:f}"
         )
-        return np.Null, np.Null
+        return None, None
     eqvals = [odf[i] for i in eqvert]
     eqargmax = np.argmax(eqvals)
     eqvertmax = eqvert[eqargmax]
@@ -288,7 +288,7 @@ def patch_sum(vertices, odf, pole, width):
         logger.info(
             f"empty cone around pole {np.array_str(pole)} with with width {width:f}"
         )
-        return np.Null
+        return None
     return np.sum([odf[i] for i in eqvert])
 
 

--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1886,16 +1886,31 @@ def H(value):
 
 
 @warning_for_keywords()
-def generalized_crossvalidation(data, M, LR, *, startpoint=5e-4):
+def generalized_crossvalidation(data, M, LR, *, startpoint=1e-4):
     r"""Generalized Cross Validation Function.
 
     See :footcite:p:`Craven1979` for further details about the method.
+
+    Parameters
+    ----------
+    data : ndarray
+        Measured signal to fit.
+    M : ndarray
+        Observation matrix.
+    LR : ndarray
+        Regularization matrix.
+    startpoint : float, optional
+        Initial guess handed to the optimizer for the regularization weight.
+
+    Returns
+    -------
+    float
+        The optimal regularization weight.
 
     References
     ----------
     .. footbibliography::
     """
-    startpoint = 1e-4
     MMt = np.dot(M.T, M)
     K = len(data)
     input_stuff = (data, M, MMt, K, LR)

--- a/dipy/workflows/flow_runner.py
+++ b/dipy/workflows/flow_runner.py
@@ -11,13 +11,22 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def get_level(lvl):
-    """Transforms the logging level passed on the commandline into a proper
-    logging level name.
+    """Transform the logging level passed on the commandline into a logging
+    level value.
+
+    Parameters
+    ----------
+    lvl : str
+        Level name, e.g. ``"DEBUG"``. Unknown names fall back to ``INFO``.
+
+    Returns
+    -------
+    int
+        The numeric logging level.
     """
-    try:
-        return logging._levelNames[lvl]
-    except Exception:
+    if not isinstance(lvl, str):
         return logging.INFO
+    return logging.getLevelNamesMapping().get(lvl.upper(), logging.INFO)
 
 
 def run_flow(flow, *, extra_args=None):


### PR DESCRIPTION
While auditing the codebase for duplicated / near-duplicated functions, several
of the duplicate pairs turned out to have **already drifted**: one copy carried a
fix or a guard the other did not. This PR collects the small, zero-risk fixes that
came out of that comparison, one commit per issue.

None of these change numerical output.

### `BF: replace non-existent np.Null with None in gqi empty-cone paths`
`dipy/reconst/gqi.py`

`patch_maximum()` and `patch_sum()` returned `np.Null` on the empty-cone path.
`np.Null` does not exist in NumPy, so both raised `AttributeError` instead of
returning. The twin function `equatorial_maximum()` — whose body is otherwise
identical — already returns `None, None` for the equivalent empty-band case.

### `BF: revive the dead --log_level CLI option in workflows`
`dipy/workflows/flow_runner.py`

`get_level()` looked up `logging._levelNames`, which was removed in Python 3.4.
The lookup always raised, the bare `except` swallowed it, and the function always
returned `logging.INFO`. Every workflow therefore ignored `--log_level`.

Replaced with `logging.getLevelNamesMapping()` (Python 3.11+; DIPY requires 3.12),
keeping the INFO fallback for unrecognised values.

### `BF: honour the startpoint argument of qtdmri generalized_crossvalidation`
`dipy/reconst/qtdmri.py`

The body overwrote its own keyword argument with `startpoint = 1e-4` on the first
line, so `startpoint=5e-4` in the signature was dead. Made `1e-4` the default and
dropped the overwrite. No caller passes `startpoint`, so this is numerically a
no-op while making the argument usable. Also added the missing parameter docs.

### `BF: stop shadowing the mask parameter inside force_peaks`
`dipy/reconst/force.py`

The ODF normalisation branch rebound the local name `mask`, clobbering the
function's own `mask` argument. Harmless today because `mask` is already consumed
by that point, but it silently breaks any later use of the parameter.

### `RF: build FORCE peaks through _pam_from_attrs`
`dipy/reconst/force.py`

`force_peaks` hand-rolled a `PeaksAndMetrics` and set 5 of its 10 attributes,
duplicating the canonical constructor in `dipy.direction.peaks`. Reuse
`_pam_from_attrs` so the attribute list lives in one place.

### Testing
`test_gqi.py`, `test_qtdmri.py`, `test_force.py`, `test_iap.py`, `test_io.py` pass.