### PR TITLE
STYLE: Prefer using `pytest` temporary path fixtures in tests

### DIFF
--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 import nibabel as nib
 import numpy as np
 import numpy.testing as npt
@@ -61,36 +58,35 @@ def setup_module():
     subset_t2_img = nib.Nifti1Image(subset_t2, MNI_T2_affine)
 
 
-def test_syn_registration():
-    with TemporaryDirectory() as tmpdir:
-        warped_moving, mapping = syn_registration(
-            subset_b0,
-            subset_t2,
-            moving_affine=hardi_affine,
-            static_affine=MNI_T2_affine,
-            step_length=0.1,
-            metric="CC",
-            dim=3,
-            level_iters=[5, 5, 5],
-            sigma_diff=2.0,
-            radius=1,
-            prealign=None,
+def test_syn_registration(tmp_path):
+    warped_moving, mapping = syn_registration(
+        subset_b0,
+        subset_t2,
+        moving_affine=hardi_affine,
+        static_affine=MNI_T2_affine,
+        step_length=0.1,
+        metric="CC",
+        dim=3,
+        level_iters=[5, 5, 5],
+        sigma_diff=2.0,
+        radius=1,
+        prealign=None,
+    )
+
+    npt.assert_equal(warped_moving.shape, subset_t2.shape)
+    mapping_fname = tmp_path / "mapping.nii.gz"
+    write_mapping(mapping, mapping_fname)
+    file_mapping = read_mapping(mapping_fname, subset_b0_img, subset_t2_img)
+
+    # Test that it has the same effect on the data:
+    warped_from_file = file_mapping.transform(subset_b0)
+    npt.assert_equal(warped_from_file, warped_moving)
+
+    # Test that it is, attribute by attribute, identical:
+    for k in mapping.__dict__:
+        npt.assert_(
+            np.all(mapping.__getattribute__(k) == file_mapping.__getattribute__(k))
         )
-
-        npt.assert_equal(warped_moving.shape, subset_t2.shape)
-        mapping_fname = Path(tmpdir) / "mapping.nii.gz"
-        write_mapping(mapping, mapping_fname)
-        file_mapping = read_mapping(mapping_fname, subset_b0_img, subset_t2_img)
-
-        # Test that it has the same effect on the data:
-        warped_from_file = file_mapping.transform(subset_b0)
-        npt.assert_equal(warped_from_file, warped_moving)
-
-        # Test that it is, attribute by attribute, identical:
-        for k in mapping.__dict__:
-            npt.assert_(
-                np.all(mapping.__getattribute__(k) == file_mapping.__getattribute__(k))
-            )
 
 
 def test_register_dwi_to_template():
@@ -305,31 +301,29 @@ def test_register_series():
     npt.assert_(np.all(xformed[..., ref_idx] == img.get_fdata()[..., ref_idx]))
 
 
-def test_register_dwi_series_and_motion_correction():
+def test_register_dwi_series_and_motion_correction(tmp_path):
     fdata, fbval, fbvec = dpd.get_fnames(name="small_64D")
-    with TemporaryDirectory() as tmpdir:
-        # Use an abbreviated data-set:
-        img = nib.load(fdata)
-        data = img.get_fdata()[..., :10]
-        nib.save(nib.Nifti1Image(data, img.affine), Path(tmpdir) / "data.nii.gz")
-        # Save a subset:
-        bvals = np.loadtxt(fbval)
-        bvecs = np.loadtxt(fbvec)
-        np.savetxt(Path(tmpdir) / "bvals.txt", bvals[:10])
-        np.savetxt(Path(tmpdir) / "bvecs.txt", bvecs[:10])
-        gtab = dpg.gradient_table(
-            Path(tmpdir) / "bvals.txt", bvecs=Path(tmpdir) / "bvecs.txt"
-        )
-        reg_img, reg_affines = register_dwi_series(data, gtab, affine=img.affine)
-        reg_img_2, reg_affines_2 = motion_correction(data, gtab, affine=img.affine)
-        npt.assert_(isinstance(reg_img, nib.Nifti1Image))
 
-        npt.assert_array_equal(reg_img.get_fdata(), reg_img_2.get_fdata())
-        npt.assert_array_equal(reg_affines, reg_affines_2)
+    # Use an abbreviated data-set:
+    img = nib.load(fdata)
+    data = img.get_fdata()[..., :10]
+    nib.save(nib.Nifti1Image(data, img.affine), tmp_path / "data.nii.gz")
+    # Save a subset:
+    bvals = np.loadtxt(fbval)
+    bvecs = np.loadtxt(fbvec)
+    np.savetxt(tmp_path / "bvals.txt", bvals[:10])
+    np.savetxt(tmp_path / "bvecs.txt", bvecs[:10])
+    gtab = dpg.gradient_table(tmp_path / "bvals.txt", bvecs=tmp_path / "bvecs.txt")
+    reg_img, reg_affines = register_dwi_series(data, gtab, affine=img.affine)
+    reg_img_2, reg_affines_2 = motion_correction(data, gtab, affine=img.affine)
+    npt.assert_(isinstance(reg_img, nib.Nifti1Image))
+
+    npt.assert_array_equal(reg_img.get_fdata(), reg_img_2.get_fdata())
+    npt.assert_array_equal(reg_affines, reg_affines_2)
 
 
 @set_random_number_generator()
-def test_streamline_registration(rng):
+def test_streamline_registration(tmp_path, rng=None):
     sl1 = [
         np.array([[0, 0, 0], [0, 0, 0.5], [0, 0, 1], [0, 0, 1.5]]),
         np.array([[0, 0, 0], [0, 0.5, 0.5], [0, 1, 1]]),
@@ -348,39 +342,38 @@ def test_streamline_registration(rng):
     base_aff[:3, 3] = np.array([1, 2, 3])
     base_aff[3, 3] = 1
 
-    with TemporaryDirectory() as tmpdir:
-        for use_aff in [None, base_aff]:
-            fname1 = Path(tmpdir) / "sl1.trx"
-            fname2 = Path(tmpdir) / "sl2.trx"
-            if use_aff is not None:
-                img = nib.Nifti1Image(np.zeros((2, 2, 2)), use_aff)
-                # Move the streamlines to this other space, and report it:
-                tgm1 = StatefulTractogram(
-                    transform_tracking_output(sl1, np.linalg.inv(use_aff)),
-                    img,
-                    Space.VOX,
-                )
+    for use_aff in [None, base_aff]:
+        fname1 = tmp_path / "sl1.trx"
+        fname2 = tmp_path / "sl2.trx"
+        if use_aff is not None:
+            img = nib.Nifti1Image(np.zeros((2, 2, 2)), use_aff)
+            # Move the streamlines to this other space, and report it:
+            tgm1 = StatefulTractogram(
+                transform_tracking_output(sl1, np.linalg.inv(use_aff)),
+                img,
+                Space.VOX,
+            )
 
-                save_tractogram(tgm1, fname1, bbox_valid_check=False)
+            save_tractogram(tgm1, fname1, bbox_valid_check=False)
 
-                tgm2 = StatefulTractogram(
-                    transform_tracking_output(sl2, np.linalg.inv(use_aff)),
-                    img,
-                    Space.VOX,
-                )
+            tgm2 = StatefulTractogram(
+                transform_tracking_output(sl2, np.linalg.inv(use_aff)),
+                img,
+                Space.VOX,
+            )
 
-                save_tractogram(tgm2, fname2, bbox_valid_check=False)
+            save_tractogram(tgm2, fname2, bbox_valid_check=False)
 
-            else:
-                img = nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4))
-                tgm1 = StatefulTractogram(sl1, img, Space.RASMM)
-                tgm2 = StatefulTractogram(sl2, img, Space.RASMM)
-                save_tractogram(tgm1, fname1, bbox_valid_check=False)
-                save_tractogram(tgm2, fname2, bbox_valid_check=False)
+        else:
+            img = nib.Nifti1Image(np.zeros((2, 2, 2)), np.eye(4))
+            tgm1 = StatefulTractogram(sl1, img, Space.RASMM)
+            tgm2 = StatefulTractogram(sl2, img, Space.RASMM)
+            save_tractogram(tgm1, fname1, bbox_valid_check=False)
+            save_tractogram(tgm2, fname2, bbox_valid_check=False)
 
-            aligned, matrix = streamline_registration(fname2, fname1)
-            npt.assert_almost_equal(aligned[0], sl1[0], decimal=5)
-            npt.assert_almost_equal(aligned[1], sl1[1], decimal=5)
+        aligned, matrix = streamline_registration(fname2, fname1)
+        npt.assert_almost_equal(aligned[0], sl1[0], decimal=5)
+        npt.assert_almost_equal(aligned[1], sl1[1], decimal=5)
 
 
 def test_register_dwi_series_multi_b0():

--- a/dipy/align/tests/test_crosscorr.py
+++ b/dipy/align/tests/test_crosscorr.py
@@ -39,7 +39,7 @@ def test_cc_factors_3d():
 
 
 @set_random_number_generator(1147572)
-def test_compute_cc_affine_2d(rng):
+def test_compute_cc_affine_2d(rng=None):
     """Compare affine CC with the existing dense backward step in 2D."""
     sh = (32, 32)
     radius = 2
@@ -79,7 +79,7 @@ def test_compute_cc_affine_2d(rng):
 
 
 @set_random_number_generator(1147572)
-def test_compute_cc_affine_3d(rng):
+def test_compute_cc_affine_3d(rng=None):
     """Compare affine CC with the existing dense backward step in 3D."""
     sh = (32, 32, 32)
     radius = 2
@@ -120,7 +120,7 @@ def test_compute_cc_affine_3d(rng):
 
 
 @set_random_number_generator(1147572)
-def test_compute_cc_steps_2d(rng):
+def test_compute_cc_steps_2d(rng=None):
     # Select arbitrary images' shape (same shape for both images)
     sh = (32, 32)
     radius = 2
@@ -210,7 +210,7 @@ def test_compute_cc_steps_2d(rng):
 
 
 @set_random_number_generator(12465825)
-def test_compute_cc_steps_3d(rng):
+def test_compute_cc_steps_3d(rng=None):
     sh = (32, 32, 32)
     radius = 2
 

--- a/dipy/align/tests/test_expectmax.py
+++ b/dipy/align/tests/test_expectmax.py
@@ -11,7 +11,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator(1346491)
-def test_compute_em_demons_step_2d(rng):
+def test_compute_em_demons_step_2d(rng=None):
     r"""
     Compares the output of the demons step in 2d against an analytical
     step. The fixed image is given by $F(x) = \frac{1}{2}||x - c_f||^2$, the
@@ -154,7 +154,7 @@ def test_compute_em_demons_step_2d(rng):
 
 
 @set_random_number_generator(1346491)
-def test_compute_em_demons_step_3d(rng):
+def test_compute_em_demons_step_3d(rng=None):
     r"""
     Compares the output of the demons step in 3d against an analytical
     step. The fixed image is given by $F(x) = \frac{1}{2}||x - c_f||^2$, the
@@ -302,7 +302,7 @@ def test_compute_em_demons_step_3d(rng):
 
 
 @set_random_number_generator(1246592)
-def test_quantize_positive_2d(rng):
+def test_quantize_positive_2d(rng=None):
     # an arbitrary number of quantization levels
     num_levels = 11
     # arbitrary test image shape (must contain at least 3 elements)
@@ -364,7 +364,7 @@ def test_quantize_positive_2d(rng):
 
 
 @set_random_number_generator(1246592)
-def test_quantize_positive_3d(rng):
+def test_quantize_positive_3d(rng=None):
     # an arbitrary number of quantization levels
     num_levels = 11
     # arbitrary test image shape (must contain at least 3 elements)
@@ -426,7 +426,7 @@ def test_quantize_positive_3d(rng):
 
 
 @set_random_number_generator(1246592)
-def test_compute_masked_class_stats_2d(rng):
+def test_compute_masked_class_stats_2d(rng=None):
     shape = (32, 32)
 
     # Create random labels
@@ -452,7 +452,7 @@ def test_compute_masked_class_stats_2d(rng):
 
 
 @set_random_number_generator(1246592)
-def test_compute_masked_class_stats_3d(rng):
+def test_compute_masked_class_stats_3d(rng=None):
     shape = (32, 32, 32)
 
     # Create random labels

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -206,7 +206,7 @@ def test_transform_origins_3d():
 
 
 @set_random_number_generator(202311)
-def test_affreg_all_transforms(rng):
+def test_affreg_all_transforms(rng=None):
     # Test affine registration using all transforms with typical settings
 
     # Make sure dictionary entries are processed in the same order regardless
@@ -305,7 +305,7 @@ def test_affreg_all_transforms(rng):
 
 
 @set_random_number_generator(202311)
-def test_affreg_cc(rng):
+def test_affreg_cc(rng=None):
     """Test affine registration with cross-correlation in 2D and 3D."""
     for ttype in [("TRANSLATION", 2), ("TRANSLATION", 3)]:
         dim = ttype[1]
@@ -339,7 +339,7 @@ def test_affreg_cc(rng):
 
 
 @set_random_number_generator(202311)
-def test_affreg_defaults(rng):
+def test_affreg_defaults(rng=None):
     # Test all default arguments with an arbitrary transform
     # Select an arbitrary transform (all of them are already tested
     # in test_affreg_all_transforms)
@@ -408,7 +408,7 @@ def test_affreg_defaults(rng):
 
 
 @set_random_number_generator(2022966)
-def test_mi_gradient(rng):
+def test_mi_gradient(rng=None):
     # Test the gradient of mutual information
     h = 1e-5
     # Make sure dictionary entries are processed in the same order regardless
@@ -462,7 +462,7 @@ def test_mi_gradient(rng):
 
 
 @set_random_number_generator(2022966)
-def test_cc_gradient(rng):
+def test_cc_gradient(rng=None):
     """Compare affine CC gradients with finite differences in 2D and 3D."""
     h = 1e-4
 
@@ -558,7 +558,7 @@ def create_affine_transforms(dim, translations, rotations, scales, rot_axis=None
 
 
 @set_random_number_generator(2112927)
-def test_affine_map(rng):
+def test_affine_map(rng=None):
     dom_shape = np.array([64, 64, 64], dtype=np.int32)
     cod_shape = np.array([80, 80, 80], dtype=np.int32)
     # Radius of the circle/sphere (testing image)
@@ -758,7 +758,7 @@ def test_affine_map(rng):
 
 
 @set_random_number_generator()
-def test_MIMetric_invalid_params(rng):
+def test_MIMetric_invalid_params(rng=None):
     transform = regtransforms[("AFFINE", 3)]
     static = rng.random((20, 20, 20))
     moving = rng.random((20, 20, 20))
@@ -791,7 +791,7 @@ def test_MIMetric_invalid_params(rng):
 
 
 @set_random_number_generator()
-def test_CCMetric_invalid_params(rng):
+def test_CCMetric_invalid_params(rng=None):
     """Test affine CC behavior for invalid transform parameters."""
     transform = regtransforms[("AFFINE", 3)]
     static = rng.random((20, 20, 20))

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -40,7 +40,7 @@ def test_mult_aff():
 
 
 @set_random_number_generator(2022966)
-def test_diffeomorphic_map_2d(rng):
+def test_diffeomorphic_map_2d(rng=None):
     r"""Test 2D DiffeomorphicMap
 
     Creates a random displacement field that exactly maps pixels from an
@@ -354,7 +354,7 @@ def test_diffeomorphic_map_simplification_3d():
 
 
 @set_random_number_generator(1234)
-def test_diffeomorphic_map_warp_threading(rng):
+def test_diffeomorphic_map_warp_threading(rng=None):
     """Threaded map warping matches one-thread map warping."""
     cases = (
         (2, (32, 29)),
@@ -1221,7 +1221,7 @@ def test_em_2d_demons():
 
 
 @set_random_number_generator(1741332)
-def test_coordinate_mapping(rng):
+def test_coordinate_mapping(rng=None):
     r"""Test coordinate mapping with DiffeomorphicMap
 
     1. Create a random displacement field and a small affine transform to map

--- a/dipy/align/tests/test_metrics.py
+++ b/dipy/align/tests/test_metrics.py
@@ -91,7 +91,7 @@ def mi_energy_from_pdfs(joint, smarginal, mmarginal):
 
 
 @set_random_number_generator(7181309)
-def test_mi_metric_energy_matches_negative_mutual_information(rng):
+def test_mi_metric_energy_matches_negative_mutual_information(rng=None):
     """Verify that MIMetric reports the negative mutual information energy.
 
     The forward and backward MI steps both should store the negative of the
@@ -127,7 +127,7 @@ def test_mi_metric_energy_matches_negative_mutual_information(rng):
 
 
 @set_random_number_generator(7181309)
-def test_cc_metric_energy_matches_local_cross_correlation(rng):
+def test_cc_metric_energy_matches_local_cross_correlation(rng=None):
     """Verify that CCMetric reports the local cross-correlation energy.
 
     The forward and backward CC steps both should store the same scalar data
@@ -153,7 +153,7 @@ def test_cc_metric_energy_matches_local_cross_correlation(rng):
 
 
 @set_random_number_generator(7181309)
-def test_ssd_metric_energy_matches_squared_difference(rng):
+def test_ssd_metric_energy_matches_squared_difference(rng=None):
     """Verify that SSDMetric reports the sum of squared differences energy.
 
     The forward and backward SSD steps both should store the same
@@ -177,7 +177,7 @@ def test_ssd_metric_energy_matches_squared_difference(rng):
 
 
 @set_random_number_generator(7181309)
-def test_EMMetric_image_dynamics(rng):
+def test_EMMetric_image_dynamics(rng=None):
     metric = EMMetric(2)
 
     target_shape = (10, 10)

--- a/dipy/align/tests/test_parzenhist.py
+++ b/dipy/align/tests/test_parzenhist.py
@@ -185,7 +185,7 @@ def test_parzen_joint_histogram():
 
 
 @set_random_number_generator(1246592)
-def test_parzen_densities(rng):
+def test_parzen_densities(rng=None):
     # Test the computation of the joint intensity distribution
     # using a dense and a sparse set of values
     nbins = 32
@@ -265,7 +265,7 @@ def test_parzen_densities(rng):
 
 
 @set_random_number_generator(1246592)
-def test_dense_mi_update(rng):
+def test_dense_mi_update(rng=None):
     # Compare the analytical and numerical (finite differences) gradient of
     # mutual information w.r.t. a local displacement at one voxel. The effect
     # of a small displacement is approximated directly in intensity space
@@ -394,7 +394,7 @@ def setup_random_transform(transform, rfactor, nslices=45, sigma=1, rng=None):
 
 
 @set_random_number_generator(3147702)
-def test_joint_pdf_gradients_dense(rng):
+def test_joint_pdf_gradients_dense(rng=None):
     # Compare the analytical and numerical (finite differences) gradient of
     # the joint distribution (i.e. derivatives of each histogram cell) w.r.t.
     # the transform parameters. Since the histograms are discrete partitions
@@ -501,7 +501,7 @@ def test_joint_pdf_gradients_dense(rng):
 
 
 @set_random_number_generator(3147702)
-def test_joint_pdf_gradients_sparse(rng):
+def test_joint_pdf_gradients_sparse(rng=None):
     h = 1e-4
 
     # Make sure dictionary entries are processed in the same order regardless

--- a/dipy/align/tests/test_scalespace.py
+++ b/dipy/align/tests/test_scalespace.py
@@ -69,7 +69,7 @@ def test_scale_space():
 
 
 @set_random_number_generator(2022966)
-def test_scale_space_exceptions(rng):
+def test_scale_space_exceptions(rng=None):
     target_shape = (32, 32)
     # create a random image
     image = np.ndarray(target_shape, dtype=np.float32)

--- a/dipy/align/tests/test_streamlinear.py
+++ b/dipy/align/tests/test_streamlinear.py
@@ -204,7 +204,7 @@ def test_min_vs_min_fast_precision():
 
 
 @set_random_number_generator()
-def test_same_number_of_points(rng):
+def test_same_number_of_points(rng=None):
     A = [rng.random((10, 3)), rng.random((20, 3))]
     B = [rng.random((21, 3)), rng.random((30, 3))]
     C = [rng.random((10, 3)), rng.random((10, 3))]
@@ -263,7 +263,7 @@ def test_efficient_bmd():
 
 
 @set_random_number_generator()
-def test_openmp_locks(rng):
+def test_openmp_locks(rng=None):
     static = []
     moving = []
     pts = 20
@@ -427,7 +427,7 @@ def test_vectorize_streamlines():
 
 
 @set_random_number_generator()
-def test_x0_input(rng):
+def test_x0_input(rng=None):
     for x0 in [6, 7, 12, "Rigid", "rigid", "similarity", "Affine"]:
         StreamlineLinearRegistration(x0=x0)
 
@@ -452,7 +452,7 @@ def test_x0_input(rng):
 
 
 @set_random_number_generator()
-def test_compose_decompose_matrix44(rng):
+def test_compose_decompose_matrix44(rng=None):
     for _ in range(20):
         x0 = rng.random(12)
         mat = compose_matrix44(x0[:6])
@@ -495,7 +495,7 @@ def test_cascade_of_optimizations_and_threading():
 
 
 @set_random_number_generator()
-def test_wrong_num_threads(rng):
+def test_wrong_num_threads(rng=None):
     A = [rng.random((10, 3)), rng.random((10, 3))]
     B = [rng.random((10, 3)), rng.random((10, 3))]
 

--- a/dipy/align/tests/test_sumsqdiff.py
+++ b/dipy/align/tests/test_sumsqdiff.py
@@ -130,7 +130,7 @@ def iterate_residual_field_ssd_3d(
 
 
 @set_random_number_generator(5512751)
-def test_compute_residual_displacement_field_ssd_2d(rng):
+def test_compute_residual_displacement_field_ssd_2d(rng=None):
     # Select arbitrary images' shape (same shape for both images)
     sh = (20, 10)
 
@@ -283,7 +283,7 @@ def test_compute_residual_displacement_field_ssd_2d(rng):
 
 
 @set_random_number_generator(5512751)
-def test_compute_residual_displacement_field_ssd_3d(rng):
+def test_compute_residual_displacement_field_ssd_3d(rng=None):
     # Select arbitrary images' shape (same shape for both images)
     sh = (20, 15, 10)
 
@@ -587,7 +587,7 @@ def test_compute_energy_ssd_3d():
 
 
 @set_random_number_generator(1137271)
-def test_compute_ssd_demons_step_2d(rng):
+def test_compute_ssd_demons_step_2d(rng=None):
     r"""
     Compares the output of the demons step in 2d against an analytical
     step. The fixed image is given by $F(x) = \frac{1}{2}||x - c_f||^2$, the
@@ -682,7 +682,7 @@ def test_compute_ssd_demons_step_2d(rng):
 
 
 @set_random_number_generator(1137271)
-def test_compute_ssd_demons_step_3d(rng):
+def test_compute_ssd_demons_step_3d(rng=None):
     r"""
     Compares the output of the demons step in 3d against an analytical
     step. The fixed image is given by $F(x) = \frac{1}{2}||x - c_f||^2$, the

--- a/dipy/align/tests/test_transforms.py
+++ b/dipy/align/tests/test_transforms.py
@@ -33,7 +33,7 @@ def test_number_of_parameters():
 
 
 @set_random_number_generator()
-def test_param_to_matrix_2d(rng):
+def test_param_to_matrix_2d(rng=None):
     # Test translation matrix 2D
     transform = regtransforms[("TRANSLATION", 2)]
     dx, dy = rng.uniform(size=(2,))
@@ -110,7 +110,7 @@ def test_param_to_matrix_2d(rng):
 
 
 @set_random_number_generator()
-def test_param_to_matrix_3d(rng):
+def test_param_to_matrix_3d(rng=None):
     # Test translation matrix 3D
     transform = regtransforms[("TRANSLATION", 3)]
     dx, dy, dz = rng.uniform(size=(3,))
@@ -215,7 +215,7 @@ def test_identity_parameters():
 
 
 @set_random_number_generator()
-def test_jacobian_functions(rng):
+def test_jacobian_functions(rng=None):
     # Compare the analytical Jacobians with their numerical approximations
     h = 1e-8
     nsamples = 50

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -18,7 +18,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator(3921116)
-def test_random_displacement_field_2d(rng):
+def test_random_displacement_field_2d(rng=None):
     from_shape = (25, 32)
     to_shape = (33, 29)
 
@@ -103,7 +103,7 @@ def test_random_displacement_field_2d(rng):
 
 
 @set_random_number_generator(7127562)
-def test_random_displacement_field_3d(rng):
+def test_random_displacement_field_3d(rng=None):
     from_shape = (25, 32, 31)
     to_shape = (33, 29, 35)
 
@@ -636,7 +636,7 @@ def test_warping_3d():
 
 
 @set_random_number_generator(1234)
-def test_warping_threading(rng):
+def test_warping_threading(rng=None):
     """Threaded warping matches one-thread warping."""
     cases = (
         (vfu.warp_2d, vfu.warp_2d_nn, (32, 29), 2),
@@ -848,7 +848,7 @@ def test_affine_transforms_3d():
 
 
 @set_random_number_generator(8315759)
-def test_compose_vector_fields_2d(rng):
+def test_compose_vector_fields_2d(rng=None):
     r"""
     Creates two random displacement field that exactly map pixels from an input
     image to an output image. The resulting displacements and their
@@ -1022,7 +1022,7 @@ def test_compose_vector_fields_2d(rng):
 
 
 @set_random_number_generator(8315759)
-def test_compose_vector_fields_3d(rng):
+def test_compose_vector_fields_3d(rng=None):
     r"""
     Creates two random displacement field that exactly map pixels from an input
     image to an output image. The resulting displacements and their
@@ -1373,7 +1373,7 @@ def test_resample_vector_field_3d():
 
 
 @set_random_number_generator(8315759)
-def test_downsample_scalar_field_2d(rng):
+def test_downsample_scalar_field_2d(rng=None):
     size = 32
     sh = (size, size)
     for reduce_r in [True, False]:
@@ -1405,7 +1405,7 @@ def test_downsample_scalar_field_2d(rng):
 
 
 @set_random_number_generator(2115556)
-def test_downsample_displacement_field_2d(rng):
+def test_downsample_displacement_field_2d(rng=None):
     size = 32
     sh = (size, size, 2)
     for reduce_r in [True, False]:
@@ -1437,7 +1437,7 @@ def test_downsample_displacement_field_2d(rng):
 
 
 @set_random_number_generator(8315759)
-def test_downsample_scalar_field_3d(rng):
+def test_downsample_scalar_field_3d(rng=None):
     size = 32
     sh = (size, size, size)
     for reduce_s in [True, False]:
@@ -1479,7 +1479,7 @@ def test_downsample_scalar_field_3d(rng):
 
 
 @set_random_number_generator(8315759)
-def test_downsample_displacement_field_3d(rng):
+def test_downsample_displacement_field_3d(rng=None):
     size = 32
     sh = (size, size, size, 3)
     for reduce_s in [True, False]:
@@ -1584,7 +1584,7 @@ def test_reorient_vector_field_3d():
 
 
 @set_random_number_generator(1134781)
-def test_reorient_random_vector_fields(rng):
+def test_reorient_random_vector_fields(rng=None):
     # Test reorienting vector field
     for n_dims, func in (
         (2, vfu.reorient_vector_field_2d),
@@ -1609,7 +1609,7 @@ def test_reorient_random_vector_fields(rng):
 
 
 @set_random_number_generator(3921116)
-def test_gradient_2d(rng):
+def test_gradient_2d(rng=None):
     sh = (25, 32)
     # Create grid coordinates
     x_0 = np.asarray(range(sh[0]))
@@ -1681,7 +1681,7 @@ def test_gradient_2d(rng):
 
 
 @set_random_number_generator(3921116)
-def test_gradient_3d(rng):
+def test_gradient_3d(rng=None):
     shape = (25, 32, 15)
     # Create grid coordinates
     x_0 = np.asarray(range(shape[0]))
@@ -1765,7 +1765,7 @@ def test_gradient_3d(rng):
 
 
 @set_random_number_generator(1234)
-def test_compose_vector_fields_threading(rng):
+def test_compose_vector_fields_threading(rng=None):
     """Threaded composition matches one-thread composition and statistics."""
     cases = (
         (vfu.compose_vector_fields_2d, (32, 29, 2)),

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -150,7 +150,7 @@ def test_sphere_distance():
 
 
 @set_random_number_generator()
-def test_vector_cosine(rng):
+def test_vector_cosine(rng=None):
     a = [0, 1]
     b = [1, 0]
     assert_array_almost_equal(vector_cosine(a, b), 0)
@@ -266,7 +266,7 @@ def test_compose_transformations():
 
 
 @set_random_number_generator()
-def test_compose_decompose_matrix(rng):
+def test_compose_decompose_matrix(rng=None):
     for translate in permutations(40 * rng.random(3), 3):
         for angles in permutations(np.deg2rad(90 * rng.random(3)), 3):
             for shears in permutations(3 * rng.random(3), 3):
@@ -346,7 +346,7 @@ def _rotation_from_angles(r):
 
 
 @set_random_number_generator()
-def test_dist_to_corner(rng):
+def test_dist_to_corner(rng=None):
     affine = np.eye(4)
     # Calculate the distance with the pythagorean theorem:
     pythagoras = np.sqrt(np.sum((np.diag(affine)[:-1] / 2) ** 2))

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -416,7 +416,7 @@ def test_qvalues():
 
 
 @set_random_number_generator()
-def test_reorient_bvecs(rng):
+def test_reorient_bvecs(rng=None):
     sq2 = np.sqrt(2) / 2
     bvals = np.concatenate([[0], np.ones(6) * 1000])
     bvecs = np.array(
@@ -516,7 +516,7 @@ def test_nan_bvecs():
 
 
 @set_random_number_generator()
-def test_generate_bvecs(rng):
+def test_generate_bvecs(rng=None):
     """Tests whether we have properly generated bvecs."""
     # Test if the generated b-vectors are unit vectors
     bvecs = generate_bvecs(100, rng=rng)
@@ -709,7 +709,7 @@ def test_check_multi_b():
 
 
 @set_random_number_generator()
-def test_btens_to_params(rng):
+def test_btens_to_params(rng=None):
     """
     Checks if bvals, bdeltas and b_etas are as expected for 4 b-tensor shapes
     (LTE, PTE, STE, CTE) as well as scaled and rotated versions of them

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -21,7 +21,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator()
-def test_trilinear_interpolate(rng):
+def test_trilinear_interpolate(rng=None):
     """This tests that the trilinear interpolation returns the correct values."""
     a, b, c = rng.random(3)
 
@@ -66,7 +66,7 @@ def test_trilinear_interpolate(rng):
 
 
 @set_random_number_generator(5324989)
-def test_interpolate_scalar_2d(rng):
+def test_interpolate_scalar_2d(rng=None):
     sz = 64
     target_shape = (sz, sz)
     image = np.empty(target_shape, dtype=np.float32)
@@ -108,7 +108,7 @@ def test_interpolate_scalar_2d(rng):
 
 
 @set_random_number_generator(1924781)
-def test_interpolate_scalar_nn_2d(rng):
+def test_interpolate_scalar_nn_2d(rng=None):
     sz = 64
     target_shape = (sz, sz)
     image = np.empty(target_shape, dtype=np.float32)
@@ -136,7 +136,7 @@ def test_interpolate_scalar_nn_2d(rng):
 
 
 @set_random_number_generator(3121121)
-def test_interpolate_scalar_nn_3d(rng):
+def test_interpolate_scalar_nn_3d(rng=None):
     sz = 64
     target_shape = (sz, sz, sz)
     image = np.empty(target_shape, dtype=np.float32)
@@ -164,7 +164,7 @@ def test_interpolate_scalar_nn_3d(rng):
 
 
 @set_random_number_generator(9216326)
-def test_interpolate_scalar_3d(rng):
+def test_interpolate_scalar_3d(rng=None):
     sz = 64
     target_shape = (sz, sz, sz)
     image = np.empty(target_shape, dtype=np.float32)
@@ -208,7 +208,7 @@ def test_interpolate_scalar_3d(rng):
 
 
 @set_random_number_generator(7711219)
-def test_interpolate_vector_3d(rng):
+def test_interpolate_vector_3d(rng=None):
     sz = 64
     target_shape = (sz, sz, sz)
     field = np.empty(target_shape + (3,), dtype=np.float32)
@@ -258,7 +258,7 @@ def test_interpolate_vector_3d(rng):
 
 
 @set_random_number_generator(1271244)
-def test_interpolate_vector_2d(rng):
+def test_interpolate_vector_2d(rng=None):
     sz = 64
     target_shape = (sz, sz)
     field = np.empty(target_shape + (2,), dtype=np.float32)

--- a/dipy/core/tests/test_optimize.py
+++ b/dipy/core/tests/test_optimize.py
@@ -69,7 +69,7 @@ def test_optimize_new_scipy():
 
 
 @set_random_number_generator()
-def test_sklearn_linear_solver(rng):
+def test_sklearn_linear_solver(rng=None):
     class SillySolver(opt.SKLearnLinearSolver):
         def fit(self, X, y):
             self.coef_ = np.ones(X.shape[-1])
@@ -85,7 +85,7 @@ def test_sklearn_linear_solver(rng):
 
 
 @set_random_number_generator()
-def test_nonnegativeleastsquares(rng):
+def test_nonnegativeleastsquares(rng=None):
     n = 100
     X = np.eye(n)
     beta = rng.random(n)
@@ -97,7 +97,7 @@ def test_nonnegativeleastsquares(rng):
 
 
 @set_random_number_generator()
-def test_spdot(rng):
+def test_spdot(rng=None):
     n = 100
     m = 20
     k = 10
@@ -113,7 +113,7 @@ def test_spdot(rng):
 
 
 @set_random_number_generator()
-def test_sparse_nnls(rng):
+def test_sparse_nnls(rng=None):
     # Set up the regression:
     beta = rng.random(10)
     X = rng.standard_normal((1000, 10))

--- a/dipy/core/tests/test_rng.py
+++ b/dipy/core/tests/test_rng.py
@@ -8,7 +8,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator()
-def test_wichmann_hill2006(rng):
+def test_wichmann_hill2006(rng=None):
     # These functions are stateless: same seeds → same value each call.
     # Use varied seeds to generate a sequence and verify outputs are in [0, 1].
     seeds = rng.integers(1, 2**20, size=(100, 4))
@@ -25,7 +25,7 @@ def test_wichmann_hill2006(rng):
 
 
 @set_random_number_generator()
-def test_wichmann_hill1982(rng):
+def test_wichmann_hill1982(rng=None):
     seeds = rng.integers(1, 2**15, size=(100, 3))
     n_generated = np.array(
         [
@@ -38,7 +38,7 @@ def test_wichmann_hill1982(rng):
 
 
 @set_random_number_generator()
-def test_LEcuyer(rng):
+def test_LEcuyer(rng=None):
     seeds = rng.integers(1, 2**20, size=(100, 2))
     n_generated = np.array(
         [core_rng.LEcuyer(s1=int(s[0]), s2=int(s[1])) for s in seeds]

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -359,7 +359,7 @@ def test_disperse_charges_alt():
 
 
 @set_random_number_generator()
-def test_fibonacci_sphere(rng):
+def test_fibonacci_sphere(rng=None):
     # Test that the number of points is correct
     points = fibonacci_sphere(n_points=724, rng=rng)
     nt.assert_equal(len(points), 724)
@@ -375,7 +375,7 @@ def test_fibonacci_sphere(rng):
 
 
 @set_random_number_generator()
-def test_fibonacci_hemisphere(rng):
+def test_fibonacci_hemisphere(rng=None):
     # Test that the number of points is correct
     points = fibonacci_sphere(n_points=724, hemisphere=True, rng=rng)
     nt.assert_equal(len(points), 724)

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -263,20 +263,19 @@ def test_fetch_data_all_skip_logs_already_there(
     assert "already" in caplog.text.lower()
 
 
-def test_dipy_home():
+def test_dipy_home(tmp_path):
     old_home = os.environ.pop("DIPY_HOME", None)
     try:
         importlib.reload(fetcher)
-        expected = str(Path("~").expanduser() / ".dipy")
-        assert str(fetcher.dipy_home) == expected
+        expected = Path("~").expanduser() / ".dipy"
+        assert fetcher.dipy_home == expected
 
-        with tempfile.TemporaryDirectory() as test_path:
-            os.environ["DIPY_HOME"] = test_path
-            importlib.reload(fetcher)
-            assert str(fetcher.dipy_home) == test_path
+        os.environ["DIPY_HOME"] = str(tmp_path)
+        importlib.reload(fetcher)
+        assert fetcher.dipy_home == tmp_path
     finally:
         if old_home is not None:
-            os.environ["DIPY_HOME"] = old_home
+            os.environ["DIPY_HOME"] = str(old_home)
         elif "DIPY_HOME" in os.environ:
             del os.environ["DIPY_HOME"]
         importlib.reload(fetcher)

--- a/dipy/denoise/tests/test_ascm.py
+++ b/dipy/denoise/tests/test_ascm.py
@@ -23,7 +23,7 @@ def test_ascm_static():
 
 
 @set_random_number_generator()
-def test_ascm_random_noise(rng):
+def test_ascm_random_noise(rng=None):
     S0 = 100 + 2 * rng.standard_normal((22, 23, 30))
     S0n1 = nlmeans(S0, sigma=1, rician=False, patch_radius=1, block_radius=1)
     S0n2 = nlmeans(S0, sigma=1, rician=False, patch_radius=2, block_radius=1)
@@ -41,7 +41,7 @@ def test_ascm_random_noise(rng):
 
 
 @set_random_number_generator()
-def test_ascm_rmse_with_nlmeans(rng):
+def test_ascm_rmse_with_nlmeans(rng=None):
     # checks the smoothness
     S0 = np.ones((30, 30, 30)) * 100
     S0[10:20, 10:20, 10:20] = 50
@@ -67,7 +67,7 @@ def test_ascm_rmse_with_nlmeans(rng):
 
 
 @set_random_number_generator()
-def test_sharpness(rng):
+def test_sharpness(rng=None):
     # check the edge-preserving nature
     S0 = np.ones((30, 30, 30)) * 100
     S0[10:20, 10:20, 10:20] = 50

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -118,7 +118,7 @@ def test_lpca_static():
 
 
 @set_random_number_generator()
-def test_lpca_random_noise(rng):
+def test_lpca_random_noise(rng=None):
     S0 = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
     S0ns = localpca(S0, sigma=np.std(S0))
 
@@ -128,7 +128,7 @@ def test_lpca_random_noise(rng):
 
 
 @set_random_number_generator()
-def test_lpca_complex_random_noise(rng):
+def test_lpca_complex_random_noise(rng=None):
     S0 = (
         100
         + 100j
@@ -148,7 +148,7 @@ def test_lpca_complex_random_noise(rng):
 
 
 @set_random_number_generator()
-def test_lpca_boundary_behaviour(rng):
+def test_lpca_boundary_behaviour(rng=None):
     # check is first slice is getting denoised or not ?
     S0 = 100 * np.ones((20, 20, 20, 20), dtype="f8")
     S0[:, :, 0, :] = S0[:, :, 0, :] + 2 * rng.standard_normal((20, 20, 20))
@@ -169,7 +169,7 @@ def test_lpca_boundary_behaviour(rng):
 
 
 @set_random_number_generator()
-def test_lpca_rmse(rng):
+def test_lpca_rmse(rng=None):
     S0_w_noise = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
     rmse_w_noise = np.sqrt(np.mean((S0_w_noise - 100) ** 2))
     S0_denoised = localpca(S0_w_noise, sigma=np.std(S0_w_noise))
@@ -179,7 +179,7 @@ def test_lpca_rmse(rng):
 
 
 @set_random_number_generator()
-def test_lpca_complex_rmse(rng):
+def test_lpca_complex_rmse(rng=None):
     S0_w_noise = (
         100
         + 100j
@@ -198,7 +198,7 @@ def test_lpca_complex_rmse(rng):
 
 
 @set_random_number_generator()
-def test_lpca_complex_phase(rng):
+def test_lpca_complex_phase(rng=None):
     S0 = 100 * np.exp(1j * np.pi / 4)
     S0_w_noise = S0 + (2 / np.sqrt(2)) * (
         rng.standard_normal((22, 23, 30, 20))
@@ -212,7 +212,7 @@ def test_lpca_complex_phase(rng):
 
 
 @set_random_number_generator()
-def test_lpca_sharpness(rng):
+def test_lpca_sharpness(rng=None):
     S0 = np.ones((30, 30, 30, 20), dtype=np.float64) * 100
     S0[10:20, 10:20, 10:20, :] = 50
     S0[20:30, 20:30, 20:30, :] = 0
@@ -254,7 +254,7 @@ def test_lpca_wrong():
 
 
 @set_random_number_generator()
-def test_phantom(rng):
+def test_phantom(rng=None):
     DWI_clean = rfiw_phantom(gtab, snr=None, rng=rng)
     DWI, sigma = rfiw_phantom(gtab, snr=30, rng=rng)
     # To test without Rician correction
@@ -322,7 +322,7 @@ def test_phantom(rng):
 
 
 @set_random_number_generator()
-def test_compare_pca_methods_complex(rng):
+def test_compare_pca_methods_complex(rng=None):
     S0_w_noise = (
         100
         + 100j
@@ -341,21 +341,21 @@ def test_compare_pca_methods_complex(rng):
 
 
 @set_random_number_generator()
-def test_lpca_ill_conditioned(rng):
+def test_lpca_ill_conditioned(rng=None):
     DWI, sigma = rfiw_phantom(gtab, snr=30, rng=rng)
     for patch_radius in [1, [1, 1, 1]]:
         assert_warns(UserWarning, localpca, DWI, sigma=sigma, patch_radius=patch_radius)
 
 
 @set_random_number_generator()
-def test_lpca_radius_wrong_shape(rng):
+def test_lpca_radius_wrong_shape(rng=None):
     DWI, sigma = rfiw_phantom(gtab, snr=30, rng=rng)
     for patch_radius in [[2, 2], [2, 2, 2, 2]]:
         assert_raises(ValueError, localpca, DWI, sigma=sigma, patch_radius=patch_radius)
 
 
 @set_random_number_generator()
-def test_lpca_sigma_wrong_shape(rng):
+def test_lpca_sigma_wrong_shape(rng=None):
     DWI, sigma = rfiw_phantom(gtab, snr=30, rng=rng)
     # If sigma is 3D but shape is not like DWI.shape[:-1], an error is raised:
     sigma = np.zeros((DWI.shape[0], DWI.shape[1] + 1, DWI.shape[2]))
@@ -363,13 +363,13 @@ def test_lpca_sigma_wrong_shape(rng):
 
 
 @set_random_number_generator()
-def test_lpca_no_gtab_no_sigma(rng):
+def test_lpca_no_gtab_no_sigma(rng=None):
     DWI, sigma = rfiw_phantom(gtab, snr=30, rng=rng)
     assert_raises(ValueError, localpca, DWI, sigma=None, mask=None)
 
 
 @set_random_number_generator()
-def test_pca_classifier(rng):
+def test_pca_classifier(rng=None):
     # Produce small phantom with well aligned single voxels and ground truth
     # snr = 50, i.e signal std = 0.02 (Gaussian noise)
     std_gt = 0.02
@@ -407,7 +407,7 @@ def test_pca_classifier(rng):
 
 
 @set_random_number_generator()
-def test_mppca_in_phantom(rng):
+def test_mppca_in_phantom(rng=None):
     DWIgt = rfiw_phantom(gtab, snr=None, rng=rng)
     std_gt = 0.02
     noise = std_gt * rng.standard_normal(DWIgt.shape)
@@ -437,7 +437,7 @@ def test_mppca_in_phantom(rng):
 
 
 @set_random_number_generator()
-def test_create_patch_radius_arr(rng):
+def test_create_patch_radius_arr(rng=None):
     shape = (10, 10, 8, 104)
     arr = rng.standard_normal(shape)
     pr = 2
@@ -466,7 +466,7 @@ def test_compute_num_samples():
 
 
 @set_random_number_generator()
-def test_compute_suggested_patch_radius(rng):
+def test_compute_suggested_patch_radius(rng=None):
     shape = (10, 10, 8, 104)
     arr = rng.standard_normal(shape)
     patch_size = [3, 3, 3]
@@ -480,7 +480,7 @@ def test_compute_suggested_patch_radius(rng):
 
 
 @set_random_number_generator()
-def test_mppca_returned_sigma(rng):
+def test_mppca_returned_sigma(rng=None):
     DWIgt = rfiw_phantom(gtab, snr=None, rng=rng)
     std_gt = 0.02
     noise = std_gt * rng.standard_normal(DWIgt.shape)

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -17,7 +17,7 @@ from dipy.utils.omp import cpu_count, have_openmp
 
 
 @set_random_number_generator()
-def test_nlmeans_padding(rng):
+def test_nlmeans_padding(rng=None):
     S0 = 100 + 2 * rng.standard_normal((50, 50, 50))
     S0 = S0.astype("f8")
     S0n = add_padding_reflection(S0, 5)
@@ -43,7 +43,7 @@ def test_nlmeans_wrong():
 
 
 @set_random_number_generator()
-def test_nlmeans_random_noise(rng):
+def test_nlmeans_random_noise(rng=None):
     """Test random noise reduction with classic method."""
     S0 = 100 + 2 * rng.standard_normal((22, 23, 30))
 
@@ -58,7 +58,7 @@ def test_nlmeans_random_noise(rng):
 
 
 @set_random_number_generator()
-def test_nlmeans_boundary(rng):
+def test_nlmeans_boundary(rng=None):
     """Test boundary preservation with classic method."""
     S0 = 100 + np.zeros((20, 20, 20))
     noise = 2 * rng.standard_normal((20, 20, 20))
@@ -72,7 +72,7 @@ def test_nlmeans_boundary(rng):
 
 
 @set_random_number_generator(42)
-def test_nlmeans_rician_noise_reduction(rng):
+def test_nlmeans_rician_noise_reduction(rng=None):
     """Test rician=True output is non-negative and reduces variance."""
     clean = np.zeros((30, 30, 30), dtype="f8")
     clean[8:22, 8:22, 8:22] = 100.0

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -36,7 +36,7 @@ def test_inv_nchi():
 
 
 @set_random_number_generator()
-def test_piesno(rng):
+def test_piesno(rng=None):
     # Values taken from hispeed.OptimalPIESNO with the test data
     # in the package computed in matlab
     test_piesno_data = load_nifti_data(dpd.get_fnames(name="test_piesno"))
@@ -189,7 +189,7 @@ def test_estimate_sigma():
 
 
 @set_random_number_generator(1984)
-def test_pca_noise_estimate(rng):
+def test_pca_noise_estimate(rng=None):
     # MUBE:
     bvals1 = np.concatenate([np.zeros(17), np.ones(3) * 1000])
     bvecs1 = np.concatenate([np.zeros((17, 3)), np.eye(3)])

--- a/dipy/denoise/tests/test_patch2self.py
+++ b/dipy/denoise/tests/test_patch2self.py
@@ -27,7 +27,7 @@ needs_sklearn = pytest.mark.skipif(not has_sklearn, reason="Requires sklearn")
 
 @needs_sklearn
 @set_random_number_generator(1234)
-def test_patch2self_random_noise(rng):
+def test_patch2self_random_noise(rng=None):
     S0 = 30 + 2 * rng.standard_normal((20, 20, 20, 50))
 
     bvals = np.repeat(30, 50)
@@ -96,7 +96,7 @@ def test_patch2self_random_noise(rng):
 
 @needs_sklearn
 @set_random_number_generator(1234)
-def test_patch2self_boundary(rng):
+def test_patch2self_boundary(rng=None):
     # patch2self preserves boundaries
     S0 = 100 + np.zeros((20, 20, 20, 20))
     noise = 2 * rng.standard_normal((20, 20, 20, 20))
@@ -182,7 +182,7 @@ def rfiw_phantom(gtab, snr=None, rng=None):
 
 @needs_sklearn
 @set_random_number_generator(4321)
-def test_phantom(rng):
+def test_phantom(rng=None):
     # generate a gradient table for phantom data
     directions8 = generate_bvecs(8)
     directions30 = generate_bvecs(20)
@@ -319,7 +319,7 @@ def test_single_slice_data():
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_patch2self_small_data_edge_cases(rng):
+def test_patch2self_small_data_edge_cases(rng=None):
     data = (30 + 2 * rng.standard_normal((4, 4, 4, 5))).astype(np.float64)
     bvals = np.array([0, 1000, 1000, 1000, 1000])
 
@@ -332,7 +332,7 @@ def test_patch2self_small_data_edge_cases(rng):
 
 @needs_sklearn
 @set_random_number_generator(2025)
-def test_patch2self_v3_preserves_out_dtype_and_precision_invariance(rng):
+def test_patch2self_v3_preserves_out_dtype_and_precision_invariance(rng=None):
     shape = (10, 10, 6, 13)
     base = 30.0 + 2.0 * rng.standard_normal(shape)
     bvals = np.repeat(1000.0, shape[-1])
@@ -375,7 +375,7 @@ def test_patch_radius_requires_scalar_or_3_tuple():
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_fit_denoising_model_copy_x_is_keyword_only(rng):
+def test_fit_denoising_model_copy_x_is_keyword_only(rng=None):
     train = rng.standard_normal((4, 3, 8))
 
     with pytest.raises(TypeError, match="positional|keyword-only"):
@@ -394,7 +394,7 @@ def test_fit_denoising_model_copy_x_is_keyword_only(rng):
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_fit_denoising_model_accepts_non_linear_base_estimator(rng):
+def test_fit_denoising_model_accepts_non_linear_base_estimator(rng=None):
     from sklearn.dummy import DummyRegressor
 
     train = rng.standard_normal((4, 3, 8))
@@ -471,7 +471,7 @@ def test_patch2self_v1_models_and_verbose(model):
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_patch2self_v3_b0_passthrough_when_b0_denoising_disabled(rng):
+def test_patch2self_v3_b0_passthrough_when_b0_denoising_disabled(rng=None):
     # Regression test: when b0_denoising=False, the previous code copied
     # data_tmp[..., b0_counter] which indexed the wrong volume whenever the
     # b0s were not the leading volumes. The fix indexes by vol_idx so each
@@ -498,7 +498,7 @@ def test_patch2self_v3_b0_passthrough_when_b0_denoising_disabled(rng):
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_patch2self_v3_volumes_count_not_divisible_by_5(rng):
+def test_patch2self_v3_volumes_count_not_divisible_by_5(rng=None):
     # Regression test for the buffer-flush bug: when data_shape[-1] % 5 != 0,
     # the previous code computed denoised_arr_idx and full_result_idx using
     # different bases, leaving a tail of zero volumes in the output.
@@ -516,7 +516,7 @@ def test_patch2self_v3_volumes_count_not_divisible_by_5(rng):
 
 @needs_sklearn
 @set_random_number_generator(2026)
-def test_patch2self_v3_small_spatial_uses_minimum_chunk_size(rng):
+def test_patch2self_v3_small_spatial_uses_minimum_chunk_size(rng=None):
     # Regression test: vol_denoise computed `p = data_tmp.shape[0] // 10`,
     # which became 0 when the flattened spatial dimension had < 10 voxels and
     # caused an empty inner loop. The fix uses `max(..., 1)`.

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -149,7 +149,7 @@ def test_bdg_get_direction():
 
 
 @set_random_number_generator()
-def test_bdg_residual(rng):
+def test_bdg_residual(rng=None):
     """This tests the bootstrapping residual."""
 
     hsph_updated = HemiSphere.from_sphere(unit_icosahedron).subdivide(n=2)

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -455,7 +455,7 @@ def test_difference_with_minmax():
 
 
 @set_random_number_generator()
-def test_degenerate_cases(rng):
+def test_degenerate_cases(rng=None):
     sphere = default_sphere
 
     # completely isotropic and degenerate case
@@ -788,7 +788,7 @@ def test_peaks_shm_coeff():
 
 
 @set_random_number_generator()
-def test_reshape_peaks_for_visualization(rng):
+def test_reshape_peaks_for_visualization(rng=None):
     data1 = rng.standard_normal((10, 5, 3)).astype("float32")
     data2 = rng.standard_normal((10, 2, 5, 3)).astype("float32")
     data3 = rng.standard_normal((10, 2, 12, 5, 3)).astype("float32")

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -13,7 +13,7 @@ response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
 
 
 @set_random_number_generator()
-def test_pmf_val(rng):
+def test_pmf_val(rng=None):
     sphere = get_sphere(name="symmetric724")
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -1,33 +1,29 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import numpy.testing as npt
 
 from dipy.io.dpy import Dpy, Streamlines
 
 
-def test_dpy():
-    with TemporaryDirectory() as tmpdir:
-        fname = Path(tmpdir) / "test.bin"
-        dpw = Dpy(fname, mode="w")
-        A = np.ones((5, 3))
-        B = 2 * A.copy()
-        C = 3 * A.copy()
-        dpw.write_track(A)
-        dpw.write_track(B)
-        dpw.write_track(C)
-        dpw.write_tracks(Streamlines([C, B, A]))
+def test_dpy(tmp_path):
+    fname = tmp_path / "test.bin"
+    dpw = Dpy(fname, mode="w")
+    A = np.ones((5, 3))
+    B = 2 * A.copy()
+    C = 3 * A.copy()
+    dpw.write_track(A)
+    dpw.write_track(B)
+    dpw.write_track(C)
+    dpw.write_tracks(Streamlines([C, B, A]))
 
-        all_tracks = np.ascontiguousarray(np.vstack([A, B, C, C, B, A]))
-        npt.assert_array_equal(all_tracks, dpw.tracks[:])
-        dpw.close()
+    all_tracks = np.ascontiguousarray(np.vstack([A, B, C, C, B, A]))
+    npt.assert_array_equal(all_tracks, dpw.tracks[:])
+    dpw.close()
 
-        dpr = Dpy(fname, mode="r")
-        npt.assert_equal(dpr.version() == "0.0.1", True)
-        T = dpr.read_tracksi([0, 1, 2, 0, 0, 2])
-        T2 = dpr.read_tracks()
-        npt.assert_equal(len(T2), 6)
-        dpr.close()
-        npt.assert_array_equal(A, T[0])
-        npt.assert_array_equal(C, T[5])
+    dpr = Dpy(fname, mode="r")
+    npt.assert_equal(dpr.version() == "0.0.1", True)
+    T = dpr.read_tracksi([0, 1, 2, 0, 0, 2])
+    T2 = dpr.read_tracks()
+    npt.assert_equal(len(T2), 6)
+    dpr.close()
+    npt.assert_array_equal(A, T[0])
+    npt.assert_array_equal(C, T[5])

--- a/dipy/io/tests/test_io_gradients.py
+++ b/dipy/io/tests/test_io_gradients.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -11,7 +10,7 @@ from dipy.io.gradients import read_bvals_bvecs
 from dipy.testing import assert_true
 
 
-def test_read_bvals_bvecs():
+def test_read_bvals_bvecs(tmp_path):
     fimg, fbvals, fbvecs = get_fnames(name="small_101D")
     bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
     gt = gradient_table(bvals, bvecs=bvecs)
@@ -32,108 +31,107 @@ def test_read_bvals_bvecs():
 
     # Test for error raising with incorrect file-contents:
 
-    with TemporaryDirectory() as tmpdir:
-        # These bvecs only have two rows/columns:
-        new_bvecs1 = bvecs[:, :2]
-        # Make a temporary file
-        fname = "test_bv_file1.txt"
-        with open(Path(tmpdir) / fname, "w") as bv_file1:
-            # And fill it with these 2-columned bvecs:
-            bv_file1.writelines(
-                f"{new_bvecs1[x][0]} {new_bvecs1[x][1]}\n"
-                for x in range(new_bvecs1.shape[0])
-            )
-        npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
-
-        # These bvecs are saved as one long array:
-        fname = "test_bv_file2.npy"
-        new_bvecs2 = np.ravel(bvecs)
-        with open(Path(tmpdir) / fname, "w") as bv_file2:
-            np.save(bv_file2.name, new_bvecs2)
-        npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
-
-        # There are less bvecs than bvals:
-        fname = "test_bv_file3.txt"
-        new_bvecs3 = bvecs[:-1, :]
-        with open(Path(tmpdir) / fname, "w") as bv_file3:
-            np.savetxt(bv_file3.name, new_bvecs3)
-        npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
-
-        # You entered the bvecs on both sides:
-        npt.assert_raises(OSError, read_bvals_bvecs, fbvecs, fbvecs)
-
-        # All possible delimiters should work
-        bv_file4 = "test_space.txt"
-        with open(Path(tmpdir) / bv_file4, "w") as f:
-            f.write("66 55 33")
-        bvals_1, _ = read_bvals_bvecs(Path(tmpdir) / bv_file4, "")
-
-        bv_file5 = "test_coma.txt"
-        with open(Path(tmpdir) / bv_file5, "w") as f:
-            f.write("66, 55, 33")
-        bvals_2, _ = read_bvals_bvecs(Path(tmpdir) / bv_file5, "")
-
-        bv_file6 = "test_tabs.txt"
-        with open(Path(tmpdir) / bv_file6, "w") as f:
-            f.write("66 \t 55 \t 33")
-        bvals_3, _ = read_bvals_bvecs(Path(tmpdir) / bv_file6, "")
-
-        ans = np.array([66.0, 55.0, 33.0])
-        npt.assert_array_equal(ans, bvals_1)
-        npt.assert_array_equal(ans, bvals_2)
-        npt.assert_array_equal(ans, bvals_3)
-
-        bv_file7 = "test_space_2.txt"
-        with open(Path(tmpdir) / bv_file7, "w") as f:
-            f.write("66 55 33\n45 34 21\n55 32 65\n")
-        _, bvecs_1 = read_bvals_bvecs("", Path(tmpdir) / bv_file7)
-
-        bv_file8 = "test_coma_2.txt"
-        with open(Path(tmpdir) / bv_file8, "w") as f:
-            f.write("66, 55, 33\n45, 34, 21 \n 55, 32, 65\n")
-        _, bvecs_2 = read_bvals_bvecs("", Path(tmpdir) / bv_file8)
-
-        bv_file9 = "test_tabs_2.txt"
-        with open(Path(tmpdir) / bv_file9, "w") as f:
-            f.write("66 \t 55 \t 33\n45 \t 34 \t 21\n55 \t 32 \t 65\n")
-        _, bvecs_3 = read_bvals_bvecs("", Path(tmpdir) / bv_file9)
-
-        bv_file10 = "test_multiple_space.txt"
-        with open(Path(tmpdir) / bv_file10, "w") as f:
-            f.write("66   55   33\n45,   34,   21 \n 55,   32,     65\n")
-        _, bvecs_4 = read_bvals_bvecs("", Path(tmpdir) / bv_file10)
-
-        ans = np.array([[66.0, 55.0, 33.0], [45.0, 34.0, 21.0], [55.0, 32.0, 65.0]])
-        npt.assert_array_equal(ans, bvecs_1)
-        npt.assert_array_equal(ans, bvecs_2)
-        npt.assert_array_equal(ans, bvecs_3)
-        npt.assert_array_equal(ans, bvecs_4)
-
-        bv_two_volume = "bv_two_volume.txt"
-        with open(Path(tmpdir) / bv_two_volume, "w") as f:
-            f.write("0 0 \n0 0 \n0 0")
-        bval_two_volume = "bval_two_volume.txt"
-        with open(Path(tmpdir) / bval_two_volume, "w") as f:
-            f.write("0\n0\n")
-        bval_5, bvecs_5 = read_bvals_bvecs(
-            Path(tmpdir) / bval_two_volume, Path(tmpdir) / bv_two_volume
+    # These bvecs only have two rows/columns:
+    new_bvecs1 = bvecs[:, :2]
+    # Make a temporary file
+    fname = "test_bv_file1.txt"
+    with open(tmp_path / fname, "w") as bv_file1:
+        # And fill it with these 2-columned bvecs:
+        bv_file1.writelines(
+            f"{new_bvecs1[x][0]} {new_bvecs1[x][1]}\n"
+            for x in range(new_bvecs1.shape[0])
         )
-        npt.assert_array_equal(bvecs_5, np.zeros((2, 3)))
-        npt.assert_array_equal(bval_5, np.zeros(2))
+    npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
 
-        bv_single_volume = "test_single_volume.txt"
-        with open(Path(tmpdir) / bv_single_volume, "w") as f:
-            f.write("0 \n0 \n0 ")
-        bval_single_volume = "test_single_volume_2.txt"
-        with open(Path(tmpdir) / bval_single_volume, "w") as f:
-            f.write("0\n")
+    # These bvecs are saved as one long array:
+    fname = "test_bv_file2.npy"
+    new_bvecs2 = np.ravel(bvecs)
+    with open(tmp_path / fname, "w") as bv_file2:
+        np.save(bv_file2.name, new_bvecs2)
+    npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
 
-        with warnings.catch_warnings(record=True) as w:
-            bval_5, bvecs_5 = read_bvals_bvecs(
-                Path(tmpdir) / bval_single_volume, Path(tmpdir) / bv_single_volume
-            )
-            npt.assert_array_equal(bvecs_5, np.zeros((1, 3)))
-            npt.assert_array_equal(bval_5, np.zeros(1))
-            assert_true(len(w) == 1)
-            assert_true(issubclass(w[0].category, UserWarning))
-            assert_true("Detected only 1 direction on" in str(w[0].message))
+    # There are less bvecs than bvals:
+    fname = "test_bv_file3.txt"
+    new_bvecs3 = bvecs[:-1, :]
+    with open(tmp_path / fname, "w") as bv_file3:
+        np.savetxt(bv_file3.name, new_bvecs3)
+    npt.assert_raises(OSError, read_bvals_bvecs, fbvals, fname)
+
+    # You entered the bvecs on both sides:
+    npt.assert_raises(OSError, read_bvals_bvecs, fbvecs, fbvecs)
+
+    # All possible delimiters should work
+    bv_file4 = "test_space.txt"
+    with open(tmp_path / bv_file4, "w") as f:
+        f.write("66 55 33")
+    bvals_1, _ = read_bvals_bvecs(tmp_path / bv_file4, "")
+
+    bv_file5 = "test_coma.txt"
+    with open(tmp_path / bv_file5, "w") as f:
+        f.write("66, 55, 33")
+    bvals_2, _ = read_bvals_bvecs(tmp_path / bv_file5, "")
+
+    bv_file6 = "test_tabs.txt"
+    with open(tmp_path / bv_file6, "w") as f:
+        f.write("66 \t 55 \t 33")
+    bvals_3, _ = read_bvals_bvecs(tmp_path / bv_file6, "")
+
+    ans = np.array([66.0, 55.0, 33.0])
+    npt.assert_array_equal(ans, bvals_1)
+    npt.assert_array_equal(ans, bvals_2)
+    npt.assert_array_equal(ans, bvals_3)
+
+    bv_file7 = "test_space_2.txt"
+    with open(tmp_path / bv_file7, "w") as f:
+        f.write("66 55 33\n45 34 21\n55 32 65\n")
+    _, bvecs_1 = read_bvals_bvecs("", tmp_path / bv_file7)
+
+    bv_file8 = "test_coma_2.txt"
+    with open(tmp_path / bv_file8, "w") as f:
+        f.write("66, 55, 33\n45, 34, 21 \n 55, 32, 65\n")
+    _, bvecs_2 = read_bvals_bvecs("", tmp_path / bv_file8)
+
+    bv_file9 = "test_tabs_2.txt"
+    with open(tmp_path / bv_file9, "w") as f:
+        f.write("66 \t 55 \t 33\n45 \t 34 \t 21\n55 \t 32 \t 65\n")
+    _, bvecs_3 = read_bvals_bvecs("", tmp_path / bv_file9)
+
+    bv_file10 = "test_multiple_space.txt"
+    with open(tmp_path / bv_file10, "w") as f:
+        f.write("66   55   33\n45,   34,   21 \n 55,   32,     65\n")
+    _, bvecs_4 = read_bvals_bvecs("", tmp_path / bv_file10)
+
+    ans = np.array([[66.0, 55.0, 33.0], [45.0, 34.0, 21.0], [55.0, 32.0, 65.0]])
+    npt.assert_array_equal(ans, bvecs_1)
+    npt.assert_array_equal(ans, bvecs_2)
+    npt.assert_array_equal(ans, bvecs_3)
+    npt.assert_array_equal(ans, bvecs_4)
+
+    bv_two_volume = "bv_two_volume.txt"
+    with open(tmp_path / bv_two_volume, "w") as f:
+        f.write("0 0 \n0 0 \n0 0")
+    bval_two_volume = "bval_two_volume.txt"
+    with open(tmp_path / bval_two_volume, "w") as f:
+        f.write("0\n0\n")
+    bval_5, bvecs_5 = read_bvals_bvecs(
+        tmp_path / bval_two_volume, tmp_path / bv_two_volume
+    )
+    npt.assert_array_equal(bvecs_5, np.zeros((2, 3)))
+    npt.assert_array_equal(bval_5, np.zeros(2))
+
+    bv_single_volume = "test_single_volume.txt"
+    with open(tmp_path / bv_single_volume, "w") as f:
+        f.write("0 \n0 \n0 ")
+    bval_single_volume = "test_single_volume_2.txt"
+    with open(tmp_path / bval_single_volume, "w") as f:
+        f.write("0\n")
+
+    with warnings.catch_warnings(record=True) as w:
+        bval_5, bvecs_5 = read_bvals_bvecs(
+            tmp_path / bval_single_volume, tmp_path / bv_single_volume
+        )
+        npt.assert_array_equal(bvecs_5, np.zeros((1, 3)))
+        npt.assert_array_equal(bval_5, np.zeros(1))
+        assert_true(len(w) == 1)
+        assert_true(issubclass(w[0].category, UserWarning))
+        assert_true("Detected only 1 direction on" in str(w[0].message))

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
@@ -38,156 +37,151 @@ def generate_default_pam(rng):
 
 
 @set_random_number_generator()
-def test_io_peaks(rng):
-    with TemporaryDirectory() as tmpdir:
-        fname = Path(tmpdir) / "test.pam5"
+def test_io_peaks(tmp_path, rng=None):
+    fname = tmp_path / "test.pam5"
 
-        pam = generate_default_pam(rng)
-        save_pam(fname, pam)
-        pam2 = load_pam(fname, verbose=False)
-        npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
+    pam = generate_default_pam(rng)
+    save_pam(fname, pam)
+    pam2 = load_pam(fname, verbose=False)
+    npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
 
-        pam2.affine = None
+    pam2.affine = None
 
-        fname2 = Path(tmpdir) / "test2.pam5"
-        save_pam(fname2, pam2, affine=np.eye(4))
-        pam2_res = load_pam(fname2, verbose=True)
-        npt.assert_array_equal(pam.peak_dirs, pam2_res.peak_dirs)
+    fname2 = tmp_path / "test2.pam5"
+    save_pam(fname2, pam2, affine=np.eye(4))
+    pam2_res = load_pam(fname2, verbose=True)
+    npt.assert_array_equal(pam.peak_dirs, pam2_res.peak_dirs)
 
-        pam3 = load_pam(fname2, verbose=False)
+    pam3 = load_pam(fname2, verbose=False)
 
-        for attr in [
-            "peak_dirs",
-            "peak_values",
-            "peak_indices",
-            "gfa",
-            "qa",
-            "shm_coeff",
-            "B",
-            "odf",
-        ]:
-            npt.assert_array_equal(getattr(pam3, attr), getattr(pam, attr))
+    for attr in [
+        "peak_dirs",
+        "peak_values",
+        "peak_indices",
+        "gfa",
+        "qa",
+        "shm_coeff",
+        "B",
+        "odf",
+    ]:
+        npt.assert_array_equal(getattr(pam3, attr), getattr(pam, attr))
 
-        npt.assert_equal(pam3.total_weight, pam.total_weight)
-        npt.assert_equal(pam3.ang_thr, pam.ang_thr)
-        npt.assert_array_almost_equal(pam3.sphere.vertices, pam.sphere.vertices)
+    npt.assert_equal(pam3.total_weight, pam.total_weight)
+    npt.assert_equal(pam3.ang_thr, pam.ang_thr)
+    npt.assert_array_almost_equal(pam3.sphere.vertices, pam.sphere.vertices)
 
-        fname3 = Path(tmpdir) / "test3.pam5"
-        pam4 = PeaksAndMetrics()
-        npt.assert_raises((ValueError, AttributeError), save_pam, fname3, pam4)
+    fname3 = tmp_path / "test3.pam5"
+    pam4 = PeaksAndMetrics()
+    npt.assert_raises((ValueError, AttributeError), save_pam, fname3, pam4)
 
-        fname4 = Path(tmpdir) / "test4.pam5"
-        del pam.affine
-        save_pam(fname4, pam, affine=None)
+    fname4 = tmp_path / "test4.pam5"
+    del pam.affine
+    save_pam(fname4, pam, affine=None)
 
-        fname5 = Path(tmpdir) / "test5.pkm"
-        npt.assert_raises(IOError, save_pam, fname5, pam)
+    fname5 = tmp_path / "test5.pkm"
+    npt.assert_raises(IOError, save_pam, fname5, pam)
 
-        pam.affine = np.eye(4)
-        fname6 = Path(tmpdir) / "test6.pam5"
-        save_pam(fname6, pam, verbose=True)
+    pam.affine = np.eye(4)
+    fname6 = tmp_path / "test6.pam5"
+    save_pam(fname6, pam, verbose=True)
 
-        del pam.shm_coeff
-        save_pam(Path(tmpdir) / fname6, pam, verbose=False)
+    del pam.shm_coeff
+    save_pam(tmp_path / fname6, pam, verbose=False)
 
-        pam.shm_coeff = np.zeros((10, 10, 10, 45))
-        del pam.odf
-        save_pam(fname6, pam)
-        pam_tmp = load_pam(fname6, verbose=True)
-        npt.assert_equal(pam_tmp.odf, None)
+    pam.shm_coeff = np.zeros((10, 10, 10, 45))
+    del pam.odf
+    save_pam(fname6, pam)
+    pam_tmp = load_pam(fname6, verbose=True)
+    npt.assert_equal(pam_tmp.odf, None)
 
-        fname7 = Path(tmpdir) / "test7.paw"
-        npt.assert_raises(OSError, load_pam, fname7)
+    fname7 = tmp_path / "test7.paw"
+    npt.assert_raises(OSError, load_pam, fname7)
 
-        del pam.shm_coeff
-        save_pam(fname6, pam, verbose=True)
+    del pam.shm_coeff
+    save_pam(fname6, pam, verbose=True)
 
-        fname_shm = Path(tmpdir) / "shm.nii.gz"
-        fname_dirs = Path(tmpdir) / "peaks_dirs.nii.gz"
-        fname_values = Path(tmpdir) / "peaks_values.nii.gz"
-        fname_indices = Path(tmpdir) / "peaks_indices.nii.gz"
-        fname_gfa = Path(tmpdir) / "gfa.nii.gz"
-        fname_sphere = Path(tmpdir) / "sphere.txt"
-        fname_b = Path(tmpdir) / "B.nii.gz"
-        fname_qa = Path(tmpdir) / "qa.nii.gz"
+    fname_shm = tmp_path / "shm.nii.gz"
+    fname_dirs = tmp_path / "peaks_dirs.nii.gz"
+    fname_values = tmp_path / "peaks_values.nii.gz"
+    fname_indices = tmp_path / "peaks_indices.nii.gz"
+    fname_gfa = tmp_path / "gfa.nii.gz"
+    fname_sphere = tmp_path / "sphere.txt"
+    fname_b = tmp_path / "B.nii.gz"
+    fname_qa = tmp_path / "qa.nii.gz"
 
-        pam.shm_coeff = np.ones((10, 10, 10, 45))
-        pam_to_niftis(
-            pam,
-            fname_shm=fname_shm,
-            fname_peaks_dir=fname_dirs,
-            fname_peaks_values=fname_values,
-            fname_peaks_indices=fname_indices,
-            fname_gfa=fname_gfa,
-            fname_sphere=fname_sphere,
-            fname_b=fname_b,
-            fname_qa=fname_qa,
-            reshape_dirs=False,
+    pam.shm_coeff = np.ones((10, 10, 10, 45))
+    pam_to_niftis(
+        pam,
+        fname_shm=fname_shm,
+        fname_peaks_dir=fname_dirs,
+        fname_peaks_values=fname_values,
+        fname_peaks_indices=fname_indices,
+        fname_gfa=fname_gfa,
+        fname_sphere=fname_sphere,
+        fname_b=fname_b,
+        fname_qa=fname_qa,
+        reshape_dirs=False,
+    )
+
+    for name in [
+        "shm.nii.gz",
+        "peaks_dirs.nii.gz",
+        "peaks_values.nii.gz",
+        "gfa.nii.gz",
+        "peaks_indices.nii.gz",
+        "shm.nii.gz",
+    ]:
+        npt.assert_(
+            Path(tmp_path / name).is_file(),
+            f"{tmp_path / name} file does not exist",
         )
-
-        for name in [
-            "shm.nii.gz",
-            "peaks_dirs.nii.gz",
-            "peaks_values.nii.gz",
-            "gfa.nii.gz",
-            "peaks_indices.nii.gz",
-            "shm.nii.gz",
-        ]:
-            npt.assert_(
-                Path(Path(tmpdir) / name).is_file(),
-                f"{Path(tmpdir) / name} file does not exist",
-            )
 
 
 @set_random_number_generator()
-def test_io_save_pam_error(rng):
-    with TemporaryDirectory() as tmpdir:
-        fname = "test.pam5"
+def test_io_save_pam_error(tmp_path, rng=None):
+    fname = "test.pam5"
 
-        pam = PeaksAndMetrics()
+    pam = PeaksAndMetrics()
 
-        npt.assert_raises(IOError, save_pam, Path(tmpdir) / "test.pam", pam)
-        npt.assert_raises(
-            (ValueError, AttributeError), save_pam, Path(tmpdir) / fname, pam
-        )
+    npt.assert_raises(IOError, save_pam, tmp_path / "test.pam", pam)
+    npt.assert_raises((ValueError, AttributeError), save_pam, tmp_path / fname, pam)
 
-        pam.affine = np.eye(4)
-        pam.peak_dirs = rng.random((10, 10, 10, 5, 3))
-        pam.peak_values = np.zeros((10, 10, 10, 5))
-        pam.peak_indices = np.zeros((10, 10, 10, 5))
-        pam.shm_coeff = np.zeros((10, 10, 10, 45))
-        pam.sphere = default_sphere
-        pam.B = np.zeros((45, default_sphere.vertices.shape[0]))
-        pam.total_weight = 0.5
-        pam.ang_thr = 60
-        pam.gfa = np.zeros((10, 10, 10))
-        pam.qa = np.zeros((10, 10, 10, 5))
-        pam.odf = np.zeros((10, 10, 10, default_sphere.vertices.shape[0]))
+    pam.affine = np.eye(4)
+    pam.peak_dirs = rng.random((10, 10, 10, 5, 3))
+    pam.peak_values = np.zeros((10, 10, 10, 5))
+    pam.peak_indices = np.zeros((10, 10, 10, 5))
+    pam.shm_coeff = np.zeros((10, 10, 10, 45))
+    pam.sphere = default_sphere
+    pam.B = np.zeros((45, default_sphere.vertices.shape[0]))
+    pam.total_weight = 0.5
+    pam.ang_thr = 60
+    pam.gfa = np.zeros((10, 10, 10))
+    pam.qa = np.zeros((10, 10, 10, 5))
+    pam.odf = np.zeros((10, 10, 10, default_sphere.vertices.shape[0]))
 
 
-def test_io_niftis_to_pam():
-    with TemporaryDirectory() as tmpdir:
-        pam = niftis_to_pam(
-            affine=np.eye(4),
-            peak_dirs=np.random.rand(10, 10, 10, 5, 3),
-            peak_values=np.zeros((10, 10, 10, 5)),
-            peak_indices=np.zeros((10, 10, 10, 5)),
-            shm_coeff=np.zeros((10, 10, 10, 45)),
-            sphere=default_sphere,
-            gfa=np.zeros((10, 10, 10)),
-            B=np.zeros((45, default_sphere.vertices.shape[0])),
-            qa=np.zeros((10, 10, 10, 5)),
-            odf=np.zeros((10, 10, 10, default_sphere.vertices.shape[0])),
-            total_weight=0.5,
-            ang_thr=60,
-            pam_file=Path(tmpdir) / "test15.pam5",
-        )
+def test_io_niftis_to_pam(tmp_path):
+    pam = niftis_to_pam(
+        affine=np.eye(4),
+        peak_dirs=np.random.rand(10, 10, 10, 5, 3),
+        peak_values=np.zeros((10, 10, 10, 5)),
+        peak_indices=np.zeros((10, 10, 10, 5)),
+        shm_coeff=np.zeros((10, 10, 10, 45)),
+        sphere=default_sphere,
+        gfa=np.zeros((10, 10, 10)),
+        B=np.zeros((45, default_sphere.vertices.shape[0])),
+        qa=np.zeros((10, 10, 10, 5)),
+        odf=np.zeros((10, 10, 10, default_sphere.vertices.shape[0])),
+        total_weight=0.5,
+        ang_thr=60,
+        pam_file=tmp_path / "test15.pam5",
+    )
 
-        npt.assert_equal(pam.peak_dirs.shape, (10, 10, 10, 5, 3))
-        npt.assert_(Path(Path(tmpdir) / "test15.pam5").is_file())
+    npt.assert_equal(pam.peak_dirs.shape, (10, 10, 10, 5, 3))
+    npt.assert_(Path(tmp_path / "test15.pam5").is_file())
 
 
-def test_tensor_to_pam():
+def test_tensor_to_pam(tmp_path):
     fdata, fbval, fbvec = get_fnames(name="small_25")
     gtab = gradient_table(fbval, bvecs=fbvec)
     data, affine = load_nifti(fdata)
@@ -197,21 +191,20 @@ def test_tensor_to_pam():
     sphere = create_unit_sphere(recursion_level=4)
     odf = df.odf(sphere)
 
-    with TemporaryDirectory() as tmpdir:
-        fname = "test_tt.pam5"
-        pam = tensor_to_pam(
-            evals=df.evals,
-            evecs=df.evecs,
-            affine=affine,
-            sphere=sphere,
-            odf=odf,
-            pam_file=Path(tmpdir) / fname,
-        )
-        npt.assert_(Path(Path(tmpdir) / fname).is_file())
-        save_pam(Path(tmpdir) / "test_tt_2.pam5", pam)
-        pam2 = load_pam(Path(tmpdir) / "test_tt_2.pam5")
+    fname = "test_tt.pam5"
+    pam = tensor_to_pam(
+        evals=df.evals,
+        evecs=df.evecs,
+        affine=affine,
+        sphere=sphere,
+        odf=odf,
+        pam_file=tmp_path / fname,
+    )
+    npt.assert_(Path(tmp_path / fname).is_file())
+    save_pam(tmp_path / "test_tt_2.pam5", pam)
+    pam2 = load_pam(tmp_path / "test_tt_2.pam5")
 
-        npt.assert_array_equal(pam.peak_values, pam2.peak_values)
-        npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
-        npt.assert_array_almost_equal(pam.peak_indices, pam2.peak_indices)
-        del pam
+    npt.assert_array_equal(pam.peak_values, pam2.peak_values)
+    npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
+    npt.assert_array_almost_equal(pam.peak_indices, pam2.peak_indices)
+    del pam

--- a/dipy/io/tests/test_stateful_surface.py
+++ b/dipy/io/tests/test_stateful_surface.py
@@ -1,6 +1,4 @@
 import itertools
-from os.path import join as pjoin
-from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
 import numpy as np
@@ -219,7 +217,7 @@ def test_equality():
 
 
 @set_random_number_generator(0)
-def test_random_space_transformations(rng):
+def test_random_space_transformations(rng=None):
     sfs = load_surface(
         FILEPATH_DIX["naf_lh.pial"], FILEPATH_DIX["naf_mni_masked.nii.gz"]
     )
@@ -426,21 +424,20 @@ def test_from_sfs_dtype_dict_attributes():
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize("extension", ["vtk", "gii", "pial"])
-def test_save_load_many_times(extension):
+def test_save_load_many_times(tmp_path, extension):
     # Load initial surface
     sfs = load_surface(
         FILEPATH_DIX["naf_lh.pial"], FILEPATH_DIX["naf_mni_masked.nii.gz"]
     )
     ref_vertices = sfs.vertices.copy()
 
-    with TemporaryDirectory() as tmpdir:
-        # Save and load 10 times
-        for i in range(10):
-            save_surface(sfs, pjoin(tmpdir, f"test_{i}.{extension}"))
-            sfs = load_surface(
-                pjoin(tmpdir, f"test_{i}.{extension}"),
-                FILEPATH_DIX["naf_mni_masked.nii.gz"],
-            )
+    # Save and load 10 times
+    for i in range(10):
+        save_surface(sfs, tmp_path / f"test_{i}.{extension}")
+        sfs = load_surface(
+            tmp_path / f"test_{i}.{extension}",
+            FILEPATH_DIX["naf_mni_masked.nii.gz"],
+        )
 
-        # Final vertices should match original
-        npt.assert_almost_equal(ref_vertices, sfs.vertices, decimal=5)
+    # Final vertices should match original
+    npt.assert_almost_equal(ref_vertices, sfs.vertices, decimal=5)

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 import itertools
 from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
 import numpy as np
@@ -249,7 +248,7 @@ def test_empty_sft_case():
 
 @pytest.mark.skipif(not have_vtk, reason="Requires FURY")
 @pytest.mark.parametrize("ext", EXTENSIONS)
-def test_iterative_saving_loading(ext):
+def test_iterative_saving_loading(tmp_path, ext):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
     from_space = Space.LPSMM if ext in ["vtk", "fib"] else Space.RASMM
     sft = load_tractogram(
@@ -258,20 +257,19 @@ def test_iterative_saving_loading(ext):
         to_space=Space.RASMM,
         from_space=from_space,
     )
-    with TemporaryDirectory() as tmp_dir:
-        save_tractogram(sft, Path(tmp_dir) / f"gs_iter.{ext}")
-        tmp_points_rasmm = np.loadtxt(FILEPATH_DIX["gs_streamlines_rasmm_space.txt"])
+    save_tractogram(sft, tmp_path / f"gs_iter.{ext}")
+    tmp_points_rasmm = np.loadtxt(FILEPATH_DIX["gs_streamlines_rasmm_space.txt"])
 
-        for _ in range(100):
-            sft_iter = load_tractogram(
-                Path(tmp_dir) / f"gs_iter.{ext}",
-                FILEPATH_DIX["gs_volume.nii"],
-                to_space=Space.RASMM,
-            )
-            npt.assert_allclose(
-                tmp_points_rasmm, sft_iter.streamlines.get_data(), atol=1e-3, rtol=1e-6
-            )
-            save_tractogram(sft_iter, Path(tmp_dir) / f"gs_iter.{ext}")
+    for _ in range(100):
+        sft_iter = load_tractogram(
+            tmp_path / f"gs_iter.{ext}",
+            FILEPATH_DIX["gs_volume.nii"],
+            to_space=Space.RASMM,
+        )
+        npt.assert_allclose(
+            tmp_points_rasmm, sft_iter.streamlines.get_data(), atol=1e-3, rtol=1e-6
+        )
+        save_tractogram(sft_iter, tmp_path / f"gs_iter.{ext}")
 
 
 def test_iterative_to_vox_transformation():
@@ -457,7 +455,7 @@ def test_bounding_bbox_valid(standard):
 
 
 @set_random_number_generator(0)
-def test_random_point_color(rng):
+def test_random_point_color(tmp_path, rng=None):
     sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.tck"], FILEPATH_DIX["gs_volume.nii"]
     )
@@ -467,15 +465,14 @@ def test_random_point_color(rng):
 
     try:
         sft.data_per_point = coloring_dict
-        with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, Path(tmp_dir) / "random_points_color.trk")
+        save_tractogram(sft, tmp_path / "random_points_color.trk")
         npt.assert_(True)
     except (TypeError, ValueError):
         npt.assert_(False)
 
 
 @set_random_number_generator(0)
-def test_random_point_gray(rng):
+def test_random_point_gray(tmp_path, rng=None):
     sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.tck"], FILEPATH_DIX["gs_volume.nii"]
     )
@@ -489,15 +486,14 @@ def test_random_point_gray(rng):
 
     try:
         sft.data_per_point = coloring_dict
-        with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, Path(tmp_dir) / "random_points_gray.trk")
+        save_tractogram(sft, tmp_path / "random_points_gray.trk")
         npt.assert_(True)
     except ValueError:
         npt.assert_(False)
 
 
 @set_random_number_generator(0)
-def test_random_streamline_color(rng):
+def test_random_streamline_color(tmp_path, rng=None):
     sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.tck"], FILEPATH_DIX["gs_volume.nii"]
     )
@@ -517,8 +513,7 @@ def test_random_streamline_color(rng):
 
     try:
         sft.data_per_point = coloring_dict
-        with TemporaryDirectory() as tmp_dir:
-            save_tractogram(sft, Path(tmp_dir) / "random_streamlines_color.trk")
+        save_tractogram(sft, tmp_path / "random_streamlines_color.trk")
         npt.assert_(True)
     except (TypeError, ValueError):
         npt.assert_(False)

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -1,6 +1,4 @@
 import itertools
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
 import numpy as np
@@ -175,38 +173,38 @@ def teardown_module():
     FILEPATH_DIX, POINTS_DATA, STREAMLINES_DATA = None, None, None
 
 
-def io_tractogram(extension):
-    with TemporaryDirectory() as tmp_dir:
-        fname = f"test.{extension}"
-        fpath = Path(tmp_dir) / fname
+def io_tractogram(tmp_path, extension):
 
-        in_affine = np.eye(4)
-        in_dimensions = np.array([50, 50, 50])
-        in_voxel_sizes = np.array([2, 1.5, 1.5])
-        in_affine = np.dot(in_affine, np.diag(np.r_[in_voxel_sizes, 1]))
-        nii_header = create_nifti_header(in_affine, in_dimensions, in_voxel_sizes)
+    fname = f"test.{extension}"
+    fpath = tmp_path / fname
 
-        sft = StatefulTractogram(STREAMLINES, nii_header, space=Space.RASMM)
-        save_tractogram(sft, fpath, bbox_valid_check=False)
+    in_affine = np.eye(4)
+    in_dimensions = np.array([50, 50, 50])
+    in_voxel_sizes = np.array([2, 1.5, 1.5])
+    in_affine = np.dot(in_affine, np.diag(np.r_[in_voxel_sizes, 1]))
+    nii_header = create_nifti_header(in_affine, in_dimensions, in_voxel_sizes)
 
-        if extension in ["trk", "trx"]:
-            reference = "same"
-        else:
-            reference = nii_header
+    sft = StatefulTractogram(STREAMLINES, nii_header, space=Space.RASMM)
+    save_tractogram(sft, fpath, bbox_valid_check=False)
 
-        sft = load_tractogram(fpath, reference, bbox_valid_check=False)
-        affine, dimensions, voxel_sizes, _ = sft.space_attributes
+    if extension in ["trk", "trx"]:
+        reference = "same"
+    else:
+        reference = nii_header
 
-        npt.assert_array_equal(in_affine, affine)
-        npt.assert_array_equal(in_voxel_sizes, voxel_sizes)
-        npt.assert_array_equal(in_dimensions, dimensions)
-        npt.assert_equal(len(sft), len(STREAMLINES))
-        npt.assert_array_almost_equal(sft.streamlines[1], STREAMLINE, decimal=4)
+    sft = load_tractogram(fpath, reference, bbox_valid_check=False)
+    affine, dimensions, voxel_sizes, _ = sft.space_attributes
+
+    npt.assert_array_equal(in_affine, affine)
+    npt.assert_array_equal(in_voxel_sizes, voxel_sizes)
+    npt.assert_array_equal(in_dimensions, dimensions)
+    npt.assert_equal(len(sft), len(STREAMLINES))
+    npt.assert_array_almost_equal(sft.streamlines[1], STREAMLINE, decimal=4)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize("space,origin", list(itertools.product(SPACES, ORIGINS)))
-def test_vtk_matching_space(space, origin):
+def test_vtk_matching_space(tmp_path, space, origin):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
     sfs = load_tractogram(
         FILEPATH_DIX["gs_streamlines.vtk"],
@@ -217,106 +215,103 @@ def test_vtk_matching_space(space, origin):
     sfs.to_center()
     ref_coords = sfs.streamlines._data.copy()
 
-    with TemporaryDirectory() as tmpdir:
-        save_tractogram(sfs, Path(tmpdir) / "tmp.vtk", to_space=space, to_origin=origin)
-        sfs = load_tractogram(
-            Path(tmpdir) / "tmp.vtk",
-            FILEPATH_DIX["gs_volume.nii"],
-            from_space=space,
-            from_origin=origin,
-        )
+    save_tractogram(sfs, tmp_path / "tmp.vtk", to_space=space, to_origin=origin)
+    sfs = load_tractogram(
+        tmp_path / "tmp.vtk",
+        FILEPATH_DIX["gs_volume.nii"],
+        from_space=space,
+        from_origin=origin,
+    )
 
-        sfs.to_rasmm()
-        sfs.to_center()
-        save_coords = sfs.streamlines._data.copy()
-        npt.assert_almost_equal(ref_coords, save_coords, decimal=5)
+    sfs.to_rasmm()
+    sfs.to_center()
+    save_coords = sfs.streamlines._data.copy()
+    npt.assert_almost_equal(ref_coords, save_coords, decimal=5)
 
 
 @pytest.mark.parametrize("ext", ["trk", "tck", "trx", "dpy"])
-def test_io_ext_non_vtk(ext):
-    io_tractogram(ext)
+def test_io_ext_non_vtk(tmp_path, ext):
+    io_tractogram(tmp_path, ext)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize("ext", ["vtk", "vtp"])
-def test_io_vtk(ext):
-    io_tractogram(ext)
+def test_io_vtk(tmp_path, ext):
+    io_tractogram(tmp_path, ext)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
-def test_low_io_vtk():
-    with TemporaryDirectory() as tmp_dir:
-        fname = Path(tmp_dir) / "test.fib"
+def test_low_io_vtk(tmp_path):
+    fname = tmp_path / "test.fib"
 
-        # Test save
-        save_vtk_streamlines(STREAMLINES, fname, binary=True)
-        tracks = load_vtk_streamlines(fname)
-        npt.assert_equal(len(tracks), len(STREAMLINES))
-        npt.assert_array_almost_equal(tracks[1], STREAMLINE, decimal=4)
+    # Test save
+    save_vtk_streamlines(STREAMLINES, fname, binary=True)
+    tracks = load_vtk_streamlines(fname)
+    npt.assert_equal(len(tracks), len(STREAMLINES))
+    npt.assert_array_almost_equal(tracks[1], STREAMLINE, decimal=4)
 
 
-def trk_loader(filename):
+def trk_loader(tmp_path, filename):
     try:
-        with TemporaryDirectory() as tmp_dir:
-            load_trk(Path(tmp_dir) / filename, FILEPATH_DIX["gs_volume.nii"])
+        load_trk(tmp_path / filename, FILEPATH_DIX["gs_volume.nii"])
         return True
     except ValueError:
         return False
 
 
-def trk_saver(filename):
+def trk_saver(tmp_path, filename):
     sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.trk"], FILEPATH_DIX["gs_volume.nii"]
     )
 
     try:
-        with TemporaryDirectory() as tmp_dir:
-            save_trk(sft, Path(tmp_dir) / filename)
+        save_trk(sft, tmp_path / filename)
         return True
     except ValueError:
         return False
 
 
-def test_io_trk_load():
+def test_io_trk_load(tmp_path):
     npt.assert_(
-        trk_loader(FILEPATH_DIX["gs_streamlines.trk"]),
+        trk_loader(tmp_path, FILEPATH_DIX["gs_streamlines.trk"]),
         msg="trk_loader should be able to load a trk",
     )
     npt.assert_(
-        not trk_loader("fake_file.TRK"),
+        not trk_loader(tmp_path, "fake_file.TRK"),
         msg="trk_loader should not be able to load a TRK",
     )
     npt.assert_(
-        not trk_loader(FILEPATH_DIX["gs_streamlines.tck"]),
+        not trk_loader(tmp_path, FILEPATH_DIX["gs_streamlines.tck"]),
         msg="trk_loader should not be able to load a tck",
     )
     npt.assert_(
-        not trk_loader(FILEPATH_DIX["gs_streamlines.fib"]),
+        not trk_loader(tmp_path, FILEPATH_DIX["gs_streamlines.fib"]),
         msg="trk_loader should not be able to load a fib",
     )
     npt.assert_(
-        not trk_loader(FILEPATH_DIX["gs_streamlines.dpy"]),
+        not trk_loader(tmp_path, FILEPATH_DIX["gs_streamlines.dpy"]),
         msg="trk_loader should not be able to load a dpy",
     )
 
 
-def test_io_trk_save():
+def test_io_trk_save(tmp_path):
     npt.assert_(
-        trk_saver(FILEPATH_DIX["gs_streamlines.trk"]),
+        trk_saver(tmp_path, FILEPATH_DIX["gs_streamlines.trk"]),
         msg="trk_saver should be able to save a trk",
     )
     npt.assert_(
-        not trk_saver("fake_file.TRK"), msg="trk_saver should not be able to save a TRK"
+        not trk_saver(tmp_path, "fake_file.TRK"),
+        msg="trk_saver should not be able to save a TRK",
     )
     npt.assert_(
-        not trk_saver(FILEPATH_DIX["gs_streamlines.tck"]),
+        not trk_saver(tmp_path, FILEPATH_DIX["gs_streamlines.tck"]),
         msg="trk_saver should not be able to save a tck",
     )
     npt.assert_(
-        not trk_saver(FILEPATH_DIX["gs_streamlines.fib"]),
+        not trk_saver(tmp_path, FILEPATH_DIX["gs_streamlines.fib"]),
         msg="trk_saver should not be able to save a fib",
     )
     npt.assert_(
-        not trk_saver(FILEPATH_DIX["gs_streamlines.dpy"]),
+        not trk_saver(tmp_path, FILEPATH_DIX["gs_streamlines.dpy"]),
         msg="trk_saver should not be able to save a dpy",
     )

--- a/dipy/io/tests/test_surface.py
+++ b/dipy/io/tests/test_surface.py
@@ -1,6 +1,4 @@
 import itertools
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from urllib.error import HTTPError, URLError
 
 import nibabel as nib
@@ -40,7 +38,7 @@ def setup_module():
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
-def test_pial_load_save():
+def test_pial_load_save(tmp_path):
     data_raw = nib.freesurfer.read_geometry(FILEPATH_DIX["naf_lh.pial"])
 
     sfs = load_surface(
@@ -51,17 +49,14 @@ def test_pial_load_save():
     sfs.to_vox()
     sfs.to_corner()
 
-    with TemporaryDirectory() as tmpdir:
-        save_surface(
-            sfs, Path(tmpdir) / "lh.pial", ref_pial=FILEPATH_DIX["naf_lh.pial"]
-        )
-        data_save = nib.freesurfer.read_geometry(Path(tmpdir) / "lh.pial")
+    save_surface(sfs, tmp_path / "lh.pial", ref_pial=FILEPATH_DIX["naf_lh.pial"])
+    data_save = nib.freesurfer.read_geometry(tmp_path / "lh.pial")
     npt.assert_almost_equal(data_raw[0], data_save[0], decimal=5)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize("space,origin", list(itertools.product(SPACES, ORIGINS)))
-def test_vtk_matching_space(space, origin):
+def test_vtk_matching_space(tmp_path, space, origin):
     sfs = load_surface(
         FILEPATH_DIX["naf_lh.pial"], FILEPATH_DIX["naf_mni_masked.nii.gz"]
     )
@@ -69,19 +64,18 @@ def test_vtk_matching_space(space, origin):
     sfs.to_center()
     ref_vertices = sfs.vertices.copy()
 
-    with TemporaryDirectory() as tmpdir:
-        save_surface(sfs, Path(tmpdir) / "tmp.vtk", to_space=space, to_origin=origin)
-        sfs = load_surface(
-            Path(tmpdir) / "tmp.vtk",
-            FILEPATH_DIX["naf_mni_masked.nii.gz"],
-            from_space=space,
-            from_origin=origin,
-        )
+    save_surface(sfs, tmp_path / "tmp.vtk", to_space=space, to_origin=origin)
+    sfs = load_surface(
+        tmp_path / "tmp.vtk",
+        FILEPATH_DIX["naf_mni_masked.nii.gz"],
+        from_space=space,
+        from_origin=origin,
+    )
 
-        sfs.to_rasmm()
-        sfs.to_center()
-        save_vertices = sfs.vertices.copy()
-        npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
+    sfs.to_rasmm()
+    sfs.to_center()
+    save_vertices = sfs.vertices.copy()
+    npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
@@ -89,7 +83,7 @@ def test_vtk_matching_space(space, origin):
     "_type,fname,space,origin",
     list(itertools.product(FOLDERS_GII, FILENAMES_GII, SPACES, ORIGINS)),
 )
-def test_gifti_matching_space(_type, fname, space, origin):
+def test_gifti_matching_space(tmp_path, _type, fname, space, origin):
     if _type == "gzip_base64":
         fname += ".gz"
     sfs = load_surface(FILEPATH_DIX[fname], FILEPATH_DIX["anat.nii.gz"])
@@ -97,26 +91,25 @@ def test_gifti_matching_space(_type, fname, space, origin):
     sfs.to_center()
     ref_vertices = sfs.vertices.copy()
 
-    with TemporaryDirectory() as tmpdir:
-        save_surface(sfs, Path(tmpdir) / "tmp.gii", to_space=space, to_origin=origin)
-        sfs = load_surface(
-            Path(tmpdir) / "tmp.gii",
-            FILEPATH_DIX["anat.nii.gz"],
-            from_space=space,
-            from_origin=origin,
-        )
+    save_surface(sfs, tmp_path / "tmp.gii", to_space=space, to_origin=origin)
+    sfs = load_surface(
+        tmp_path / "tmp.gii",
+        FILEPATH_DIX["anat.nii.gz"],
+        from_space=space,
+        from_origin=origin,
+    )
 
-        sfs.to_rasmm()
-        sfs.to_center()
-        save_vertices = sfs.vertices.copy()
-        npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
+    sfs.to_rasmm()
+    sfs.to_center()
+    save_vertices = sfs.vertices.copy()
+    npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
 
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize(
     "dataset,hemisphere,type", list(itertools.product(FOLDERS, HEMISPHERES, TYPES))
 )
-def test_freesurfer_density_operation(dataset, hemisphere, type):
+def test_freesurfer_density_operation(tmp_path, dataset, hemisphere, type):
     prefix = "baf" if dataset == "big_affine_freesurfer" else "saf"
     fname = f"{prefix}_{hemisphere}.{type}"
     sfs = load_surface(FILEPATH_DIX[fname], FILEPATH_DIX[f"{prefix}_t1.nii.gz"])
@@ -133,11 +126,10 @@ def test_freesurfer_density_operation(dataset, hemisphere, type):
         coord = tuple(vertex.astype(np.int32))
         data[coord] += 1
 
-    with TemporaryDirectory() as tmpdir:
-        nib.save(
-            nib.Nifti1Image(data, sfs.affine),
-            Path(tmpdir) / f"{hemisphere}_{type}.nii.gz",
-        )
+    nib.save(
+        nib.Nifti1Image(data, sfs.affine),
+        tmp_path / f"{hemisphere}_{type}.nii.gz",
+    )
 
     # Compute the barycenter of the density map and compare it to the
     # approximate barycenter

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -240,7 +240,7 @@ def test_all_zeros_affine():
 
 
 @set_random_number_generator()
-def test_read_img_arr_or_path(rng):
+def test_read_img_arr_or_path(rng=None):
     data = rng.random((4, 4, 4, 3))
     aff = np.eye(4)
     aff[:3, :] = rng.standard_normal((3, 4))

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -21,7 +21,7 @@ fdata, fbval, fbvec = dpd.get_fnames(name="small_64D")
 
 
 @set_random_number_generator()
-def test_coeff_of_determination(rng):
+def test_coeff_of_determination(rng=None):
     model = rng.standard_normal((10, 10, 10, 150))
     data = np.copy(model)
     # If the model predicts the data perfectly, the COD is all 100s:
@@ -64,7 +64,7 @@ def test_dti_xval():
 
 
 @set_random_number_generator(12345)
-def test_csd_xval(rng):
+def test_csd_xval(rng=None):
     # First, let's see that it works with some data:
     data = load_nifti_data(fdata)[1:3, 1:3, 1:3]  # Make it *small*
     gtab = gt.gradient_table(fbval, bvecs=fbvec)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -614,7 +614,7 @@ def test_r2_term_odf_sharp():
 
 
 @set_random_number_generator()
-def test_csd_predict(rng):
+def test_csd_predict(rng=None):
     """
     Test prediction API
     """
@@ -694,7 +694,7 @@ def test_csd_predict(rng):
 
 
 @set_random_number_generator()
-def test_csd_predict_multi(rng):
+def test_csd_predict_multi(rng=None):
     """
     Check that we can predict reasonably from multi-voxel fits:
 

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -54,7 +54,7 @@ def test_roll_evals():
 
 
 @set_random_number_generator()
-def test_tensor_algebra(rng):
+def test_tensor_algebra(rng=None):
     # Test that the computation of tensor determinant and norm is correct
     test_arr = rng.random((10, 3, 3))
     t_det = dti.determinant(test_arr)
@@ -719,7 +719,7 @@ def test_mask():
 
 
 @set_random_number_generator()
-def test_nnls_jacobian_func(rng):
+def test_nnls_jacobian_func(rng=None):
     b0 = 1000.0
     bval, bvecs = read_bvals_bvecs(*get_fnames(name="55dir_grad"))
     gtab = grad.gradient_table(bval, bvecs=bvecs)

--- a/dipy/reconst/tests/test_eudx_dg.py
+++ b/dipy/reconst/tests/test_eudx_dg.py
@@ -9,7 +9,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator()
-def test_EuDXDirectionGetter(rng):
+def test_EuDXDirectionGetter(rng=None):
     class SillyModel:
         def fit(self, data, mask=None):
             return SillyFit(self)

--- a/dipy/reconst/tests/test_mcsd.py
+++ b/dipy/reconst/tests/test_mcsd.py
@@ -303,7 +303,7 @@ def test_multi_shell_fiber_response():
 
 
 @set_random_number_generator()
-def test_mask_for_response_msmt(rng):
+def test_mask_for_response_msmt(rng=None):
     gtab, data, masks_gt, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:
@@ -333,7 +333,7 @@ def test_mask_for_response_msmt(rng):
 
 
 @set_random_number_generator()
-def test_mask_for_response_msmt_nvoxels(rng):
+def test_mask_for_response_msmt_nvoxels(rng=None):
     gtab, data, _, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:
@@ -390,7 +390,7 @@ def test_mask_for_response_msmt_nvoxels(rng):
 
 
 @set_random_number_generator()
-def test_response_from_mask_msmt(rng):
+def test_response_from_mask_msmt(rng=None):
     gtab, data, masks_gt, responses_gt = get_test_data(rng)
 
     response_wm, response_gm, response_csf = response_from_mask_msmt(
@@ -415,7 +415,7 @@ def test_response_from_mask_msmt(rng):
 
 
 @set_random_number_generator()
-def test_auto_response_msmt(rng):
+def test_auto_response_msmt(rng=None):
     gtab, data, _, _ = get_test_data(rng)
 
     with warnings.catch_warnings(record=True) as w:

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -168,7 +168,7 @@ def test_CallableArray():
 
 
 @set_random_number_generator()
-def test_multi_voxel_fit(rng):
+def test_multi_voxel_fit(rng=None):
     class SillyModel:
         @warning_for_keywords()
         @multi_voxel_fit
@@ -350,7 +350,7 @@ def _verbose_declaring_model(seen_verbose):
 
 
 @set_random_number_generator()
-def test_multi_voxel_fit_no_orchestration_leak(rng):
+def test_multi_voxel_fit_no_orchestration_leak(rng=None):
     """Orchestration kwargs never reach a per-voxel fit that doesn't declare them.
 
     Covers the serial (explicit ``engine="serial"``) and the in-process parallel

--- a/dipy/reconst/tests/test_qti.py
+++ b/dipy/reconst/tests/test_qti.py
@@ -331,7 +331,7 @@ def _qti_gtab(rng):
 
 
 @set_random_number_generator(123)
-def test_ls_sdp_fits(rng):
+def test_ls_sdp_fits(rng=None):
     """Test ordinary and weighted least squares and semidefinite programming
     QTI fits by comparing the estimated parameters to the ground-truth values."""
     gtab = _qti_gtab(rng)
@@ -465,7 +465,7 @@ def test_ls_sdp_fits(rng):
 
 
 @set_random_number_generator(123)
-def test_qti_model(rng):
+def test_qti_model(rng=None):
     """Test the QTI model class."""
 
     # Input validation
@@ -482,7 +482,7 @@ def test_qti_model(rng):
 
 
 @set_random_number_generator(4321)
-def test_qti_fit(rng):
+def test_qti_fit(rng=None):
     """Test the QTI fit class."""
 
     # Generate a diffusion tensor distribution

--- a/dipy/reconst/tests/test_rumba.py
+++ b/dipy/reconst/tests/test_rumba.py
@@ -179,7 +179,7 @@ def test_multishell_rumba():
 
 
 @set_random_number_generator(42)
-def test_mvoxel_rumba(*, rng):
+def test_mvoxel_rumba(*, rng=None):
     # Verify form of results in multi-voxel situation.
 
     data, gtab = dsi_voxels()
@@ -328,7 +328,7 @@ def test_global_fit():
 
 
 @set_random_number_generator(42)
-def test_mvoxel_global_fit(*, rng):
+def test_mvoxel_global_fit(*, rng=None):
     # Verify form of results in global fitting paradigm.
 
     data, gtab = dsi_voxels()

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -57,7 +57,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator(42)
-def test_anisotropic_power_non_negative(rng):
+def test_anisotropic_power_non_negative(rng=None):
     sh_coeffs = rng.normal(size=(10, 15))
 
     ap = anisotropic_power(sh_coeffs, non_negative=True)
@@ -66,7 +66,7 @@ def test_anisotropic_power_non_negative(rng):
 
 
 @set_random_number_generator(0)
-def test_anisotropic_power_negative_allowed(rng):
+def test_anisotropic_power_negative_allowed(rng=None):
     # Use very small coefficients so ap < norm_factor, yielding negative log_ap
     sh_coeffs = rng.normal(size=(5, 15)) * 1e-4
 

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -94,7 +94,7 @@ def test_shore_odf():
 
 
 @set_random_number_generator()
-def test_multivox_shore(rng):
+def test_multivox_shore(rng=None):
     gtab = get_3shell_gtab()
 
     data = rng.random([20, 30, 1, gtab.gradients.shape[0]])

--- a/dipy/reconst/tests/test_weights_method.py
+++ b/dipy/reconst/tests/test_weights_method.py
@@ -23,7 +23,7 @@ MIN_POSITIVE_SIGNAL = 0.0001
 
 
 @set_random_number_generator()
-def test_outlier_funcs(rng):
+def test_outlier_funcs(rng=None):
     """Test functions that define outliers."""
 
     # true signal
@@ -66,7 +66,7 @@ def test_outlier_funcs(rng):
 
 
 @set_random_number_generator()
-def test_weights_funcs(rng):
+def test_weights_funcs(rng=None):
     """Test functions that define weights."""
 
     # true signal

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -98,7 +98,7 @@ def test_rb_disable_slr():
 
 
 @set_random_number_generator(42)
-def test_rb_slr_threads(rng):
+def test_rb_slr_threads(rng=None):
     rb_multi = RecoBundles(f, greater_than=0, clust_thr=10, rng=rng)
     rec_trans_multi_threads, _ = rb_multi.recognize(
         model_bundle=f2,

--- a/dipy/segment/tests/test_clustering.py
+++ b/dipy/segment/tests/test_clustering.py
@@ -69,7 +69,7 @@ def test_cluster_assign():
 
 
 @set_random_number_generator()
-def test_cluster_iter(rng):
+def test_cluster_iter(rng=None):
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering
 
@@ -85,7 +85,7 @@ def test_cluster_iter(rng):
 
 
 @set_random_number_generator()
-def test_cluster_getitem(rng):
+def test_cluster_getitem(rng=None):
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
@@ -145,7 +145,7 @@ def test_cluster_getitem(rng):
 
 
 @set_random_number_generator()
-def test_cluster_str_and_repr(rng):
+def test_cluster_str_and_repr(rng=None):
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering
 
@@ -199,7 +199,7 @@ def test_cluster_centroid_assign():
 
 
 @set_random_number_generator()
-def test_cluster_centroid_iter(rng):
+def test_cluster_centroid_iter(rng=None):
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering
 
@@ -218,7 +218,7 @@ def test_cluster_centroid_iter(rng):
 
 
 @set_random_number_generator()
-def test_cluster_centroid_getitem(rng):
+def test_cluster_centroid_getitem(rng=None):
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering
     advanced_indices = indices + [0, 1, 2, -1, -2, -3]
@@ -374,7 +374,7 @@ def test_cluster_map_clear():
 
 
 @set_random_number_generator(42)
-def test_cluster_map_iter(rng):
+def test_cluster_map_iter(rng=None):
     nb_clusters = 11
 
     # Test without specifying refdata in ClusterMap
@@ -401,7 +401,7 @@ def test_cluster_map_iter(rng):
 
 
 @set_random_number_generator()
-def test_cluster_map_getitem(rng):
+def test_cluster_map_getitem(rng=None):
     nb_clusters = 11
     indices = list(range(nb_clusters))
     rng.shuffle(indices)  # None trivial ordering
@@ -462,7 +462,7 @@ def test_cluster_map_size():
 
 
 @set_random_number_generator(42)
-def test_cluster_map_clusters_sizes(rng):
+def test_cluster_map_clusters_sizes(rng=None):
     nb_clusters = 11
     # Generate random indices
     indices = [range(rng.integers(1, 10)) for _ in range(nb_clusters)]
@@ -475,7 +475,7 @@ def test_cluster_map_clusters_sizes(rng):
 
 
 @set_random_number_generator(42)
-def test_cluster_map_get_small_and_large_clusters(rng):
+def test_cluster_map_get_small_and_large_clusters(rng=None):
     nb_clusters = 11
     cluster_map = ClusterMap()
 
@@ -614,7 +614,7 @@ def test_cluster_map_centroid_add_cluster():
 
 
 @set_random_number_generator()
-def test_cluster_map_centroid_remove_cluster(rng):
+def test_cluster_map_centroid_remove_cluster(rng=None):
     clusters = ClusterMapCentroid()
 
     centroid1 = rng.random(features_shape).astype(dtype)
@@ -653,7 +653,7 @@ def test_cluster_map_centroid_remove_cluster(rng):
 
 
 @set_random_number_generator(42)
-def test_cluster_map_centroid_iter(rng):
+def test_cluster_map_centroid_iter(rng=None):
     nb_clusters = 11
 
     cluster_map = ClusterMapCentroid()
@@ -678,7 +678,7 @@ def test_cluster_map_centroid_iter(rng):
 
 
 @set_random_number_generator()
-def test_cluster_map_centroid_getitem(rng):
+def test_cluster_map_centroid_getitem(rng=None):
     nb_clusters = 11
     indices = list(range(len(data)))
     rng.shuffle(indices)  # None trivial ordering

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -235,7 +235,7 @@ def test_feature_vector_of_endpoints():
 
 
 @set_random_number_generator(1234)
-def test_feature_extract(rng):
+def test_feature_extract(rng=None):
     # Test that features are automatically cast into float32 when
     # coming from Python space
     class CenterOfMass64bit(dipysfeature.Feature):

--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -238,7 +238,7 @@ def test_subclassing_metric():
 
 
 @set_random_number_generator()
-def test_distance_matrix(rng):
+def test_distance_matrix(rng=None):
     metric = dipysmetric.SumPointwiseEuclideanMetric()
 
     for dtype in [np.int32, np.int64, np.float32, np.float64]:
@@ -269,7 +269,7 @@ def test_distance_matrix(rng):
 
 
 @set_random_number_generator()
-def test_mean_distances(rng):
+def test_mean_distances(rng=None):
     nb_slines = 10
     nb_pts = 22
     dim = 3

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -231,7 +231,7 @@ def test_grayscale_iter():
 
 
 @set_random_number_generator()
-def test_square_iter(rng):
+def test_square_iter(rng=None):
     nclasses = 4
     beta = np.float64(0.0)
     max_iter = 10
@@ -322,7 +322,7 @@ def test_square_iter(rng):
 
 
 @set_random_number_generator()
-def test_icm_square(rng):
+def test_icm_square(rng=None):
     nclasses = 4
     max_iter = 10
 

--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -209,7 +209,7 @@ def test_raise_mdf():
 
 
 @set_random_number_generator(42)
-def test_qbx_and_merge(rng):
+def test_qbx_and_merge(rng=None):
     # Generate synthetic streamlines
     bundles = bearing_bundles(4, 2)
     bundles.append(straight_bundle(1, rng=rng))

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -65,7 +65,7 @@ def test_quickbundles_shape_incompatibility():
 
 
 @set_random_number_generator(7)
-def test_quickbundles_2D(rng):
+def test_quickbundles_2D(rng=None):
     # Test quickbundles clustering using 2D points and the Eulidean metric.
     data = []
     data += [rng.standard_normal((1, 2)) + np.array([0, 0]) for _ in range(1)]

--- a/dipy/sims/tests/test_phantom.py
+++ b/dipy/sims/tests/test_phantom.py
@@ -57,7 +57,7 @@ def test_phantom():
 
 
 @set_random_number_generator(1980)
-def test_add_noise(rng):
+def test_add_noise(rng=None):
     N = 50
     S0 = 100
 

--- a/dipy/stats/tests/test_resampling.py
+++ b/dipy/stats/tests/test_resampling.py
@@ -6,7 +6,7 @@ from dipy.testing.decorators import set_random_number_generator
 
 
 @set_random_number_generator(1741332)
-def test_bootstrap(rng):
+def test_bootstrap(rng=None):
     # Generate a sample data
     x = rng.standard_normal(size=100)
 
@@ -24,7 +24,7 @@ def test_bootstrap(rng):
 
 
 @set_random_number_generator(1741333)
-def test_jackknife(rng):
+def test_jackknife(rng=None):
     # Generate a sample data
     pdf = rng.standard_normal(size=100)
 

--- a/dipy/stats/tests/test_sketching.py
+++ b/dipy/stats/tests/test_sketching.py
@@ -28,83 +28,79 @@ def setup_matrices():
     os.unlink(matrixa_file_name)
 
 
-def test_count_sketch_basic_functionality(setup_matrices):
+def test_count_sketch_basic_functionality(tmp_path, setup_matrices):
     """Test the basic functionality of the count_sketch function."""
     matrixa_name, matrixa_dtype, matrixa_shape = setup_matrices
     sketch_rows = 10
 
-    # Create a temporary directory for the output files
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
-            matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_dir
-        )
+    matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
+        matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_path
+    )
 
-        # Load the resulting sketch matrix to check properties
-        matrixc = np.memmap(
-            matrixc_file_name, dtype=matrixc_dtype, mode="r+", shape=matrixc_shape
-        )
+    # Load the resulting sketch matrix to check properties
+    matrixc = np.memmap(
+        matrixc_file_name, dtype=matrixc_dtype, mode="r+", shape=matrixc_shape
+    )
 
-        # Verify the output sketch matrix shape and dtype
-        assert matrixc.shape == (sketch_rows, matrixa_shape[1]), "Output shape mismatch"
-        assert matrixc.dtype == matrixa_dtype, "Output dtype mismatch"
+    # Verify the output sketch matrix shape and dtype
+    assert matrixc.shape == (sketch_rows, matrixa_shape[1]), "Output shape mismatch"
+    assert matrixc.dtype == matrixa_dtype, "Output dtype mismatch"
 
-        # Clean up
-        del matrixc
-        os.unlink(matrixc_file_name)
+    # Clean up
+    del matrixc
+    os.unlink(matrixc_file_name)
 
 
-def test_count_sketch_randomness(setup_matrices):
+def test_count_sketch_randomness(tmp_path, setup_matrices):
     """Test if count_sketch produces different results with different random seeds."""
     matrixa_name, matrixa_dtype, matrixa_shape = setup_matrices
     sketch_rows = 10
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        np.random.seed(42)
-        matrixc_file_name_1, _, _ = count_sketch(
-            matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_dir
-        )
-        matrixc_1 = np.memmap(matrixc_file_name_1, dtype=matrixa_dtype, mode="r+")
+    np.random.seed(42)
+    matrixc_file_name_1, _, _ = count_sketch(
+        matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_path
+    )
+    matrixc_1 = np.memmap(matrixc_file_name_1, dtype=matrixa_dtype, mode="r+")
 
-        np.random.seed(43)
-        matrixc_file_name_2, _, _ = count_sketch(
-            matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_dir
-        )
-        matrixc_2 = np.memmap(matrixc_file_name_2, dtype=matrixa_dtype, mode="r+")
+    np.random.seed(43)
+    matrixc_file_name_2, _, _ = count_sketch(
+        matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_path
+    )
+    matrixc_2 = np.memmap(matrixc_file_name_2, dtype=matrixa_dtype, mode="r+")
 
-        # Verify that the two resulting sketches are different
-        assert not np.allclose(matrixc_1, matrixc_2), (
-            "Sketches should differ with different random seeds"
-        )
+    # Verify that the two resulting sketches are different
+    assert not np.allclose(matrixc_1, matrixc_2), (
+        "Sketches should differ with different random seeds"
+    )
 
-        # Clean up
-        del matrixc_1
-        del matrixc_2
-        os.unlink(matrixc_file_name_1)
-        os.unlink(matrixc_file_name_2)
+    # Clean up
+    del matrixc_1
+    del matrixc_2
+    os.unlink(matrixc_file_name_1)
+    os.unlink(matrixc_file_name_2)
 
 
-def test_count_sketch_preserves_shape_and_dtype(setup_matrices):
+def test_count_sketch_preserves_shape_and_dtype(tmp_path, setup_matrices):
     """Test if the count_sketch preserves the shape and dtype of the input matrix A."""
     matrixa_name, matrixa_dtype, matrixa_shape = setup_matrices
     sketch_rows = 20
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
-            matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_dir
-        )
+    matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
+        matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_path
+    )
 
-        # Check the resulting matrix properties
-        assert matrixc_shape == (
-            sketch_rows,
-            matrixa_shape[1],
-        ), "Sketch matrix shape is incorrect"
-        assert matrixc_dtype == matrixa_dtype, "Sketch matrix dtype is incorrect"
+    # Check the resulting matrix properties
+    assert matrixc_shape == (
+        sketch_rows,
+        matrixa_shape[1],
+    ), "Sketch matrix shape is incorrect"
+    assert matrixc_dtype == matrixa_dtype, "Sketch matrix dtype is incorrect"
 
-        # Clean up
-        os.unlink(matrixc_file_name)
+    # Clean up
+    os.unlink(matrixc_file_name)
 
 
-def test_count_sketch_with_large_matrix():
+def test_count_sketch_with_large_matrix(tmp_path):
     """Test count_sketch function with a large matrix to check performance."""
     matrixa_dtype = np.float64
     matrixa_shape = (1000, 500)
@@ -117,23 +113,22 @@ def test_count_sketch_with_large_matrix():
         matrixa_name = matrixa_file.name
 
     sketch_rows = 50
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
-            matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_dir
-        )
+    matrixc_file_name, matrixc_dtype, matrixc_shape = count_sketch(
+        matrixa_name, matrixa_dtype, matrixa_shape, sketch_rows, tmp_path
+    )
 
-        # Load the resulting sketch matrix
-        matrixc = np.memmap(
-            matrixc_file_name, dtype=matrixc_dtype, mode="r+", shape=matrixc_shape
-        )
+    # Load the resulting sketch matrix
+    matrixc = np.memmap(
+        matrixc_file_name, dtype=matrixc_dtype, mode="r+", shape=matrixc_shape
+    )
 
-        # Verify that the sketch was successfully computed
-        assert matrixc.shape == (
-            sketch_rows,
-            matrixa_shape[1],
-        ), "Output shape mismatch for large matrix"
+    # Verify that the sketch was successfully computed
+    assert matrixc.shape == (
+        sketch_rows,
+        matrixa_shape[1],
+    ), "Output shape mismatch for large matrix"
 
-        # Clean up
-        del matrixc
-        os.unlink(matrixa_name)
-        os.unlink(matrixc_file_name)
+    # Clean up
+    del matrixc
+    os.unlink(matrixa_name)
+    os.unlink(matrixc_file_name)

--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -94,16 +94,23 @@ def set_random_number_generator(seed_v=1234):
     """
 
     def _set_random_number_generator(func):
-        def _set_random_number_generator_wrapper(pytestconfig, *args, **kwargs):
+        @wraps(func)
+        def _set_random_number_generator_wrapper(*args, **kwargs):
             rng = np.random.default_rng(seed_v)
             kwargs["rng"] = rng
-            signature = inspect.signature(func)
-            if pytestconfig and "pytestconfig" in signature.parameters.keys():
-                output = func(pytestconfig, *args, **kwargs)
-            else:
-                output = func(*args, **kwargs)
-            return output
 
+            sig = inspect.signature(func)
+            params = sig.parameters
+
+            # If the wrapped test expects pytestconfig, preserve it as the
+            # first positional argument when present.
+            if "pytestconfig" in params and args:
+                return func(*args, **kwargs)
+
+            return func(*args, **kwargs)
+
+        _set_random_number_generator_wrapper.__wrapped__ = func
+        _set_random_number_generator_wrapper.__signature__ = inspect.signature(func)
         return _set_random_number_generator_wrapper
 
     return _set_random_number_generator

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -8,7 +8,6 @@ Run scripts and check outputs
 import glob
 import os
 import shutil
-from tempfile import TemporaryDirectory
 
 from os.path import (dirname, join as pjoin, abspath)
 
@@ -65,86 +64,99 @@ def assert_image_shape_affine(filename, shape, affine):
     nt.assert_array_almost_equal(image.affine, affine)
 
 
-def test_dipy_fit_tensor_again():
-    with TemporaryDirectory():
-        dwi, bval, bvec = get_fnames(name="small_25")
-        # Copy data to tmp directory
-        shutil.copyfile(dwi, "small_25.nii.gz")
-        shutil.copyfile(bval, "small_25.bval")
-        shutil.copyfile(bvec, "small_25.bvec")
-        # Call script
-        cmd = ["dipy_fit_tensor", "--mask=none", "small_25.nii.gz"]
-        out = run_command(cmd)
-        npt.assert_equal(out[0], 0)
-        # Get expected values
-        img = nib.load("small_25.nii.gz")
-        affine = img.affine
-        shape = img.shape[:-1]
-        # Check expected outputs
-        assert_image_shape_affine("small_25_fa.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_t2di.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_dirFA.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_ad.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_md.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_rd.nii.gz", shape, affine)
+def test_dipy_fit_tensor_again(tmp_path, monkeypatch):
 
-    with TemporaryDirectory():
-        dwi, bval, bvec = get_fnames(name="small_25")
-        # Copy data to tmp directory
-        shutil.copyfile(dwi, "small_25.nii.gz")
-        shutil.copyfile(bval, "small_25.bval")
-        shutil.copyfile(bvec, "small_25.bvec")
-        # Call script
-        cmd = ["dipy_fit_tensor", "--save-tensor",
-               "--mask=none", "small_25.nii.gz"]
-        out = run_command(cmd)
-        npt.assert_equal(out[0], 0)
-        # Get expected values
-        img = nib.load("small_25.nii.gz")
-        affine = img.affine
-        shape = img.shape[:-1]
-        # Check expected outputs
-        assert_image_shape_affine("small_25_fa.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_t2di.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_dirFA.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_ad.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_md.nii.gz", shape, affine)
-        assert_image_shape_affine("small_25_rd.nii.gz", shape, affine)
-        # small_25_tensor saves the tensor as a symmetric matrix following
-        # the nifti standard.
-        ten_shape = shape + (1, 6)
-        assert_image_shape_affine("small_25_tensor.nii.gz", ten_shape,
-                                  affine)
+    tmp_path1 = tmp_path / "no_tensor"
+    os.mkdir(tmp_path1)
+
+    monkeypatch.chdir(tmp_path1)
+
+    dwi, bval, bvec = get_fnames(name="small_25")
+    # Copy data to tmp directory
+    shutil.copyfile(dwi, tmp_path1 / "small_25.nii.gz")
+    shutil.copyfile(bval, tmp_path1 / "small_25.bval")
+    shutil.copyfile(bvec, tmp_path1 / "small_25.bvec")
+    # Call script
+    cmd = ["dipy_fit_tensor", "--mask=none", "small_25.nii.gz"]
+    out = run_command(cmd)
+    npt.assert_equal(out[0], 0)
+    # Get expected values
+    img = nib.load("small_25.nii.gz")
+    affine = img.affine
+    shape = img.shape[:-1]
+    # Check expected outputs
+    assert_image_shape_affine(tmp_path1 / "small_25_fa.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path1 / "small_25_t2di.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path1 / "small_25_dirFA.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path1 / "small_25_ad.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path1 / "small_25_md.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path1 / "small_25_rd.nii.gz", shape, affine)
+
+    tmp_path2 = tmp_path / "tensor"
+    os.mkdir(tmp_path2)
+
+    monkeypatch.chdir(tmp_path2)
+
+    # Copy data to tmp directory
+    shutil.copyfile(dwi, tmp_path2 / "small_25.nii.gz")
+    shutil.copyfile(bval, tmp_path2 / "small_25.bval")
+    shutil.copyfile(bvec, tmp_path2 / "small_25.bvec")
+    # Call script
+    cmd = ["dipy_fit_tensor", "--save-tensor", "--mask=none", "small_25.nii.gz"]
+    out = run_command(cmd)
+    npt.assert_equal(out[0], 0)
+    # Get expected values
+    img = nib.load("small_25.nii.gz")
+    affine = img.affine
+    shape = img.shape[:-1]
+    # Check expected outputs
+    assert_image_shape_affine(tmp_path2 / "small_25_fa.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path2 / "small_25_t2di.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path2 / "small_25_dirFA.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path2 / "small_25_ad.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path2 / "small_25_md.nii.gz", shape, affine)
+    assert_image_shape_affine(tmp_path2 / "small_25_rd.nii.gz", shape, affine)
+    # small_25_tensor saves the tensor as a symmetric matrix following
+    # the nifti standard.
+    ten_shape = shape + (1, 6)
+    assert_image_shape_affine(tmp_path2 / "small_25_tensor.nii.gz", ten_shape, affine)
+
+
+@pytest.mark.skipif(no_mpl)
+def test_qb_commandline(tmp_path, monkeypatch):
+
+    monkeypatch.chdir(tmp_path)
+
+    tracks_file = get_fnames(name='fornix')
+    cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
+           '--out_file', 'tracks300.trk']
+    out = run_command(cmd)
+    npt.assert_equal(tmp_path / out[0], 0)
 
 
 @pytest.mark.skipif(no_mpl)
-def test_qb_commandline():
-    with TemporaryDirectory():
-        tracks_file = get_fnames(name='fornix')
-        cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
-               '--out_file', 'tracks300.trk']
-        out = run_command(cmd)
-        npt.assert_equal(out[0], 0)
+def test_qb_commandline_output_path_handling(tmp_path, monkeypatch):
 
-@pytest.mark.skipif(no_mpl)
-def test_qb_commandline_output_path_handling():
-    with TemporaryDirectory():
-        # Create temporary subdirectory for input and for output
-        os.mkdir('work')
-        os.mkdir('output')
+    # Create temporary subdirectory for input and for output
+    work_dir = tmp_path / "work"
+    output_dir = tmp_path / "output"
 
-        os.chdir('work')
-        tracks_file = get_fnames(name='fornix')
+    os.mkdir(work_dir)
+    os.mkdir(output_dir)
 
-        # Need to specify an output directory with a "../" style path
-        # to trigger old bug.
-        cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
-               '--out_file', os.path.join('..', 'output', 'tracks300.trk')]
-        out = run_command(cmd)
-        npt.assert_equal(out[0], 0)
+    monkeypatch.chdir(work_dir)
 
-        # Make sure the files were created in the output directory
-        os.chdir('../')
-        output_files_list = glob.glob('output/tracks300_*.trk')
-        assert_true(output_files_list)
+    tracks_file = get_fnames(name='fornix')
+
+    # Need to specify an output directory with a "../" style path
+    # to trigger old bug.
+    cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
+           '--out_file', os.path.join('..', 'output', 'tracks300.trk')]
+    out = run_command(cmd)
+    npt.assert_equal(out[0], 0)
+
+    # Make sure the files were created in the output directory
+    os.chdir('../')
+    output_files_list = glob.glob('output/tracks300_*.trk')
+    assert_true(output_files_list)
 """

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -8,7 +8,7 @@ from dipy.tracking import distances as pf, metrics as tm
 
 
 @set_random_number_generator()
-def test_splines(rng):
+def test_splines(rng=None):
     # create a helix
     t = np.linspace(0, 1.75 * 2 * np.pi, 100)
     x = np.sin(t)

--- a/dipy/tracking/tests/test_stopping_criterion.py
+++ b/dipy/tracking/tests/test_stopping_criterion.py
@@ -14,7 +14,7 @@ from dipy.tracking.stopping_criterion import (
 
 
 @set_random_number_generator()
-def test_binary_stopping_criterion(rng):
+def test_binary_stopping_criterion(rng=None):
     """This tests that the binary stopping criterion returns expected
     streamline statuses.
     """
@@ -68,7 +68,7 @@ def test_binary_stopping_criterion(rng):
 
 
 @set_random_number_generator()
-def test_threshold_stopping_criterion(rng):
+def test_threshold_stopping_criterion(rng=None):
     """This tests that the threshold stopping criterion returns expected
     streamline statuses.
     """
@@ -127,7 +127,7 @@ def test_threshold_stopping_criterion(rng):
 
 
 @set_random_number_generator()
-def test_act_stopping_criterion(rng):
+def test_act_stopping_criterion(rng=None):
     """This tests that the act stopping criterion returns expected
     streamline statuses.
     """

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -347,7 +347,7 @@ def test_set_number_of_points():
 
 
 @set_random_number_generator(1234)
-def test_set_number_of_points_memory_leaks(rng):
+def test_set_number_of_points_memory_leaks(rng=None):
     # Test some dtypes
     dtypes = [np.float32, np.float64, np.int32, np.int64]
     for dtype in dtypes:
@@ -497,7 +497,7 @@ def test_length():
 
 
 @set_random_number_generator(1234)
-def test_length_memory_leaks(rng):
+def test_length_memory_leaks(rng=None):
     # Test some dtypes
     dtypes = [np.float32, np.float64, np.int32, np.int64]
     for dtype in dtypes:
@@ -537,7 +537,7 @@ def test_length_memory_leaks(rng):
 
 
 @set_random_number_generator()
-def test_unlist_relist_streamlines(rng):
+def test_unlist_relist_streamlines(rng=None):
     streamlines = [rng.random((10, 3)), rng.random((20, 3)), rng.random((5, 3))]
     points, offsets = unlist_streamlines(streamlines)
     assert_equal(offsets.dtype, np.dtype("i8"))
@@ -583,7 +583,7 @@ def test_transform_empty_streamlines():
 
 
 @set_random_number_generator()
-def test_deform_streamlines(rng):
+def test_deform_streamlines(rng=None):
     # Create Random deformation field
     deformation_field = rng.standard_normal((200, 200, 200, 3))
     stream2grid = np.array(
@@ -646,7 +646,7 @@ def test_center_and_transform():
 
 
 @set_random_number_generator()
-def test_select_random_streamlines(rng):
+def test_select_random_streamlines(rng=None):
     streamlines = [rng.random((10, 3)), rng.random((20, 3)), rng.random((5, 3))]
     new_streamlines = select_random_set_of_streamlines(streamlines, 2)
     assert_equal(len(new_streamlines), 2)
@@ -831,7 +831,7 @@ def test_compress_streamlines_identical_points():
 
 
 @set_random_number_generator(1234)
-def test_compress_streamlines_memory_leaks(rng):
+def test_compress_streamlines_memory_leaks(rng=None):
     # Test some dtypes
     dtypes = [np.float32, np.float64, np.int32, np.int64]
     for dtype in dtypes:

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -265,7 +265,7 @@ def test_save_seeds():
 
 
 @set_random_number_generator(0)
-def test_tracking_max_angle(rng):
+def test_tracking_max_angle(rng=None):
     """This tests that the angle between streamline points is always smaller
     then the input `max_angle` parameter.
     """
@@ -421,7 +421,7 @@ def test_probabilistic_odf_weighted_tracker():
 
 
 @set_random_number_generator(0)
-def test_particle_filtering_tractography(rng):
+def test_particle_filtering_tractography(rng=None):
     """This tests that the ParticleFilteringTracking produces
     more streamlines connecting the gray matter than LocalTracking.
     """
@@ -1158,7 +1158,7 @@ def test_affine_transformations():
 
 
 @set_random_number_generator()
-def test_random_seed_initialization(rng):
+def test_random_seed_initialization(rng=None):
     """Test that the random generator can be initialized correctly with the
     tracking seeds.
     """

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -640,7 +640,7 @@ def test_streamline_mapping():
 
 
 @set_random_number_generator()
-def test_length(rng):
+def test_length(rng=None):
     # Generate a simulated bundle of fibers:
     n_streamlines = 50
     n_pts = 100
@@ -664,7 +664,7 @@ def test_length(rng):
 
 
 @set_random_number_generator()
-def test_seeds_from_mask(rng):
+def test_seeds_from_mask(rng=None):
     mask = rng.integers(0, 1, size=(10, 10, 10))
     seeds = seeds_from_mask(mask, np.eye(4), density=1)
     npt.assert_equal(mask.sum(), len(seeds))
@@ -687,7 +687,7 @@ def test_seeds_from_mask(rng):
 
 
 @set_random_number_generator()
-def test_random_seeds_from_mask(rng):
+def test_random_seeds_from_mask(rng=None):
     mask = rng.integers(0, 1, size=(4, 6, 3))
     seeds = random_seeds_from_mask(
         mask, np.eye(4), seeds_count=24, seed_count_per_voxel=True
@@ -803,7 +803,7 @@ def test_reduce_rois():
 
 
 @set_random_number_generator()
-def test_path_length(rng):
+def test_path_length(rng=None):
     aoi = np.zeros((20, 20, 20), dtype=bool)
     aoi[0, 0, 0] = 1
 
@@ -882,7 +882,7 @@ def test_curvature_angle():
 
 
 @set_random_number_generator()
-def test_seeds_directions_pairs(rng):
+def test_seeds_directions_pairs(rng=None):
     positions = rng.random(size=(10, 3))
     peaks = rng.random(size=(10, 5, 3))
 

--- a/dipy/utils/tests/test_arrfuncs.py
+++ b/dipy/utils/tests/test_arrfuncs.py
@@ -28,7 +28,7 @@ def test_as_native():
 
 
 @set_random_number_generator()
-def test_pinv(rng):
+def test_pinv(rng=None):
     arr = rng.standard_normal((4, 4, 4, 3, 7))
     _pinv = pinv(arr)
     for i in range(4):

--- a/dipy/viz/horizon/tab/tests/test_peak.py
+++ b/dipy/viz/horizon/tab/tests/test_peak.py
@@ -18,7 +18,7 @@ skip_it = use_xvfb == "skip" or not has_fury
 
 @pytest.fixture
 @set_random_number_generator()
-def peak_actor(rng):
+def peak_actor(rng=None):
     """Fixture to create a Peaks Actor."""
     peak_dirs = 255 * rng.random((5, 5, 5, 5, 3))
     pam = PeaksAndMetrics()

--- a/dipy/viz/horizon/tab/tests/test_slices.py
+++ b/dipy/viz/horizon/tab/tests/test_slices.py
@@ -17,7 +17,7 @@ skip_it = use_xvfb == "skip" or not has_fury
 
 @pytest.fixture
 @set_random_number_generator()
-def slice_viz(rng):
+def slice_viz(rng=None):
     """Fixture to create a Slice Actors."""
     affine = np.array(
         [

--- a/dipy/viz/horizon/tab/tests/test_surface.py
+++ b/dipy/viz/horizon/tab/tests/test_surface.py
@@ -16,7 +16,7 @@ skip_it = use_xvfb == "skip" or not has_fury
 
 @pytest.fixture
 @set_random_number_generator()
-def surface_viz(rng):
+def surface_viz(rng=None):
     """Fixture to create a Surface Visualizer."""
     vertices = rng.random((100, 3))
     faces = rng.integers(0, 100, size=(100, 3))

--- a/dipy/viz/tests/test_apps.py
+++ b/dipy/viz/tests/test_apps.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -29,7 +28,7 @@ skip_it = use_xvfb == "skip"
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator()
-def test_horizon_events(rng):
+def test_horizon_events(tmp_path, rng=None):
     # using here MNI template affine 2009a
     affine = np.array(
         [
@@ -70,29 +69,28 @@ def test_horizon_events(rng):
     # blocks recording
     fname = Path(DATA_DIR) / "record_horizon.log.gz"
 
-    with TemporaryDirectory() as out_dir:
-        horizon(
-            tractograms=tractograms,
-            images=images,
-            pams=pams,
-            cluster=True,
-            cluster_thr=5.0,
-            roi_images=True,
-            random_colors=False,
-            length_gt=0,
-            length_lt=np.inf,
-            clusters_gt=0,
-            clusters_lt=np.inf,
-            world_coords=True,
-            interactive=True,
-            out_png=str(Path(out_dir) / "horizon-event.png"),
-            recorded_events=str(fname),
-        )
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        pams=pams,
+        cluster=True,
+        cluster_thr=5.0,
+        roi_images=True,
+        random_colors=False,
+        length_gt=0,
+        length_lt=np.inf,
+        clusters_gt=0,
+        clusters_lt=np.inf,
+        world_coords=True,
+        interactive=True,
+        out_png=str(tmp_path / "horizon-event.png"),
+        recorded_events=str(fname),
+    )
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator()
-def test_horizon(rng):
+def test_horizon(tmp_path, rng=None):
     s1 = 10 * np.array(
         [[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0]], dtype="f8"
     )
@@ -131,7 +129,24 @@ def test_horizon(rng):
     # only tractograms
     tractograms = [sft]
     images = None
-    with TemporaryDirectory() as out_dir:
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        cluster=True,
+        cluster_thr=5,
+        random_colors=False,
+        length_lt=np.inf,
+        length_gt=0,
+        clusters_lt=np.inf,
+        clusters_gt=0,
+        world_coords=True,
+        interactive=False,
+        out_png=tmp_path / "only-tractograms.png",
+    )
+
+    images = [(data, affine, "/test/filename.nii.gz")]
+    # tractograms in native coords (not supported for now)
+    with npt.assert_raises(ValueError) as ve:
         horizon(
             tractograms=tractograms,
             images=images,
@@ -142,68 +157,50 @@ def test_horizon(rng):
             length_gt=0,
             clusters_lt=np.inf,
             clusters_gt=0,
-            world_coords=True,
+            world_coords=False,
             interactive=False,
-            out_png=Path(out_dir) / "only-tractograms.png",
+            out_png=tmp_path / "native-tractograms.png",
         )
 
-        images = [(data, affine, "/test/filename.nii.gz")]
-        # tractograms in native coords (not supported for now)
-        with npt.assert_raises(ValueError) as ve:
-            horizon(
-                tractograms=tractograms,
-                images=images,
-                cluster=True,
-                cluster_thr=5,
-                random_colors=False,
-                length_lt=np.inf,
-                length_gt=0,
-                clusters_lt=np.inf,
-                clusters_gt=0,
-                world_coords=False,
-                interactive=False,
-                out_png=Path(out_dir) / "native-tractograms.png",
-            )
+    msg = "Currently native coordinates are not supported for streamlines."
+    npt.assert_(msg in str(ve.exception))
 
-        msg = "Currently native coordinates are not supported for streamlines."
-        npt.assert_(msg in str(ve.exception))
+    # only images
+    tractograms = None
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        cluster=True,
+        cluster_thr=5,
+        random_colors=False,
+        length_lt=np.inf,
+        length_gt=0,
+        clusters_lt=np.inf,
+        clusters_gt=0,
+        world_coords=True,
+        interactive=False,
+        out_png=tmp_path / "only-images.png",
+    )
 
-        # only images
-        tractograms = None
-        horizon(
-            tractograms=tractograms,
-            images=images,
-            cluster=True,
-            cluster_thr=5,
-            random_colors=False,
-            length_lt=np.inf,
-            length_gt=0,
-            clusters_lt=np.inf,
-            clusters_gt=0,
-            world_coords=True,
-            interactive=False,
-            out_png=Path(out_dir) / "only-images.png",
-        )
-
-        # no clustering tractograms and images
-        horizon(
-            tractograms=tractograms,
-            images=images,
-            cluster=False,
-            cluster_thr=5,
-            random_colors=False,
-            length_lt=np.inf,
-            length_gt=0,
-            clusters_lt=np.inf,
-            clusters_gt=0,
-            world_coords=True,
-            interactive=False,
-            out_png=Path(out_dir) / "no-clusting-tractograms-and-images.png",
-        )
+    # no clustering tractograms and images
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        cluster=False,
+        cluster_thr=5,
+        random_colors=False,
+        length_lt=np.inf,
+        length_gt=0,
+        clusters_lt=np.inf,
+        clusters_gt=0,
+        world_coords=True,
+        interactive=False,
+        out_png=tmp_path / "no-clusting-tractograms-and-images.png",
+    )
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
-def test_horizon_wrong_dtype_images():
+def test_horizon_wrong_dtype_images(tmp_path):
     affine = np.array(
         [
             [1.0, 0.0, 0.0, -98.0],
@@ -215,21 +212,18 @@ def test_horizon_wrong_dtype_images():
 
     data = np.random.rand(197, 233, 189).astype(np.bool_)
     images = [(data, affine)]
-    with TemporaryDirectory() as out_dir:
-        horizon(
-            images=images,
-            interactive=False,
-            out_png=str(Path(out_dir) / "wrong-dtype.png"),
-        )
-        # Asserting the image will not get added and the image will be black.
-        assert (
-            len(np.unique(io.load_image(str(Path(out_dir) / "wrong-dtype.png")))) == 1
-        )
+    horizon(
+        images=images,
+        interactive=False,
+        out_png=str(tmp_path / "wrong-dtype.png"),
+    )
+    # Asserting the image will not get added and the image will be black.
+    assert len(np.unique(io.load_image(tmp_path / "wrong-dtype.png"))) == 1
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator()
-def test_horizon_empty_tractogram(rng):
+def test_horizon_empty_tractogram(tmp_path, rng=None):
     """Test that empty tractograms are handled gracefully without errors."""
     # Create an empty streamlines container
     empty_streamlines = Streamlines()
@@ -257,22 +251,21 @@ def test_horizon_empty_tractogram(rng):
     # with a warning
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        with TemporaryDirectory() as out_dir:
-            horizon(
-                tractograms=tractograms,
-                images=images,
-                cluster=False,
-                world_coords=True,
-                interactive=False,
-                out_png=Path(out_dir) / "empty-tractogram.png",
-            )
-        # Check that a warning was raised about empty tractogram
-        check_for_warnings(w, "Tractogram 0 is empty and will be skipped.")
+        horizon(
+            tractograms=tractograms,
+            images=images,
+            cluster=False,
+            world_coords=True,
+            interactive=False,
+            out_png=tmp_path / "empty-tractogram.png",
+        )
+    # Check that a warning was raised about empty tractogram
+    check_for_warnings(w, "Tractogram 0 is empty and will be skipped.")
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator(42)
-def test_roi_images(rng):
+def test_roi_images(rng=None):
     img1 = rng.random((5, 5, 5))
     img2 = np.zeros((5, 5, 5))
     img2[2, 2, 2] = 1
@@ -296,7 +289,7 @@ def test_roi_images(rng):
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator(42)
-def test_surfaces(rng):
+def test_surfaces(rng=None):
     vertices = rng.random((100, 3))
     faces = rng.integers(0, 100, size=(100, 3))
     surfaces = [

--- a/dipy/viz/tests/test_fury.py
+++ b/dipy/viz/tests/test_fury.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -31,7 +29,7 @@ skip_it = use_xvfb == "skip"
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator()
-def test_slicer(rng):
+def test_slicer(rng=None):
     scene = window.Scene()
     data = 255 * rng.random((50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
@@ -52,7 +50,7 @@ def test_slicer(rng):
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
-def test_contour_from_roi():
+def test_contour_from_roi(tmp_path):
     hardi_img, gtab, labels_img = read_stanford_labels()
     data = np.asanyarray(hardi_img.dataobj)
     labels = np.asanyarray(labels_img.dataobj)
@@ -106,37 +104,32 @@ def test_contour_from_roi():
         seed_mask, affine=affine, color=[0, 1, 1], opacity=0.5
     )
 
-    with TemporaryDirectory() as out_dir:
-        # Create the 3d display.
-        sc = window.Scene()
-        sc2 = window.Scene()
-        sc.add(streamlines_actor)
-        arr3 = window.snapshot(
-            sc, fname=Path(out_dir) / "test_surface3.png", offscreen=True
-        )
-        report3 = window.analyze_snapshot(arr3, find_objects=True)
-        sc2.add(streamlines_actor)
-        sc2.add(seedroi_actor)
-        arr4 = window.snapshot(
-            sc2, fname=Path(out_dir) / "test_surface4.png", offscreen=True
-        )
-        report4 = window.analyze_snapshot(arr4, find_objects=True)
+    # Create the 3d display.
+    sc = window.Scene()
+    sc2 = window.Scene()
+    sc.add(streamlines_actor)
+    arr3 = window.snapshot(sc, fname=tmp_path / "test_surface3.png", offscreen=True)
+    report3 = window.analyze_snapshot(arr3, find_objects=True)
+    sc2.add(streamlines_actor)
+    sc2.add(seedroi_actor)
+    arr4 = window.snapshot(sc2, fname=tmp_path / "test_surface4.png", offscreen=True)
+    report4 = window.analyze_snapshot(arr4, find_objects=True)
 
-        # assert that the seed ROI rendering is not far
-        # away from the streamlines (affine error).
-        # If the ROI were affine-shifted far away, it would appear as a
-        # completely separate object, increasing the count beyond report3.
-        # Platform rendering differences (e.g. Windows vs Linux) can cause
-        # the streamlines to appear as more or fewer connected regions, so
-        # we only require that adding the ROI does not increase the count.
-        npt.assert_array_less(report4.objects, report3.objects + 1)
-        # window.show(sc)
-        # window.show(sc2)
+    # assert that the seed ROI rendering is not far
+    # away from the streamlines (affine error).
+    # If the ROI were affine-shifted far away, it would appear as a
+    # completely separate object, increasing the count beyond report3.
+    # Platform rendering differences (e.g. Windows vs Linux) can cause
+    # the streamlines to appear as more or fewer connected regions, so
+    # we only require that adding the ROI does not increase the count.
+    npt.assert_array_less(report4.objects, report3.objects + 1)
+    # window.show(sc)
+    # window.show(sc2)
 
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Needs xvfb")
 @set_random_number_generator()
-def test_bundle_maps(rng):
+def test_bundle_maps(rng=None):
     scene = window.Scene()
     bundle = fornix_streamlines()
     bundle, _ = center_streamlines(bundle)

--- a/dipy/viz/tests/test_regtools.py
+++ b/dipy/viz/tests/test_regtools.py
@@ -14,7 +14,7 @@ _, have_matplotlib, _ = optional_package("matplotlib")
 
 @pytest.mark.skipif(not have_matplotlib, reason="Requires Matplotlib")
 @set_random_number_generator()
-def test_plot_2d_diffeomorphic_map(rng):
+def test_plot_2d_diffeomorphic_map(rng=None):
     # Test the regtools plotting interface (lightly).
     mv_shape = (11, 12)
     moving = rng.random(mv_shape)

--- a/dipy/viz/tests/test_util.py
+++ b/dipy/viz/tests/test_util.py
@@ -14,7 +14,7 @@ from dipy.viz.horizon.util import (
 
 
 @set_random_number_generator()
-def test_check_img_shapes(rng):
+def test_check_img_shapes(rng=None):
     affine = np.array(
         [
             [1.0, 0.0, 0.0, -98.0],
@@ -65,7 +65,7 @@ def test_check_img_shapes(rng):
 
 
 @set_random_number_generator()
-def test_check_img_dtype(rng):
+def test_check_img_dtype(rng=None):
     affine = np.array(
         [
             [1.0, 0.0, 0.0, -98.0],
@@ -116,7 +116,7 @@ def test_show_ellipsis():
 
 
 @set_random_number_generator()
-def test_unpack_surface(rng):
+def test_unpack_surface(rng=None):
     vertices = rng.random((100, 4))
     faces = rng.integers(0, 100, size=(100, 3))
 
@@ -138,7 +138,7 @@ def test_unpack_surface(rng):
 
 
 @set_random_number_generator()
-def test_check_peak_size(rng):
+def test_check_peak_size(rng=None):
     peak_dirs = rng.random((100, 100, 100, 10, 6))
 
     pam = PeaksAndMetrics()
@@ -175,7 +175,7 @@ def test_check_peak_size(rng):
 
 
 @set_random_number_generator()
-def test_unpack_data(rng):
+def test_unpack_data(rng=None):
     # Test with a non-tuple object (single data array)
     pam_data = rng.random((10, 10))
     result = unpack_data(pam_data, return_size=2)

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -878,7 +878,7 @@ class FetchFlow(Workflow):
         """
         if out_dir:
             dipy_home = os.environ.get("DIPY_HOME", None)
-            os.environ["DIPY_HOME"] = out_dir
+            os.environ["DIPY_HOME"] = str(out_dir)
 
         available_data = FetchFlow.get_fetcher_datanames()
 

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import nibabel as nib
 import numpy as np
@@ -30,149 +29,143 @@ from dipy.workflows.align import (
 _, have_pd, _ = optional_package("pandas")
 
 
-def test_reslice():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
+def test_reslice(tmp_path):
+    data_path, _, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
 
-        reslice_flow = ResliceFlow()
-        reslice_flow.run(data_path, [1.5, 1.5, 1.5], out_dir=out_dir)
+    reslice_flow = ResliceFlow()
+    reslice_flow.run(data_path, [1.5, 1.5, 1.5], out_dir=tmp_path)
 
-        out_path = reslice_flow.last_generated_outputs["out_resliced"]
-        resliced = load_nifti_data(out_path)
+    out_path = reslice_flow.last_generated_outputs["out_resliced"]
+    resliced = load_nifti_data(out_path)
 
-        npt.assert_equal(resliced.shape[0] > volume.shape[0], True)
-        npt.assert_equal(resliced.shape[1] > volume.shape[1], True)
-        npt.assert_equal(resliced.shape[2] > volume.shape[2], True)
-        npt.assert_equal(resliced.shape[-1], volume.shape[-1])
+    npt.assert_equal(resliced.shape[0] > volume.shape[0], True)
+    npt.assert_equal(resliced.shape[1] > volume.shape[1], True)
+    npt.assert_equal(resliced.shape[2] > volume.shape[2], True)
+    npt.assert_equal(resliced.shape[-1], volume.shape[-1])
 
 
-def test_reslice_auto_voxsize(caplog):
+def test_reslice_auto_voxsize(tmp_path, caplog):
     """Test ResliceFlow with automatic voxel size calculation."""
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
+    data_path, _, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
 
-        with caplog.at_level(logging.WARNING, logger="dipy"):
-            reslice_flow = ResliceFlow()
-            reslice_flow.run(data_path, out_dir=out_dir)
+    with caplog.at_level(logging.WARNING, logger="dipy"):
+        reslice_flow = ResliceFlow()
+        reslice_flow.run(data_path, out_dir=tmp_path)
 
-        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warning_records) > 0, "Expected WARNING level log message"
-        assert any(
-            "new_vox_size not provided" in record.message for record in warning_records
-        ), "Expected warning about auto-calculation"
-        assert any("vox_factor=0.14" in record.message for record in warning_records), (
-            "Expected warning to include vox_factor value"
-        )
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warning_records) > 0, "Expected WARNING level log message"
+    assert any(
+        "new_vox_size not provided" in record.message for record in warning_records
+    ), "Expected warning about auto-calculation"
+    assert any("vox_factor=0.14" in record.message for record in warning_records), (
+        "Expected warning to include vox_factor value"
+    )
 
-        out_path = reslice_flow.last_generated_outputs["out_resliced"]
-        resliced = load_nifti_data(out_path)
+    out_path = reslice_flow.last_generated_outputs["out_resliced"]
+    resliced = load_nifti_data(out_path)
 
-        npt.assert_equal(resliced.shape[-1], volume.shape[-1])
+    npt.assert_equal(resliced.shape[-1], volume.shape[-1])
 
 
-def test_reslice_custom_voxfactor(caplog):
+def test_reslice_custom_voxfactor(tmp_path, caplog):
     """Test ResliceFlow with custom vox_factor parameter."""
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
 
-        with caplog.at_level(logging.WARNING, logger="dipy"):
-            reslice_flow = ResliceFlow()
-            custom_factor = 0.5
-            reslice_flow.run(data_path, vox_factor=custom_factor, out_dir=out_dir)
+    data_path, _, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
 
-        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warning_records) > 0, "Expected WARNING level log message"
-        assert any(
-            f"vox_factor={custom_factor}" in record.message
-            for record in warning_records
-        ), f"Expected warning to include vox_factor={custom_factor}"
+    with caplog.at_level(logging.WARNING, logger="dipy"):
+        reslice_flow = ResliceFlow()
+        custom_factor = 0.5
+        reslice_flow.run(data_path, vox_factor=custom_factor, out_dir=tmp_path)
 
-        out_path = reslice_flow.last_generated_outputs["out_resliced"]
-        resliced = load_nifti_data(out_path)
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warning_records) > 0, "Expected WARNING level log message"
+    assert any(
+        f"vox_factor={custom_factor}" in record.message for record in warning_records
+    ), f"Expected warning to include vox_factor={custom_factor}"
 
-        npt.assert_equal(resliced.shape[-1], volume.shape[-1])
+    out_path = reslice_flow.last_generated_outputs["out_resliced"]
+    resliced = load_nifti_data(out_path)
+
+    npt.assert_equal(resliced.shape[-1], volume.shape[-1])
 
 
-def test_reslice_skip_when_matching(caplog):
+def test_reslice_skip_when_matching(tmp_path, caplog):
     """Test ResliceFlow skips reslicing when voxel size already matches."""
     import logging
 
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
-        _, _, zooms = load_nifti(data_path, return_voxsize=True)
+    data_path, _, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
+    _, _, zooms = load_nifti(data_path, return_voxsize=True)
 
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            reslice_flow = ResliceFlow()
-            reslice_flow.run(data_path, new_vox_size=list(zooms[:3]), out_dir=out_dir)
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        reslice_flow = ResliceFlow()
+        reslice_flow.run(data_path, new_vox_size=list(zooms[:3]), out_dir=tmp_path)
 
-        info_records = [r for r in caplog.records if r.levelname == "INFO"]
-        assert any("Skipping reslicing" in record.message for record in info_records), (
-            "Expected INFO message about skipping. "
-            f"Found: {[r.message for r in info_records]}"
-        )
-        assert any(
-            "already matches target" in record.message for record in info_records
-        ), "Expected INFO message about matching voxel size"
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert any("Skipping reslicing" in record.message for record in info_records), (
+        "Expected INFO message about skipping. "
+        f"Found: {[r.message for r in info_records]}"
+    )
+    assert any("already matches target" in record.message for record in info_records), (
+        "Expected INFO message about matching voxel size"
+    )
 
-        out_path = reslice_flow.last_generated_outputs["out_resliced"]
-        resliced = load_nifti_data(out_path)
+    out_path = reslice_flow.last_generated_outputs["out_resliced"]
+    resliced = load_nifti_data(out_path)
 
-        npt.assert_equal(resliced.shape, volume.shape)
+    npt.assert_equal(resliced.shape, volume.shape)
 
 
-def test_reslice_skip_idempotent(caplog):
+def test_reslice_skip_idempotent(tmp_path, caplog):
     """Test ResliceFlow is idempotent when force option is used."""
 
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        _, _, zooms = load_nifti(data_path, return_voxsize=True)
-        target_vox = list(zooms[:3])
+    data_path, _, _ = get_fnames(name="small_25")
+    _, _, zooms = load_nifti(data_path, return_voxsize=True)
+    target_vox = list(zooms[:3])
 
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            ResliceFlow().run(data_path, new_vox_size=target_vox, out_dir=out_dir)
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        ResliceFlow().run(data_path, new_vox_size=target_vox, out_dir=tmp_path)
 
-        caplog.clear()
+    caplog.clear()
 
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            ResliceFlow(force=True).run(
-                data_path, new_vox_size=target_vox, out_dir=out_dir
-            )
-
-        info_messages = [r.message for r in caplog.records if r.levelname == "INFO"]
-        assert any("already linked" in m or "Skipping" in m for m in info_messages), (
-            f"Expected idempotent skip message on second run. Found: {info_messages}"
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        ResliceFlow(force=True).run(
+            data_path, new_vox_size=target_vox, out_dir=tmp_path
         )
 
+    info_messages = [r.message for r in caplog.records if r.levelname == "INFO"]
+    assert any("already linked" in m or "Skipping" in m for m in info_messages), (
+        f"Expected idempotent skip message on second run. Found: {info_messages}"
+    )
 
-def test_reslice_skip_returns_original_path(caplog):
+
+def test_reslice_skip_returns_original_path(tmp_path, caplog):
     """Test ResliceFlow returns original input path when voxel size matches."""
-    with TemporaryDirectory() as tmp_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        data, affine, zooms = load_nifti(data_path, return_voxsize=True)
+    data_path, _, _ = get_fnames(name="small_25")
+    data, affine, zooms = load_nifti(data_path, return_voxsize=True)
 
-        nii_path = Path(tmp_dir) / "input.nii"
-        nib.save(nib.Nifti1Image(data, affine), str(nii_path))
+    nii_path = tmp_path / "input.nii"
+    nib.save(nib.Nifti1Image(data, affine), str(nii_path))
 
-        out_dir = Path(tmp_dir) / "out"
-        out_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
 
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            reslice_flow = ResliceFlow()
-            reslice_flow.run(
-                str(nii_path), new_vox_size=list(zooms[:3]), out_dir=str(out_dir)
-            )
-
-        out_path = Path(reslice_flow.last_generated_outputs["out_resliced"])
-        assert out_path.resolve() == nii_path.resolve(), (
-            f"Expected original input path {nii_path}, got {out_path}"
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        reslice_flow = ResliceFlow()
+        reslice_flow.run(
+            str(nii_path), new_vox_size=list(zooms[:3]), out_dir=str(out_dir)
         )
 
-        resliced = np.array(load_nifti_data(str(out_path)))
-        npt.assert_equal(resliced.shape, data.shape)
+    out_path = Path(reslice_flow.last_generated_outputs["out_resliced"])
+    assert out_path.resolve() == nii_path.resolve(), (
+        f"Expected original input path {nii_path}, got {out_path}"
+    )
+
+    resliced = np.array(load_nifti_data(str(out_path)))
+    npt.assert_equal(resliced.shape, data.shape)
 
 
 def test_reslice_auto_scale_guard(caplog, tmp_path):
@@ -224,443 +217,437 @@ def test_reslice_auto_scale_guard_no_trigger(caplog, tmp_path):
     )
 
 
-def test_slr_flow(caplog):
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
+def test_slr_flow(tmp_path, caplog):
+    data_path = get_fnames(name="fornix")
 
-        sft = load_tractogram(data_path, "same", bbox_valid_check=False)
-        sft.streamlines._data += np.array([50, 0, 0])
-        moved_path = Path(out_dir) / "moved.trx"
-        save_tractogram(sft, moved_path, bbox_valid_check=False)
+    sft = load_tractogram(data_path, "same", bbox_valid_check=False)
+    sft.streamlines._data += np.array([50, 0, 0])
+    moved_path = tmp_path / "moved.trx"
+    save_tractogram(sft, moved_path, bbox_valid_check=False)
 
-        slr_flow = SlrWithQbxFlow(force=True)
-        slr_flow.run(data_path, moved_path, out_dir=out_dir, bbox_valid_check=False)
+    slr_flow = SlrWithQbxFlow(force=True)
+    slr_flow.run(data_path, moved_path, out_dir=tmp_path, bbox_valid_check=False)
 
-        out_path = slr_flow.last_generated_outputs["out_moved"]
+    out_path = slr_flow.last_generated_outputs["out_moved"]
 
-        npt.assert_equal(Path(out_path).is_file(), True)
+    npt.assert_equal(Path(out_path).is_file(), True)
 
-        sft = sft.from_sft(np.array([]), sft)
-        empty_path = Path(out_dir) / "empty.trk"
-        save_tractogram(sft, empty_path, bbox_valid_check=False)
+    sft = sft.from_sft(np.array([]), sft)
+    empty_path = tmp_path / "empty.trk"
+    save_tractogram(sft, empty_path, bbox_valid_check=False)
 
-        slr_flow = SlrWithQbxFlow(force=True)
+    slr_flow = SlrWithQbxFlow(force=True)
 
-        # Test empty static file
-        with caplog.at_level(logging.ERROR, logger="dipy"):
-            slr_flow.run(
-                empty_path,
-                moved_path,
-                out_dir=out_dir,
-                bbox_valid_check=False,
-            )
+    # Test empty static file
+    with caplog.at_level(logging.ERROR, logger="dipy"):
+        slr_flow.run(
+            empty_path,
+            moved_path,
+            out_dir=tmp_path,
+            bbox_valid_check=False,
+        )
 
-        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert len(error_records) > 0, "Expected ERROR level log message"
-        error_msg = f"Static file {empty_path} is empty"
-        assert any(err.msg in error_msg for err in error_records)
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0, "Expected ERROR level log message"
+    error_msg = f"Static file {empty_path} is empty"
+    assert any(err.msg in error_msg for err in error_records)
 
-        caplog.clear()
+    caplog.clear()
 
-        # Test empty moving file
-        with caplog.at_level(logging.ERROR, logger="dipy"):
-            slr_flow.run(
-                data_path,
-                empty_path,
-                out_dir=out_dir,
-                bbox_valid_check=False,
-            )
+    # Test empty moving file
+    with caplog.at_level(logging.ERROR, logger="dipy"):
+        slr_flow.run(
+            data_path,
+            empty_path,
+            out_dir=tmp_path,
+            bbox_valid_check=False,
+        )
 
-        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert len(error_records) > 0, "Expected ERROR level log message"
-        error_msg = f"Moving file {empty_path} is empty"
-        assert any(err.msg in error_msg for err in error_records)
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0, "Expected ERROR level log message"
+    error_msg = f"Moving file {empty_path} is empty"
+    assert any(err.msg in error_msg for err in error_records)
 
 
-def test_slr_flow_empty_after_length_filtering(caplog):
+def test_slr_flow_empty_after_length_filtering(tmp_path, caplog):
     """Test that SlrWithQbxFlow logs error when all streamlines are filtered
     out by length constraints.
     """
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
+    data_path = get_fnames(name="fornix")
 
-        sft = load_tractogram(data_path, "same", bbox_valid_check=False)
-        moved_path = Path(out_dir) / "moved.trx"
-        save_tractogram(sft, moved_path, bbox_valid_check=False)
+    sft = load_tractogram(data_path, "same", bbox_valid_check=False)
+    moved_path = tmp_path / "moved.trx"
+    save_tractogram(sft, moved_path, bbox_valid_check=False)
 
-        slr_flow = SlrWithQbxFlow(force=True)
+    slr_flow = SlrWithQbxFlow(force=True)
 
-        caplog.clear()
-        with caplog.at_level(logging.ERROR, logger="dipy"):
-            slr_flow.run(
-                data_path,
-                moved_path,
-                out_dir=out_dir,
-                bbox_valid_check=False,
-                greater_than=1000,
-                less_than=np.inf,
-            )
-
-        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert len(error_records) > 0, "Expected ERROR level log message"
-        assert any("SLR with QBX failed" in err.message for err in error_records)
-
-        caplog.clear()
-        with caplog.at_level(logging.ERROR, logger="dipy"):
-            slr_flow.run(
-                data_path,
-                moved_path,
-                out_dir=out_dir,
-                bbox_valid_check=False,
-                greater_than=0,
-                less_than=1,
-            )
-
-        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert len(error_records) > 0, "Expected ERROR level log message"
-        assert any("SLR with QBX failed" in err.message for err in error_records)
-
-
-def test_slr_flow_remove_invalid_streamlines():
-    """Test that SlrWithQbxFlow removes out-of-bounds streamlines when
-    remove_invalid_streamlines=True and does not raise a ValueError on save.
-    """
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
-
-        sft = load_tractogram(data_path, "same", bbox_valid_check=False)
-        sft.streamlines._data += np.array([50, 0, 0])
-        moved_path = Path(out_dir) / "moved.trx"
-        save_tractogram(sft, moved_path, bbox_valid_check=False)
-
-        slr_flow = SlrWithQbxFlow(force=True)
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="dipy"):
         slr_flow.run(
             data_path,
             moved_path,
-            out_dir=out_dir,
+            out_dir=tmp_path,
             bbox_valid_check=False,
-            remove_invalid_streamlines=True,
+            greater_than=1000,
+            less_than=np.inf,
         )
 
-        out_path = slr_flow.last_generated_outputs["out_moved"]
-        assert Path(out_path).is_file()
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0, "Expected ERROR level log message"
+    assert any("SLR with QBX failed" in err.message for err in error_records)
 
-        result_sft = load_tractogram(out_path, "same", bbox_valid_check=True)
-        assert len(result_sft.streamlines) >= 0
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="dipy"):
+        slr_flow.run(
+            data_path,
+            moved_path,
+            out_dir=tmp_path,
+            bbox_valid_check=False,
+            greater_than=0,
+            less_than=1,
+        )
+
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0, "Expected ERROR level log message"
+    assert any("SLR with QBX failed" in err.message for err in error_records)
+
+
+def test_slr_flow_remove_invalid_streamlines(tmp_path):
+    """Test that SlrWithQbxFlow removes out-of-bounds streamlines when
+    remove_invalid_streamlines=True and does not raise a ValueError on save.
+    """
+    data_path = get_fnames(name="fornix")
+
+    sft = load_tractogram(data_path, "same", bbox_valid_check=False)
+    sft.streamlines._data += np.array([50, 0, 0])
+    moved_path = tmp_path / "moved.trx"
+    save_tractogram(sft, moved_path, bbox_valid_check=False)
+
+    slr_flow = SlrWithQbxFlow(force=True)
+    slr_flow.run(
+        data_path,
+        moved_path,
+        out_dir=tmp_path,
+        bbox_valid_check=False,
+        remove_invalid_streamlines=True,
+    )
+
+    out_path = slr_flow.last_generated_outputs["out_moved"]
+    assert Path(out_path).is_file()
+
+    result_sft = load_tractogram(out_path, "same", bbox_valid_check=True)
+    assert len(result_sft.streamlines) >= 0
 
 
 @set_random_number_generator(1234)
-def test_image_registration(rng):
-    with TemporaryDirectory() as temp_out_dir:
-        static, moving, static_g2w, moving_g2w, smask, mmask, M = (
-            setup_random_transform(
-                transform=regtransforms[("AFFINE", 3)], rfactor=0.1, rng=rng
-            )
+def test_image_registration(tmp_path, rng=None):
+    static, moving, static_g2w, moving_g2w, smask, mmask, M = setup_random_transform(
+        transform=regtransforms[("AFFINE", 3)], rfactor=0.1, rng=rng
+    )
+
+    save_nifti(tmp_path / "b0.nii.gz", data=static, affine=static_g2w)
+    save_nifti(tmp_path / "t1.nii.gz", data=moving, affine=moving_g2w)
+    # simulate three direction DWI by repeating b0 three times
+    save_nifti(
+        tmp_path / "dwi.nii.gz",
+        data=np.repeat(static[..., None], 3, axis=-1),
+        affine=static_g2w,
+    )
+
+    static_image_file = tmp_path / "b0.nii.gz"
+    moving_image_file = tmp_path / "t1.nii.gz"
+    dwi_image_file = tmp_path / "dwi.nii.gz"
+
+    image_registration_flow = ImageRegistrationFlow()
+    apply_trans = ApplyTransformFlow()
+
+    def read_distance(qual_fname):
+        with open(tmp_path / qual_fname) as f:
+            return float(f.readlines()[-1])
+
+    def test_com():
+        out_moved = tmp_path / "com_moved.nii.gz"
+        out_affine = tmp_path / "com_affine.txt"
+
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="com",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+        )
+        check_existence(out_moved, out_affine)
+
+    def test_translation():
+        out_moved = tmp_path / "trans_moved.nii.gz"
+        out_affine = tmp_path / "trans_affine.txt"
+
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="trans",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="trans_q.txt",
         )
 
-        save_nifti(Path(temp_out_dir) / "b0.nii.gz", data=static, affine=static_g2w)
-        save_nifti(Path(temp_out_dir) / "t1.nii.gz", data=moving, affine=moving_g2w)
-        # simulate three direction DWI by repeating b0 three times
-        save_nifti(
-            Path(temp_out_dir) / "dwi.nii.gz",
-            data=np.repeat(static[..., None], 3, axis=-1),
-            affine=static_g2w,
+        dist = read_distance("trans_q.txt")
+        npt.assert_almost_equal(float(dist), -0.42097809101318934, 1)
+        check_existence(out_moved, out_affine)
+
+    def test_translation_cc():
+        out_moved = tmp_path / "trans_cc_moved.nii.gz"
+        out_affine = tmp_path / "trans_cc_affine.txt"
+
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="trans",
+            metric="cc",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="trans_cc_q.txt",
         )
 
-        static_image_file = Path(temp_out_dir) / "b0.nii.gz"
-        moving_image_file = Path(temp_out_dir) / "t1.nii.gz"
-        dwi_image_file = Path(temp_out_dir) / "dwi.nii.gz"
+        dist = read_distance("trans_cc_q.txt")
+        # L-BFGS-B relies on BLAS/LAPACK internally, and the local-window
+        # CC landscape is rough enough that platform-level numerical
+        # differences (e.g. Apple Accelerate vs OpenBLAS) can steer the
+        # optimizer to a slightly different local optimum. Use a
+        # relative tolerance instead of a tight absolute one so this
+        # stays meaningful without being platform-flaky.
+        npt.assert_allclose(float(dist), -189758.99583579277, rtol=1e-3)
+        check_existence(out_moved, out_affine)
 
-        image_registration_flow = ImageRegistrationFlow()
-        apply_trans = ApplyTransformFlow()
+    def test_rigid_cc():
+        out_moved = tmp_path / "rigid_cc_moved.nii.gz"
+        out_affine = tmp_path / "rigid_cc_affine.txt"
 
-        def read_distance(qual_fname):
-            with open(Path(temp_out_dir) / qual_fname) as f:
-                return float(f.readlines()[-1])
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="rigid",
+            metric="cc",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="rigid_cc_q.txt",
+        )
 
-        def test_com():
-            out_moved = Path(temp_out_dir) / "com_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "com_affine.txt"
+        dist = read_distance("rigid_cc_q.txt")
+        # Same cross-platform BLAS/LAPACK caveat as test_translation_cc,
+        # amplified here since the rigid transform's Jacobian depends on
+        # the rotation parameters (not constant like translation).
+        npt.assert_allclose(float(dist), -198329.15149667568, rtol=1e-3)
+        check_existence(out_moved, out_affine)
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="com",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-            )
-            check_existence(out_moved, out_affine)
+    def test_rigid():
+        out_moved = tmp_path / "rigid_moved.nii.gz"
+        out_affine = tmp_path / "rigid_affine.txt"
 
-        def test_translation():
-            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "trans_affine.txt"
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="rigid",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="rigid_q.txt",
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="trans",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="trans_q.txt",
-            )
+        dist = read_distance("rigid_q.txt")
+        npt.assert_almost_equal(dist, -0.7246454252101615, 1)
+        check_existence(out_moved, out_affine)
 
-            dist = read_distance("trans_q.txt")
-            npt.assert_almost_equal(float(dist), -0.42097809101318934, 1)
-            check_existence(out_moved, out_affine)
+    def test_rigid_isoscaling():
+        out_moved = tmp_path / "rigid_isoscaling_moved.nii.gz"
+        out_affine = tmp_path / "rigid_isoscaling_affine.txt"
 
-        def test_translation_cc():
-            out_moved = Path(temp_out_dir) / "trans_cc_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "trans_cc_affine.txt"
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="rigid_isoscaling",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="rigid_isoscaling_q.txt",
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="trans",
-                metric="cc",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="trans_cc_q.txt",
-            )
+        dist = read_distance("rigid_isoscaling_q.txt")
+        npt.assert_almost_equal(dist, -0.7357104551669915, 1)
+        check_existence(out_moved, out_affine)
 
-            dist = read_distance("trans_cc_q.txt")
-            # L-BFGS-B relies on BLAS/LAPACK internally, and the local-window
-            # CC landscape is rough enough that platform-level numerical
-            # differences (e.g. Apple Accelerate vs OpenBLAS) can steer the
-            # optimizer to a slightly different local optimum. Use a
-            # relative tolerance instead of a tight absolute one so this
-            # stays meaningful without being platform-flaky.
-            npt.assert_allclose(float(dist), -189758.99583579277, rtol=1e-3)
-            check_existence(out_moved, out_affine)
+    def test_rigid_scaling():
+        out_moved = tmp_path / "rigid_scaling_moved.nii.gz"
+        out_affine = tmp_path / "rigid_scaling_affine.txt"
 
-        def test_rigid_cc():
-            out_moved = Path(temp_out_dir) / "rigid_cc_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "rigid_cc_affine.txt"
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="rigid_scaling",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="rigid_scaling_q.txt",
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="rigid",
-                metric="cc",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="rigid_cc_q.txt",
-            )
+        dist = read_distance("rigid_scaling_q.txt")
+        npt.assert_almost_equal(dist, -0.698688892993124, 1)
+        check_existence(out_moved, out_affine)
 
-            dist = read_distance("rigid_cc_q.txt")
-            # Same cross-platform BLAS/LAPACK caveat as test_translation_cc,
-            # amplified here since the rigid transform's Jacobian depends on
-            # the rotation parameters (not constant like translation).
-            npt.assert_allclose(float(dist), -198329.15149667568, rtol=1e-3)
-            check_existence(out_moved, out_affine)
+    def test_affine():
+        out_moved = tmp_path / "affine_moved.nii.gz"
+        out_affine = tmp_path / "affine_affine.txt"
 
-        def test_rigid():
-            out_moved = Path(temp_out_dir) / "rigid_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "rigid_affine.txt"
+        image_registration_flow._force_overwrite = True
+        image_registration_flow.run(
+            static_image_file,
+            moving_image_file,
+            transform="affine",
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            save_metric=True,
+            level_iters=[100, 10, 1],
+            out_quality="affine_q.txt",
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="rigid",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="rigid_q.txt",
-            )
+        dist = read_distance("affine_q.txt")
+        npt.assert_almost_equal(dist, -0.7317371886943095, 1)
+        check_existence(out_moved, out_affine)
 
-            dist = read_distance("rigid_q.txt")
-            npt.assert_almost_equal(dist, -0.7246454252101615, 1)
-            check_existence(out_moved, out_affine)
+    # Creating the erroneous behavior
+    def test_err():
+        image_registration_flow._force_overwrite = True
+        npt.assert_raises(
+            ValueError,
+            image_registration_flow.run,
+            static_image_file,
+            moving_image_file,
+            transform="notransform",
+        )
 
-        def test_rigid_isoscaling():
-            out_moved = Path(temp_out_dir) / "rigid_isoscaling_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "rigid_isoscaling_affine.txt"
+        image_registration_flow._force_overwrite = True
+        npt.assert_raises(
+            ValueError,
+            image_registration_flow.run,
+            static_image_file,
+            moving_image_file,
+            metric="wrong_metric",
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="rigid_isoscaling",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="rigid_isoscaling_q.txt",
-            )
+    def check_existence(movedfile, affine_mat_file):
+        assert Path(movedfile).exists()
+        assert Path(affine_mat_file).exists()
+        return True
 
-            dist = read_distance("rigid_isoscaling_q.txt")
-            npt.assert_almost_equal(dist, -0.7357104551669915, 1)
-            check_existence(out_moved, out_affine)
+    def test_4D_static():
+        out_moved = tmp_path / "trans_moved.nii.gz"
+        out_affine = tmp_path / "trans_affine.txt"
 
-        def test_rigid_scaling():
-            out_moved = Path(temp_out_dir) / "rigid_scaling_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "rigid_scaling_affine.txt"
+        image_registration_flow._force_overwrite = True
+        kwargs = {
+            "static_image_files": dwi_image_file,
+            "moving_image_files": moving_image_file,
+            "transform": "trans",
+            "out_dir": tmp_path,
+            "out_moved": out_moved,
+            "out_affine": out_affine,
+            "save_metric": True,
+            "level_iters": [100, 10, 1],
+            "out_quality": "trans_q.txt",
+        }
+        with pytest.raises(ValueError, match="Dimension mismatch"):
+            image_registration_flow.run(**kwargs)
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="rigid_scaling",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="rigid_scaling_q.txt",
-            )
+        image_registration_flow.run(static_vol_idx=0, **kwargs)
 
-            dist = read_distance("rigid_scaling_q.txt")
-            npt.assert_almost_equal(dist, -0.698688892993124, 1)
-            check_existence(out_moved, out_affine)
+        dist = read_distance("trans_q.txt")
+        npt.assert_almost_equal(float(dist), -0.42097809101318934, 1)
+        check_existence(out_moved, out_affine)
 
-        def test_affine():
-            out_moved = Path(temp_out_dir) / "affine_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "affine_affine.txt"
+        apply_trans.run(
+            static_image_files=dwi_image_file,
+            moving_image_files=moving_image_file,
+            out_dir=tmp_path,
+            transform_map_file=out_affine,
+        )
 
-            image_registration_flow._force_overwrite = True
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform="affine",
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                save_metric=True,
-                level_iters=[100, 10, 1],
-                out_quality="affine_q.txt",
-            )
+        # Checking for the transformed volume shape
+        volume = load_nifti_data(tmp_path / "transformed.nii.gz")
+        assert volume.ndim == 3
 
-            dist = read_distance("affine_q.txt")
-            npt.assert_almost_equal(dist, -0.7317371886943095, 1)
-            check_existence(out_moved, out_affine)
+    def test_4D_moving():
+        out_moved = tmp_path / "trans_moved.nii.gz"
+        out_affine = tmp_path / "trans_affine.txt"
 
-        # Creating the erroneous behavior
-        def test_err():
-            image_registration_flow._force_overwrite = True
-            npt.assert_raises(
-                ValueError,
-                image_registration_flow.run,
-                static_image_file,
-                moving_image_file,
-                transform="notransform",
-            )
+        image_registration_flow._force_overwrite = True
 
-            image_registration_flow._force_overwrite = True
-            npt.assert_raises(
-                ValueError,
-                image_registration_flow.run,
-                static_image_file,
-                moving_image_file,
-                metric="wrong_metric",
-            )
+        kwargs = {
+            "static_image_files": static_image_file,
+            "moving_image_files": dwi_image_file,
+            "transform": "trans",
+            "out_dir": tmp_path,
+            "out_moved": out_moved,
+            "out_affine": out_affine,
+            "save_metric": True,
+            "level_iters": [100, 10, 1],
+            "out_quality": "trans_q.txt",
+        }
+        with pytest.raises(ValueError, match="Dimension mismatch"):
+            image_registration_flow.run(**kwargs)
 
-        def check_existence(movedfile, affine_mat_file):
-            assert Path(movedfile).exists()
-            assert Path(affine_mat_file).exists()
-            return True
+        image_registration_flow.run(moving_vol_idx=0, **kwargs)
 
-        def test_4D_static():
-            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "trans_affine.txt"
+        dist = read_distance("trans_q.txt")
+        npt.assert_almost_equal(float(dist), -1.0002607616786339, 1)
+        check_existence(out_moved, out_affine)
 
-            image_registration_flow._force_overwrite = True
-            kwargs = {
-                "static_image_files": dwi_image_file,
-                "moving_image_files": moving_image_file,
-                "transform": "trans",
-                "out_dir": temp_out_dir,
-                "out_moved": out_moved,
-                "out_affine": out_affine,
-                "save_metric": True,
-                "level_iters": [100, 10, 1],
-                "out_quality": "trans_q.txt",
-            }
-            with pytest.raises(ValueError, match="Dimension mismatch"):
-                image_registration_flow.run(**kwargs)
+        apply_trans.run(
+            static_image_files=static_image_file,
+            moving_image_files=dwi_image_file,
+            out_dir=tmp_path,
+            transform_map_file=out_affine,
+            out_file="transformed2.nii.gz",
+        )
 
-            image_registration_flow.run(static_vol_idx=0, **kwargs)
+        # Checking for the transformed volume shape
+        volume = load_nifti_data(tmp_path / "transformed2.nii.gz")
+        assert volume.ndim == 4
 
-            dist = read_distance("trans_q.txt")
-            npt.assert_almost_equal(float(dist), -0.42097809101318934, 1)
-            check_existence(out_moved, out_affine)
-
-            apply_trans.run(
-                static_image_files=dwi_image_file,
-                moving_image_files=moving_image_file,
-                out_dir=temp_out_dir,
-                transform_map_file=out_affine,
-            )
-
-            # Checking for the transformed volume shape
-            volume = load_nifti_data(Path(temp_out_dir) / "transformed.nii.gz")
-            assert volume.ndim == 3
-
-        def test_4D_moving():
-            out_moved = Path(temp_out_dir) / "trans_moved.nii.gz"
-            out_affine = Path(temp_out_dir) / "trans_affine.txt"
-
-            image_registration_flow._force_overwrite = True
-
-            kwargs = {
-                "static_image_files": static_image_file,
-                "moving_image_files": dwi_image_file,
-                "transform": "trans",
-                "out_dir": temp_out_dir,
-                "out_moved": out_moved,
-                "out_affine": out_affine,
-                "save_metric": True,
-                "level_iters": [100, 10, 1],
-                "out_quality": "trans_q.txt",
-            }
-            with pytest.raises(ValueError, match="Dimension mismatch"):
-                image_registration_flow.run(**kwargs)
-
-            image_registration_flow.run(moving_vol_idx=0, **kwargs)
-
-            dist = read_distance("trans_q.txt")
-            npt.assert_almost_equal(float(dist), -1.0002607616786339, 1)
-            check_existence(out_moved, out_affine)
-
-            apply_trans.run(
-                static_image_files=static_image_file,
-                moving_image_files=dwi_image_file,
-                out_dir=temp_out_dir,
-                transform_map_file=out_affine,
-                out_file="transformed2.nii.gz",
-            )
-
-            # Checking for the transformed volume shape
-            volume = load_nifti_data(Path(temp_out_dir) / "transformed2.nii.gz")
-            assert volume.ndim == 4
-
-        test_com()
-        test_translation()
-        test_translation_cc()
-        test_rigid_cc()
-        test_rigid()
-        test_rigid_isoscaling()
-        test_rigid_scaling()
-        test_affine()
-        test_err()
-        test_4D_static()
-        test_4D_moving()
+    test_com()
+    test_translation()
+    test_translation_cc()
+    test_rigid_cc()
+    test_rigid()
+    test_rigid_isoscaling()
+    test_rigid_scaling()
+    test_affine()
+    test_err()
+    test_4D_static()
+    test_4D_moving()
 
 
 def test_apply_transform_type_error():
@@ -688,155 +675,151 @@ def test_apply_transform_interp_error():
     )
 
 
-def test_apply_affine_transform():
-    with TemporaryDirectory() as temp_out_dir:
-        factors = {
-            ("TRANSLATION", 3): (2.0, None, np.array([2.3, 4.5, 1.7])),
-            ("RIGID", 3): (0.1, None, np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7])),
-            ("RIGIDISOSCALING", 3): (
-                0.1,
-                None,
-                np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7, 0.8]),
+def test_apply_affine_transform(tmp_path):
+    factors = {
+        ("TRANSLATION", 3): (2.0, None, np.array([2.3, 4.5, 1.7])),
+        ("RIGID", 3): (0.1, None, np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7])),
+        ("RIGIDISOSCALING", 3): (
+            0.1,
+            None,
+            np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7, 0.8]),
+        ),
+        ("RIGIDSCALING", 3): (
+            0.1,
+            None,
+            np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7, 0.8, 0.9, 1.1]),
+        ),
+        ("AFFINE", 3): (
+            0.1,
+            None,
+            np.array(
+                [
+                    0.99,
+                    -0.05,
+                    0.03,
+                    1.3,
+                    0.05,
+                    0.99,
+                    -0.10,
+                    2.5,
+                    -0.07,
+                    0.10,
+                    0.99,
+                    -1.4,
+                ]
             ),
-            ("RIGIDSCALING", 3): (
-                0.1,
-                None,
-                np.array([0.1, 0.15, -0.11, 2.3, 4.5, 1.7, 0.8, 0.9, 1.1]),
-            ),
-            ("AFFINE", 3): (
-                0.1,
-                None,
-                np.array(
-                    [
-                        0.99,
-                        -0.05,
-                        0.03,
-                        1.3,
-                        0.05,
-                        0.99,
-                        -0.10,
-                        2.5,
-                        -0.07,
-                        0.10,
-                        0.99,
-                        -1.4,
-                    ]
-                ),
-            ),
-        }
+        ),
+    }
 
-        image_registration_flow = ImageRegistrationFlow()
-        apply_trans = ApplyTransformFlow()
+    image_registration_flow = ImageRegistrationFlow()
+    apply_trans = ApplyTransformFlow()
 
-        for i in factors.keys():
-            static, moving, static_g2w, moving_g2w, smask, mmask, M = (
-                setup_random_transform(
-                    transform=regtransforms[i], rfactor=factors[i][0]
-                )
-            )
-
-            stat_file = str(i[0]) + "_static.nii.gz"
-            mov_file = str(i[0]) + "_moving.nii.gz"
-
-            save_nifti(Path(temp_out_dir) / stat_file, data=static, affine=static_g2w)
-
-            save_nifti(Path(temp_out_dir) / mov_file, data=moving, affine=moving_g2w)
-
-            static_image_file = Path(temp_out_dir) / str(i[0] + "_static.nii.gz")
-            moving_image_file = Path(temp_out_dir) / str(i[0] + "_moving.nii.gz")
-
-            out_moved = Path(temp_out_dir) / str(i[0] + "_moved.nii.gz")
-            out_affine = Path(temp_out_dir) / str(i[0] + "_affine.txt")
-
-            if str(i[0]) == "TRANSLATION":
-                transform_type = "trans"
-            elif str(i[0]) == "RIGIDISOSCALING":
-                transform_type = "rigid_isoscaling"
-            elif str(i[0]) == "RIGIDSCALING":
-                transform_type = "rigid_scaling"
-            else:
-                transform_type = str(i[0]).lower()
-
-            image_registration_flow.run(
-                static_image_file,
-                moving_image_file,
-                transform=transform_type,
-                out_dir=temp_out_dir,
-                out_moved=out_moved,
-                out_affine=out_affine,
-                level_iters=[1, 1, 1],
-                save_metric=False,
-            )
-
-            # Checking for the created moved file.
-            assert Path(out_moved).exists()
-            assert Path(out_affine).exists()
-
-        images = Path(temp_out_dir) / "*moving*"
-        apply_trans.run(
-            static_image_file,
-            images,
-            out_dir=temp_out_dir,
-            transform_map_file=out_affine,
+    for i in factors.keys():
+        static, moving, static_g2w, moving_g2w, smask, mmask, M = (
+            setup_random_transform(transform=regtransforms[i], rfactor=factors[i][0])
         )
 
-        # Checking for the transformed file.
-        assert Path(Path(temp_out_dir) / "transformed.nii.gz").exists()
+        stat_file = str(i[0]) + "_static.nii.gz"
+        mov_file = str(i[0]) + "_moving.nii.gz"
 
-        apply_trans.run(
+        save_nifti(tmp_path / stat_file, data=static, affine=static_g2w)
+
+        save_nifti(tmp_path / mov_file, data=moving, affine=moving_g2w)
+
+        static_image_file = tmp_path / str(i[0] + "_static.nii.gz")
+        moving_image_file = tmp_path / str(i[0] + "_moving.nii.gz")
+
+        out_moved = tmp_path / str(i[0] + "_moved.nii.gz")
+        out_affine = tmp_path / str(i[0] + "_affine.txt")
+
+        if str(i[0]) == "TRANSLATION":
+            transform_type = "trans"
+        elif str(i[0]) == "RIGIDISOSCALING":
+            transform_type = "rigid_isoscaling"
+        elif str(i[0]) == "RIGIDSCALING":
+            transform_type = "rigid_scaling"
+        else:
+            transform_type = str(i[0]).lower()
+
+        image_registration_flow.run(
             static_image_file,
-            images,
-            out_dir=temp_out_dir,
-            transform_map_file=out_affine,
-            out_file="transformed_linear.nii.gz",
+            moving_image_file,
+            transform=transform_type,
+            out_dir=tmp_path,
+            out_moved=out_moved,
+            out_affine=out_affine,
+            level_iters=[1, 1, 1],
+            save_metric=False,
         )
 
-        assert Path(Path(temp_out_dir) / "transformed_linear.nii.gz").exists()
+        # Checking for the created moved file.
+        assert Path(out_moved).exists()
+        assert Path(out_affine).exists()
 
-        apply_trans.run(
-            static_image_file,
-            images,
-            out_dir=temp_out_dir,
-            transform_map_file=out_affine,
-            interpolation="nearest",
-            out_file="transformed_nearest.nii.gz",
-        )
+    images = tmp_path / "*moving*"
+    apply_trans.run(
+        static_image_file,
+        images,
+        out_dir=tmp_path,
+        transform_map_file=out_affine,
+    )
 
-        assert Path(Path(temp_out_dir) / "transformed_nearest.nii.gz").exists()
+    # Checking for the transformed file.
+    assert Path(tmp_path / "transformed.nii.gz").exists()
+
+    apply_trans.run(
+        static_image_file,
+        images,
+        out_dir=tmp_path,
+        transform_map_file=out_affine,
+        out_file="transformed_linear.nii.gz",
+    )
+
+    assert Path(tmp_path / "transformed_linear.nii.gz").exists()
+
+    apply_trans.run(
+        static_image_file,
+        images,
+        out_dir=tmp_path,
+        transform_map_file=out_affine,
+        interpolation="nearest",
+        out_file="transformed_nearest.nii.gz",
+    )
+
+    assert Path(tmp_path / "transformed_nearest.nii.gz").exists()
 
 
-def test_motion_correction():
+def test_motion_correction(tmp_path):
     data_path, fbvals_path, fbvecs_path = get_fnames(name="small_64D")
 
-    with TemporaryDirectory() as out_dir:
-        # Use an abbreviated data-set:
-        img = nib.load(data_path)
-        data = img.get_fdata()[..., :10]
-        nib.save(nib.Nifti1Image(data, img.affine), Path(out_dir) / "data.nii.gz")
-        # Save a subset:
-        bvals = np.loadtxt(fbvals_path)
-        bvecs = np.loadtxt(fbvecs_path)
-        np.savetxt(Path(out_dir) / "bvals.txt", bvals[:10])
-        np.savetxt(Path(out_dir) / "bvecs.txt", bvecs[:10])
+    # Use an abbreviated data-set:
+    img = nib.load(data_path)
+    data = img.get_fdata()[..., :10]
+    nib.save(nib.Nifti1Image(data, img.affine), tmp_path / "data.nii.gz")
+    # Save a subset:
+    bvals = np.loadtxt(fbvals_path)
+    bvecs = np.loadtxt(fbvecs_path)
+    np.savetxt(tmp_path / "bvals.txt", bvals[:10])
+    np.savetxt(tmp_path / "bvecs.txt", bvecs[:10])
 
-        motion_correction_flow = MotionCorrectionFlow()
+    motion_correction_flow = MotionCorrectionFlow()
 
-        motion_correction_flow._force_overwrite = True
-        motion_correction_flow.run(
-            str(Path(out_dir) / "data.nii.gz"),
-            str(Path(out_dir) / "bvals.txt"),
-            str(Path(out_dir) / "bvecs.txt"),
-            out_dir=out_dir,
-        )
-        out_path = motion_correction_flow.last_generated_outputs["out_moved"]
-        corrected = load_nifti_data(out_path)
+    motion_correction_flow._force_overwrite = True
+    motion_correction_flow.run(
+        str(tmp_path / "data.nii.gz"),
+        str(tmp_path / "bvals.txt"),
+        str(tmp_path / "bvecs.txt"),
+        out_dir=tmp_path,
+    )
+    out_path = motion_correction_flow.last_generated_outputs["out_moved"]
+    corrected = load_nifti_data(out_path)
 
-        npt.assert_equal(corrected.shape, data.shape)
-        npt.assert_equal(corrected.min(), data.min())
-        npt.assert_equal(corrected.max(), data.max())
+    npt.assert_equal(corrected.shape, data.shape)
+    npt.assert_equal(corrected.min(), data.min())
+    npt.assert_equal(corrected.max(), data.max())
 
 
-def test_syn_registration_flow():
+def test_syn_registration_flow(tmp_path):
     moving_data, static_data = get_synthetic_warped_circle(40)
     moving_data[..., :10] = 0
     moving_data[..., -1:-11:-1] = 0
@@ -845,115 +828,113 @@ def test_syn_registration_flow():
 
     syn_flow = SynRegistrationFlow()
 
-    with TemporaryDirectory() as out_dir:
-        static_img = nib.Nifti1Image(static_data.astype(float), np.eye(4))
-        fname_static = Path(out_dir) / "tmp_static.nii.gz"
-        nib.save(static_img, fname_static)
+    static_img = nib.Nifti1Image(static_data.astype(float), np.eye(4))
+    fname_static = tmp_path / "tmp_static.nii.gz"
+    nib.save(static_img, fname_static)
 
-        moving_img = nib.Nifti1Image(moving_data.astype(float), np.eye(4))
-        fname_moving = Path(out_dir) / "tmp_moving.nii.gz"
-        nib.save(moving_img, fname_moving)
+    moving_img = nib.Nifti1Image(moving_data.astype(float), np.eye(4))
+    fname_moving = tmp_path / "tmp_moving.nii.gz"
+    nib.save(moving_img, fname_moving)
 
-        positional_args = [fname_static, fname_moving]
+    positional_args = [fname_static, fname_moving]
 
-        # Test the cc metric
-        metric_optional_args = {
-            "metric": "cc",
-            "mopt_sigma_diff": 2.0,
-            "mopt_radius": 4,
-        }
-        optimizer_optional_args = {
-            "level_iters": [10, 10, 5],
-            "step_length": 0.25,
-            "opt_tol": 1e-5,
-            "inv_iter": 20,
-            "inv_tol": 1e-3,
-            "ss_sigma_factor": 0.2,
-        }
+    # Test the cc metric
+    metric_optional_args = {
+        "metric": "cc",
+        "mopt_sigma_diff": 2.0,
+        "mopt_radius": 4,
+    }
+    optimizer_optional_args = {
+        "level_iters": [10, 10, 5],
+        "step_length": 0.25,
+        "opt_tol": 1e-5,
+        "inv_iter": 20,
+        "inv_tol": 1e-3,
+        "ss_sigma_factor": 0.2,
+    }
 
-        all_args = dict(metric_optional_args, **optimizer_optional_args)
-        syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
+    all_args = dict(metric_optional_args, **optimizer_optional_args)
+    syn_flow.run(*positional_args, out_dir=tmp_path, **all_args)
 
-        warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(Path(warped_path).is_file(), True)
-        warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(Path(warped_map_path).is_file(), True)
+    warped_path = syn_flow.last_generated_outputs["out_warped"]
+    npt.assert_equal(Path(warped_path).is_file(), True)
+    warped_map_path = syn_flow.last_generated_outputs["out_field"]
+    npt.assert_equal(Path(warped_map_path).is_file(), True)
 
-        # Test the ssd metric
-        metric_optional_args = {
-            "metric": "ssd",
-            "mopt_smooth": 4.0,
-            "mopt_inner_iter": 5,
-            "mopt_step_type": "demons",
-        }
-        optimizer_optional_args = {
-            "level_iters": [200, 100, 50, 25],
-            "step_length": 0.5,
-            "opt_tol": 1e-4,
-            "inv_iter": 40,
-            "inv_tol": 1e-3,
-            "ss_sigma_factor": 0.2,
-        }
+    # Test the ssd metric
+    metric_optional_args = {
+        "metric": "ssd",
+        "mopt_smooth": 4.0,
+        "mopt_inner_iter": 5,
+        "mopt_step_type": "demons",
+    }
+    optimizer_optional_args = {
+        "level_iters": [200, 100, 50, 25],
+        "step_length": 0.5,
+        "opt_tol": 1e-4,
+        "inv_iter": 40,
+        "inv_tol": 1e-3,
+        "ss_sigma_factor": 0.2,
+    }
 
-        all_args = dict(metric_optional_args, **optimizer_optional_args)
-        syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
+    all_args = dict(metric_optional_args, **optimizer_optional_args)
+    syn_flow.run(*positional_args, out_dir=tmp_path, **all_args)
 
-        warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(Path(warped_path).is_file(), True)
-        warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(Path(warped_map_path).is_file(), True)
+    warped_path = syn_flow.last_generated_outputs["out_warped"]
+    npt.assert_equal(Path(warped_path).is_file(), True)
+    warped_map_path = syn_flow.last_generated_outputs["out_field"]
+    npt.assert_equal(Path(warped_map_path).is_file(), True)
 
-        # Test the em metric
-        metric_optional_args = {
-            "metric": "em",
-            "mopt_smooth": 1.0,
-            "mopt_inner_iter": 5,
-            "mopt_step_type": "gauss_newton",
-        }
-        optimizer_optional_args = {
-            "level_iters": [200, 100, 50, 25],
-            "step_length": 0.5,
-            "opt_tol": 1e-4,
-            "inv_iter": 40,
-            "inv_tol": 1e-3,
-            "ss_sigma_factor": 0.2,
-        }
+    # Test the em metric
+    metric_optional_args = {
+        "metric": "em",
+        "mopt_smooth": 1.0,
+        "mopt_inner_iter": 5,
+        "mopt_step_type": "gauss_newton",
+    }
+    optimizer_optional_args = {
+        "level_iters": [200, 100, 50, 25],
+        "step_length": 0.5,
+        "opt_tol": 1e-4,
+        "inv_iter": 40,
+        "inv_tol": 1e-3,
+        "ss_sigma_factor": 0.2,
+    }
 
-        all_args = dict(metric_optional_args, **optimizer_optional_args)
-        syn_flow.run(*positional_args, out_dir=out_dir, **all_args)
+    all_args = dict(metric_optional_args, **optimizer_optional_args)
+    syn_flow.run(*positional_args, out_dir=tmp_path, **all_args)
 
-        warped_path = syn_flow.last_generated_outputs["out_warped"]
-        npt.assert_equal(Path(warped_path).is_file(), True)
-        warped_map_path = syn_flow.last_generated_outputs["out_field"]
-        npt.assert_equal(Path(warped_map_path).is_file(), True)
+    warped_path = syn_flow.last_generated_outputs["out_warped"]
+    npt.assert_equal(Path(warped_path).is_file(), True)
+    warped_map_path = syn_flow.last_generated_outputs["out_field"]
+    npt.assert_equal(Path(warped_map_path).is_file(), True)
 
 
 @pytest.mark.skipif(not have_pd, reason="Requires pandas")
-def test_bundlewarp_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
+def test_bundlewarp_flow(tmp_path):
+    data_path = get_fnames(name="fornix")
 
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
 
-        f = Streamlines(fornix)
-        f1 = f.copy()
+    f = Streamlines(fornix)
+    f1 = f.copy()
 
-        f1_path = Path(out_dir) / "f1.trk"
-        sft = StatefulTractogram(f1, data_path, Space.RASMM)
-        save_tractogram(sft, f1_path, bbox_valid_check=False)
+    f1_path = tmp_path / "f1.trk"
+    sft = StatefulTractogram(f1, data_path, Space.RASMM)
+    save_tractogram(sft, f1_path, bbox_valid_check=False)
 
-        f2 = f1.copy()
-        f2._data += np.array([50, 0, 0])
+    f2 = f1.copy()
+    f2._data += np.array([50, 0, 0])
 
-        f2_path = Path(out_dir) / "f2.trk"
-        sft = StatefulTractogram(f2, data_path, Space.RASMM)
-        save_tractogram(sft, f2_path, bbox_valid_check=False)
+    f2_path = tmp_path / "f2.trk"
+    sft = StatefulTractogram(f2, data_path, Space.RASMM)
+    save_tractogram(sft, f2_path, bbox_valid_check=False)
 
-        bw_flow = BundleWarpFlow(force=True)
-        bw_flow.run(f1_path, f2_path, out_dir=out_dir, bbox_valid_check=False)
+    bw_flow = BundleWarpFlow(force=True)
+    bw_flow.run(f1_path, f2_path, out_dir=tmp_path, bbox_valid_check=False)
 
-        out_linearly_moved = Path(out_dir) / "linearly_moved.trx"
-        out_nonlinearly_moved = Path(out_dir) / "nonlinearly_moved.trx"
+    out_linearly_moved = tmp_path / "linearly_moved.trx"
+    out_nonlinearly_moved = tmp_path / "nonlinearly_moved.trx"
 
-        assert out_linearly_moved.exists()
-        assert out_nonlinearly_moved.exists()
+    assert out_linearly_moved.exists()
+    assert out_nonlinearly_moved.exists()

--- a/dipy/workflows/tests/test_denoise.py
+++ b/dipy/workflows/tests/test_denoise.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
@@ -24,80 +23,72 @@ needs_sklearn = pytest.mark.skipif(
 )
 
 
-def test_nlmeans_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames()
-        volume, affine = load_nifti(data_path)
+def test_nlmeans_flow(tmp_path):
+    data_path, _, _ = get_fnames()
+    volume, affine = load_nifti(data_path)
 
-        nlmeans_flow = NLMeansFlow()
+    nlmeans_flow = NLMeansFlow()
 
-        nlmeans_flow.run(data_path, out_dir=out_dir)
-        assert_true(Path(nlmeans_flow.last_generated_outputs["out_denoised"]).is_file())
+    nlmeans_flow.run(data_path, out_dir=tmp_path)
+    assert_true(Path(nlmeans_flow.last_generated_outputs["out_denoised"]).is_file())
 
-        nlmeans_flow._force_overwrite = True
-        nlmeans_flow.run(data_path, sigma=4, out_dir=out_dir)
-        denoised_path = nlmeans_flow.last_generated_outputs["out_denoised"]
-        assert_true(Path(denoised_path).is_file())
-        denoised_data, denoised_affine = load_nifti(denoised_path)
-        npt.assert_equal(denoised_data.shape, volume.shape)
-        npt.assert_array_almost_equal(denoised_affine, affine)
+    nlmeans_flow._force_overwrite = True
+    nlmeans_flow.run(data_path, sigma=4, out_dir=tmp_path)
+    denoised_path = nlmeans_flow.last_generated_outputs["out_denoised"]
+    assert_true(Path(denoised_path).is_file())
+    denoised_data, denoised_affine = load_nifti(denoised_path)
+    npt.assert_equal(denoised_data.shape, volume.shape)
+    npt.assert_array_almost_equal(denoised_affine, affine)
 
 
 @needs_sklearn
-def test_patch2self_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path, fbvals, _ = get_fnames()
+def test_patch2self_flow(tmp_path):
+    data_path, fbvals, _ = get_fnames()
 
-        patch2self_flow = Patch2SelfFlow()
-        patch2self_flow.run(
-            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=1
-        )
-        assert_true(
-            Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
-        )
-        patch2self_flow = Patch2SelfFlow()
-        patch2self_flow.run(
-            data_path, fbvals, patch_radius=(0, 0, 0), out_dir=out_dir, ver=3
-        )
-        assert_true(
-            Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file()
-        )
+    patch2self_flow = Patch2SelfFlow()
+    patch2self_flow.run(
+        data_path, fbvals, patch_radius=(0, 0, 0), out_dir=tmp_path, ver=1
+    )
+    assert_true(Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file())
+    patch2self_flow = Patch2SelfFlow()
+    patch2self_flow.run(
+        data_path, fbvals, patch_radius=(0, 0, 0), out_dir=tmp_path, ver=3
+    )
+    assert_true(Path(patch2self_flow.last_generated_outputs["out_denoised"]).is_file())
 
 
-def test_lpca_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path, fbvals, fbvecs = get_fnames()
+def test_lpca_flow(tmp_path):
+    data_path, fbvals, fbvecs = get_fnames()
 
     lpca_flow = LPCAFlow()
-    lpca_flow.run(data_path, fbvals, fbvecs, out_dir=out_dir)
+    lpca_flow.run(data_path, fbvals, fbvecs, out_dir=tmp_path)
     assert_true(Path(lpca_flow.last_generated_outputs["out_denoised"]).is_file())
 
 
 @set_random_number_generator()
-def test_mppca_flow(rng):
-    with TemporaryDirectory() as out_dir:
-        S0 = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
-        data_path = Path(out_dir) / "random_noise.nii.gz"
-        save_nifti(data_path, S0, np.eye(4))
+def test_mppca_flow(tmp_path, rng=None):
+    S0 = 100 + 2 * rng.standard_normal((22, 23, 30, 20))
+    data_path = tmp_path / "random_noise.nii.gz"
+    save_nifti(data_path, S0, np.eye(4))
 
-        mppca_flow = MPPCAFlow()
-        mppca_flow.run(data_path, out_dir=out_dir)
-        assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
-        assert_false(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
+    mppca_flow = MPPCAFlow()
+    mppca_flow.run(data_path, out_dir=tmp_path)
+    assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
+    assert_false(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
-        mppca_flow._force_overwrite = True
-        mppca_flow.run(data_path, return_sigma=True, pca_method="svd", out_dir=out_dir)
-        assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
-        assert_true(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
+    mppca_flow._force_overwrite = True
+    mppca_flow.run(data_path, return_sigma=True, pca_method="svd", out_dir=tmp_path)
+    assert_true(Path(mppca_flow.last_generated_outputs["out_denoised"]).is_file())
+    assert_true(Path(mppca_flow.last_generated_outputs["out_sigma"]).is_file())
 
-        denoised_path = mppca_flow.last_generated_outputs["out_denoised"]
-        denoised_data = load_nifti_data(denoised_path)
-        assert_greater(denoised_data.min(), S0.min())
-        assert_less(denoised_data.max(), S0.max())
-        npt.assert_equal(np.round(denoised_data.mean()), 100)
+    denoised_path = mppca_flow.last_generated_outputs["out_denoised"]
+    denoised_data = load_nifti_data(denoised_path)
+    assert_greater(denoised_data.min(), S0.min())
+    assert_less(denoised_data.max(), S0.max())
+    npt.assert_equal(np.round(denoised_data.mean()), 100)
 
 
-def test_gibbs_flow():
+def test_gibbs_flow(tmp_path):
     def generate_slice():
         Nori = 32
         image = np.zeros((6 * Nori, 6 * Nori))
@@ -115,15 +106,14 @@ def test_gibbs_flow():
         image_gibbs = abs(np.fft.ifft2(c_crop) / 4)
         return image_gibbs
 
-    with TemporaryDirectory() as out_dir:
-        image4d = np.zeros((96, 96, 2, 2))
-        image4d[:, :, 0, 0] = generate_slice()
-        image4d[:, :, 1, 0] = generate_slice()
-        image4d[:, :, 0, 1] = generate_slice()
-        image4d[:, :, 1, 1] = generate_slice()
-        data_path = Path(out_dir) / "random_noise.nii.gz"
-        save_nifti(data_path, image4d, np.eye(4))
+    image4d = np.zeros((96, 96, 2, 2))
+    image4d[:, :, 0, 0] = generate_slice()
+    image4d[:, :, 1, 0] = generate_slice()
+    image4d[:, :, 0, 1] = generate_slice()
+    image4d[:, :, 1, 1] = generate_slice()
+    data_path = tmp_path / "random_noise.nii.gz"
+    save_nifti(data_path, image4d, np.eye(4))
 
-        gibbs_flow = GibbsRingingFlow()
-        gibbs_flow.run(data_path, out_dir=out_dir)
-        assert_true(Path(gibbs_flow.last_generated_outputs["out_unring"]).is_file())
+    gibbs_flow = GibbsRingingFlow()
+    gibbs_flow.run(data_path, out_dir=tmp_path)
+    assert_true(Path(gibbs_flow.last_generated_outputs["out_unring"]).is_file())

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 
 import numpy.testing as npt
 
@@ -53,30 +52,24 @@ def test_none_or_dtype():
     dec = none_or_dtype(tuple)
 
 
-def test_variable_type():
-    with TemporaryDirectory() as out_dir:
-        open(Path(out_dir) / "test", "w").close()
-        open(Path(out_dir) / "test1", "w").close()
-        open(Path(out_dir) / "test2", "w").close()
+def test_variable_type(tmp_path):
+    open(tmp_path / "test", "w").close()
+    open(tmp_path / "test1", "w").close()
+    open(tmp_path / "test2", "w").close()
 
-        sys.argv = [sys.argv[0]]
-        pos_results = [
-            Path(out_dir) / "test",
-            Path(out_dir) / "test1",
-            Path(out_dir) / "test2",
-            12,
-        ]
-        inputs = inputs_from_results(pos_results)
-        sys.argv.extend(inputs)
-        dcwf = DummyVariableTypeWorkflow()
-        _, positional_res, positional_res2 = run_flow(dcwf)
-        npt.assert_equal(positional_res2, 12)
+    sys.argv = [sys.argv[0]]
+    pos_results = [tmp_path / "test", tmp_path / "test1", tmp_path / "test2", 12]
+    inputs = inputs_from_results(pos_results)
+    sys.argv.extend(inputs)
+    dcwf = DummyVariableTypeWorkflow()
+    _, positional_res, positional_res2 = run_flow(dcwf)
+    npt.assert_equal(positional_res2, 12)
 
-        for k, v in zip(positional_res, pos_results[:-1]):
-            npt.assert_equal(Path(k), v)
+    for k, v in zip(positional_res, pos_results[:-1]):
+        npt.assert_equal(Path(k), v)
 
-        dcwf = DummyVariableTypeErrorWorkflow()
-        npt.assert_raises(ValueError, run_flow, dcwf)
+    dcwf = DummyVariableTypeErrorWorkflow()
+    npt.assert_raises(ValueError, run_flow, dcwf)
 
 
 def test_iap():

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 import shutil
 import sys
-from tempfile import TemporaryDirectory, mkstemp
+from tempfile import mkstemp
 
 import numpy as np
 import numpy.testing as npt
@@ -56,7 +56,7 @@ logging.basicConfig(
 is_big_endian = "big" in sys.byteorder.lower()
 
 
-def test_io_info(caplog):
+def test_io_info(tmp_path, caplog):
     fimg, fbvals, fbvecs = get_fnames(name="small_101D")
     io_info_flow = IoInfoFlow()
     io_info_flow.run([fimg, fbvals, fbvecs])
@@ -92,12 +92,11 @@ def test_io_info(caplog):
     )
 
     pam = generate_random_pam()
-    with TemporaryDirectory() as out_dir:
-        pam_fname = Path(out_dir) / "test_info.pam5"
-        save_pam(pam_fname, pam)
-        io_info_flow = IoInfoFlow()
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            io_info_flow.run(pam_fname)
+    pam_fname = tmp_path / "test_info.pam5"
+    save_pam(pam_fname, pam)
+    io_info_flow = IoInfoFlow()
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        io_info_flow.run(pam_fname)
 
     npt.assert_equal("PAM5 version" in caplog.text, True)
     npt.assert_equal("Volume dimensions" in caplog.text, True)
@@ -112,7 +111,7 @@ def test_io_info(caplog):
             pass
 
 
-def test_io_info_pam_missing_fields(caplog):
+def test_io_info_pam_missing_fields(tmp_path, caplog):
     pam = PeaksAndMetrics()
     pam.peak_dirs = np.zeros((5, 5, 5, 3, 3))
     pam.peak_values = np.zeros((5, 5, 5, 3))
@@ -129,12 +128,11 @@ def test_io_info_pam_missing_fields(caplog):
     pam.qa = None
     pam.odf = None
 
-    with TemporaryDirectory() as out_dir:
-        pam_fname = Path(out_dir) / "minimal.pam5"
-        save_pam(pam_fname, pam)
-        io_info_flow = IoInfoFlow()
-        with caplog.at_level(logging.INFO, logger="dipy"):
-            io_info_flow.run(pam_fname)
+    pam_fname = tmp_path / "minimal.pam5"
+    save_pam(pam_fname, pam)
+    io_info_flow = IoInfoFlow()
+    with caplog.at_level(logging.INFO, logger="dipy"):
+        io_info_flow.run(pam_fname)
 
     lines = caplog.text.splitlines()
     for label in [
@@ -152,14 +150,13 @@ def test_io_info_pam_missing_fields(caplog):
         npt.assert_equal(len(matching) > 0, True)
 
 
-def test_io_fetch():
+def test_io_fetch(tmp_path):
     fetch_flow = FetchFlow()
-    with TemporaryDirectory() as out_dir:
-        fetch_flow.run(["bundle_fa_hcp"])
-        npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
+    fetch_flow.run(["bundle_fa_hcp"])
+    npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
 
-        fetch_flow.run(["bundle_fa_hcp"], out_dir=out_dir)
-        npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
+    fetch_flow.run(["bundle_fa_hcp"], out_dir=tmp_path)
+    npt.assert_equal(Path(dipy_home / "bundle_fa_hcp").is_dir(), True)
 
 
 def test_io_fetch_fetcher_datanames():
@@ -334,148 +331,141 @@ def test_format_data_names_table():
     )
 
 
-def test_split_flow():
-    with TemporaryDirectory() as out_dir:
-        split_flow = SplitFlow()
-        data_path, _, _ = get_fnames()
-        volume, affine = load_nifti(data_path)
-        split_flow.run(data_path, out_dir=out_dir)
-        assert_true(Path(split_flow.last_generated_outputs["out_split"]).is_file())
-        split_flow._force_overwrite = True
-        split_flow.run(data_path, vol_idx=0, out_dir=out_dir)
-        split_path = split_flow.last_generated_outputs["out_split"]
-        assert_true(Path(split_path).is_file())
-        split_data, split_affine = load_nifti(split_path)
-        npt.assert_equal(split_data.shape, volume[..., 0].shape)
-        npt.assert_array_almost_equal(split_affine, affine)
+def test_split_flow(tmp_path):
+    split_flow = SplitFlow()
+    data_path, _, _ = get_fnames()
+    volume, affine = load_nifti(data_path)
+    split_flow.run(data_path, out_dir=tmp_path)
+    assert_true(Path(split_flow.last_generated_outputs["out_split"]).is_file())
+    split_flow._force_overwrite = True
+    split_flow.run(data_path, vol_idx=0, out_dir=tmp_path)
+    split_path = split_flow.last_generated_outputs["out_split"]
+    assert_true(Path(split_path).is_file())
+    split_data, split_affine = load_nifti(split_path)
+    npt.assert_equal(split_data.shape, volume[..., 0].shape)
+    npt.assert_array_almost_equal(split_affine, affine)
 
 
-def test_concatenate_flow():
-    with TemporaryDirectory() as out_dir:
-        concatenate_flow = ConcatenateTractogramFlow()
-        data_path, _, _ = get_fnames(name="gold_standard_io")
-        input_files = [
-            v
-            for k, v in data_path.items()
-            if k
-            in [
-                "gs_streamlines.trk",
-                "gs_streamlines.tck",
-                "gs_streamlines.trx",
-                "gs_streamlines.fib",
-            ]
+def test_concatenate_flow(tmp_path):
+    concatenate_flow = ConcatenateTractogramFlow()
+    data_path, _, _ = get_fnames(name="gold_standard_io")
+    input_files = [
+        v
+        for k, v in data_path.items()
+        if k
+        in [
+            "gs_streamlines.trk",
+            "gs_streamlines.tck",
+            "gs_streamlines.trx",
+            "gs_streamlines.fib",
         ]
-        concatenate_flow.run(*input_files, out_dir=out_dir)
-        assert_true(
-            str(concatenate_flow.last_generated_outputs["out_extension"]).endswith(
-                "trx"
-            )
-        )
-        _fname = concatenate_flow.last_generated_outputs["out_tractogram"]
-        _fname = Path(_fname).with_suffix(Path(_fname).suffix + ".trx")
-        assert_true(_fname.is_file())
+    ]
+    concatenate_flow.run(*input_files, out_dir=tmp_path)
+    assert_true(
+        str(concatenate_flow.last_generated_outputs["out_extension"]).endswith("trx")
+    )
+    _fname = concatenate_flow.last_generated_outputs["out_tractogram"]
+    _fname = Path(_fname).with_suffix(Path(_fname).suffix + ".trx")
+    assert_true(_fname.is_file())
 
-        trk = load_tractogram(_fname, "same")
-        npt.assert_equal(len(trk), 13)
-
-
-def test_convert_sh_flow():
-    with TemporaryDirectory() as out_dir:
-        filepath_in = Path(out_dir) / "sh_coeff_img.nii.gz"
-        filename_out = "sh_coeff_img_converted.nii.gz"
-        filepath_out = Path(out_dir) / filename_out
-
-        # Create an input image
-        dim0, dim1, dim2 = 2, 3, 3  # spatial dimensions of array
-        num_sh_coeffs = 15  # 15 sh coeffs means l_max is 4
-        img_in = np.arange(dim0 * dim1 * dim2 * num_sh_coeffs, dtype=float).reshape(
-            dim0, dim1, dim2, num_sh_coeffs
-        )
-        save_nifti(filepath_in, img_in, np.eye(4))
-
-        # Compute expected result to compare against later
-        expected_img_out = convert_sh_descoteaux_tournier(img_in)
-
-        # Run the workflow and load the output
-        workflow = ConvertSHFlow()
-        workflow.run(
-            filepath_in,
-            out_dir=out_dir,
-            out_file=filename_out,
-        )
-        img_out, _ = load_nifti(filepath_out)
-
-        # Compare
-        npt.assert_array_almost_equal(img_out, expected_img_out)
+    trk = load_tractogram(_fname, "same")
+    npt.assert_equal(len(trk), 13)
 
 
-def test_convert_tractogram_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="gold_standard_io")
-        input_files = [
-            v
-            for k, v in data_path.items()
-            if k
-            in [
-                "gs_streamlines.tck",
-            ]
+def test_convert_sh_flow(tmp_path):
+    filepath_in = tmp_path / "sh_coeff_img.nii.gz"
+    filename_out = "sh_coeff_img_converted.nii.gz"
+    filepath_out = tmp_path / filename_out
+
+    # Create an input image
+    dim0, dim1, dim2 = 2, 3, 3  # spatial dimensions of array
+    num_sh_coeffs = 15  # 15 sh coeffs means l_max is 4
+    img_in = np.arange(dim0 * dim1 * dim2 * num_sh_coeffs, dtype=float).reshape(
+        dim0, dim1, dim2, num_sh_coeffs
+    )
+    save_nifti(filepath_in, img_in, np.eye(4))
+
+    # Compute expected result to compare against later
+    expected_img_out = convert_sh_descoteaux_tournier(img_in)
+
+    # Run the workflow and load the output
+    workflow = ConvertSHFlow()
+    workflow.run(
+        filepath_in,
+        out_dir=tmp_path,
+        out_file=filename_out,
+    )
+    img_out, _ = load_nifti(filepath_out)
+
+    # Compare
+    npt.assert_array_almost_equal(img_out, expected_img_out)
+
+
+def test_convert_tractogram_flow(tmp_path):
+    data_path, _, _ = get_fnames(name="gold_standard_io")
+    input_files = [
+        v
+        for k, v in data_path.items()
+        if k
+        in [
+            "gs_streamlines.tck",
         ]
+    ]
 
-        convert_tractogram_flow = ConvertTractogramFlow(mix_names=True)
-        convert_tractogram_flow.run(
-            input_files, reference=str(data_path["gs_volume.nii"]), out_dir=out_dir
+    convert_tractogram_flow = ConvertTractogramFlow(mix_names=True)
+    convert_tractogram_flow.run(
+        input_files, reference=str(data_path["gs_volume.nii"]), out_dir=tmp_path
+    )
+
+    convert_tractogram_flow._force_overwrite = True
+    npt.assert_raises(
+        ValueError, convert_tractogram_flow.run, input_files, out_dir=tmp_path
+    )
+
+    if not is_big_endian:
+        assert_warns(
+            UserWarning,
+            convert_tractogram_flow.run,
+            str(data_path["gs_streamlines.trx"]),
+            out_dir=tmp_path,
+            out_tractogram="gs_converted.trx",
         )
 
-        convert_tractogram_flow._force_overwrite = True
-        npt.assert_raises(
-            ValueError, convert_tractogram_flow.run, input_files, out_dir=out_dir
-        )
 
-        if not is_big_endian:
-            assert_warns(
-                UserWarning,
-                convert_tractogram_flow.run,
-                str(data_path["gs_streamlines.trx"]),
-                out_dir=out_dir,
-                out_tractogram="gs_converted.trx",
-            )
+def test_convert_tensors_flow(tmp_path):
+    filepath_in = tmp_path / "tensors_img.nii.gz"
+    filename_out = "tensors_converted.nii.gz"
+    filepath_out = tmp_path / filename_out
 
+    # Create an input image
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    data, affine = load_nifti(fdata)
+    gtab = grad.gradient_table(fbval, bvecs=fbvec)
+    tenmodel = dti.TensorModel(gtab)
+    tenfit = tenmodel.fit(data)
 
-def test_convert_tensors_flow():
-    with TemporaryDirectory() as out_dir:
-        filepath_in = Path(out_dir) / "tensors_img.nii.gz"
-        filename_out = "tensors_converted.nii.gz"
-        filepath_out = Path(out_dir) / filename_out
+    tensor_vals = dti.lower_triangular(tenfit.quadratic_form)
+    ten_img = nifti1_symmat(tensor_vals, affine=affine)
 
-        # Create an input image
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        data, affine = load_nifti(fdata)
-        gtab = grad.gradient_table(fbval, bvecs=fbvec)
-        tenmodel = dti.TensorModel(gtab)
-        tenfit = tenmodel.fit(data)
+    save_nifti(filepath_in, ten_img.get_fdata().squeeze(), affine)
 
-        tensor_vals = dti.lower_triangular(tenfit.quadratic_form)
-        ten_img = nifti1_symmat(tensor_vals, affine=affine)
+    # Compute expected result to compare against later
+    expected_img_out = reconst_utils.convert_tensors(
+        ten_img.get_fdata(), "dipy", "mrtrix"
+    )
 
-        save_nifti(filepath_in, ten_img.get_fdata().squeeze(), affine)
+    # Run the workflow and load the output
+    workflow = ConvertTensorsFlow()
+    workflow.run(
+        filepath_in,
+        from_format="dipy",
+        to_format="mrtrix",
+        out_dir=tmp_path,
+        out_tensor=filename_out,
+    )
 
-        # Compute expected result to compare against later
-        expected_img_out = reconst_utils.convert_tensors(
-            ten_img.get_fdata(), "dipy", "mrtrix"
-        )
-
-        # Run the workflow and load the output
-        workflow = ConvertTensorsFlow()
-        workflow.run(
-            filepath_in,
-            from_format="dipy",
-            to_format="mrtrix",
-            out_dir=out_dir,
-            out_tensor=filename_out,
-        )
-
-        img_out, _ = load_nifti(filepath_out)
-        npt.assert_array_almost_equal(img_out, expected_img_out)
+    img_out, _ = load_nifti(filepath_out)
+    npt.assert_array_almost_equal(img_out, expected_img_out)
 
 
 def generate_random_pam():
@@ -495,35 +485,34 @@ def generate_random_pam():
     return pam
 
 
-def test_niftis_to_pam_flow():
+def test_niftis_to_pam_flow(tmp_path):
     pam = generate_random_pam()
-    with TemporaryDirectory() as out_dir:
-        fname = Path(out_dir) / "test.pam5"
-        save_pam(fname, pam)
+    fname = tmp_path / "test.pam5"
+    save_pam(fname, pam)
 
-        args = [fname, out_dir]
-        flow = PamToNiftisFlow()
-        flow.run(*args)
+    args = [fname, tmp_path]
+    flow = PamToNiftisFlow()
+    flow.run(*args)
 
-        args = [
-            flow.last_generated_outputs["out_peaks_dir"],
-            flow.last_generated_outputs["out_peaks_values"],
-            flow.last_generated_outputs["out_peaks_indices"],
-        ]
+    args = [
+        flow.last_generated_outputs["out_peaks_dir"],
+        flow.last_generated_outputs["out_peaks_values"],
+        flow.last_generated_outputs["out_peaks_indices"],
+    ]
 
-        flow2 = NiftisToPamFlow()
-        flow2.run(*args, out_dir=out_dir)
-        pam_file = flow2.last_generated_outputs["out_pam"]
-        assert_true(Path(pam_file).is_file())
+    flow2 = NiftisToPamFlow()
+    flow2.run(*args, out_dir=tmp_path)
+    pam_file = flow2.last_generated_outputs["out_pam"]
+    assert_true(Path(pam_file).is_file())
 
-        res_pam = load_pam(pam_file)
-        npt.assert_array_equal(pam.affine, res_pam.affine)
-        npt.assert_array_almost_equal(pam.peak_dirs, res_pam.peak_dirs)
-        npt.assert_array_almost_equal(pam.peak_values, res_pam.peak_values)
-        npt.assert_array_almost_equal(pam.peak_indices, res_pam.peak_indices)
+    res_pam = load_pam(pam_file)
+    npt.assert_array_equal(pam.affine, res_pam.affine)
+    npt.assert_array_almost_equal(pam.peak_dirs, res_pam.peak_dirs)
+    npt.assert_array_almost_equal(pam.peak_values, res_pam.peak_values)
+    npt.assert_array_almost_equal(pam.peak_indices, res_pam.peak_indices)
 
 
-def test_tensor_to_pam_flow():
+def test_tensor_to_pam_flow(tmp_path):
     fdata, fbval, fbvec = get_fnames(name="small_25")
     gtab = grad.gradient_table(fbval, bvecs=fbvec)
     data, affine = load_nifti(fdata)
@@ -531,211 +520,200 @@ def test_tensor_to_pam_flow():
     df = dm.fit(data)
     df.evals[0, 0, 0] = np.array([0, 0, 0])
 
-    with TemporaryDirectory() as out_dir:
-        f_mevals, f_mevecs = (
-            Path(out_dir) / "evals.nii.gz",
-            Path(out_dir) / "evecs.nii.gz",
-        )
-        save_nifti(f_mevals, df.evals, affine)
-        save_nifti(f_mevecs, df.evecs, affine)
+    f_mevals, f_mevecs = (tmp_path / "evals.nii.gz", tmp_path / "evecs.nii.gz")
+    save_nifti(f_mevals, df.evals, affine)
+    save_nifti(f_mevecs, df.evecs, affine)
 
-        args = [f_mevals, f_mevecs]
-        flow = TensorToPamFlow()
-        flow.run(*args, out_dir=out_dir)
-        pam_file = flow.last_generated_outputs["out_pam"]
-        assert_true(Path(pam_file).is_file())
+    args = [f_mevals, f_mevecs]
+    flow = TensorToPamFlow()
+    flow.run(*args, out_dir=tmp_path)
+    pam_file = flow.last_generated_outputs["out_pam"]
+    assert_true(Path(pam_file).is_file())
 
-        pam = load_pam(pam_file)
-        npt.assert_array_equal(pam.affine, affine)
-        npt.assert_array_almost_equal(pam.peak_dirs[..., :3, :], df.evecs)
-        npt.assert_array_almost_equal(pam.peak_values[..., :3], df.evals)
+    pam = load_pam(pam_file)
+    npt.assert_array_equal(pam.affine, affine)
+    npt.assert_array_almost_equal(pam.peak_dirs[..., :3, :], df.evecs)
+    npt.assert_array_almost_equal(pam.peak_values[..., :3], df.evals)
 
 
-def test_pam_to_niftis_flow():
+def test_pam_to_niftis_flow(tmp_path):
     pam = generate_random_pam()
 
-    with TemporaryDirectory() as out_dir:
-        fname = Path(out_dir) / "test.pam5"
-        save_pam(fname, pam)
+    fname = tmp_path / "test.pam5"
+    save_pam(fname, pam)
 
-        args = [fname, out_dir]
-        flow = PamToNiftisFlow()
-        flow.run(*args)
-        assert_true(Path(flow.last_generated_outputs["out_peaks_dir"]).is_file())
-        assert_true(Path(flow.last_generated_outputs["out_peaks_values"]).is_file())
-        assert_true(Path(flow.last_generated_outputs["out_peaks_indices"]).is_file())
-        assert_true(Path(flow.last_generated_outputs["out_shm"]).is_file())
-        assert_true(Path(flow.last_generated_outputs["out_gfa"]).is_file())
-        assert_true(Path(flow.last_generated_outputs["out_sphere"]).is_file())
+    args = [fname, tmp_path]
+    flow = PamToNiftisFlow()
+    flow.run(*args)
+    assert_true(Path(flow.last_generated_outputs["out_peaks_dir"]).is_file())
+    assert_true(Path(flow.last_generated_outputs["out_peaks_values"]).is_file())
+    assert_true(Path(flow.last_generated_outputs["out_peaks_indices"]).is_file())
+    assert_true(Path(flow.last_generated_outputs["out_shm"]).is_file())
+    assert_true(Path(flow.last_generated_outputs["out_gfa"]).is_file())
+    assert_true(Path(flow.last_generated_outputs["out_sphere"]).is_file())
 
 
-def test_math():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_101D")
-        data_path_a = Path(out_dir) / "data_a.nii.gz"
-        data_path_b = Path(out_dir) / "data_b.nii.gz"
-        shutil.copy(data_path, data_path_a)
-        shutil.copy(data_path, data_path_b)
+def test_math(tmp_path):
+    data_path, _, _ = get_fnames(name="small_101D")
+    data_path_a = tmp_path / "data_a.nii.gz"
+    data_path_b = tmp_path / "data_b.nii.gz"
+    shutil.copy(data_path, data_path_a)
+    shutil.copy(data_path, data_path_b)
 
-        data, _ = load_nifti(data_path)
-        operations = ["vol1*3", "vol1+vol2+vol3", "5*vol1-vol2-vol3", "vol3*2 + vol2"]
-        kwargs = [{"dtype": "i"}, {"dtype": "float32"}, {}, {}]
+    data, _ = load_nifti(data_path)
+    operations = ["vol1*3", "vol1+vol2+vol3", "5*vol1-vol2-vol3", "vol3*2 + vol2"]
+    kwargs = [{"dtype": "i"}, {"dtype": "float32"}, {}, {}]
 
-        if have_ne:
-            for op, kwarg in zip(operations, kwargs):
-                math_flow = MathFlow()
-                math_flow.run(
-                    op,
-                    [data_path_a, data_path_b, data_path],
-                    out_dir=out_dir,
-                    **kwarg,
-                )
-                out_path = Path(out_dir) / "math_out.nii.gz"
-                out_data, _ = load_nifti(out_path)
-                npt.assert_array_equal(out_data, data * 3)
-                if kwarg:
-                    npt.assert_equal(out_data.dtype, np.dtype(kwarg["dtype"]))
-
-            # Test broadcasting 3D/4D
-            data_3d = np.ones(data.shape[:-1]) * 15
-            data_3d_path = Path(out_dir) / "data_3d.nii.gz"
-            save_nifti(data_3d_path, data_3d, np.eye(4))
+    if have_ne:
+        for op, kwarg in zip(operations, kwargs):
             math_flow = MathFlow()
             math_flow.run(
-                "vol1*vol2",
-                [data_path_a, data_3d_path],
-                disable_check=True,
-                out_dir=out_dir,
+                op,
+                [data_path_a, data_path_b, data_path],
+                out_dir=tmp_path,
+                **kwarg,
             )
-
-            # Test boolean data type
-            data_bool = np.ones(data.shape, dtype=np.uint8)
-            data_bool_2 = np.zeros(data.shape, dtype=np.uint8)
-            data_bool_path = Path(out_dir) / "data_bool.nii.gz"
-            data_bool_2_path = Path(out_dir) / "data_bool_2.nii.gz"
-            save_nifti(data_bool_path, data_bool, np.eye(4))
-            save_nifti(data_bool_2_path, data_bool_2, np.eye(4))
-            math_flow = MathFlow()
-            math_flow.run(
-                "vol1*vol2",
-                [data_bool_path, data_bool_2_path],
-                disable_check=True,
-                dtype="bool",
-                out_dir=out_dir,
-            )
-            out_path = Path(out_dir) / "math_out.nii.gz"
+            out_path = tmp_path / "math_out.nii.gz"
             out_data, _ = load_nifti(out_path)
-            npt.assert_array_equal(out_data, data_bool * data_bool_2)
-            npt.assert_equal(out_data.dtype, np.uint8)
+            npt.assert_array_equal(out_data, data * 3)
+            if kwarg:
+                npt.assert_equal(out_data.dtype, np.dtype(kwarg["dtype"]))
 
-        else:
-            math_flow = MathFlow()
-            npt.assert_raises(TripWireError, math_flow.run, "vol1*3", [data_path_a])
+        # Test broadcasting 3D/4D
+        data_3d = np.ones(data.shape[:-1]) * 15
+        data_3d_path = tmp_path / "data_3d.nii.gz"
+        save_nifti(data_3d_path, data_3d, np.eye(4))
+        math_flow = MathFlow()
+        math_flow.run(
+            "vol1*vol2",
+            [data_path_a, data_3d_path],
+            disable_check=True,
+            out_dir=tmp_path,
+        )
+
+        # Test boolean data type
+        data_bool = np.ones(data.shape, dtype=np.uint8)
+        data_bool_2 = np.zeros(data.shape, dtype=np.uint8)
+        data_bool_path = tmp_path / "data_bool.nii.gz"
+        data_bool_2_path = tmp_path / "data_bool_2.nii.gz"
+        save_nifti(data_bool_path, data_bool, np.eye(4))
+        save_nifti(data_bool_2_path, data_bool_2, np.eye(4))
+        math_flow = MathFlow()
+        math_flow.run(
+            "vol1*vol2",
+            [data_bool_path, data_bool_2_path],
+            disable_check=True,
+            dtype="bool",
+            out_dir=tmp_path,
+        )
+        out_path = tmp_path / "math_out.nii.gz"
+        out_data, _ = load_nifti(out_path)
+        npt.assert_array_equal(out_data, data_bool * data_bool_2)
+        npt.assert_equal(out_data.dtype, np.uint8)
+
+    else:
+        math_flow = MathFlow()
+        npt.assert_raises(TripWireError, math_flow.run, "vol1*3", [data_path_a])
 
 
 @pytest.mark.skipif(not have_ne, reason="numexpr not installed")
-def test_math_error():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_101D")
-        data_path_2, _, _ = get_fnames(name="small_64D")
-        data_path_a = Path(out_dir) / "data_a.nii.gz"
-        data_path_b = Path(out_dir) / "data_b.gz"
-        data_path_c = Path(out_dir) / "data_c.nii"
-        shutil.copy(data_path, data_path_a)
-        shutil.copy(data_path, data_path_b)
+def test_math_error(tmp_path):
+    data_path, _, _ = get_fnames(name="small_101D")
+    data_path_2, _, _ = get_fnames(name="small_64D")
+    data_path_a = tmp_path / "data_a.nii.gz"
+    data_path_b = tmp_path / "data_b.gz"
+    data_path_c = tmp_path / "data_c.nii"
+    shutil.copy(data_path, data_path_a)
+    shutil.copy(data_path, data_path_b)
 
-        math_flow = MathFlow()
-        npt.assert_raises(
-            SyntaxError, math_flow.run, "vol1*", [data_path_a], out_dir=out_dir
-        )
-        npt.assert_raises(
-            SystemExit,
-            math_flow.run,
-            "vol1*2",
-            [data_path_a],
-            dtype="k",
-            out_dir=out_dir,
-        )
-        npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [data_path_b], out_dir=out_dir
-        )
-        npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*2", [data_path_c], out_dir=out_dir
-        )
-        npt.assert_raises(
-            SystemExit, math_flow.run, "vol1*vol3", [data_path_a], out_dir=out_dir
-        )
-        npt.assert_raises(
-            SystemExit,
-            math_flow.run,
-            "vol1*vol2",
-            [data_path, data_path_2],
-            out_dir=out_dir,
-        )
-
-
-def test_extract_b0_flow():
-    with TemporaryDirectory() as out_dir:
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        data, affine = load_nifti(fdata)
-        b0_data = data[..., 0]
-        b0_path = Path(out_dir) / "b0_expected.nii.gz"
-        save_nifti(b0_path, b0_data, affine)
-
-        extract_b0_flow = ExtractB0Flow()
-        extract_b0_flow.run(fdata, fbval, out_dir=out_dir, strategy="first")
-        npt.assert_equal(
-            Path(extract_b0_flow.last_generated_outputs["out_b0"]),
-            Path(out_dir) / "b0.nii.gz",
-        )
-        res, _ = load_nifti(extract_b0_flow.last_generated_outputs["out_b0"])
-        npt.assert_array_equal(res, b0_data)
+    math_flow = MathFlow()
+    npt.assert_raises(
+        SyntaxError, math_flow.run, "vol1*", [data_path_a], out_dir=tmp_path
+    )
+    npt.assert_raises(
+        SystemExit,
+        math_flow.run,
+        "vol1*2",
+        [data_path_a],
+        dtype="k",
+        out_dir=tmp_path,
+    )
+    npt.assert_raises(
+        SystemExit, math_flow.run, "vol1*2", [data_path_b], out_dir=tmp_path
+    )
+    npt.assert_raises(
+        SystemExit, math_flow.run, "vol1*2", [data_path_c], out_dir=tmp_path
+    )
+    npt.assert_raises(
+        SystemExit, math_flow.run, "vol1*vol3", [data_path_a], out_dir=tmp_path
+    )
+    npt.assert_raises(
+        SystemExit,
+        math_flow.run,
+        "vol1*vol2",
+        [data_path, data_path_2],
+        out_dir=tmp_path,
+    )
 
 
-def test_extract_shell_flow():
-    with TemporaryDirectory() as out_dir:
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        data, affine = load_nifti(fdata)
+def test_extract_b0_flow(tmp_path):
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    data, affine = load_nifti(fdata)
+    b0_data = data[..., 0]
+    b0_path = tmp_path / "b0_expected.nii.gz"
+    save_nifti(b0_path, b0_data, affine)
 
-        extract_shell_flow = ExtractShellFlow()
-        extract_shell_flow.run(
-            fdata, fbval, fbvec, bvals_to_extract="2000", out_dir=out_dir
-        )
-        res, _ = load_nifti(Path(out_dir) / "shell_2000.nii.gz")
-        npt.assert_array_equal(res, data[..., 1:])
-
-        extract_shell_flow._force_overwrite = True
-        extract_shell_flow.run(
-            fdata,
-            fbval,
-            fbvec,
-            bvals_to_extract="0, 2000",
-            group_shells=False,
-            out_dir=out_dir,
-        )
-        npt.assert_equal(Path(Path(out_dir) / "shell_0.nii.gz").is_file(), True)
-        npt.assert_equal(Path(Path(out_dir) / "shell_2000.nii.gz").is_file(), True)
-        res0, _ = load_nifti(Path(out_dir) / "shell_0.nii.gz")
-        res2000, _ = load_nifti(Path(out_dir) / "shell_2000.nii.gz")
-        npt.assert_array_equal(np.squeeze(res0), data[..., 0])
-        npt.assert_array_equal(res2000[..., 9], data[..., 10])
+    extract_b0_flow = ExtractB0Flow()
+    extract_b0_flow.run(fdata, fbval, out_dir=tmp_path, strategy="first")
+    npt.assert_equal(
+        extract_b0_flow.last_generated_outputs["out_b0"], tmp_path / "b0.nii.gz"
+    )
+    res, _ = load_nifti(extract_b0_flow.last_generated_outputs["out_b0"])
+    npt.assert_array_equal(res, b0_data)
 
 
-def test_extract_volume_flow():
-    with TemporaryDirectory() as out_dir:
-        fdata, _, _ = get_fnames(name="small_25")
-        data, affine = load_nifti(fdata)
+def test_extract_shell_flow(tmp_path):
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    data, affine = load_nifti(fdata)
 
-        extract_volume_flow = ExtractVolumeFlow()
-        extract_volume_flow.run(fdata, vol_idx="0-3,5", out_dir=out_dir)
-        res, _ = load_nifti(extract_volume_flow.last_generated_outputs["out_vol"])
-        npt.assert_equal(res.shape[-1], 5)
+    extract_shell_flow = ExtractShellFlow()
+    extract_shell_flow.run(
+        fdata, fbval, fbvec, bvals_to_extract="2000", out_dir=tmp_path
+    )
+    res, _ = load_nifti(tmp_path / "shell_2000.nii.gz")
+    npt.assert_array_equal(res, data[..., 1:])
 
-        extract_volume_flow._force_overwrite = True
-        extract_volume_flow.run(fdata, vol_idx="0-3,5", grouped=False, out_dir=out_dir)
-        npt.assert_equal(Path(Path(out_dir) / "volume_2.nii.gz").is_file(), True)
-        npt.assert_equal(Path(Path(out_dir) / "volume_5.nii.gz").is_file(), True)
-        res2, _ = load_nifti(Path(out_dir) / "volume_2.nii.gz")
-        res5, _ = load_nifti(Path(out_dir) / "volume_5.nii.gz")
-        npt.assert_array_equal(res2, data[..., 2])
-        npt.assert_array_equal(res5, data[..., 5])
+    extract_shell_flow._force_overwrite = True
+    extract_shell_flow.run(
+        fdata,
+        fbval,
+        fbvec,
+        bvals_to_extract="0, 2000",
+        group_shells=False,
+        out_dir=tmp_path,
+    )
+    npt.assert_equal(Path(tmp_path / "shell_0.nii.gz").is_file(), True)
+    npt.assert_equal(Path(tmp_path / "shell_2000.nii.gz").is_file(), True)
+    res0, _ = load_nifti(tmp_path / "shell_0.nii.gz")
+    res2000, _ = load_nifti(tmp_path / "shell_2000.nii.gz")
+    npt.assert_array_equal(np.squeeze(res0), data[..., 0])
+    npt.assert_array_equal(res2000[..., 9], data[..., 10])
+
+
+def test_extract_volume_flow(tmp_path):
+    fdata, _, _ = get_fnames(name="small_25")
+    data, affine = load_nifti(fdata)
+
+    extract_volume_flow = ExtractVolumeFlow()
+    extract_volume_flow.run(fdata, vol_idx="0-3,5", out_dir=tmp_path)
+    res, _ = load_nifti(extract_volume_flow.last_generated_outputs["out_vol"])
+    npt.assert_equal(res.shape[-1], 5)
+
+    extract_volume_flow._force_overwrite = True
+    extract_volume_flow.run(fdata, vol_idx="0-3,5", grouped=False, out_dir=tmp_path)
+    npt.assert_equal(Path(tmp_path / "volume_2.nii.gz").is_file(), True)
+    npt.assert_equal(Path(tmp_path / "volume_5.nii.gz").is_file(), True)
+    res2, _ = load_nifti(tmp_path / "volume_2.nii.gz")
+    res5, _ = load_nifti(tmp_path / "volume_5.nii.gz")
+    npt.assert_array_equal(res2, data[..., 2])
+    npt.assert_array_equal(res5, data[..., 5])

--- a/dipy/workflows/tests/test_masking.py
+++ b/dipy/workflows/tests/test_masking.py
@@ -1,5 +1,3 @@
-from tempfile import TemporaryDirectory
-
 import numpy.testing as npt
 
 from dipy.data import get_fnames
@@ -8,18 +6,17 @@ from dipy.testing import assert_false
 from dipy.workflows.mask import MaskFlow
 
 
-def test_mask():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume, affine = load_nifti(data_path)
+def test_mask(tmp_path):
+    data_path, _, _ = get_fnames(name="small_25")
+    volume, affine = load_nifti(data_path)
 
-        mask_flow = MaskFlow()
+    mask_flow = MaskFlow()
 
-        mask_flow.run(data_path, 10, out_dir=out_dir, ub=9)
-        assert_false(mask_flow.last_generated_outputs)
+    mask_flow.run(data_path, 10, out_dir=tmp_path, ub=9)
+    assert_false(mask_flow.last_generated_outputs)
 
-        mask_flow.run(data_path, 10, out_dir=out_dir)
-        mask_path = mask_flow.last_generated_outputs["out_mask"]
-        mask_data, mask_affine = load_nifti(mask_path)
-        npt.assert_equal(mask_data.shape, volume.shape)
-        npt.assert_array_almost_equal(mask_affine, affine)
+    mask_flow.run(data_path, 10, out_dir=tmp_path)
+    mask_path = mask_flow.last_generated_outputs["out_mask"]
+    mask_data, mask_affine = load_nifti(mask_path)
+    npt.assert_equal(mask_data.shape, volume.shape)
+    npt.assert_array_almost_equal(mask_affine, affine)

--- a/dipy/workflows/tests/test_nn.py
+++ b/dipy/workflows/tests/test_nn.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -17,117 +14,107 @@ have_nn = have_tf or have_torch
 
 
 @pytest.mark.skipif(not have_nn, reason="Requires TensorFlow or Torch")
-def test_evac_plus_flow():
-    with TemporaryDirectory() as out_dir:
-        file_path = get_fnames(name="evac_test_data")
+def test_evac_plus_flow(tmp_path):
+    file_path = get_fnames(name="evac_test_data")
 
-        volume = np.load(file_path)["input"][0]
-        temp_affine = np.eye(4)
-        temp_path = Path(out_dir) / "temp.nii.gz"
-        save_nifti(temp_path, volume, temp_affine)
-        save_masked = True
+    volume = np.load(file_path)["input"][0]
+    temp_affine = np.eye(4)
+    temp_path = tmp_path / "temp.nii.gz"
+    save_nifti(temp_path, volume, temp_affine)
+    save_masked = True
 
-        evac_flow = EVACPlusFlow()
-        evac_flow.run(temp_path, out_dir=out_dir, save_masked=save_masked)
+    evac_flow = EVACPlusFlow()
+    evac_flow.run(temp_path, out_dir=tmp_path, save_masked=save_masked)
 
-        mask_name = evac_flow.last_generated_outputs["out_mask"]
-        masked_name = evac_flow.last_generated_outputs["out_masked"]
+    mask_name = evac_flow.last_generated_outputs["out_mask"]
+    masked_name = evac_flow.last_generated_outputs["out_masked"]
 
-        evac = EVACPlus()
-        mask = evac.predict(volume, temp_affine)
-        masked = volume * mask
+    evac = EVACPlus()
+    mask = evac.predict(volume, temp_affine)
+    masked = volume * mask
 
-        result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
-        npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
+    result_mask_data = load_nifti_data(tmp_path / mask_name)
+    npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
 
-        result_masked_data = load_nifti_data(Path(out_dir) / masked_name)
+    result_masked_data = load_nifti_data(tmp_path / masked_name)
 
-        npt.assert_array_equal(result_masked_data, masked)
+    npt.assert_array_equal(result_masked_data, masked)
 
 
-def test_correct_biasfield_flow():
+def test_correct_biasfield_flow(tmp_path):
     # Test with T1 data
     if have_nn:
-        with TemporaryDirectory() as out_dir:
-            t1_path = get_fnames(name="stanford_t1")
+        t1_path = get_fnames(name="stanford_t1")
 
-            volume, affine = load_nifti(t1_path)
+        volume, affine = load_nifti(t1_path)
 
-            bias_flow = BiasFieldCorrectionFlow()
-            bias_flow.run(t1_path, out_dir=out_dir, method="n4")
-
-            corrected_name = bias_flow.last_generated_outputs["out_corrected"]
-
-            corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
-            assert corrected_data.shape == volume.shape
-
-    # Test with DWI data
-    with TemporaryDirectory() as out_dir:
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        args = {
-            "input_files": fdata,
-            "bval": fbval,
-            "bvec": fbvec,
-            "out_dir": out_dir,
-        }
         bias_flow = BiasFieldCorrectionFlow()
-        bias_flow.run(**args)
+        bias_flow.run(t1_path, out_dir=tmp_path, method="n4")
 
         corrected_name = bias_flow.last_generated_outputs["out_corrected"]
 
-        corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
-        npt.assert_almost_equal(corrected_data.mean(), 44.00769230769231, decimal=0)
+        corrected_data = load_nifti_data(tmp_path / corrected_name)
+        assert corrected_data.shape == volume.shape
+
+    # Test with DWI data
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    args = {"input_files": fdata, "bval": fbval, "bvec": fbvec, "out_dir": tmp_path}
+    bias_flow = BiasFieldCorrectionFlow()
+    bias_flow.run(**args)
+
+    corrected_name = bias_flow.last_generated_outputs["out_corrected"]
+
+    corrected_data = load_nifti_data(tmp_path / corrected_name)
+    npt.assert_almost_equal(corrected_data.mean(), 44.00769230769231, decimal=0)
 
     args = {
         "input_files": fdata,
         "bval": fbval,
         "bvec": fbvec,
         "method": "random",
-        "out_dir": out_dir,
+        "out_dir": tmp_path,
     }
     npt.assert_raises(SystemExit, bias_flow.run, **args)
 
 
-def test_correct_biasfield_flow_with_mask():
+def test_correct_biasfield_flow_with_mask(tmp_path):
     """Test that a mask file can be passed to BiasFieldCorrectionFlow."""
-    with TemporaryDirectory() as out_dir:
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        volume, affine = load_nifti(fdata)
-        mask_data = np.ones(volume.shape[:3], dtype=np.uint8)
-        mask_path = Path(out_dir) / "mask.nii.gz"
-        save_nifti(mask_path, mask_data, affine)
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    volume, affine = load_nifti(fdata)
+    mask_data = np.ones(volume.shape[:3], dtype=np.uint8)
+    mask_path = tmp_path / "mask.nii.gz"
+    save_nifti(mask_path, mask_data, affine)
 
-        args = {
-            "input_files": fdata,
-            "bval": fbval,
-            "bvec": fbvec,
-            "mask": str(mask_path),
-            "out_dir": out_dir,
-        }
-        bias_flow = BiasFieldCorrectionFlow()
-        bias_flow.run(**args)
+    args = {
+        "input_files": fdata,
+        "bval": fbval,
+        "bvec": fbvec,
+        "mask": str(mask_path),
+        "out_dir": tmp_path,
+    }
+    bias_flow = BiasFieldCorrectionFlow()
+    bias_flow.run(**args)
 
-        corrected_name = bias_flow.last_generated_outputs["out_corrected"]
-        corrected_data = load_nifti_data(Path(out_dir) / corrected_name)
-        assert corrected_data.shape == volume.shape
+    corrected_name = bias_flow.last_generated_outputs["out_corrected"]
+    corrected_data = load_nifti_data(tmp_path / corrected_name)
+    assert corrected_data.shape == volume.shape
 
 
-def test_correct_biasfield_flow_with_bias_output():
+def test_correct_biasfield_flow_with_bias_output(tmp_path):
     """Test that out_bias_field is saved when using poly/bspline methods."""
-    with TemporaryDirectory() as out_dir:
-        fdata, fbval, fbvec = get_fnames(name="small_25")
-        bias_field_name = "my_bias_field.nii.gz"
-        args = {
-            "input_files": fdata,
-            "bval": fbval,
-            "bvec": fbvec,
-            "method": "poly",
-            "out_dir": out_dir,
-            "out_bias_field": bias_field_name,
-        }
-        bias_flow = BiasFieldCorrectionFlow()
-        bias_flow.run(**args)
+    fdata, fbval, fbvec = get_fnames(name="small_25")
+    bias_field_name = "my_bias_field.nii.gz"
+    args = {
+        "input_files": fdata,
+        "bval": fbval,
+        "bvec": fbvec,
+        "method": "poly",
+        "out_dir": tmp_path,
+        "out_bias_field": bias_field_name,
+    }
+    bias_flow = BiasFieldCorrectionFlow()
+    bias_flow.run(**args)
 
-        corrected_name = bias_flow.last_generated_outputs["out_corrected"]
-        assert (Path(out_dir) / corrected_name).exists()
-        assert (Path(out_dir) / bias_field_name).exists()
+    corrected_name = bias_flow.last_generated_outputs["out_corrected"]
+    assert (tmp_path / corrected_name).exists()
+    assert (tmp_path / bias_field_name).exists()

--- a/dipy/workflows/tests/test_reconst.py
+++ b/dipy/workflows/tests/test_reconst.py
@@ -1,6 +1,4 @@
 import logging
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -49,132 +47,127 @@ def simulate_multitensor_data(gtab):
     return dwi
 
 
-def test_reconst_rumba():
+def test_reconst_rumba(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstRUMBAFlow, n_iter=2)
+        reconst_flow_core(tmp_path, ReconstRUMBAFlow, n_iter=2)
 
 
 @pytest.mark.skipif(not has_sklearn, reason="Requires sklearn")
-def test_reconst_sfm():
+def test_reconst_sfm(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstSFMFlow)
+        reconst_flow_core(tmp_path, ReconstSFMFlow)
 
 
-def test_reconst_gqi():
+def test_reconst_gqi(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstGQIFlow)
+        reconst_flow_core(tmp_path, ReconstGQIFlow)
 
 
-def test_reconst_forecast():
+def test_reconst_forecast(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstForecastFlow, use_multishell_data=True)
+        reconst_flow_core(tmp_path, ReconstForecastFlow, use_multishell_data=True)
 
 
-def reconst_flow_core(flow, *, use_multishell_data=None, **kwargs):
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-        if use_multishell_data:
-            bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+def reconst_flow_core(tmp_path, flow, *, use_multishell_data=None, **kwargs):
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    if use_multishell_data:
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
 
-            # FW model requires multishell data
-            bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
-            bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
-            gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
-            bval_path = Path(out_dir) / bval_path.name
-            bvec_path = Path(out_dir) / bvec_path.name
-            np.savetxt(bval_path, bvals_2s)
-            np.savetxt(bvec_path, bvecs_2s)
+        # FW model requires multishell data
+        bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
+        bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
+        gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
+        bval_path = tmp_path / bval_path.name
+        bvec_path = tmp_path / bvec_path.name
+        np.savetxt(bval_path, bvals_2s)
+        np.savetxt(bvec_path, bvecs_2s)
 
-            volume = simulate_multitensor_data(gtab_2s)
-            data_path = Path(out_dir) / "dwi.nii.gz"
-            mask = np.ones_like(volume[..., 0], dtype=bool)
-            mask_path = Path(out_dir) / "mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.int32), np.eye(4))
-            save_nifti(data_path, volume, np.eye(4))
-        else:
-            volume, affine = load_nifti(data_path)
-            volume = volume[:5, :5, :5]
-            data_path = Path(out_dir) / "tmp_data.nii.gz"
-            save_nifti(data_path, volume, affine)
-            mask = np.ones_like(volume[:, :, :, 0])
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
+        volume = simulate_multitensor_data(gtab_2s)
+        data_path = tmp_path / "dwi.nii.gz"
+        mask = np.ones_like(volume[..., 0], dtype=bool)
+        mask_path = tmp_path / "mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.int32), np.eye(4))
+        save_nifti(data_path, volume, np.eye(4))
+    else:
+        volume, affine = load_nifti(data_path)
+        volume = volume[:5, :5, :5]
+        data_path = tmp_path / "tmp_data.nii.gz"
+        save_nifti(data_path, volume, affine)
+        mask = np.ones_like(volume[:, :, :, 0])
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-        reconst_flow = flow()
-        for sh_order_max in [
-            8,
-        ]:
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                sh_order_max=sh_order_max,
-                out_dir=out_dir,
-                extract_pam_values=True,
-                **kwargs,
-            )
+    reconst_flow = flow()
+    for sh_order_max in [8]:
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            sh_order_max=sh_order_max,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+            **kwargs,
+        )
 
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            gfa_data = load_nifti_data(gfa_path)
-            npt.assert_equal(gfa_data.shape, volume.shape[:-1])
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        gfa_data = load_nifti_data(gfa_path)
+        npt.assert_equal(gfa_data.shape, volume.shape[:-1])
 
-            peaks_dir_path = reconst_flow.last_generated_outputs["out_peaks_dir"]
-            peaks_dir_data = load_nifti_data(peaks_dir_path)
-            npt.assert_equal(peaks_dir_data.shape[-1], 15)
-            npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+        peaks_dir_path = reconst_flow.last_generated_outputs["out_peaks_dir"]
+        peaks_dir_data = load_nifti_data(peaks_dir_path)
+        npt.assert_equal(peaks_dir_data.shape[-1], 15)
+        npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
 
-            peaks_idx_path = reconst_flow.last_generated_outputs["out_peaks_indices"]
-            peaks_idx_data = load_nifti_data(peaks_idx_path)
-            npt.assert_equal(peaks_idx_data.shape[-1], 5)
-            npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+        peaks_idx_path = reconst_flow.last_generated_outputs["out_peaks_indices"]
+        peaks_idx_data = load_nifti_data(peaks_idx_path)
+        npt.assert_equal(peaks_idx_data.shape[-1], 5)
+        npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
 
-            peaks_vals_path = reconst_flow.last_generated_outputs["out_peaks_values"]
-            peaks_vals_data = load_nifti_data(peaks_vals_path)
-            npt.assert_equal(peaks_vals_data.shape[-1], 5)
-            npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+        peaks_vals_path = reconst_flow.last_generated_outputs["out_peaks_values"]
+        peaks_vals_data = load_nifti_data(peaks_vals_path)
+        npt.assert_equal(peaks_vals_data.shape[-1], 5)
+        npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
 
-            shm_path = reconst_flow.last_generated_outputs["out_shm"]
-            shm_data = load_nifti_data(shm_path)
-            # Test that the number of coefficients is what you would expect
-            # given the order of the sh basis:
-            npt.assert_equal(
-                shm_data.shape[-1], sph_harm_ind_list(sh_order_max)[0].shape[0]
-            )
-            npt.assert_equal(shm_data.shape[:-1], volume.shape[:-1])
+        shm_path = reconst_flow.last_generated_outputs["out_shm"]
+        shm_data = load_nifti_data(shm_path)
+        # Test that the number of coefficients is what you would expect
+        # given the order of the sh basis:
+        npt.assert_equal(
+            shm_data.shape[-1], sph_harm_ind_list(sh_order_max)[0].shape[0]
+        )
+        npt.assert_equal(shm_data.shape[:-1], volume.shape[:-1])
 
-            pam = load_pam(reconst_flow.last_generated_outputs["out_pam"])
-            npt.assert_allclose(
-                pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data
-            )
+        pam = load_pam(reconst_flow.last_generated_outputs["out_pam"])
+        npt.assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
 
-            npt.assert_allclose(pam.peak_values, peaks_vals_data)
-            npt.assert_allclose(pam.peak_indices, peaks_idx_data)
-            npt.assert_allclose(pam.shm_coeff, shm_data, atol=1e-7)
-            npt.assert_allclose(pam.gfa, gfa_data)
+        npt.assert_allclose(pam.peak_values, peaks_vals_data)
+        npt.assert_allclose(pam.peak_indices, peaks_idx_data)
+        npt.assert_allclose(pam.shm_coeff, shm_data, atol=1e-7)
+        npt.assert_allclose(pam.gfa, gfa_data)
 
 
-def test_reconst_powermap_basic():
+def test_reconst_powermap_basic(tmp_path):
     """Test ReconstPowermapFlow basic functionality and parameter variations."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -183,91 +176,88 @@ def test_reconst_powermap_basic():
             category=PendingDeprecationWarning,
         )
 
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
+        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+        volume, affine = load_nifti(data_path)
+        mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-            reconst_flow = ReconstPowermapFlow()
+        reconst_flow = ReconstPowermapFlow()
 
-            # Test basic functionality with default parameters
+        # Test basic functionality with default parameters
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            out_dir=tmp_path,
+        )
+
+        powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists(), "Powermap file was not created"
+        powermap_data = load_nifti_data(powermap_path)
+        npt.assert_equal(powermap_data.shape, volume.shape[:-1])
+        assert np.all(powermap_data >= 0), "Powermap should be non-negative"
+        assert not np.all(powermap_data == 0), "Powermap should not be all zeros"
+        assert np.isfinite(powermap_data).all(), "Powermap should contain finite values"
+
+        # Test different SH orders
+        for sh_order in [4, 6]:
             reconst_flow.run(
                 data_path,
                 bval_path,
                 bvec_path,
                 mask_path,
-                out_dir=out_dir,
-            )
-
-            powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
-            assert powermap_path.exists(), "Powermap file was not created"
-            powermap_data = load_nifti_data(powermap_path)
-            npt.assert_equal(powermap_data.shape, volume.shape[:-1])
-            assert np.all(powermap_data >= 0), "Powermap should be non-negative"
-            assert not np.all(powermap_data == 0), "Powermap should not be all zeros"
-            assert np.isfinite(powermap_data).all(), (
-                "Powermap should contain finite values"
-            )
-
-            # Test different SH orders
-            for sh_order in [4, 6]:
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    sh_order_max=sh_order,
-                    out_dir=out_dir,
-                    out_powermap=f"powermap_sh{sh_order}.nii.gz",
-                )
-                powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
-                assert powermap_path.exists()
-
-            # Test different power values and norm factors
-            for power in [1, 3]:
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    power=power,
-                    out_dir=out_dir,
-                    out_powermap=f"powermap_power{power}.nii.gz",
-                )
-                powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
-                assert powermap_path.exists()
-
-            # Test with smoothing
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                smooth=0.006,
-                out_dir=out_dir,
-                out_powermap="powermap_smooth.nii.gz",
+                sh_order_max=sh_order,
+                out_dir=tmp_path,
+                out_powermap=f"powermap_sh{sh_order}.nii.gz",
             )
             powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
             assert powermap_path.exists()
 
-            # Test non_negative=False
+        # Test different power values and norm factors
+        for power in [1, 3]:
             reconst_flow.run(
                 data_path,
                 bval_path,
                 bvec_path,
                 mask_path,
-                non_negative=False,
-                out_dir=out_dir,
-                out_powermap="powermap_negative_allowed.nii.gz",
+                power=power,
+                out_dir=tmp_path,
+                out_powermap=f"powermap_power{power}.nii.gz",
             )
             powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
             assert powermap_path.exists()
-            assert reconst_flow.get_short_name() == "powermap"
+
+        # Test with smoothing
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            smooth=0.006,
+            out_dir=tmp_path,
+            out_powermap="powermap_smooth.nii.gz",
+        )
+        powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists()
+
+        # Test non_negative=False
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            non_negative=False,
+            out_dir=tmp_path,
+            out_powermap="powermap_negative_allowed.nii.gz",
+        )
+        powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists()
+        assert reconst_flow.get_short_name() == "powermap"
 
 
-def test_reconst_powermap_with_shm_files():
+def test_reconst_powermap_with_shm_files(tmp_path):
     """Test ReconstPowermapFlow with precomputed SH coefficients."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -276,59 +266,58 @@ def test_reconst_powermap_with_shm_files():
             category=PendingDeprecationWarning,
         )
 
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
+        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+        volume, affine = load_nifti(data_path)
+        mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-            # Generate SH coefficients using GQI
-            reconst_flow = ReconstGQIFlow()
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                sh_order_max=6,
-                extract_pam_values=True,
-                out_dir=out_dir,
-            )
+        # Generate SH coefficients using GQI
+        reconst_flow = ReconstGQIFlow()
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            sh_order_max=6,
+            extract_pam_values=True,
+            out_dir=tmp_path,
+        )
 
-            shm_path = reconst_flow.last_generated_outputs["out_shm"]
-            pam_path = reconst_flow.last_generated_outputs["out_pam"]
+        shm_path = reconst_flow.last_generated_outputs["out_shm"]
+        pam_path = reconst_flow.last_generated_outputs["out_pam"]
 
-            # Test with NIfTI SH file
-            powermap_flow = ReconstPowermapFlow()
-            powermap_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                shm_files=shm_path,
-                out_dir=out_dir,
-                out_powermap="powermap_from_shm.nii.gz",
-            )
-            powermap_path = powermap_flow.last_generated_outputs["out_powermap"]
-            assert powermap_path.exists()
-            powermap_data = load_nifti_data(powermap_path)
-            npt.assert_equal(powermap_data.shape, volume.shape[:-1])
+        # Test with NIfTI SH file
+        powermap_flow = ReconstPowermapFlow()
+        powermap_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            shm_files=shm_path,
+            out_dir=tmp_path,
+            out_powermap="powermap_from_shm.nii.gz",
+        )
+        powermap_path = powermap_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists()
+        powermap_data = load_nifti_data(powermap_path)
+        npt.assert_equal(powermap_data.shape, volume.shape[:-1])
 
-            # Test with PAM file
-            powermap_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                shm_files=pam_path,
-                out_dir=out_dir,
-                out_powermap="powermap_from_pam.nii.gz",
-            )
-            powermap_path = powermap_flow.last_generated_outputs["out_powermap"]
-            assert powermap_path.exists()
+        # Test with PAM file
+        powermap_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            shm_files=pam_path,
+            out_dir=tmp_path,
+            out_powermap="powermap_from_pam.nii.gz",
+        )
+        powermap_path = powermap_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists()
 
 
-def test_reconst_powermap_edge_cases():
+def test_reconst_powermap_edge_cases(tmp_path):
     """Test ReconstPowermapFlow error handling and edge cases."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -337,64 +326,63 @@ def test_reconst_powermap_edge_cases():
             category=PendingDeprecationWarning,
         )
 
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
+        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+        volume, affine = load_nifti(data_path)
+        mask = np.ones_like(volume[:, :, :, 0], dtype=bool)
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-            reconst_flow = ReconstPowermapFlow()
+        reconst_flow = ReconstPowermapFlow()
 
-            # Test with invalid SH file extension
-            invalid_shm_path = Path(out_dir) / "invalid.txt"
-            invalid_shm_path.write_text("dummy content")
-            with pytest.raises(ValueError, match="SH coefficients file must be"):
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    shm_files=str(invalid_shm_path),
-                    out_dir=out_dir,
-                )
-
-            # Test with invalid sh_basis (should fallback to default)
+        # Test with invalid SH file extension
+        invalid_shm_path = tmp_path / "invalid.txt"
+        invalid_shm_path.write_text("dummy content")
+        with pytest.raises(ValueError, match="SH coefficients file must be"):
             reconst_flow.run(
                 data_path,
                 bval_path,
                 bvec_path,
                 mask_path,
-                sh_basis="invalid_basis",
-                out_dir=out_dir,
-                out_powermap="powermap_invalid_basis.nii.gz",
+                shm_files=str(invalid_shm_path),
+                out_dir=tmp_path,
+            )
+
+        # Test with invalid sh_basis (should fallback to default)
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            sh_basis="invalid_basis",
+            out_dir=tmp_path,
+            out_powermap="powermap_invalid_basis.nii.gz",
+        )
+        powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
+        assert powermap_path.exists()
+
+        # Test different norm factors produce different results
+        norm_factors = [0.00001, 0.001]
+        powermaps = []
+        for i, norm_factor in enumerate(norm_factors):
+            reconst_flow.run(
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
+                norm_factor=norm_factor,
+                out_dir=tmp_path,
+                out_powermap=f"powermap_norm{i}.nii.gz",
             )
             powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
-            assert powermap_path.exists()
+            powermap_data = load_nifti_data(powermap_path)
+            assert np.all(powermap_data >= 0), "Powermap should be non-negative"
+            assert np.isfinite(powermap_data).all(), "All values should be finite"
+            powermaps.append(powermap_data)
 
-            # Test different norm factors produce different results
-            norm_factors = [0.00001, 0.001]
-            powermaps = []
-            for i, norm_factor in enumerate(norm_factors):
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    norm_factor=norm_factor,
-                    out_dir=out_dir,
-                    out_powermap=f"powermap_norm{i}.nii.gz",
-                )
-                powermap_path = reconst_flow.last_generated_outputs["out_powermap"]
-                powermap_data = load_nifti_data(powermap_path)
-                assert np.all(powermap_data >= 0), "Powermap should be non-negative"
-                assert np.isfinite(powermap_data).all(), "All values should be finite"
-                powermaps.append(powermap_data)
-
-            # Different norm factors should produce different results
-            assert not np.allclose(powermaps[0], powermaps[1], rtol=0.1), (
-                "Different norm factors should produce different results"
-            )
+        # Different norm factors should produce different results
+        assert not np.allclose(powermaps[0], powermaps[1], rtol=0.1), (
+            "Different norm factors should produce different results"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -1,6 +1,4 @@
 import logging
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -22,58 +20,58 @@ needs_cvxpy = pytest.mark.skipif(not have_cvxpy, reason="Requires CVXPY")
 logging.getLogger().setLevel(logging.INFO)
 
 
-def test_reconst_csa():
+def test_reconst_csa(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstQBallBaseFlow)
+        reconst_flow_core(tmp_path, ReconstQBallBaseFlow)
 
 
-def test_reconst_opdt():
+def test_reconst_opdt(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstQBallBaseFlow, method="opdt")
+        reconst_flow_core(tmp_path, ReconstQBallBaseFlow, method="opdt")
 
 
-def test_reconst_qball():
+def test_reconst_qball(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstQBallBaseFlow, method="qball")
+        reconst_flow_core(tmp_path, ReconstQBallBaseFlow, method="qball")
 
 
-def test_reconst_csd():
+def test_reconst_csd(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstCSDFlow)
+        reconst_flow_core(tmp_path, ReconstCSDFlow)
 
 
-def test_reconst_sdt():
+def test_reconst_sdt(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstSDTFlow)
+        reconst_flow_core(tmp_path, ReconstSDTFlow)
 
 
 @needs_cvxpy
-def test_reconst_csd_msmt():
+def test_reconst_csd_msmt(tmp_path):
     """Test MSMT-CSD functionality."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -86,41 +84,40 @@ def test_reconst_csd_msmt():
             message="Solution may be inaccurate.*",
             category=UserWarning,
         )
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            mask = np.ones_like(volume[:, :, :, 0])
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
+        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+        volume, affine = load_nifti(data_path)
+        mask = np.ones_like(volume[:, :, :, 0])
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-            reconst_flow = ReconstCSDFlow()
-            reconst_flow._force_overwrite = True
+        reconst_flow = ReconstCSDFlow()
+        reconst_flow._force_overwrite = True
 
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                use_msmt=True,
-                iso=3,
-                sh_order_max=4,
-                out_dir=out_dir,
-                extract_pam_values=True,
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            use_msmt=True,
+            iso=3,
+            sh_order_max=4,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+        )
+
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
+
+        for fname in ["wm_mask.nii.gz", "gm_mask.nii.gz", "csf_mask.nii.gz"]:
+            mask_path_out = tmp_path / fname
+            assert mask_path_out.exists()
+            npt.assert_equal(
+                load_nifti_data(str(mask_path_out)).shape, volume.shape[:-1]
             )
-
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
-
-            for fname in ["wm_mask.nii.gz", "gm_mask.nii.gz", "csf_mask.nii.gz"]:
-                mask_path_out = Path(out_dir) / fname
-                assert mask_path_out.exists()
-                npt.assert_equal(
-                    load_nifti_data(str(mask_path_out)).shape, volume.shape[:-1]
-                )
 
 
 @needs_cvxpy
-def test_reconst_csd_msmt_with_t1():
+def test_reconst_csd_msmt_with_t1(tmp_path):
     """Test MSMT-CSD with provided T1 image (T1-based HMRF tissue segmentation).
 
     The anisotropic power map is used as the T1 substitute so that the HMRF
@@ -138,215 +135,207 @@ def test_reconst_csd_msmt_with_t1():
             message="Solution may be inaccurate.*",
             category=UserWarning,
         )
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-            mask = np.ones_like(volume[:, :, :, 0])
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
-
-            # Compute the anisotropic power map from DWI data and save it as a
-            # "T1" so HMRF tissue labels are consistent with DWI signal.
-            from dipy.core.gradients import gradient_table
-            from dipy.core.sphere import HemiSphere
-            from dipy.reconst.shm import (
-                anisotropic_power,
-                normalize_data,
-                smooth_pinv,
-                sph_harm_lookup,
-            )
-
-            gtab = gradient_table(bvals, bvecs=bvecs)
-            dwi_mask = ~gtab.b0s_mask
-            normed = normalize_data(volume, gtab.b0s_mask)[..., dwi_mask]
-            normed = normed * mask[..., None]
-            signal_pts = HemiSphere(xyz=gtab.bvecs[dwi_mask])
-            Ba, m, n = sph_harm_lookup.get("descoteaux07")(
-                4, signal_pts.theta, signal_pts.phi
-            )
-            invB = smooth_pinv(Ba, np.sqrt(0.0) * (-n * (n + 1)))
-            shm = np.dot(normed, invB.T)
-            amap = anisotropic_power(
-                shm, norm_factor=0.00001, power=2, non_negative=True
-            )
-            t1_path = Path(out_dir) / "t1.nii.gz"
-            save_nifti(str(t1_path), amap.astype(np.float32), affine)
-
-            reconst_flow = ReconstCSDFlow()
-            reconst_flow._force_overwrite = True
-
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                use_msmt=True,
-                t1_file=str(t1_path),
-                iso=3,
-                sh_order_max=4,
-                out_dir=out_dir,
-                extract_pam_values=True,
-            )
-
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
-
-            for fname in ["wm_mask.nii.gz", "gm_mask.nii.gz", "csf_mask.nii.gz"]:
-                mask_path_out = Path(out_dir) / fname
-                assert mask_path_out.exists()
-                npt.assert_equal(
-                    load_nifti_data(str(mask_path_out)).shape, volume.shape[:-1]
-                )
-
-
-def reconst_flow_core(flow, **kwargs):
-    with TemporaryDirectory() as out_dir:
         data_path, bval_path, bvec_path = get_fnames(name="small_64D")
         volume, affine = load_nifti(data_path)
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
+        mask_path = tmp_path / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-        reconst_flow = flow()
-        for sh_order in [4, 6, 8]:
+        # Compute the anisotropic power map from DWI data and save it as a
+        # "T1" so HMRF tissue labels are consistent with DWI signal.
+        from dipy.core.gradients import gradient_table
+        from dipy.core.sphere import HemiSphere
+        from dipy.reconst.shm import (
+            anisotropic_power,
+            normalize_data,
+            smooth_pinv,
+            sph_harm_lookup,
+        )
+
+        gtab = gradient_table(bvals, bvecs=bvecs)
+        dwi_mask = ~gtab.b0s_mask
+        normed = normalize_data(volume, gtab.b0s_mask)[..., dwi_mask]
+        normed = normed * mask[..., None]
+        signal_pts = HemiSphere(xyz=gtab.bvecs[dwi_mask])
+        Ba, m, n = sph_harm_lookup.get("descoteaux07")(
+            4, signal_pts.theta, signal_pts.phi
+        )
+        invB = smooth_pinv(Ba, np.sqrt(0.0) * (-n * (n + 1)))
+        shm = np.dot(normed, invB.T)
+        amap = anisotropic_power(shm, norm_factor=0.00001, power=2, non_negative=True)
+        t1_path = tmp_path / "t1.nii.gz"
+        save_nifti(str(t1_path), amap.astype(np.float32), affine)
+
+        reconst_flow = ReconstCSDFlow()
+        reconst_flow._force_overwrite = True
+
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            use_msmt=True,
+            t1_file=str(t1_path),
+            iso=3,
+            sh_order_max=4,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+        )
+
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
+
+        for fname in ["wm_mask.nii.gz", "gm_mask.nii.gz", "csf_mask.nii.gz"]:
+            mask_path_out = tmp_path / fname
+            assert mask_path_out.exists()
+            npt.assert_equal(
+                load_nifti_data(str(mask_path_out)).shape, volume.shape[:-1]
+            )
+
+
+def reconst_flow_core(tmp_path, flow, **kwargs):
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0])
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask.astype(np.uint8), affine)
+
+    reconst_flow = flow()
+    for sh_order in [4, 6, 8]:
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            sh_order_max=sh_order,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+            **kwargs,
+        )
+
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        gfa_data = load_nifti_data(gfa_path)
+        npt.assert_equal(gfa_data.shape, volume.shape[:-1])
+
+        peaks_dir_path = reconst_flow.last_generated_outputs["out_peaks_dir"]
+        peaks_dir_data = load_nifti_data(peaks_dir_path)
+        npt.assert_equal(peaks_dir_data.shape[-1], 15)
+        npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+
+        peaks_idx_path = reconst_flow.last_generated_outputs["out_peaks_indices"]
+        peaks_idx_data = load_nifti_data(peaks_idx_path)
+        npt.assert_equal(peaks_idx_data.shape[-1], 5)
+        npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+
+        peaks_vals_path = reconst_flow.last_generated_outputs["out_peaks_values"]
+        peaks_vals_data = load_nifti_data(peaks_vals_path)
+        npt.assert_equal(peaks_vals_data.shape[-1], 5)
+        npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+
+        shm_path = reconst_flow.last_generated_outputs["out_shm"]
+        shm_data = load_nifti_data(shm_path)
+        # Test that the number of coefficients is what you would expect
+        # given the order of the sh basis:
+        npt.assert_equal(shm_data.shape[-1], sph_harm_ind_list(sh_order)[0].shape[0])
+        npt.assert_equal(shm_data.shape[:-1], volume.shape[:-1])
+
+        pam = load_pam(reconst_flow.last_generated_outputs["out_pam"])
+        npt.assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
+        npt.assert_allclose(pam.peak_values, peaks_vals_data)
+        npt.assert_allclose(pam.peak_indices, peaks_idx_data)
+        npt.assert_allclose(pam.shm_coeff, shm_data)
+        npt.assert_allclose(pam.gfa, gfa_data)
+
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+        bvals[0] = 5.0
+        bvecs = generate_bvecs(len(bvals))
+
+        tmp_bval_path = tmp_path / "tmp.bval"
+        tmp_bvec_path = tmp_path / "tmp.bvec"
+        np.savetxt(tmp_bval_path, bvals)
+        np.savetxt(tmp_bvec_path, bvecs.T)
+        reconst_flow._force_overwrite = True
+
+        if flow.get_short_name() == "csd":
+            reconst_flow = flow()
+            reconst_flow._force_overwrite = True
             reconst_flow.run(
                 data_path,
                 bval_path,
                 bvec_path,
                 mask_path,
-                sh_order_max=sh_order,
-                out_dir=out_dir,
-                extract_pam_values=True,
+                out_dir=tmp_path,
+                frf=[15, 5, 5],
+                **kwargs,
+            )
+            reconst_flow = flow()
+            reconst_flow._force_overwrite = True
+            reconst_flow.run(
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
+                out_dir=tmp_path,
+                frf="15, 5, 5",
+                **kwargs,
+            )
+            reconst_flow = flow()
+            reconst_flow._force_overwrite = True
+            reconst_flow.run(
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
+                out_dir=tmp_path,
+                frf=None,
+                **kwargs,
+            )
+            reconst_flow2 = flow()
+            reconst_flow2._force_overwrite = True
+            reconst_flow2.run(
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
+                out_dir=tmp_path,
+                frf=None,
+                roi_center=[5, 5, 5],
+                **kwargs,
+            )
+        else:
+            with npt.assert_raises(BaseException):
+                assert_warns(
+                    UserWarning,
+                    reconst_flow.run,
+                    data_path,
+                    tmp_bval_path,
+                    tmp_bvec_path,
+                    mask_path,
+                    out_dir=tmp_path,
+                    extract_pam_values=True,
+                    **kwargs,
+                )
+
+        # test parallel implementation
+        # Avoid SDT for now, as it is quite slow, something to introspect
+        if flow.get_short_name() != "sdt":
+            reconst_flow = flow()
+            reconst_flow._force_overwrite = True
+            reconst_flow.run(
+                data_path,
+                bval_path,
+                bvec_path,
+                mask_path,
+                out_dir=tmp_path,
+                parallel=True,
+                num_processes=2,
                 **kwargs,
             )
 
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            gfa_data = load_nifti_data(gfa_path)
-            npt.assert_equal(gfa_data.shape, volume.shape[:-1])
-
-            peaks_dir_path = reconst_flow.last_generated_outputs["out_peaks_dir"]
-            peaks_dir_data = load_nifti_data(peaks_dir_path)
-            npt.assert_equal(peaks_dir_data.shape[-1], 15)
-            npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
-
-            peaks_idx_path = reconst_flow.last_generated_outputs["out_peaks_indices"]
-            peaks_idx_data = load_nifti_data(peaks_idx_path)
-            npt.assert_equal(peaks_idx_data.shape[-1], 5)
-            npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
-
-            peaks_vals_path = reconst_flow.last_generated_outputs["out_peaks_values"]
-            peaks_vals_data = load_nifti_data(peaks_vals_path)
-            npt.assert_equal(peaks_vals_data.shape[-1], 5)
-            npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
-
-            shm_path = reconst_flow.last_generated_outputs["out_shm"]
-            shm_data = load_nifti_data(shm_path)
-            # Test that the number of coefficients is what you would expect
-            # given the order of the sh basis:
-            npt.assert_equal(
-                shm_data.shape[-1], sph_harm_ind_list(sh_order)[0].shape[0]
-            )
-            npt.assert_equal(shm_data.shape[:-1], volume.shape[:-1])
-
-            pam = load_pam(reconst_flow.last_generated_outputs["out_pam"])
-            npt.assert_allclose(
-                pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data
-            )
-            npt.assert_allclose(pam.peak_values, peaks_vals_data)
-            npt.assert_allclose(pam.peak_indices, peaks_idx_data)
-            npt.assert_allclose(pam.shm_coeff, shm_data)
-            npt.assert_allclose(pam.gfa, gfa_data)
-
-            bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-            bvals[0] = 5.0
-            bvecs = generate_bvecs(len(bvals))
-
-            tmp_bval_path = Path(out_dir) / "tmp.bval"
-            tmp_bvec_path = Path(out_dir) / "tmp.bvec"
-            np.savetxt(tmp_bval_path, bvals)
-            np.savetxt(tmp_bvec_path, bvecs.T)
-            reconst_flow._force_overwrite = True
-
-            if flow.get_short_name() == "csd":
-                reconst_flow = flow()
-                reconst_flow._force_overwrite = True
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    out_dir=out_dir,
-                    frf=[15, 5, 5],
-                    **kwargs,
-                )
-                reconst_flow = flow()
-                reconst_flow._force_overwrite = True
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    out_dir=out_dir,
-                    frf="15, 5, 5",
-                    **kwargs,
-                )
-                reconst_flow = flow()
-                reconst_flow._force_overwrite = True
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    out_dir=out_dir,
-                    frf=None,
-                    **kwargs,
-                )
-                reconst_flow2 = flow()
-                reconst_flow2._force_overwrite = True
-                reconst_flow2.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    out_dir=out_dir,
-                    frf=None,
-                    roi_center=[5, 5, 5],
-                    **kwargs,
-                )
-            else:
-                with npt.assert_raises(BaseException):
-                    assert_warns(
-                        UserWarning,
-                        reconst_flow.run,
-                        data_path,
-                        tmp_bval_path,
-                        tmp_bvec_path,
-                        mask_path,
-                        out_dir=out_dir,
-                        extract_pam_values=True,
-                        **kwargs,
-                    )
-
-            # test parallel implementation
-            # Avoid SDT for now, as it is quite slow, something to introspect
-            if flow.get_short_name() != "sdt":
-                reconst_flow = flow()
-                reconst_flow._force_overwrite = True
-                reconst_flow.run(
-                    data_path,
-                    bval_path,
-                    bvec_path,
-                    mask_path,
-                    out_dir=out_dir,
-                    parallel=True,
-                    num_processes=2,
-                    **kwargs,
-                )
-
 
 @needs_cvxpy
-def test_reconst_csd_msmt_parallel():
+def test_reconst_csd_msmt_parallel(tmp_path):
     """Test MSMT-CSD with parallel processing."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -359,59 +348,57 @@ def test_reconst_csd_msmt_parallel():
             message="Solution may be inaccurate.*",
             category=UserWarning,
         )
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            mask = np.ones_like(volume[:, :, :, 0])
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            save_nifti(mask_path, mask.astype(np.uint8), affine)
-
-            reconst_flow = ReconstCSDFlow()
-            reconst_flow._force_overwrite = True
-
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                use_msmt=True,
-                iso=3,
-                sh_order_max=4,
-                out_dir=out_dir,
-                extract_pam_values=True,
-                parallel=True,
-                num_processes=2,
-            )
-
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
-
-
-def test_reconst_csd_msmt_invalid_iso():
-    """Test that iso < 3 raises an error."""
-    with TemporaryDirectory() as out_dir:
         data_path, bval_path, bvec_path = get_fnames(name="small_64D")
         volume, affine = load_nifti(data_path)
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
+        mask_path = tmp_path / "tmp_mask.nii.gz"
         save_nifti(mask_path, mask.astype(np.uint8), affine)
 
         reconst_flow = ReconstCSDFlow()
-        with npt.assert_raises(SystemExit):
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                use_msmt=True,
-                iso=2,
-                sh_order_max=4,
-                out_dir=out_dir,
-            )
+        reconst_flow._force_overwrite = True
+
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            use_msmt=True,
+            iso=3,
+            sh_order_max=4,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+            parallel=True,
+            num_processes=2,
+        )
+
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
+
+
+def test_reconst_csd_msmt_invalid_iso(tmp_path):
+    """Test that iso < 3 raises an error."""
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0])
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask.astype(np.uint8), affine)
+
+    reconst_flow = ReconstCSDFlow()
+    with npt.assert_raises(SystemExit):
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            use_msmt=True,
+            iso=2,
+            sh_order_max=4,
+            out_dir=tmp_path,
+        )
 
 
 @needs_cvxpy
-def test_reconst_csd_msmt_with_tissue_masks():
+def test_reconst_csd_msmt_with_tissue_masks(tmp_path):
     """Test MSMT-CSD with pre-provided tissue masks (no HMRF classification).
 
     Tissue masks are derived from the DWI anisotropic power map via HMRF so
@@ -429,67 +416,66 @@ def test_reconst_csd_msmt_with_tissue_masks():
             message="Solution may be inaccurate.*",
             category=UserWarning,
         )
-        with TemporaryDirectory() as out_dir:
-            data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-            volume, affine = load_nifti(data_path)
-            bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-            shape = volume.shape[:3]
+        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+        volume, affine = load_nifti(data_path)
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+        shape = volume.shape[:3]
 
-            # Derive tissue masks from the DWI-based anisotropic power map so
-            # they are consistent with the actual diffusion signal.
-            from dipy.core.gradients import gradient_table
-            from dipy.core.sphere import HemiSphere
-            from dipy.reconst.shm import (
-                anisotropic_power,
-                normalize_data,
-                smooth_pinv,
-                sph_harm_lookup,
-            )
-            from dipy.segment.tissue import TissueClassifierHMRF
+        # Derive tissue masks from the DWI-based anisotropic power map so
+        # they are consistent with the actual diffusion signal.
+        from dipy.core.gradients import gradient_table
+        from dipy.core.sphere import HemiSphere
+        from dipy.reconst.shm import (
+            anisotropic_power,
+            normalize_data,
+            smooth_pinv,
+            sph_harm_lookup,
+        )
+        from dipy.segment.tissue import TissueClassifierHMRF
 
-            gtab = gradient_table(bvals, bvecs=bvecs)
-            dwi_mask_b = ~gtab.b0s_mask
-            normed = normalize_data(volume, gtab.b0s_mask)[..., dwi_mask_b]
-            signal_pts = HemiSphere(xyz=gtab.bvecs[dwi_mask_b])
-            Ba, m, n = sph_harm_lookup.get("descoteaux07")(
-                4, signal_pts.theta, signal_pts.phi
-            )
-            invB = smooth_pinv(Ba, np.sqrt(0.0) * (-n * (n + 1)))
-            amap = anisotropic_power(
-                np.dot(normed, invB.T), norm_factor=0.00001, power=2, non_negative=True
-            )
-            hmrf = TissueClassifierHMRF()
-            _, seg, _ = hmrf.classify(amap, 3, 0.1)
-            wm_mask = np.where(seg == 3, 1, 0).astype(np.uint8)
-            gm_mask = np.where(seg == 2, 1, 0).astype(np.uint8)
-            csf_mask = np.where(seg == 1, 1, 0).astype(np.uint8)
+        gtab = gradient_table(bvals, bvecs=bvecs)
+        dwi_mask_b = ~gtab.b0s_mask
+        normed = normalize_data(volume, gtab.b0s_mask)[..., dwi_mask_b]
+        signal_pts = HemiSphere(xyz=gtab.bvecs[dwi_mask_b])
+        Ba, m, n = sph_harm_lookup.get("descoteaux07")(
+            4, signal_pts.theta, signal_pts.phi
+        )
+        invB = smooth_pinv(Ba, np.sqrt(0.0) * (-n * (n + 1)))
+        amap = anisotropic_power(
+            np.dot(normed, invB.T), norm_factor=0.00001, power=2, non_negative=True
+        )
+        hmrf = TissueClassifierHMRF()
+        _, seg, _ = hmrf.classify(amap, 3, 0.1)
+        wm_mask = np.where(seg == 3, 1, 0).astype(np.uint8)
+        gm_mask = np.where(seg == 2, 1, 0).astype(np.uint8)
+        csf_mask = np.where(seg == 1, 1, 0).astype(np.uint8)
 
-            mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-            wm_path = Path(out_dir) / "wm_in.nii.gz"
-            gm_path = Path(out_dir) / "gm_in.nii.gz"
-            csf_path = Path(out_dir) / "csf_in.nii.gz"
-            save_nifti(mask_path, np.ones(shape, dtype=np.uint8), affine)
-            save_nifti(wm_path, wm_mask, affine)
-            save_nifti(gm_path, gm_mask, affine)
-            save_nifti(csf_path, csf_mask, affine)
+        mask_path = tmp_path / "tmp_mask.nii.gz"
+        wm_path = tmp_path / "wm_in.nii.gz"
+        gm_path = tmp_path / "gm_in.nii.gz"
+        csf_path = tmp_path / "csf_in.nii.gz"
+        save_nifti(mask_path, np.ones(shape, dtype=np.uint8), affine)
+        save_nifti(wm_path, wm_mask, affine)
+        save_nifti(gm_path, gm_mask, affine)
+        save_nifti(csf_path, csf_mask, affine)
 
-            reconst_flow = ReconstCSDFlow()
-            reconst_flow._force_overwrite = True
+        reconst_flow = ReconstCSDFlow()
+        reconst_flow._force_overwrite = True
 
-            reconst_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                use_msmt=True,
-                wm_file=str(wm_path),
-                gm_file=str(gm_path),
-                csf_file=str(csf_path),
-                iso=3,
-                sh_order_max=4,
-                out_dir=out_dir,
-                extract_pam_values=True,
-            )
+        reconst_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            use_msmt=True,
+            wm_file=str(wm_path),
+            gm_file=str(gm_path),
+            csf_file=str(csf_path),
+            iso=3,
+            sh_order_max=4,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+        )
 
-            gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
-            npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])
+        gfa_path = reconst_flow.last_generated_outputs["out_gfa"]
+        npt.assert_equal(load_nifti_data(gfa_path).shape, volume.shape[:-1])

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -14,127 +12,126 @@ from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.workflows.reconst import ReconstDkiFlow
 
 
-def test_reconst_dki():
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_101D")
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-        save_nifti(mask_path, mask.astype(np.uint8), affine)
+def test_reconst_dki(tmp_path):
+    data_path, bval_path, bvec_path = get_fnames(name="small_101D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0])
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-        dki_flow = ReconstDkiFlow()
+    dki_flow = ReconstDkiFlow()
 
-        args = [data_path, bval_path, bvec_path, mask_path]
+    args = [data_path, bval_path, bvec_path, mask_path]
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            dki_flow.run(*args, out_dir=out_dir, extract_pam_values=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        dki_flow.run(*args, out_dir=tmp_path, extract_pam_values=True)
 
-        fa_path = dki_flow.last_generated_outputs["out_fa"]
-        fa_data = load_nifti_data(fa_path)
-        assert_equal(fa_data.shape, volume.shape[:-1])
+    fa_path = dki_flow.last_generated_outputs["out_fa"]
+    fa_data = load_nifti_data(fa_path)
+    assert_equal(fa_data.shape, volume.shape[:-1])
 
-        tensor_path = dki_flow.last_generated_outputs["out_dt_tensor"]
-        tensor_data = load_nifti_data(tensor_path)
-        assert_equal(tensor_data.shape[-1], 6)
-        assert_equal(tensor_data.shape[:-1], volume.shape[:-1])
+    tensor_path = dki_flow.last_generated_outputs["out_dt_tensor"]
+    tensor_data = load_nifti_data(tensor_path)
+    assert_equal(tensor_data.shape[-1], 6)
+    assert_equal(tensor_data.shape[:-1], volume.shape[:-1])
 
-        ga_path = dki_flow.last_generated_outputs["out_ga"]
-        ga_data = load_nifti_data(ga_path)
-        assert_equal(ga_data.shape, volume.shape[:-1])
+    ga_path = dki_flow.last_generated_outputs["out_ga"]
+    ga_data = load_nifti_data(ga_path)
+    assert_equal(ga_data.shape, volume.shape[:-1])
 
-        rgb_path = dki_flow.last_generated_outputs["out_rgb"]
-        rgb_data = load_nifti_data(rgb_path)
-        assert_equal(rgb_data.shape[-1], 3)
-        assert_equal(rgb_data.shape[:-1], volume.shape[:-1])
+    rgb_path = dki_flow.last_generated_outputs["out_rgb"]
+    rgb_data = load_nifti_data(rgb_path)
+    assert_equal(rgb_data.shape[-1], 3)
+    assert_equal(rgb_data.shape[:-1], volume.shape[:-1])
 
-        md_path = dki_flow.last_generated_outputs["out_md"]
-        md_data = load_nifti_data(md_path)
-        assert_equal(md_data.shape, volume.shape[:-1])
+    md_path = dki_flow.last_generated_outputs["out_md"]
+    md_data = load_nifti_data(md_path)
+    assert_equal(md_data.shape, volume.shape[:-1])
 
-        ad_path = dki_flow.last_generated_outputs["out_ad"]
-        ad_data = load_nifti_data(ad_path)
-        assert_equal(ad_data.shape, volume.shape[:-1])
+    ad_path = dki_flow.last_generated_outputs["out_ad"]
+    ad_data = load_nifti_data(ad_path)
+    assert_equal(ad_data.shape, volume.shape[:-1])
 
-        rd_path = dki_flow.last_generated_outputs["out_rd"]
-        rd_data = load_nifti_data(rd_path)
-        assert_equal(rd_data.shape, volume.shape[:-1])
+    rd_path = dki_flow.last_generated_outputs["out_rd"]
+    rd_data = load_nifti_data(rd_path)
+    assert_equal(rd_data.shape, volume.shape[:-1])
 
-        mk_path = dki_flow.last_generated_outputs["out_mk"]
-        mk_data = load_nifti_data(mk_path)
-        assert_equal(mk_data.shape, volume.shape[:-1])
+    mk_path = dki_flow.last_generated_outputs["out_mk"]
+    mk_data = load_nifti_data(mk_path)
+    assert_equal(mk_data.shape, volume.shape[:-1])
 
-        ak_path = dki_flow.last_generated_outputs["out_ak"]
-        ak_data = load_nifti_data(ak_path)
-        assert_equal(ak_data.shape, volume.shape[:-1])
+    ak_path = dki_flow.last_generated_outputs["out_ak"]
+    ak_data = load_nifti_data(ak_path)
+    assert_equal(ak_data.shape, volume.shape[:-1])
 
-        rk_path = dki_flow.last_generated_outputs["out_rk"]
-        rk_data = load_nifti_data(rk_path)
-        assert_equal(rk_data.shape, volume.shape[:-1])
+    rk_path = dki_flow.last_generated_outputs["out_rk"]
+    rk_data = load_nifti_data(rk_path)
+    assert_equal(rk_data.shape, volume.shape[:-1])
 
-        kt_path = dki_flow.last_generated_outputs["out_dk_tensor"]
-        kt_data = load_nifti_data(kt_path)
-        assert_equal(kt_data.shape[-1], 15)
-        assert_equal(kt_data.shape[:-1], volume.shape[:-1])
+    kt_path = dki_flow.last_generated_outputs["out_dk_tensor"]
+    kt_data = load_nifti_data(kt_path)
+    assert_equal(kt_data.shape[-1], 15)
+    assert_equal(kt_data.shape[:-1], volume.shape[:-1])
 
-        mode_path = dki_flow.last_generated_outputs["out_mode"]
-        mode_data = load_nifti_data(mode_path)
-        assert_equal(mode_data.shape, volume.shape[:-1])
+    mode_path = dki_flow.last_generated_outputs["out_mode"]
+    mode_data = load_nifti_data(mode_path)
+    assert_equal(mode_data.shape, volume.shape[:-1])
 
-        evecs_path = dki_flow.last_generated_outputs["out_evec"]
-        evecs_data = load_nifti_data(evecs_path)
-        assert_equal(evecs_data.shape[-2:], (3, 3))
-        assert_equal(evecs_data.shape[:-2], volume.shape[:-1])
+    evecs_path = dki_flow.last_generated_outputs["out_evec"]
+    evecs_data = load_nifti_data(evecs_path)
+    assert_equal(evecs_data.shape[-2:], (3, 3))
+    assert_equal(evecs_data.shape[:-2], volume.shape[:-1])
 
-        evals_path = dki_flow.last_generated_outputs["out_eval"]
-        evals_data = load_nifti_data(evals_path)
-        assert_equal(evals_data.shape[-1], 3)
-        assert_equal(evals_data.shape[:-1], volume.shape[:-1])
+    evals_path = dki_flow.last_generated_outputs["out_eval"]
+    evals_data = load_nifti_data(evals_path)
+    assert_equal(evals_data.shape[-1], 3)
+    assert_equal(evals_data.shape[:-1], volume.shape[:-1])
 
-        peaks_dir_path = dki_flow.last_generated_outputs["out_peaks_dir"]
-        peaks_dir_data = load_nifti_data(peaks_dir_path)
-        assert_equal(peaks_dir_data.shape[-1], 9)
-        assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+    peaks_dir_path = dki_flow.last_generated_outputs["out_peaks_dir"]
+    peaks_dir_data = load_nifti_data(peaks_dir_path)
+    assert_equal(peaks_dir_data.shape[-1], 9)
+    assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
 
-        peaks_idx_path = dki_flow.last_generated_outputs["out_peaks_indices"]
-        peaks_idx_data = load_nifti_data(peaks_idx_path)
-        assert_equal(peaks_idx_data.shape[-1], 3)
-        assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+    peaks_idx_path = dki_flow.last_generated_outputs["out_peaks_indices"]
+    peaks_idx_data = load_nifti_data(peaks_idx_path)
+    assert_equal(peaks_idx_data.shape[-1], 3)
+    assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
 
-        peaks_vals_path = dki_flow.last_generated_outputs["out_peaks_values"]
-        peaks_vals_data = load_nifti_data(peaks_vals_path)
-        assert_equal(peaks_vals_data.shape[-1], 3)
-        assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+    peaks_vals_path = dki_flow.last_generated_outputs["out_peaks_values"]
+    peaks_vals_data = load_nifti_data(peaks_vals_path)
+    assert_equal(peaks_vals_data.shape[-1], 3)
+    assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
 
-        pam = load_pam(dki_flow.last_generated_outputs["out_pam"])
-        assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
-        assert_allclose(pam.peak_values, peaks_vals_data)
-        assert_allclose(pam.peak_indices, peaks_idx_data)
+    pam = load_pam(dki_flow.last_generated_outputs["out_pam"])
+    assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
+    assert_allclose(pam.peak_values, peaks_vals_data)
+    assert_allclose(pam.peak_indices, peaks_idx_data)
 
-        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-        bvals[0] = 5.0
-        bvecs = generate_bvecs(len(bvals))
+    bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+    bvals[0] = 5.0
+    bvecs = generate_bvecs(len(bvals))
 
-        tmp_bval_path = Path(out_dir) / "tmp.bval"
-        tmp_bvec_path = Path(out_dir) / "tmp.bvec"
-        np.savetxt(tmp_bval_path, bvals)
-        np.savetxt(tmp_bvec_path, bvecs.T)
-        dki_flow._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            dki_flow.run(
-                data_path,
-                tmp_bval_path,
-                tmp_bvec_path,
-                mask_path,
-                out_dir=out_dir,
-                b0_threshold=0,
-            )
+    tmp_bval_path = tmp_path / "tmp.bval"
+    tmp_bvec_path = tmp_path / "tmp.bvec"
+    np.savetxt(tmp_bval_path, bvals)
+    np.savetxt(tmp_bvec_path, bvecs.T)
+    dki_flow._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        dki_flow.run(
+            data_path,
+            tmp_bval_path,
+            tmp_bvec_path,
+            mask_path,
+            out_dir=tmp_path,
+            b0_threshold=0,
+        )

--- a/dipy/workflows/tests/test_reconst_dsi.py
+++ b/dipy/workflows/tests/test_reconst_dsi.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -11,66 +9,65 @@ from dipy.reconst.shm import descoteaux07_legacy_msg
 from dipy.workflows.reconst import ReconstDsiFlow
 
 
-def test_reconst_dsi():
+def test_reconst_dsi(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstDsiFlow)
+        reconst_flow_core(tmp_path, ReconstDsiFlow)
 
 
-def test_reconst_dsid():
+def test_reconst_dsid(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstDsiFlow, remove_convolution=True)
+        reconst_flow_core(tmp_path, ReconstDsiFlow, remove_convolution=True)
 
 
-def reconst_flow_core(flow, **kwargs):
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0])
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-        save_nifti(mask_path, mask.astype(np.uint8), affine)
+def reconst_flow_core(tmp_path, flow, **kwargs):
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0])
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask.astype(np.uint8), affine)
 
-        dsi_flow = ReconstDsiFlow()
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            dsi_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                out_dir=out_dir,
-                extract_pam_values=True,
-                **kwargs,
-            )
+    dsi_flow = ReconstDsiFlow()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        dsi_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+            **kwargs,
+        )
 
-        peaks_dir_path = dsi_flow.last_generated_outputs["out_peaks_dir"]
-        peaks_dir_data = load_nifti_data(peaks_dir_path)
-        npt.assert_equal(peaks_dir_data.shape[-1], 15)
-        npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+    peaks_dir_path = dsi_flow.last_generated_outputs["out_peaks_dir"]
+    peaks_dir_data = load_nifti_data(peaks_dir_path)
+    npt.assert_equal(peaks_dir_data.shape[-1], 15)
+    npt.assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
 
-        peaks_idx_path = dsi_flow.last_generated_outputs["out_peaks_indices"]
-        peaks_idx_data = load_nifti_data(peaks_idx_path)
-        npt.assert_equal(peaks_idx_data.shape[-1], 5)
-        npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+    peaks_idx_path = dsi_flow.last_generated_outputs["out_peaks_indices"]
+    peaks_idx_data = load_nifti_data(peaks_idx_path)
+    npt.assert_equal(peaks_idx_data.shape[-1], 5)
+    npt.assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
 
-        peaks_vals_path = dsi_flow.last_generated_outputs["out_peaks_values"]
-        peaks_vals_data = load_nifti_data(peaks_vals_path)
-        npt.assert_equal(peaks_vals_data.shape[-1], 5)
-        npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+    peaks_vals_path = dsi_flow.last_generated_outputs["out_peaks_values"]
+    peaks_vals_data = load_nifti_data(peaks_vals_path)
+    npt.assert_equal(peaks_vals_data.shape[-1], 5)
+    npt.assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
 
-        gfa_path = dsi_flow.last_generated_outputs["out_gfa"]
-        gfa_data = load_nifti_data(gfa_path)
-        npt.assert_equal(gfa_data.shape, volume.shape[:-1])
+    gfa_path = dsi_flow.last_generated_outputs["out_gfa"]
+    gfa_data = load_nifti_data(gfa_path)
+    npt.assert_equal(gfa_data.shape, volume.shape[:-1])

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -1,5 +1,3 @@
-from os.path import join as pjoin
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -16,27 +14,27 @@ from dipy.testing import assert_greater
 from dipy.workflows.reconst import ReconstDtiFlow, ReconstFwdtiFlow
 
 
-def test_reconst_dti_wls():
+def test_reconst_dti_wls(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstDtiFlow)
+        reconst_flow_core(tmp_path, ReconstDtiFlow)
 
 
-def test_reconst_dti_nlls():
+def test_reconst_dti_nlls(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             message=descoteaux07_legacy_msg,
             category=PendingDeprecationWarning,
         )
-        reconst_flow_core(ReconstDtiFlow, extra_args=[], extra_kwargs={})
+        reconst_flow_core(tmp_path, ReconstDtiFlow, extra_args=[], extra_kwargs={})
 
 
-def test_reconst_dti_alt_tensor():
+def test_reconst_dti_alt_tensor(tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -44,85 +42,89 @@ def test_reconst_dti_alt_tensor():
             category=PendingDeprecationWarning,
         )
         reconst_flow_core(
-            ReconstDtiFlow, extra_args=[], extra_kwargs={"nifti_tensor": False}
+            tmp_path,
+            ReconstDtiFlow,
+            extra_args=[],
+            extra_kwargs={"nifti_tensor": False},
         )
 
 
-def reconst_flow_core(flow, *, dataname=None, extra_args=None, extra_kwargs=None):
+def reconst_flow_core(
+    tmp_path, flow, *, dataname=None, extra_args=None, extra_kwargs=None
+):
     extra_args = extra_args or []
     extra_kwargs = extra_kwargs or {}
     dataname = dataname or "small_25"
 
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name=dataname)
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
-        save_nifti(mask_path, mask, affine)
+    data_path, bval_path, bvec_path = get_fnames(name=dataname)
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
 
-        dti_flow = flow()
+    dti_flow = flow()
 
-        args = [data_path, bval_path, bvec_path, mask_path]
-        args.extend(extra_args)
-        kwargs = {"out_dir": out_dir, "extract_pam_values": True}
-        kwargs.update(extra_kwargs)
+    args = [data_path, bval_path, bvec_path, mask_path]
+    args.extend(extra_args)
+    kwargs = {"out_dir": tmp_path, "extract_pam_values": True}
+    kwargs.update(extra_kwargs)
 
-        dti_flow.run(*args, **kwargs)
+    dti_flow.run(*args, **kwargs)
 
-        fa_path = dti_flow.last_generated_outputs["out_fa"]
-        fa_data = load_nifti_data(fa_path)
-        assert_equal(fa_data.shape, volume.shape[:-1])
+    fa_path = dti_flow.last_generated_outputs["out_fa"]
+    fa_data = load_nifti_data(fa_path)
+    assert_equal(fa_data.shape, volume.shape[:-1])
 
-        tensor_path = dti_flow.last_generated_outputs["out_tensor"]
-        tensor_data = load_nifti_data(tensor_path)
-        # Per default, tensor data is 5D, with six tensor elements on the last
-        # dimension, except if nifti_tensor is set to False:
-        if extra_kwargs.get("nifti_tensor", True):
-            assert_equal(tensor_data.shape[-1], 6)
-            assert_equal(tensor_data.shape[:-2], volume.shape[:-1])
-        else:
-            assert_equal(tensor_data.shape[-1], 6)
-            assert_equal(tensor_data.shape[:-1], volume.shape[:-1])
+    tensor_path = dti_flow.last_generated_outputs["out_tensor"]
+    tensor_data = load_nifti_data(tensor_path)
+    # Per default, tensor data is 5D, with six tensor elements on the last
+    # dimension, except if nifti_tensor is set to False:
+    if extra_kwargs.get("nifti_tensor", True):
+        assert_equal(tensor_data.shape[-1], 6)
+        assert_equal(tensor_data.shape[:-2], volume.shape[:-1])
+    else:
+        assert_equal(tensor_data.shape[-1], 6)
+        assert_equal(tensor_data.shape[:-1], volume.shape[:-1])
 
-        for out_name in ["out_ga", "out_md", "out_ad", "out_rd", "out_mode", "out_s0"]:
-            out_path = dti_flow.last_generated_outputs[out_name]
-            out_data = load_nifti_data(out_path)
-            assert_equal(out_data.shape, volume.shape[:-1])
+    for out_name in ["out_ga", "out_md", "out_ad", "out_rd", "out_mode", "out_s0"]:
+        out_path = dti_flow.last_generated_outputs[out_name]
+        out_data = load_nifti_data(out_path)
+        assert_equal(out_data.shape, volume.shape[:-1])
 
-        rgb_path = dti_flow.last_generated_outputs["out_rgb"]
-        rgb_data = load_nifti_data(rgb_path)
-        assert_equal(rgb_data.shape[-1], 3)
-        assert_equal(rgb_data.shape[:-1], volume.shape[:-1])
+    rgb_path = dti_flow.last_generated_outputs["out_rgb"]
+    rgb_data = load_nifti_data(rgb_path)
+    assert_equal(rgb_data.shape[-1], 3)
+    assert_equal(rgb_data.shape[:-1], volume.shape[:-1])
 
-        evecs_path = dti_flow.last_generated_outputs["out_evec"]
-        evecs_data = load_nifti_data(evecs_path)
-        assert_equal(evecs_data.shape[-2:], (3, 3))
-        assert_equal(evecs_data.shape[:-2], volume.shape[:-1])
+    evecs_path = dti_flow.last_generated_outputs["out_evec"]
+    evecs_data = load_nifti_data(evecs_path)
+    assert_equal(evecs_data.shape[-2:], (3, 3))
+    assert_equal(evecs_data.shape[:-2], volume.shape[:-1])
 
-        evals_path = dti_flow.last_generated_outputs["out_eval"]
-        evals_data = load_nifti_data(evals_path)
-        assert_equal(evals_data.shape[-1], 3)
-        assert_equal(evals_data.shape[:-1], volume.shape[:-1])
+    evals_path = dti_flow.last_generated_outputs["out_eval"]
+    evals_data = load_nifti_data(evals_path)
+    assert_equal(evals_data.shape[-1], 3)
+    assert_equal(evals_data.shape[:-1], volume.shape[:-1])
 
-        peaks_dir_path = dti_flow.last_generated_outputs["out_peaks_dir"]
-        peaks_dir_data = load_nifti_data(peaks_dir_path)
-        assert_equal(peaks_dir_data.shape[-1], 3)
-        assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+    peaks_dir_path = dti_flow.last_generated_outputs["out_peaks_dir"]
+    peaks_dir_data = load_nifti_data(peaks_dir_path)
+    assert_equal(peaks_dir_data.shape[-1], 3)
+    assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
 
-        peaks_idx_path = dti_flow.last_generated_outputs["out_peaks_indices"]
-        peaks_idx_data = load_nifti_data(peaks_idx_path)
-        assert_equal(peaks_idx_data.shape[-1], 1)
-        assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+    peaks_idx_path = dti_flow.last_generated_outputs["out_peaks_indices"]
+    peaks_idx_data = load_nifti_data(peaks_idx_path)
+    assert_equal(peaks_idx_data.shape[-1], 1)
+    assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
 
-        peaks_vals_path = dti_flow.last_generated_outputs["out_peaks_values"]
-        peaks_vals_data = load_nifti_data(peaks_vals_path)
-        assert_equal(peaks_vals_data.shape[-1], 1)
-        assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+    peaks_vals_path = dti_flow.last_generated_outputs["out_peaks_values"]
+    peaks_vals_data = load_nifti_data(peaks_vals_path)
+    assert_equal(peaks_vals_data.shape[-1], 1)
+    assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
 
-        pam = load_pam(dti_flow.last_generated_outputs["out_pam"])
-        assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
-        assert_allclose(pam.peak_values, peaks_vals_data)
-        assert_allclose(pam.peak_indices, peaks_idx_data)
+    pam = load_pam(dti_flow.last_generated_outputs["out_pam"])
+    assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape), peaks_dir_data)
+    assert_allclose(pam.peak_values, peaks_vals_data)
+    assert_allclose(pam.peak_indices, peaks_idx_data)
 
 
 def simulate_multitensor_data(gtab):
@@ -146,67 +148,65 @@ def simulate_multitensor_data(gtab):
     return dwi
 
 
-def test_fwdti_error():
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_25")
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = pjoin(out_dir, "tmp_mask.nii.gz")
-        save_nifti(mask_path, mask, affine)
+def test_fwdti_error(tmp_path):
+    data_path, bval_path, bvec_path = get_fnames(name="small_25")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
 
-        flow = ReconstFwdtiFlow()
+    flow = ReconstFwdtiFlow()
 
-        assert_raises(ValueError, flow.run, data_path, bval_path, bvec_path, mask_path)
-        assert_raises(
-            ValueError,
-            flow.run,
-            data_path,
-            bval_path,
-            bvec_path,
-            mask_path,
-            fit_method="OLS",
-        )
-        assert_raises(TypeError, flow.run)
+    assert_raises(ValueError, flow.run, data_path, bval_path, bvec_path, mask_path)
+    assert_raises(
+        ValueError,
+        flow.run,
+        data_path,
+        bval_path,
+        bvec_path,
+        mask_path,
+        fit_method="OLS",
+    )
+    assert_raises(TypeError, flow.run)
 
 
-def test_fwdti():
-    with TemporaryDirectory() as out_dir:
-        _, fbvals, fbvecs = get_fnames(name="small_64D")
-        bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
+def test_fwdti(tmp_path):
+    _, fbvals, fbvecs = get_fnames(name="small_64D")
+    bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
 
-        # FW model requires multishell data
-        bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
-        bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
-        gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
-        fbvals = pjoin(out_dir, fbvals.name)
-        fbvecs = pjoin(out_dir, fbvecs.name)
-        np.savetxt(fbvals, bvals_2s)
-        np.savetxt(fbvecs, bvecs_2s)
+    # FW model requires multishell data
+    bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
+    bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
+    gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
+    fbvals = tmp_path / fbvals.name
+    fbvecs = tmp_path / fbvecs.name
+    np.savetxt(fbvals, bvals_2s)
+    np.savetxt(fbvecs, bvecs_2s)
 
-        dwi = simulate_multitensor_data(gtab_2s)
-        fdwi = pjoin(out_dir, "dwi.nii.gz")
-        mask = np.ones_like(dwi[..., 0], dtype=bool)
-        mask_path = pjoin(out_dir, "mask.nii.gz")
-        # import ipdb; ipdb.set_trace()
-        save_nifti(mask_path, mask.astype(np.int32), np.eye(4))
-        save_nifti(fdwi, dwi, np.eye(4))
+    dwi = simulate_multitensor_data(gtab_2s)
+    fdwi = tmp_path / "dwi.nii.gz"
+    mask = np.ones_like(dwi[..., 0], dtype=bool)
+    mask_path = tmp_path / "mask.nii.gz"
+    # import ipdb; ipdb.set_trace()
+    save_nifti(mask_path, mask.astype(np.int32), np.eye(4))
+    save_nifti(fdwi, dwi, np.eye(4))
 
-        fwdti_flow = ReconstFwdtiFlow()
+    fwdti_flow = ReconstFwdtiFlow()
 
-        args = [fdwi, fbvals, fbvecs, mask_path]
-        kwargs = {"out_dir": out_dir, "extract_pam_values": True}
+    args = [fdwi, fbvals, fbvecs, mask_path]
+    kwargs = {"out_dir": tmp_path, "extract_pam_values": True}
 
-        fwdti_flow.run(*args, **kwargs)
+    fwdti_flow.run(*args, **kwargs)
 
-        for out_name in [
-            "out_fa",
-            "out_tensor",
-            "out_ga",
-            "out_md",
-            "out_ad",
-            "out_rd",
-            "out_mode",
-        ]:
-            out_path = fwdti_flow.last_generated_outputs[out_name]
-            out_data = load_nifti_data(out_path)
-            assert_greater(out_data.mean(), 0)
+    for out_name in [
+        "out_fa",
+        "out_tensor",
+        "out_ga",
+        "out_md",
+        "out_ad",
+        "out_rd",
+        "out_mode",
+    ]:
+        out_path = fwdti_flow.last_generated_outputs[out_name]
+        out_data = load_nifti_data(out_path)
+        assert_greater(out_data.mean(), 0)

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -11,90 +9,89 @@ from dipy.sims.voxel import multi_tensor
 from dipy.workflows.reconst import ReconstIvimFlow
 
 
-def test_reconst_ivim():
-    with TemporaryDirectory() as out_dir:
-        bvals = np.array(
-            [
-                0.0,
-                10.0,
-                20.0,
-                30.0,
-                40.0,
-                60.0,
-                80.0,
-                100.0,
-                120.0,
-                140.0,
-                160.0,
-                180.0,
-                200.0,
-                300.0,
-                400.0,
-                500.0,
-                600.0,
-                700.0,
-                800.0,
-                900.0,
-                1000.0,
-            ]
-        )
-        N = len(bvals)
-        bvecs = generate_bvecs(N)
-        temp_bval_path = Path(out_dir) / "temp.bval"
-        np.savetxt(temp_bval_path, bvals)
-        temp_bvec_path = Path(out_dir) / "temp.bvec"
-        np.savetxt(temp_bvec_path, bvecs)
-
-        gtab = gradient_table(bvals, bvecs=bvecs)
-
-        S0, f, D_star, D = 1000.0, 0.132, 0.00885, 0.000921
-
-        mevals = np.array(([D_star, D_star, D_star], [D, D, D]))
-        # This gives an isotropic signal.
-        data = multi_tensor(
-            gtab, mevals, snr=None, S0=S0, fractions=[f * 100, 100 * (1 - f)]
-        )
-        # Single voxel data
-        data_single = data[0]
-        temp_affine = np.eye(4)
-
-        data_multi = np.zeros((2, 2, 1, len(gtab.bvals)), dtype=int)
-        data_multi[0, 0, 0] = data_multi[0, 1, 0] = data_multi[1, 0, 0] = data_multi[
-            1, 1, 0
-        ] = data_single
-        data_path = Path(out_dir) / "tmp_data.nii.gz"
-        save_nifti(data_path, data_multi, temp_affine, dtype=data_multi.dtype)
-
-        mask = np.ones_like(data_multi[..., 0], dtype=np.uint8)
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-        save_nifti(mask_path, mask, temp_affine)
-
-        ivim_flow = ReconstIvimFlow()
-
-        args = [
-            data_path,
-            temp_bval_path,
-            temp_bvec_path,
-            mask_path,
+def test_reconst_ivim(tmp_path):
+    bvals = np.array(
+        [
+            0.0,
+            10.0,
+            20.0,
+            30.0,
+            40.0,
+            60.0,
+            80.0,
+            100.0,
+            120.0,
+            140.0,
+            160.0,
+            180.0,
+            200.0,
+            300.0,
+            400.0,
+            500.0,
+            600.0,
+            700.0,
+            800.0,
+            900.0,
+            1000.0,
         ]
+    )
+    N = len(bvals)
+    bvecs = generate_bvecs(N)
+    temp_bval_path = tmp_path / "temp.bval"
+    np.savetxt(temp_bval_path, bvals)
+    temp_bvec_path = tmp_path / "temp.bvec"
+    np.savetxt(temp_bvec_path, bvecs)
 
-        msg = "Bounds for this fit have been set from experiments and * "
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=msg, category=UserWarning)
-            ivim_flow.run(*args, out_dir=out_dir)
+    gtab = gradient_table(bvals, bvecs=bvecs)
 
-        S0_path = ivim_flow.last_generated_outputs["out_S0_predicted"]
-        S0_data = load_nifti_data(S0_path)
-        assert_equal(S0_data.shape, data_multi.shape[:-1])
+    S0, f, D_star, D = 1000.0, 0.132, 0.00885, 0.000921
 
-        f_path = ivim_flow.last_generated_outputs["out_perfusion_fraction"]
-        f_data = load_nifti_data(f_path)
-        assert_equal(f_data.shape, data_multi.shape[:-1])
+    mevals = np.array(([D_star, D_star, D_star], [D, D, D]))
+    # This gives an isotropic signal.
+    data = multi_tensor(
+        gtab, mevals, snr=None, S0=S0, fractions=[f * 100, 100 * (1 - f)]
+    )
+    # Single voxel data
+    data_single = data[0]
+    temp_affine = np.eye(4)
 
-        D_star_path = ivim_flow.last_generated_outputs["out_D_star"]
-        D_star_data = load_nifti_data(D_star_path)
-        assert_equal(D_star_data.shape, data_multi.shape[:-1])
+    data_multi = np.zeros((2, 2, 1, len(gtab.bvals)), dtype=int)
+    data_multi[0, 0, 0] = data_multi[0, 1, 0] = data_multi[1, 0, 0] = data_multi[
+        1, 1, 0
+    ] = data_single
+    data_path = tmp_path / "tmp_data.nii.gz"
+    save_nifti(data_path, data_multi, temp_affine, dtype=data_multi.dtype)
 
-        D_path = ivim_flow.last_generated_outputs["out_D"]
-        D_data = load_nifti_data(D_path)
-        assert_equal(D_data.shape, data_multi.shape[:-1])
+    mask = np.ones_like(data_multi[..., 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, temp_affine)
+
+    ivim_flow = ReconstIvimFlow()
+
+    args = [
+        data_path,
+        temp_bval_path,
+        temp_bvec_path,
+        mask_path,
+    ]
+
+    msg = "Bounds for this fit have been set from experiments and * "
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=msg, category=UserWarning)
+        ivim_flow.run(*args, out_dir=tmp_path)
+
+    S0_path = ivim_flow.last_generated_outputs["out_S0_predicted"]
+    S0_data = load_nifti_data(S0_path)
+    assert_equal(S0_data.shape, data_multi.shape[:-1])
+
+    f_path = ivim_flow.last_generated_outputs["out_perfusion_fraction"]
+    f_data = load_nifti_data(f_path)
+    assert_equal(f_data.shape, data_multi.shape[:-1])
+
+    D_star_path = ivim_flow.last_generated_outputs["out_D_star"]
+    D_star_data = load_nifti_data(D_star_path)
+    assert_equal(D_star_data.shape, data_multi.shape[:-1])
+
+    D_path = ivim_flow.last_generated_outputs["out_D"]
+    D_data = load_nifti_data(D_path)
+    assert_equal(D_data.shape, data_multi.shape[:-1])

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -15,86 +13,85 @@ from dipy.testing import assert_warns
 from dipy.workflows.reconst import ReconstMAPMRIFlow
 
 
-def test_reconst_mmri_laplacian():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=False)
+def test_reconst_mmri_laplacian(tmp_path):
+    reconst_mmri_core(tmp_path, ReconstMAPMRIFlow, lap=True, pos=False)
 
 
-def test_reconst_mmri_none():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=False, pos=False)
-
-
-@pytest.mark.skipif(not mapmri.have_cvxpy, reason="Requires CVXPY")
-def test_reconst_mmri_both():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=True)
+def test_reconst_mmri_none(tmp_path):
+    reconst_mmri_core(tmp_path, ReconstMAPMRIFlow, lap=False, pos=False)
 
 
 @pytest.mark.skipif(not mapmri.have_cvxpy, reason="Requires CVXPY")
-def test_reconst_mmri_positivity():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=False)
+def test_reconst_mmri_both(tmp_path):
+    reconst_mmri_core(tmp_path, ReconstMAPMRIFlow, lap=True, pos=True)
 
 
-def reconst_mmri_core(flow, lap, pos):
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
+@pytest.mark.skipif(not mapmri.have_cvxpy, reason="Requires CVXPY")
+def test_reconst_mmri_positivity(tmp_path):
+    reconst_mmri_core(tmp_path, ReconstMAPMRIFlow, lap=True, pos=False)
 
-        mmri_flow = flow()
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="Optimization did not find a solution",
-                category=UserWarning,
-            )
-            warnings.filterwarnings(
-                "ignore",
-                message="Solution may be inaccurate.*",
-                category=UserWarning,
-            )
-            mmri_flow.run(
-                data_files=data_path,
-                bvals_files=bval_path,
-                bvecs_files=bvec_path,
-                small_delta=0.0129,
-                big_delta=0.0218,
-                laplacian=lap,
-                positivity=pos,
-                out_dir=out_dir,
-            )
+def reconst_mmri_core(tmp_path, flow, lap, pos):
+    data_path, bval_path, bvec_path = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
 
-        for out_name in [
-            "out_rtop",
-            "out_lapnorm",
-            "out_msd",
-            "out_qiv",
-            "out_rtap",
-            "out_rtpp",
-            "out_ng",
-            "out_parng",
-            "out_perng",
-        ]:
-            out_path = mmri_flow.last_generated_outputs[out_name]
-            out_data = load_nifti_data(out_path)
-            npt.assert_equal(out_data.shape, volume.shape[:-1])
+    mmri_flow = flow()
 
-        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-        bvals[0] = 5.0
-        bvecs = generate_bvecs(len(bvals))
-        tmp_bval_path = Path(out_dir) / "tmp.bval"
-        tmp_bvec_path = Path(out_dir) / "tmp.bvec"
-        np.savetxt(tmp_bval_path, bvals)
-        np.savetxt(tmp_bvec_path, bvecs.T)
-        mmri_flow._force_overwrite = True
-        with npt.assert_raises(BaseException):
-            assert_warns(
-                UserWarning,
-                mmri_flow.run,
-                data_path,
-                tmp_bval_path,
-                tmp_bvec_path,
-                small_delta=0.0129,
-                big_delta=0.0218,
-                laplacian=lap,
-                positivity=pos,
-                out_dir=out_dir,
-            )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Optimization did not find a solution",
+            category=UserWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="Solution may be inaccurate.*",
+            category=UserWarning,
+        )
+        mmri_flow.run(
+            data_files=data_path,
+            bvals_files=bval_path,
+            bvecs_files=bvec_path,
+            small_delta=0.0129,
+            big_delta=0.0218,
+            laplacian=lap,
+            positivity=pos,
+            out_dir=tmp_path,
+        )
+
+    for out_name in [
+        "out_rtop",
+        "out_lapnorm",
+        "out_msd",
+        "out_qiv",
+        "out_rtap",
+        "out_rtpp",
+        "out_ng",
+        "out_parng",
+        "out_perng",
+    ]:
+        out_path = mmri_flow.last_generated_outputs[out_name]
+        out_data = load_nifti_data(out_path)
+        npt.assert_equal(out_data.shape, volume.shape[:-1])
+
+    bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+    bvals[0] = 5.0
+    bvecs = generate_bvecs(len(bvals))
+    tmp_bval_path = tmp_path / "tmp.bval"
+    tmp_bvec_path = tmp_path / "tmp.bvec"
+    np.savetxt(tmp_bval_path, bvals)
+    np.savetxt(tmp_bvec_path, bvecs.T)
+    mmri_flow._force_overwrite = True
+    with npt.assert_raises(BaseException):
+        assert_warns(
+            UserWarning,
+            mmri_flow.run,
+            data_path,
+            tmp_bval_path,
+            tmp_bvec_path,
+            small_delta=0.0129,
+            big_delta=0.0218,
+            laplacian=lap,
+            positivity=pos,
+            out_dir=tmp_path,
+        )

--- a/dipy/workflows/tests/test_segment.py
+++ b/dipy/workflows/tests/test_segment.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import nibabel as nib
 import numpy as np
@@ -30,243 +29,329 @@ sklearn, has_sklearn, _ = optional_package("sklearn")
 torch, has_torch, _ = optional_package("torch")
 
 
-def test_median_otsu_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
-        save_masked = True
-        median_radius = 3
-        numpass = 3
-        vol_idx = "0,"
-        dilate = 0
-        finalize_mask = False
+def test_median_otsu_flow(tmp_path):
+    data_path, _, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
+    save_masked = True
+    median_radius = 3
+    numpass = 3
+    vol_idx = "0,"
+    dilate = 0
+    finalize_mask = False
 
-        mo_flow = MedianOtsuFlow()
+    mo_flow = MedianOtsuFlow()
+    mo_flow.run(
+        data_path,
+        out_dir=tmp_path,
+        save_masked=save_masked,
+        median_radius=median_radius,
+        numpass=numpass,
+        vol_idx=vol_idx,
+        dilate=dilate,
+        finalize_mask=finalize_mask,
+    )
+
+    mask_name = mo_flow.last_generated_outputs["out_mask"]
+    masked_name = mo_flow.last_generated_outputs["out_masked"]
+
+    vol_idx = [
+        0,
+    ]
+    masked, mask = median_otsu(
+        volume,
+        vol_idx=vol_idx,
+        median_radius=median_radius,
+        numpass=numpass,
+        dilate=dilate,
+    )
+
+    result_mask_data = load_nifti_data(tmp_path / mask_name)
+    npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
+
+    result_masked = nib.load(tmp_path / masked_name)
+    result_masked_data = np.asanyarray(result_masked.dataobj)
+
+    npt.assert_array_equal(np.round(result_masked_data), masked)
+
+
+def test_median_otsu_flow_autocrop_deprecated(tmp_path):
+    """Test that autocrop parameter triggers deprecation warning."""
+    data_path, _, _ = get_fnames(name="small_25")
+
+    mo_flow = MedianOtsuFlow()
+
+    with assert_warns(ArgsDeprecationWarning):
         mo_flow.run(
             data_path,
-            out_dir=out_dir,
-            save_masked=save_masked,
-            median_radius=median_radius,
-            numpass=numpass,
-            vol_idx=vol_idx,
-            dilate=dilate,
-            finalize_mask=finalize_mask,
+            out_dir=tmp_path,
+            vol_idx="0,",
+            autocrop=True,
+        )
+
+
+def test_median_otsu_flow_with_bvalues(tmp_path):
+    """Test MedianOtsuFlow with bvalues_files parameter."""
+    data_path, bval_path, _ = get_fnames(name="small_25")
+    volume = load_nifti_data(data_path)
+
+    mo_flow = MedianOtsuFlow()
+    for arg_bval in [{"bvalues_files": bval_path}, {"bvalues_files": [bval_path]}]:
+        mo_flow._force_overwrite = True
+        mo_flow.run(
+            data_path, **arg_bval, b0_threshold=50, out_dir=tmp_path, save_masked=True
         )
 
         mask_name = mo_flow.last_generated_outputs["out_mask"]
         masked_name = mo_flow.last_generated_outputs["out_masked"]
 
-        vol_idx = [
-            0,
-        ]
-        masked, mask = median_otsu(
-            volume,
-            vol_idx=vol_idx,
-            median_radius=median_radius,
-            numpass=numpass,
-            dilate=dilate,
-        )
+        npt.assert_equal(Path(tmp_path / mask_name).exists(), True)
+        npt.assert_equal(Path(tmp_path / masked_name).exists(), True)
 
-        result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
-        npt.assert_array_equal(result_mask_data.astype(np.uint8), mask)
-
-        result_masked = nib.load(Path(out_dir) / masked_name)
-        result_masked_data = np.asanyarray(result_masked.dataobj)
-
-        npt.assert_array_equal(np.round(result_masked_data), masked)
+        result_mask_data = load_nifti_data(tmp_path / mask_name)
+        npt.assert_equal(result_mask_data.shape, volume.shape[:3])
 
 
-def test_median_otsu_flow_autocrop_deprecated():
-    """Test that autocrop parameter triggers deprecation warning."""
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
+def test_recobundles_flow(tmp_path):
+    data_path = get_fnames(name="fornix")
 
-        mo_flow = MedianOtsuFlow()
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
 
-        with assert_warns(ArgsDeprecationWarning):
-            mo_flow.run(
-                data_path,
-                out_dir=out_dir,
-                vol_idx="0,",
-                autocrop=True,
-            )
+    f = Streamlines(fornix)
+    f1 = f.copy()
 
+    f2 = f1[:15].copy()
+    f2._data += np.array([40, 0, 0])
 
-def test_median_otsu_flow_with_bvalues():
-    """Test MedianOtsuFlow with bvalues_files parameter."""
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
+    f.extend(f2)
 
-        mo_flow = MedianOtsuFlow()
-        for arg_bval in [{"bvalues_files": bval_path}, {"bvalues_files": [bval_path]}]:
-            mo_flow._force_overwrite = True
-            mo_flow.run(
-                data_path,
-                **arg_bval,
-                b0_threshold=50,
-                out_dir=out_dir,
-                save_masked=True,
-            )
+    f2_path = tmp_path / "f2.trk"
+    sft = StatefulTractogram(f2, data_path, Space.RASMM)
+    save_tractogram(sft, f2_path, bbox_valid_check=False)
 
-            mask_name = mo_flow.last_generated_outputs["out_mask"]
-            masked_name = mo_flow.last_generated_outputs["out_masked"]
+    f1_path = tmp_path / "f1.trk"
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, f1_path, bbox_valid_check=False)
 
-            npt.assert_equal((Path(out_dir) / mask_name).exists(), True)
-            npt.assert_equal((Path(out_dir) / masked_name).exists(), True)
+    rb_flow = RecoBundlesFlow(force=True)
+    rb_flow.run(
+        f1_path,
+        f2_path,
+        greater_than=0,
+        clust_thr=10,
+        model_clust_thr=5.0,
+        reduction_thr=10,
+        out_dir=tmp_path,
+    )
 
-            result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
-            npt.assert_equal(result_mask_data.shape, volume.shape[:3])
+    labels = rb_flow.last_generated_outputs["out_recognized_labels"]
+    recog_trk = rb_flow.last_generated_outputs["out_recognized_transf"]
 
+    rec_bundle = load_tractogram(recog_trk, "same", bbox_valid_check=False).streamlines
+    npt.assert_equal(len(rec_bundle) == len(f2), True)
 
-def test_recobundles_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
+    label_flow = LabelsBundlesFlow(force=True)
+    label_flow.run(f1_path, labels, out_dir=tmp_path)
 
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+    recog_bundle = label_flow.last_generated_outputs["out_bundle"]
+    rec_bundle_org = load_tractogram(
+        recog_bundle, "same", bbox_valid_check=False
+    ).streamlines
 
-        f = Streamlines(fornix)
-        f1 = f.copy()
+    BMD = BundleMinDistanceMetric()
+    nb_pts = 20
+    static = set_number_of_points(f2, nb_points=nb_pts)
+    moving = set_number_of_points(rec_bundle_org, nb_points=nb_pts)
 
-        f2 = f1[:15].copy()
-        f2._data += np.array([40, 0, 0])
+    BMD.setup(static, moving)
+    x0 = np.array([0, 0, 0, 0, 0, 0, 1.0, 1.0, 1, 0, 0, 0])  # affine
+    bmd_value = BMD.distance(x0.tolist())
 
-        f.extend(f2)
-
-        f2_path = Path(out_dir) / "f2.trk"
-        sft = StatefulTractogram(f2, data_path, Space.RASMM)
-        save_tractogram(sft, f2_path, bbox_valid_check=False)
-
-        f1_path = Path(out_dir) / "f1.trk"
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, f1_path, bbox_valid_check=False)
-
-        rb_flow = RecoBundlesFlow(force=True)
-        rb_flow.run(
-            f1_path,
-            f2_path,
-            greater_than=0,
-            clust_thr=10,
-            model_clust_thr=5.0,
-            reduction_thr=10,
-            out_dir=out_dir,
-        )
-
-        labels = rb_flow.last_generated_outputs["out_recognized_labels"]
-        recog_trk = rb_flow.last_generated_outputs["out_recognized_transf"]
-
-        rec_bundle = load_tractogram(
-            recog_trk, "same", bbox_valid_check=False
-        ).streamlines
-        npt.assert_equal(len(rec_bundle) == len(f2), True)
-
-        label_flow = LabelsBundlesFlow(force=True)
-        label_flow.run(f1_path, labels, out_dir=out_dir)
-
-        recog_bundle = label_flow.last_generated_outputs["out_bundle"]
-        rec_bundle_org = load_tractogram(
-            recog_bundle, "same", bbox_valid_check=False
-        ).streamlines
-
-        BMD = BundleMinDistanceMetric()
-        nb_pts = 20
-        static = set_number_of_points(f2, nb_points=nb_pts)
-        moving = set_number_of_points(rec_bundle_org, nb_points=nb_pts)
-
-        BMD.setup(static, moving)
-        x0 = np.array([0, 0, 0, 0, 0, 0, 1.0, 1.0, 1, 0, 0, 0])  # affine
-        bmd_value = BMD.distance(x0.tolist())
-
-        npt.assert_equal(bmd_value < 1, True)
+    npt.assert_equal(bmd_value < 1, True)
 
 
 @set_random_number_generator()
-def test_classify_tissue_flow_hmrf(rng=None):
-    with TemporaryDirectory() as out_dir:
-        # Small structured volume (30x30x5 = 4500 voxels, ~70x smaller than
-        # the original 256x256x5). Three Gaussian populations with non-zero
-        # variance so the HMRF E-step statistics are well-conditioned.
-        data = np.zeros((30, 30, 5), dtype=np.float64)
-        data[:10, :, :] = 50.0
-        data[10:20, :, :] = 150.0
-        data[20:, :, :] = 250.0
-        data += rng.normal(0, 10.0, data.shape)
-        data = np.clip(data, 0, None)
-        data_path = Path(out_dir) / "data.nii.gz"
-        nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
+def test_classify_tissue_flow_hmrf(tmp_path, rng=None):
+    # Small structured volume (30x30x5 = 4500 voxels, ~70x smaller than
+    # the original 256x256x5). Three Gaussian populations with non-zero
+    # variance so the HMRF E-step statistics are well-conditioned.
+    data = np.zeros((30, 30, 5), dtype=np.float64)
+    data[:10, :, :] = 50.0
+    data[10:20, :, :] = 150.0
+    data[20:, :, :] = 250.0
+    data += rng.normal(0, 10.0, data.shape)
+    data = np.clip(data, 0, None)
+    data_path = tmp_path / "data.nii.gz"
+    nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
 
-        flow = ClassifyTissueFlow()
-        flow.run(
-            input_files=data_path,
-            method="hmrf",
-            nclass=3,
-            beta=0.1,
-            tolerance=0,
-            max_iter=3,
-            out_dir=out_dir,
-        )
+    flow = ClassifyTissueFlow()
+    flow.run(
+        input_files=data_path,
+        method="hmrf",
+        nclass=3,
+        beta=0.1,
+        tolerance=0,
+        max_iter=3,
+        out_dir=tmp_path,
+    )
 
-        tissue = flow.last_generated_outputs["out_tissue"]
-        pve = flow.last_generated_outputs["out_pve"]
+    tissue = flow.last_generated_outputs["out_tissue"]
+    pve = flow.last_generated_outputs["out_pve"]
 
-        tissue_data = load_nifti_data(tissue)
-        pve_data = load_nifti_data(pve)
+    tissue_data = load_nifti_data(tissue)
+    pve_data = load_nifti_data(pve)
 
-        npt.assert_equal(tissue_data.shape, data.shape)
-        npt.assert_equal(tissue_data.max(), 3)
-        npt.assert_equal(tissue_data.min() >= 0, True)
-        npt.assert_equal(pve_data.shape, data.shape + (3,))
-        npt.assert_equal(pve_data.max(), 1)
+    npt.assert_equal(tissue_data.shape, data.shape)
+    npt.assert_equal(tissue_data.max(), 3)
+    npt.assert_equal(tissue_data.min() >= 0, True)
+    npt.assert_equal(pve_data.shape, data.shape + (3,))
+    npt.assert_equal(pve_data.max(), 1)
 
-        npt.assert_raises(SystemExit, flow.run, data_path)
-        npt.assert_raises(SystemExit, flow.run, data_path, method="random")
-        npt.assert_raises(SystemExit, flow.run, data_path, method="dam")
-        npt.assert_raises(SystemExit, flow.run, data_path, method="hmrf")
+    npt.assert_raises(SystemExit, flow.run, data_path)
+    npt.assert_raises(SystemExit, flow.run, data_path, method="random")
+    npt.assert_raises(SystemExit, flow.run, data_path, method="dam")
+    npt.assert_raises(SystemExit, flow.run, data_path, method="hmrf")
 
 
 @pytest.mark.skipif(not has_sklearn, reason="Requires scikit-learn")
 @set_random_number_generator()
-def test_classify_tissue_flow_dam(rng=None):
-    with TemporaryDirectory() as out_dir:
-        data = rng.uniform(low=0.0, high=100.0, size=(3, 3, 3, 7))
-        bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
-        data_path = Path(out_dir) / "data.nii.gz"
-        bvals_path = Path(out_dir) / "bvals"
-        np.savetxt(bvals_path, bvals)
-        nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
+def test_classify_tissue_flow_dam(tmp_path, rng=None):
+    data = rng.uniform(low=0.0, high=100.0, size=(3, 3, 3, 7))
+    bvals = np.array([0, 100, 500, 1000, 1500, 2000, 3000])
+    data_path = tmp_path / "data.nii.gz"
+    bvals_path = tmp_path / "bvals"
+    np.savetxt(bvals_path, bvals)
+    nib.save(nib.Nifti1Image(data, np.eye(4)), data_path)
 
-        flow = ClassifyTissueFlow()
-        flow.run(
-            input_files=data_path,
-            bvals_file=bvals_path,
-            method="dam",
-            wm_threshold=0.5,
-            out_dir=out_dir,
-        )
+    flow = ClassifyTissueFlow()
+    flow.run(
+        input_files=data_path,
+        bvals_file=bvals_path,
+        method="dam",
+        wm_threshold=0.5,
+        out_dir=tmp_path,
+    )
 
-        tissue = flow.last_generated_outputs["out_tissue"]
-        pve = flow.last_generated_outputs["out_pve"]
+    tissue = flow.last_generated_outputs["out_tissue"]
+    pve = flow.last_generated_outputs["out_pve"]
 
-        tissue_data = load_nifti_data(tissue)
-        pve_data = load_nifti_data(pve)
+    tissue_data = load_nifti_data(tissue)
+    pve_data = load_nifti_data(pve)
 
-        npt.assert_equal(tissue_data.shape, data.shape[:-1])
-        npt.assert_equal(tissue_data.max(), 2)
-        npt.assert_equal(tissue_data.min(), 0)
-        npt.assert_equal(pve_data.shape, data.shape[:-1] + (2,))
-        npt.assert_equal(pve_data.max(), 1)
+    npt.assert_equal(tissue_data.shape, data.shape[:-1])
+    npt.assert_equal(tissue_data.max(), 2)
+    npt.assert_equal(tissue_data.min(), 0)
+    npt.assert_equal(pve_data.shape, data.shape[:-1] + (2,))
+    npt.assert_equal(pve_data.max(), 1)
 
 
 @pytest.mark.skipif(not has_torch, reason="Requires PyTorch")
 @set_random_number_generator()
-def test_classify_tissue_flow_synthseg(rng=None):
-    with TemporaryDirectory() as out_dir:
+def test_classify_tissue_flow_synthseg(tmp_path, rng=None):
+    data = rng.uniform(low=0.0, high=1.0, size=(96, 96, 96))
+    data_path = tmp_path / "data.nii.gz"
+    nib.save(nib.Nifti1Image(data, np.eye(4) * 2), data_path)
+
+    # SynthSeg accuracy is tested in nn/tests/test_synthseg.py.
+    # Mock it here to avoid loading multi-GB weights in this workflow test.
+    class _FakeSynthSeg:
+        def __init__(self, **kwargs):
+            pass
+
+        def predict(self, img, affine, **kwargs):
+            return (
+                np.zeros(img.shape, dtype=np.int32),
+                {0: "Background"},
+                np.zeros(img.shape, dtype=np.int32),
+            )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("dipy.workflows.segment.SynthSeg", _FakeSynthSeg)
+        flow = ClassifyTissueFlow()
+        flow.run(input_files=data_path, method="synthseg", out_dir=tmp_path)
+
+    tissue = flow.last_generated_outputs["out_tissue"]
+    tissue_data = load_nifti_data(tissue)
+
+    npt.assert_equal(tissue_data.shape, data.shape)
+    npt.assert_equal(tissue_data.min(), 0)
+    npt.assert_equal(tissue_data.max() < 60, True)
+
+
+@set_random_number_generator()
+def test_brain_mask_flow(tmp_path_factory, rng=None):
+    data_path, bval_path, _ = get_fnames(name="small_25")
+    flow = BrainMaskFlow()
+    npt.assert_raises(SystemExit, flow.run, data_path, method="invalid")
+
+    out_dir = tmp_path_factory.mktemp("full")
+    volume = load_nifti_data(data_path)
+    median_radius = 2
+    numpass = 5
+
+    flow = BrainMaskFlow()
+    flow.run(
+        data_path,
+        method="median_otsu",
+        vol_idx="0,",
+        median_radius=median_radius,
+        numpass=numpass,
+        save_masked=True,
+        out_dir=out_dir,
+    )
+
+    mask_name = flow.last_generated_outputs["out_mask"]
+    masked_name = flow.last_generated_outputs["out_masked"]
+
+    _, expected_mask = median_otsu(
+        volume, vol_idx=[0], median_radius=median_radius, numpass=numpass
+    )
+    result_mask_data = load_nifti_data(out_dir / mask_name)
+    npt.assert_array_equal(result_mask_data, expected_mask.astype(np.float64))
+    npt.assert_equal(Path(out_dir / masked_name).exists(), True)
+
+    out_dir = tmp_path_factory.mktemp("partial")
+    volume = load_nifti_data(data_path)
+
+    flow = BrainMaskFlow()
+    flow.run(data_path, method="median_otsu", bvalues_files=bval_path, out_dir=out_dir)
+
+    mask_name = flow.last_generated_outputs["out_mask"]
+    result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
+    npt.assert_equal(result_mask_data.shape, volume.shape[:3])
+
+    if has_torch:
+        out_dir = tmp_path_factory.mktemp("evacplus")
+        data = rng.uniform(low=0.0, high=1.0, size=(32, 32, 32))
+        temp_path = out_dir / "temp.nii.gz"
+        save_nifti(temp_path, data, np.eye(4))
+
+        # EVACPlus accuracy is tested in nn/tests/test_evac.py.
+        # Mock it here to avoid loading model weights in this workflow test.
+        class _FakeEVACPlus:
+            def __init__(self, **kwargs):
+                pass
+
+            def predict(self, vol, affine, **kwargs):
+                return np.ones(vol.shape)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("dipy.nn.evac.EVACPlus", _FakeEVACPlus)
+            flow = BrainMaskFlow()
+            flow.run(temp_path, method="evac", out_dir=out_dir)
+
+        mask_name = flow.last_generated_outputs["out_mask"]
+        mask_data = load_nifti_data(out_dir / mask_name)
+
+        npt.assert_equal(mask_data.shape, data.shape)
+        npt.assert_equal(mask_data.min() >= 0, True)
+        npt.assert_equal(mask_data.max() <= 1, True)
+
+    if has_torch:
+        out_dir = tmp_path_factory.mktemp("synthseg")
         data = rng.uniform(low=0.0, high=1.0, size=(96, 96, 96))
-        data_path = Path(out_dir) / "data.nii.gz"
+        data_path = out_dir / "data.nii.gz"
         nib.save(nib.Nifti1Image(data, np.eye(4) * 2), data_path)
 
-        # SynthSeg accuracy is tested in nn/tests/test_synthseg.py.
-        # Mock it here to avoid loading multi-GB weights in this workflow test.
         class _FakeSynthSeg:
             def __init__(self, **kwargs):
                 pass
@@ -280,182 +365,65 @@ def test_classify_tissue_flow_synthseg(rng=None):
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("dipy.workflows.segment.SynthSeg", _FakeSynthSeg)
-            flow = ClassifyTissueFlow()
-            flow.run(input_files=data_path, method="synthseg", out_dir=out_dir)
-
-        tissue = flow.last_generated_outputs["out_tissue"]
-        tissue_data = load_nifti_data(tissue)
-
-        npt.assert_equal(tissue_data.shape, data.shape)
-        npt.assert_equal(tissue_data.min(), 0)
-        npt.assert_equal(tissue_data.max() < 60, True)
-
-
-@set_random_number_generator()
-def test_brain_mask_flow(rng=None):
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        flow = BrainMaskFlow()
-        npt.assert_raises(SystemExit, flow.run, data_path, method="invalid")
-
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
-        median_radius = 2
-        numpass = 5
-
-        flow = BrainMaskFlow()
-        flow.run(
-            data_path,
-            method="median_otsu",
-            vol_idx="0,",
-            median_radius=median_radius,
-            numpass=numpass,
-            save_masked=True,
-            out_dir=out_dir,
-        )
+            flow = BrainMaskFlow()
+            flow.run(data_path, method="synthseg", out_dir=out_dir)
 
         mask_name = flow.last_generated_outputs["out_mask"]
-        masked_name = flow.last_generated_outputs["out_masked"]
+        mask_data = load_nifti_data(Path(out_dir) / mask_name)
 
-        _, expected_mask = median_otsu(
-            volume,
-            vol_idx=[0],
-            median_radius=median_radius,
-            numpass=numpass,
-        )
-        result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
-        npt.assert_array_equal(result_mask_data, expected_mask.astype(np.float64))
-        npt.assert_equal((Path(out_dir) / masked_name).exists(), True)
-
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, _ = get_fnames(name="small_25")
-        volume = load_nifti_data(data_path)
-
-        flow = BrainMaskFlow()
-        flow.run(
-            data_path,
-            method="median_otsu",
-            bvalues_files=bval_path,
-            out_dir=out_dir,
-        )
-
-        mask_name = flow.last_generated_outputs["out_mask"]
-        result_mask_data = load_nifti_data(Path(out_dir) / mask_name)
-        npt.assert_equal(result_mask_data.shape, volume.shape[:3])
-
-    if has_torch:
-        with TemporaryDirectory() as out_dir:
-            data = rng.uniform(low=0.0, high=1.0, size=(32, 32, 32))
-            temp_path = Path(out_dir) / "temp.nii.gz"
-            save_nifti(temp_path, data, np.eye(4))
-
-            # EVACPlus accuracy is tested in nn/tests/test_evac.py.
-            # Mock it here to avoid loading model weights in this workflow test.
-            class _FakeEVACPlus:
-                def __init__(self, **kwargs):
-                    pass
-
-                def predict(self, vol, affine, **kwargs):
-                    return np.ones(vol.shape)
-
-            with pytest.MonkeyPatch.context() as mp:
-                mp.setattr("dipy.nn.evac.EVACPlus", _FakeEVACPlus)
-                flow = BrainMaskFlow()
-                flow.run(temp_path, method="evac", out_dir=out_dir)
-
-            mask_name = flow.last_generated_outputs["out_mask"]
-            mask_data = load_nifti_data(Path(out_dir) / mask_name)
-
-            npt.assert_equal(mask_data.shape, data.shape)
-            npt.assert_equal(mask_data.min() >= 0, True)
-            npt.assert_equal(mask_data.max() <= 1, True)
-
-    if has_torch:
-        with TemporaryDirectory() as out_dir:
-            data = rng.uniform(low=0.0, high=1.0, size=(96, 96, 96))
-            data_path = Path(out_dir) / "data.nii.gz"
-            nib.save(nib.Nifti1Image(data, np.eye(4) * 2), data_path)
-
-            class _FakeSynthSeg:
-                def __init__(self, **kwargs):
-                    pass
-
-                def predict(self, img, affine, **kwargs):
-                    return (
-                        np.zeros(img.shape, dtype=np.int32),
-                        {0: "Background"},
-                        np.zeros(img.shape, dtype=np.int32),
-                    )
-
-            with pytest.MonkeyPatch.context() as mp:
-                mp.setattr("dipy.workflows.segment.SynthSeg", _FakeSynthSeg)
-                flow = BrainMaskFlow()
-                flow.run(data_path, method="synthseg", out_dir=out_dir)
-
-            mask_name = flow.last_generated_outputs["out_mask"]
-            mask_data = load_nifti_data(Path(out_dir) / mask_name)
-
-            npt.assert_equal(mask_data.shape, data.shape)
-            npt.assert_equal(mask_data.min() >= 0, True)
-            npt.assert_equal(mask_data.max() <= 1, True)
+        npt.assert_equal(mask_data.shape, data.shape)
+        npt.assert_equal(mask_data.min() >= 0, True)
+        npt.assert_equal(mask_data.max() <= 1, True)
 
 
-def test_cluster_streamlines_flow():
-    with TemporaryDirectory() as out_dir:
-        data_path = get_fnames(name="fornix")
-        sft = load_tractogram(data_path, "same", bbox_valid_check=False)
-        n_streamlines = len(sft.streamlines)
+def test_cluster_streamlines_flow(tmp_path):
+    data_path = get_fnames(name="fornix")
+    sft = load_tractogram(data_path, "same", bbox_valid_check=False)
+    n_streamlines = len(sft.streamlines)
 
-        flow = ClusterStreamlinesFlow()
-        npt.assert_raises(SystemExit, flow.run, data_path, method="invalid")
+    flow = ClusterStreamlinesFlow()
+    npt.assert_raises(SystemExit, flow.run, data_path, method="invalid")
 
-        flow = ClusterStreamlinesFlow(force=True)
-        flow.run(data_path, method="quickbundles", threshold=10.0, out_dir=out_dir)
-        centroids_sft = load_tractogram(
-            Path(out_dir) / flow.last_generated_outputs["out_centroids"],
-            "same",
-            bbox_valid_check=False,
-        )
-        labels = np.load(
-            Path(out_dir) / flow.last_generated_outputs["out_cluster_labels"]
-        )
-        npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
-        npt.assert_equal(labels.shape[0], n_streamlines)
+    flow = ClusterStreamlinesFlow(force=True)
+    flow.run(data_path, method="quickbundles", threshold=10.0, out_dir=tmp_path)
+    centroids_sft = load_tractogram(
+        tmp_path / flow.last_generated_outputs["out_centroids"],
+        "same",
+        bbox_valid_check=False,
+    )
+    labels = np.load(tmp_path / flow.last_generated_outputs["out_cluster_labels"])
+    npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
+    npt.assert_equal(labels.shape[0], n_streamlines)
 
-        flow._force_overwrite = True
-        flow.run(
-            data_path,
-            method="qbx_and_merge",
-            thresholds="30,20,10",
-            out_dir=out_dir,
-        )
-        centroids_sft = load_tractogram(
-            Path(out_dir) / flow.last_generated_outputs["out_centroids"],
-            "same",
-            bbox_valid_check=False,
-        )
-        labels = np.load(
-            Path(out_dir) / flow.last_generated_outputs["out_cluster_labels"]
-        )
-        npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
-        npt.assert_equal(labels.shape[0], n_streamlines)
+    flow._force_overwrite = True
+    flow.run(
+        data_path,
+        method="qbx_and_merge",
+        thresholds="30,20,10",
+        out_dir=tmp_path,
+    )
+    centroids_sft = load_tractogram(
+        tmp_path / flow.last_generated_outputs["out_centroids"],
+        "same",
+        bbox_valid_check=False,
+    )
+    labels = np.load(tmp_path / flow.last_generated_outputs["out_cluster_labels"])
+    npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
+    npt.assert_equal(labels.shape[0], n_streamlines)
 
-        flow._force_overwrite = True
-        flow.run(
-            data_path,
-            method="faststreamlines",
-            threshold=10.0,
-            max_radius=15.0,
-            out_dir=out_dir,
-        )
-        centroids_sft = load_tractogram(
-            Path(out_dir) / flow.last_generated_outputs["out_centroids"],
-            "same",
-            bbox_valid_check=False,
-        )
-        labels = np.load(
-            Path(out_dir) / flow.last_generated_outputs["out_cluster_labels"]
-        )
-        npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
-        npt.assert_equal(labels.shape[0], n_streamlines)
+    flow._force_overwrite = True
+    flow.run(
+        data_path,
+        method="faststreamlines",
+        threshold=10.0,
+        max_radius=15.0,
+        out_dir=tmp_path,
+    )
+    centroids_sft = load_tractogram(
+        tmp_path / flow.last_generated_outputs["out_centroids"],
+        "same",
+        bbox_valid_check=False,
+    )
+    labels = np.load(tmp_path / flow.last_generated_outputs["out_cluster_labels"])
+    npt.assert_equal(len(centroids_sft.streamlines) > 0, True)
+    npt.assert_equal(labels.shape[0], n_streamlines)

--- a/dipy/workflows/tests/test_stats.py
+++ b/dipy/workflows/tests/test_stats.py
@@ -2,7 +2,6 @@
 
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import numpy.testing as npt
@@ -30,42 +29,41 @@ _, have_tables, _ = optional_package("tables")
 _, have_matplotlib, _ = optional_package("matplotlib")
 
 
-def test_stats():
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_101D")
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = Path(out_dir) / "tmp_mask.nii.gz"
-        save_nifti(mask_path, mask, affine)
+def test_stats(tmp_path):
+    data_path, bval_path, bvec_path = get_fnames(name="small_101D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
 
-        snr_flow = SNRinCCFlow(force=True)
-        args = [data_path, bval_path, bvec_path, mask_path]
-        snr_flow.run(*args, out_dir=out_dir)
+    snr_flow = SNRinCCFlow(force=True)
+    args = [data_path, bval_path, bvec_path, mask_path]
+    snr_flow.run(*args, out_dir=tmp_path)
 
-        assert_true(Path(Path(out_dir) / "product.json").exists())
-        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
-        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
-        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
+    assert_true((tmp_path / "product.json").exists())
+    assert_true(os.stat(tmp_path / "product.json").st_size != 0)
+    assert_true((tmp_path / "cc.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "cc.nii.gz").st_size != 0)
+    assert_true((tmp_path / "mask_noise.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "mask_noise.nii.gz").st_size != 0)
 
-        snr_flow._force_overwrite = True
-        snr_flow.run(*args, out_dir=out_dir)
-        assert_true(Path(Path(out_dir) / "product.json").exists())
-        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
-        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
-        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
+    snr_flow._force_overwrite = True
+    snr_flow.run(*args, out_dir=tmp_path)
+    assert_true((tmp_path / "product.json").exists())
+    assert_true(os.stat(tmp_path / "product.json").st_size != 0)
+    assert_true((tmp_path / "cc.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "cc.nii.gz").st_size != 0)
+    assert_true((tmp_path / "mask_noise.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "mask_noise.nii.gz").st_size != 0)
 
-        snr_flow._force_overwrite = True
-        snr_flow.run(*args, bbox_threshold=(0.5, 1, 0, 0.15, 0, 0.2), out_dir=out_dir)
-        assert_true(Path(Path(out_dir) / "product.json").exists())
-        assert_true(os.stat(Path(out_dir) / "product.json").st_size != 0)
-        assert_true(Path(Path(out_dir) / "cc.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "cc.nii.gz").st_size != 0)
-        assert_true(Path(Path(out_dir) / "mask_noise.nii.gz").exists())
-        assert_true(os.stat(Path(out_dir) / "mask_noise.nii.gz").st_size != 0)
+    snr_flow._force_overwrite = True
+    snr_flow.run(*args, bbox_threshold=(0.5, 1, 0, 0.15, 0, 0.2), out_dir=tmp_path)
+    assert_true((tmp_path / "product.json").exists())
+    assert_true(os.stat(tmp_path / "product.json").st_size != 0)
+    assert_true((tmp_path / "cc.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "cc.nii.gz").st_size != 0)
+    assert_true((tmp_path / "mask_noise.nii.gz").exists())
+    assert_true(os.stat(tmp_path / "mask_noise.nii.gz").st_size != 0)
 
 
 @pytest.mark.skipif(
@@ -73,265 +71,259 @@ def test_stats():
     reason="Requires Pandas, StatsModels and PyTables",
 )
 @set_random_number_generator()
-def test_buan_bundle_profiles(rng):
-    with TemporaryDirectory() as dirpath:
-        data_path = get_fnames(name="fornix")
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+def test_buan_bundle_profiles(tmp_path, rng=None):
+    data_path = get_fnames(name="fornix")
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
 
-        f = Streamlines(fornix)
+    f = Streamlines(fornix)
 
-        mb = Path(dirpath) / "model_bundles"
+    mb = tmp_path / "model_bundles"
 
-        os.mkdir(mb)
+    os.mkdir(mb)
+
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
+
+    rb = tmp_path / "rec_bundles"
+    os.mkdir(rb)
+
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(rb) / "temp.trk", bbox_valid_check=False)
+
+    ob = tmp_path / "org_bundles"
+    os.mkdir(ob)
+
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(ob) / "temp.trk", bbox_valid_check=False)
+
+    dt = tmp_path / "anatomical_measures"
+    os.mkdir(dt)
+
+    fa = rng.random((255, 255, 255))
+
+    save_nifti(Path(dt) / "fa.nii.gz", fa, affine=np.eye(4))
+
+    out_dir = tmp_path / "output"
+    os.mkdir(out_dir)
+
+    buan_bundle_profiles(
+        mb,
+        rb,
+        ob,
+        dt,
+        group_id=1,
+        subject="10001",
+        no_disks=100,
+        out_dir=out_dir,
+    )
+
+    assert_true((out_dir / "temp_fa.h5").exists())
+
+
+@pytest.mark.skipif(
+    not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
+    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
+)
+@set_random_number_generator()
+def test_bundle_analysis_tractometry_flow(tmp_path, rng=None):
+    data_path = get_fnames(name="fornix")
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+
+    f = Streamlines(fornix)
+
+    mb = tmp_path / "model_bundles"
+    sub = tmp_path / "subjects"
+
+    os.mkdir(mb)
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
+
+    os.mkdir(sub)
+
+    os.mkdir(Path(sub) / "patient")
+
+    os.mkdir(Path(sub) / "control")
+
+    p = sub / "patient" / "10001"
+    os.mkdir(p)
+
+    c = sub / "control" / "20002"
+    os.mkdir(c)
+
+    for pre in [p, c]:
+        os.mkdir(Path(pre) / "rec_bundles")
 
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
-
-        rb = Path(dirpath) / "rec_bundles"
-        os.mkdir(rb)
-
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(rb) / "temp.trk", bbox_valid_check=False)
-
-        ob = Path(dirpath) / "org_bundles"
-        os.mkdir(ob)
+        save_tractogram(
+            sft,
+            Path(pre) / "rec_bundles" / "temp.trk",
+            bbox_valid_check=False,
+        )
+        os.mkdir(Path(pre) / "org_bundles")
 
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(ob) / "temp.trk", bbox_valid_check=False)
-
-        dt = Path(dirpath) / "anatomical_measures"
-        os.mkdir(dt)
+        save_tractogram(
+            sft,
+            Path(pre) / "org_bundles" / "temp.trk",
+            bbox_valid_check=False,
+        )
+        os.mkdir(Path(pre) / "anatomical_measures")
 
         fa = rng.random((255, 255, 255))
 
-        save_nifti(Path(dt) / "fa.nii.gz", fa, affine=np.eye(4))
-
-        out_dir = Path(dirpath) / "output"
-        os.mkdir(out_dir)
-
-        buan_bundle_profiles(
-            mb,
-            rb,
-            ob,
-            dt,
-            group_id=1,
-            subject="10001",
-            no_disks=100,
-            out_dir=out_dir,
-        )
-
-        assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
-
-
-@pytest.mark.skipif(
-    not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
-    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
-)
-@set_random_number_generator()
-def test_bundle_analysis_tractometry_flow(rng):
-    with TemporaryDirectory() as dirpath:
-        data_path = get_fnames(name="fornix")
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
-
-        f = Streamlines(fornix)
-
-        mb = Path(dirpath) / "model_bundles"
-        sub = Path(dirpath) / "subjects"
-
-        os.mkdir(mb)
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
-
-        os.mkdir(sub)
-
-        os.mkdir(Path(sub) / "patient")
-
-        os.mkdir(Path(sub) / "control")
-
-        p = sub / "patient" / "10001"
-        os.mkdir(p)
-
-        c = sub / "control" / "20002"
-        os.mkdir(c)
-
-        for pre in [p, c]:
-            os.mkdir(Path(pre) / "rec_bundles")
-
-            sft = StatefulTractogram(f, data_path, Space.RASMM)
-            save_tractogram(
-                sft,
-                Path(pre) / "rec_bundles" / "temp.trk",
-                bbox_valid_check=False,
-            )
-            os.mkdir(Path(pre) / "org_bundles")
-
-            sft = StatefulTractogram(f, data_path, Space.RASMM)
-            save_tractogram(
-                sft,
-                Path(pre) / "org_bundles" / "temp.trk",
-                bbox_valid_check=False,
-            )
-            os.mkdir(Path(pre) / "anatomical_measures")
-
-            fa = rng.random((255, 255, 255))
-
-            save_nifti(
-                Path(pre) / "anatomical_measures" / "fa.nii.gz",
-                fa,
-                affine=np.eye(4),
-            )
-
-        out_dir = Path(dirpath) / "output"
-        os.mkdir(out_dir)
-
-        ba_flow = BundleAnalysisTractometryFlow()
-
-        ba_flow.run(mb, sub, out_dir=out_dir)
-
-        assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
-
-        dft = pd.read_hdf(Path(out_dir) / "temp_fa.h5")
-
-        # assert_true(dft.bundle.unique() == "temp")
-
-        assert_true(set(dft.subject.unique()) == {"10001", "20002"})
-
-
-@pytest.mark.skipif(
-    not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
-    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
-)
-def test_linear_mixed_models_flow():
-    with TemporaryDirectory() as dirpath:
-        out_dir = Path(dirpath) / "output"
-        os.mkdir(out_dir)
-
-        d = {
-            "disk": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5] * 10,
-            "fa": [0.21, 0.234, 0.44, 0.44, 0.5, 0.23, 0.55, 0.34, 0.76, 0.34] * 10,
-            "subject": [
-                "10001",
-                "10001",
-                "10001",
-                "10001",
-                "10001",
-                "20002",
-                "20002",
-                "20002",
-                "20002",
-                "20002",
-            ]
-            * 10,
-            "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1] * 10,
-        }
-
-        df = pd.DataFrame(data=d)
-        store = pd.HDFStore(Path(out_dir) / "temp_fa.h5")
-        store.append("fa", df, data_columns=True)
-        store.close()
-
-        lmm_flow = LinearMixedModelsFlow()
-
-        out_dir2 = Path(dirpath) / "output2"
-        os.mkdir(out_dir2)
-
-        input_path = Path(out_dir) / "*"
-
-        lmm_flow.run(input_path, no_disks=5, out_dir=out_dir2)
-
-        assert_true(Path(Path(out_dir2) / "temp_fa_pvalues.npy").exists())
-        assert_true(Path(Path(out_dir2) / "temp_fa.png").exists())
-
-        # test error
-        d2 = {
-            "disk": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5] * 1,
-            "fa": [0.21, 0.234, 0.44, 0.44, 0.5, 0.23, 0.55, 0.34, 0.76, 0.34] * 1,
-            "subject": [
-                "10001",
-                "10001",
-                "10001",
-                "10001",
-                "10001",
-                "20002",
-                "20002",
-                "20002",
-                "20002",
-                "20002",
-            ]
-            * 1,
-            "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1] * 1,
-        }
-
-        df = pd.DataFrame(data=d2)
-
-        out_dir3 = Path(dirpath) / "output3"
-        os.mkdir(out_dir3)
-
-        store = pd.HDFStore(Path(out_dir3) / "temp_fa.h5")
-        store.append("fa", df, data_columns=True)
-        store.close()
-
-        out_dir4 = Path(dirpath) / "output4"
-        os.mkdir(out_dir4)
-
-        input_path = Path(out_dir3) / "f*"
-        # OS error raised if path is wrong or file does not exist
-        npt.assert_raises(
-            OSError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
-        )
-
-        input_path = Path(out_dir3) / "*"
-        # value error raised if length of data frame is less than 100
-        npt.assert_raises(
-            ValueError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
-        )
-
-
-@set_random_number_generator()
-def test_bundle_analysis_tractometry_flow_single_subject(rng):
-    with TemporaryDirectory() as dirpath:
-        data_path = get_fnames(name="fornix")
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
-
-        f = Streamlines(fornix)
-
-        mb = Path(dirpath) / "model_bundles"
-        os.mkdir(mb)
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
-
-        # Single-subject directory directly contains rec_bundles/, org_bundles/,
-        # and anatomical_measures/ (no patient/control subdirs)
-        single_sub = Path(dirpath) / "10001"
-        os.mkdir(single_sub)
-
-        os.mkdir(single_sub / "rec_bundles")
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(
-            sft, single_sub / "rec_bundles" / "temp.trk", bbox_valid_check=False
-        )
-
-        os.mkdir(single_sub / "org_bundles")
-        sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(
-            sft, single_sub / "org_bundles" / "temp.trk", bbox_valid_check=False
-        )
-
-        os.mkdir(single_sub / "anatomical_measures")
-        fa = rng.random((40, 40, 40))
         save_nifti(
-            single_sub / "anatomical_measures" / "fa.nii.gz",
+            Path(pre) / "anatomical_measures" / "fa.nii.gz",
             fa,
             affine=np.eye(4),
         )
 
-        out_dir = Path(dirpath) / "output"
-        os.mkdir(out_dir)
+    out_dir = tmp_path / "output"
+    os.mkdir(out_dir)
 
-        ba_flow = BundleAnalysisTractometryFlow()
-        ba_flow.run(mb, single_sub, out_dir=out_dir)
+    ba_flow = BundleAnalysisTractometryFlow()
 
-        assert_true(Path(out_dir / "temp_fa_profile.npy").exists())
+    ba_flow.run(mb, sub, out_dir=out_dir)
+
+    assert_true(Path(Path(out_dir) / "temp_fa.h5").exists())
+
+    dft = pd.read_hdf(Path(out_dir) / "temp_fa.h5")
+
+    # assert_true(dft.bundle.unique() == "temp")
+
+    assert_true(set(dft.subject.unique()) == {"10001", "20002"})
+
+
+@pytest.mark.skipif(
+    not have_pandas or not have_statsmodels or not have_tables or not have_matplotlib,
+    reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
+)
+def test_linear_mixed_models_flow(tmp_path):
+    out_dir = tmp_path / "output"
+    os.mkdir(out_dir)
+
+    d = {
+        "disk": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5] * 10,
+        "fa": [0.21, 0.234, 0.44, 0.44, 0.5, 0.23, 0.55, 0.34, 0.76, 0.34] * 10,
+        "subject": [
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "20002",
+            "20002",
+            "20002",
+            "20002",
+            "20002",
+        ]
+        * 10,
+        "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1] * 10,
+    }
+
+    df = pd.DataFrame(data=d)
+    store = pd.HDFStore(Path(out_dir) / "temp_fa.h5")
+    store.append("fa", df, data_columns=True)
+    store.close()
+
+    lmm_flow = LinearMixedModelsFlow()
+
+    out_dir2 = tmp_path / "output2"
+    os.mkdir(out_dir2)
+
+    input_path = Path(out_dir) / "*"
+
+    lmm_flow.run(input_path, no_disks=5, out_dir=out_dir2)
+
+    assert_true(Path(Path(out_dir2) / "temp_fa_pvalues.npy").exists())
+    assert_true(Path(Path(out_dir2) / "temp_fa.png").exists())
+
+    # test error
+    d2 = {
+        "disk": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5] * 1,
+        "fa": [0.21, 0.234, 0.44, 0.44, 0.5, 0.23, 0.55, 0.34, 0.76, 0.34] * 1,
+        "subject": [
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "10001",
+            "20002",
+            "20002",
+            "20002",
+            "20002",
+            "20002",
+        ]
+        * 1,
+        "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1] * 1,
+    }
+
+    df = pd.DataFrame(data=d2)
+
+    out_dir3 = tmp_path / "output3"
+    os.mkdir(out_dir3)
+
+    store = pd.HDFStore(Path(out_dir3) / "temp_fa.h5")
+    store.append("fa", df, data_columns=True)
+    store.close()
+
+    out_dir4 = tmp_path / "output4"
+    os.mkdir(out_dir4)
+
+    input_path = Path(out_dir3) / "f*"
+    # OS error raised if path is wrong or file does not exist
+    npt.assert_raises(OSError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4)
+
+    input_path = Path(out_dir3) / "*"
+    # value error raised if length of data frame is less than 100
+    npt.assert_raises(
+        ValueError, lmm_flow.run, input_path, no_disks=5, out_dir=out_dir4
+    )
+
+
+@set_random_number_generator()
+def test_bundle_analysis_tractometry_flow_single_subject(tmp_path, rng=None):
+    data_path = get_fnames(name="fornix")
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+
+    f = Streamlines(fornix)
+
+    mb = tmp_path / "model_bundles"
+    os.mkdir(mb)
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
+
+    # Single-subject directory directly contains rec_bundles/, org_bundles/,
+    # and anatomical_measures/ (no patient/control subdirs)
+    single_sub = tmp_path / "10001"
+    os.mkdir(single_sub)
+
+    os.mkdir(single_sub / "rec_bundles")
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(
+        sft, single_sub / "rec_bundles" / "temp.trk", bbox_valid_check=False
+    )
+
+    os.mkdir(single_sub / "org_bundles")
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(
+        sft, single_sub / "org_bundles" / "temp.trk", bbox_valid_check=False
+    )
+
+    os.mkdir(single_sub / "anatomical_measures")
+    fa = rng.random((40, 40, 40))
+    save_nifti(
+        single_sub / "anatomical_measures" / "fa.nii.gz",
+        fa,
+        affine=np.eye(4),
+    )
+
+    out_dir = tmp_path / "output"
+    os.mkdir(out_dir)
+
+    ba_flow = BundleAnalysisTractometryFlow()
+    ba_flow.run(mb, single_sub, out_dir=out_dir)
+
+    assert_true(Path(out_dir / "temp_fa_profile.npy").exists())
 
 
 @pytest.mark.skipif(
@@ -339,64 +331,63 @@ def test_bundle_analysis_tractometry_flow_single_subject(rng):
     reason="Requires Pandas, StatsModels, PyTables, and matplotlib",
 )
 @set_random_number_generator()
-def test_bundle_shape_analysis_flow(rng):
-    with TemporaryDirectory() as dirpath:
-        data_path = get_fnames(name="fornix")
-        fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
+def test_bundle_shape_analysis_flow(tmp_path, rng=None):
+    data_path = get_fnames(name="fornix")
+    fornix = load_tractogram(data_path, "same", bbox_valid_check=False).streamlines
 
-        f = Streamlines(fornix)
+    f = Streamlines(fornix)
 
-        mb = Path(dirpath) / "model_bundles"
-        sub = Path(dirpath) / "subjects"
+    mb = tmp_path / "model_bundles"
+    sub = tmp_path / "subjects"
 
-        os.mkdir(mb)
+    os.mkdir(mb)
+    sft = StatefulTractogram(f, data_path, Space.RASMM)
+    save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
+
+    os.mkdir(sub)
+
+    os.mkdir(sub / "patient")
+
+    os.mkdir(sub / "control")
+
+    p = sub / "patient" / "10001"
+    os.mkdir(p)
+
+    c = sub / "control" / "20002"
+    os.mkdir(c)
+
+    for pre in [p, c]:
+        os.mkdir(Path(pre) / "rec_bundles")
+
         sft = StatefulTractogram(f, data_path, Space.RASMM)
-        save_tractogram(sft, Path(mb) / "temp.trk", bbox_valid_check=False)
+        save_tractogram(
+            sft,
+            Path(pre) / "rec_bundles" / "temp.trk",
+            bbox_valid_check=False,
+        )
+        os.mkdir(Path(pre) / "org_bundles")
 
-        os.mkdir(sub)
+        sft = StatefulTractogram(f, data_path, Space.RASMM)
+        save_tractogram(
+            sft,
+            Path(pre) / "org_bundles" / "temp.trk",
+            bbox_valid_check=False,
+        )
+        os.mkdir(Path(pre) / "anatomical_measures")
 
-        os.mkdir(sub / "patient")
+        fa = rng.random((255, 255, 255))
 
-        os.mkdir(sub / "control")
+        save_nifti(
+            Path(pre) / "anatomical_measures" / "fa.nii.gz",
+            fa,
+            affine=np.eye(4),
+        )
 
-        p = sub / "patient" / "10001"
-        os.mkdir(p)
+    out_dir = tmp_path / "output"
+    os.mkdir(out_dir)
 
-        c = sub / "control" / "20002"
-        os.mkdir(c)
+    sm_flow = BundleShapeAnalysis()
 
-        for pre in [p, c]:
-            os.mkdir(Path(pre) / "rec_bundles")
+    sm_flow.run(sub, out_dir=out_dir)
 
-            sft = StatefulTractogram(f, data_path, Space.RASMM)
-            save_tractogram(
-                sft,
-                Path(pre) / "rec_bundles" / "temp.trk",
-                bbox_valid_check=False,
-            )
-            os.mkdir(Path(pre) / "org_bundles")
-
-            sft = StatefulTractogram(f, data_path, Space.RASMM)
-            save_tractogram(
-                sft,
-                Path(pre) / "org_bundles" / "temp.trk",
-                bbox_valid_check=False,
-            )
-            os.mkdir(Path(pre) / "anatomical_measures")
-
-            fa = rng.random((255, 255, 255))
-
-            save_nifti(
-                Path(pre) / "anatomical_measures" / "fa.nii.gz",
-                fa,
-                affine=np.eye(4),
-            )
-
-        out_dir = Path(dirpath) / "output"
-        os.mkdir(out_dir)
-
-        sm_flow = BundleShapeAnalysis()
-
-        sm_flow.run(sub, out_dir=out_dir)
-
-        assert_true(Path(Path(out_dir) / "temp.npy").exists())
+    assert_true(Path(Path(out_dir) / "temp.npy").exists())

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -1,5 +1,3 @@
-from os.path import join
-from tempfile import TemporaryDirectory
 import warnings
 
 import numpy as np
@@ -15,299 +13,297 @@ from dipy.workflows.reconst import ReconstCSDFlow
 from dipy.workflows.tracking import LocalFiberTrackingPAMFlow, PFTrackingPAMFlow
 
 
-def test_particle_filtering_tracking_workflows():
-    with TemporaryDirectory() as out_dir:
-        dwi_path, bval_path, bvec_path = get_fnames(name="small_64D")
-        volume, affine = load_nifti(dwi_path)
+def test_particle_filtering_tracking_workflows(tmp_path):
+    dwi_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(dwi_path)
 
-        # Create some mask
-        mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = join(out_dir, "tmp_mask.nii.gz")
-        save_nifti(mask_path, mask, affine)
+    # Create some mask
+    mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
 
-        simple_wm = np.array(
-            [
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-                [0, 0, 1, 1, 1, 1, 0, 1, 0, 0],
-                [0, 0, 1, 0, 1, 0, 1, 0, 0, 0],
-                [0, 0, 1, 0, 1, 1, 0, 1, 0, 0],
-                [0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            ]
+    simple_wm = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 1, 0, 1, 0, 0],
+            [0, 0, 1, 0, 1, 0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 1, 1, 0, 1, 0, 0],
+            [0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    simple_wm = np.dstack(
+        [
+            np.zeros(simple_wm.shape),
+            np.zeros(simple_wm.shape),
+            simple_wm,
+            simple_wm,
+            simple_wm,
+            simple_wm,
+            simple_wm,
+            simple_wm,
+            np.zeros(simple_wm.shape),
+            np.zeros(simple_wm.shape),
+        ]
+    )
+    simple_gm = np.array(
+        [
+            [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 0, 0, 1, 1, 1, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
+            [1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 1, 0, 0, 0, 0, 1, 0, 1, 0],
+            [0, 1, 1, 0, 1, 1, 1, 0, 1, 1],
+            [0, 0, 0, 1, 0, 0, 0, 1, 1, 0],
+        ]
+    )
+    simple_gm = np.dstack(
+        [
+            np.zeros(simple_gm.shape),
+            np.zeros(simple_gm.shape),
+            simple_gm,
+            simple_gm,
+            simple_gm,
+            simple_gm,
+            simple_gm,
+            simple_gm,
+            np.zeros(simple_gm.shape),
+            np.zeros(simple_gm.shape),
+        ]
+    )
+    simple_csf = np.ones(simple_wm.shape) - simple_wm - simple_gm
+
+    wm_path = tmp_path / "tmp_wm.nii.gz"
+    gm_path = tmp_path / "tmp_gm.nii.gz"
+    csf_path = tmp_path / "tmp_csf.nii.gz"
+
+    for path, arr in zip(
+        [wm_path, gm_path, csf_path],
+        [simple_wm, simple_gm, simple_csf],
+    ):
+        save_nifti(path, arr.astype(np.uint8), affine)
+
+    # CSD Reconstruction
+    reconst_csd_flow = ReconstCSDFlow()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
         )
-        simple_wm = np.dstack(
-            [
-                np.zeros(simple_wm.shape),
-                np.zeros(simple_wm.shape),
-                simple_wm,
-                simple_wm,
-                simple_wm,
-                simple_wm,
-                simple_wm,
-                simple_wm,
-                np.zeros(simple_wm.shape),
-                np.zeros(simple_wm.shape),
-            ]
+        reconst_csd_flow.run(
+            dwi_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            out_dir=tmp_path,
+            extract_pam_values=True,
         )
-        simple_gm = np.array(
-            [
-                [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 1, 1, 0, 0, 1, 1, 1, 0],
-                [0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
-                [0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
-                [0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
-                [0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
-                [1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-                [0, 1, 0, 0, 0, 0, 1, 0, 1, 0],
-                [0, 1, 1, 0, 1, 1, 1, 0, 1, 1],
-                [0, 0, 0, 1, 0, 0, 0, 1, 1, 0],
-            ]
+
+    pam_path = reconst_csd_flow.last_generated_outputs["out_pam"]
+    gfa_path = reconst_csd_flow.last_generated_outputs["out_gfa"]
+
+    # Create seeding mask by thresholding the gfa
+    mask_flow = MaskFlow()
+    mask_flow.run(gfa_path, 0.8, out_dir=tmp_path)
+    seeds_path = mask_flow.last_generated_outputs["out_mask"]
+
+    # Test tracking
+    pf_track_pam = PFTrackingPAMFlow()
+    assert_equal(pf_track_pam.get_short_name(), "track_pft")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
         )
-        simple_gm = np.dstack(
-            [
-                np.zeros(simple_gm.shape),
-                np.zeros(simple_gm.shape),
-                simple_gm,
-                simple_gm,
-                simple_gm,
-                simple_gm,
-                simple_gm,
-                simple_gm,
-                np.zeros(simple_gm.shape),
-                np.zeros(simple_gm.shape),
-            ]
+        pf_track_pam.run(
+            pam_path, wm_path, gm_path, csf_path, seeds_path, out_dir=tmp_path
         )
-        simple_csf = np.ones(simple_wm.shape) - simple_wm - simple_gm
+    tractogram_path = pf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
 
-        wm_path = join(out_dir, "tmp_wm.nii.gz")
-        gm_path = join(out_dir, "tmp_gm.nii.gz")
-        csf_path = join(out_dir, "tmp_csf.nii.gz")
-
-        for path, arr in zip(
-            [wm_path, gm_path, csf_path],
-            [simple_wm, simple_gm, simple_csf],
-        ):
-            save_nifti(path, arr.astype(np.uint8), affine)
-
-        # CSD Reconstruction
-        reconst_csd_flow = ReconstCSDFlow()
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            reconst_csd_flow.run(
-                dwi_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                out_dir=out_dir,
-                extract_pam_values=True,
-            )
-
-        pam_path = reconst_csd_flow.last_generated_outputs["out_pam"]
-        gfa_path = reconst_csd_flow.last_generated_outputs["out_gfa"]
-
-        # Create seeding mask by thresholding the gfa
-        mask_flow = MaskFlow()
-        mask_flow.run(gfa_path, 0.8, out_dir=out_dir)
-        seeds_path = mask_flow.last_generated_outputs["out_mask"]
-
-        # Test tracking
-        pf_track_pam = PFTrackingPAMFlow()
-        assert_equal(pf_track_pam.get_short_name(), "track_pft")
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            pf_track_pam.run(
-                pam_path, wm_path, gm_path, csf_path, seeds_path, out_dir=out_dir
-            )
-        tractogram_path = pf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
-
-        # Test that tracking returns seeds
-        pf_track_pam = PFTrackingPAMFlow()
-        pf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            pf_track_pam.run(
-                pam_path,
-                wm_path,
-                gm_path,
-                csf_path,
-                seeds_path,
-                save_seeds=True,
-                out_dir=out_dir,
-            )
-        tractogram_path = pf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_true(tractogram_has_seeds(tractogram_path))
-        assert_true(seeds_are_same_space_as_streamlines(tractogram_path))
+    # Test that tracking returns seeds
+    pf_track_pam = PFTrackingPAMFlow()
+    pf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        pf_track_pam.run(
+            pam_path,
+            wm_path,
+            gm_path,
+            csf_path,
+            seeds_path,
+            save_seeds=True,
+            out_dir=tmp_path,
+        )
+    tractogram_path = pf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_true(tractogram_has_seeds(tractogram_path))
+    assert_true(seeds_are_same_space_as_streamlines(tractogram_path))
 
 
-def test_local_fiber_tracking_workflow():
-    with TemporaryDirectory() as out_dir:
-        data_path, bval_path, bvec_path = get_fnames(name="small_64D")
-        volume, affine = load_nifti(data_path)
-        mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
-        mask_path = join(out_dir, "tmp_mask.nii.gz")
-        save_nifti(mask_path, mask, affine)
+def test_local_fiber_tracking_workflow(tmp_path):
+    data_path, bval_path, bvec_path = get_fnames(name="small_64D")
+    volume, affine = load_nifti(data_path)
+    mask = np.ones_like(volume[:, :, :, 0], dtype=np.uint8)
+    mask_path = tmp_path / "tmp_mask.nii.gz"
+    save_nifti(mask_path, mask, affine)
 
-        reconst_csd_flow = ReconstCSDFlow()
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            reconst_csd_flow.run(
-                data_path,
-                bval_path,
-                bvec_path,
-                mask_path,
-                out_dir=out_dir,
-                extract_pam_values=True,
-            )
+    reconst_csd_flow = ReconstCSDFlow()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        reconst_csd_flow.run(
+            data_path,
+            bval_path,
+            bvec_path,
+            mask_path,
+            out_dir=tmp_path,
+            extract_pam_values=True,
+        )
 
-        pam_path = reconst_csd_flow.last_generated_outputs["out_pam"]
-        gfa_path = reconst_csd_flow.last_generated_outputs["out_gfa"]
+    pam_path = reconst_csd_flow.last_generated_outputs["out_pam"]
+    gfa_path = reconst_csd_flow.last_generated_outputs["out_gfa"]
 
-        # Create seeding mask by thresholding the gfa
-        mask_flow = MaskFlow()
-        mask_flow.run(gfa_path, 0.8, out_dir=out_dir)
-        seeds_path = mask_flow.last_generated_outputs["out_mask"]
-        mask_path = mask_flow.last_generated_outputs["out_mask"]
+    # Create seeding mask by thresholding the gfa
+    mask_flow = MaskFlow()
+    mask_flow.run(gfa_path, 0.8, out_dir=tmp_path)
+    seeds_path = mask_flow.last_generated_outputs["out_mask"]
+    mask_path = mask_flow.last_generated_outputs["out_mask"]
 
-        gfa_img, gfa_affine = load_nifti(gfa_path)
-        save_nifti(gfa_path, gfa_img, gfa_affine)
+    gfa_img, gfa_affine = load_nifti(gfa_path)
+    save_nifti(gfa_path, gfa_img, gfa_affine)
 
-        # Test tracking with pam no sh
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        assert_equal(lf_track_pam.get_short_name(), "track_local")
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(pam_path, gfa_path, seeds_path, out_dir=out_dir)
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
+    # Test tracking with pam no sh
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    assert_equal(lf_track_pam.get_short_name(), "track_local")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        lf_track_pam.run(pam_path, gfa_path, seeds_path, out_dir=tmp_path)
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
 
-        # Test tracking with binary stopping criterion
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(
-                pam_path, mask_path, seeds_path, use_binary_mask=True, out_dir=out_dir
-            )
-
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
-
-        # Test tracking with pam with sh
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
+    # Test tracking with binary stopping criterion
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
         lf_track_pam.run(
-            pam_path, gfa_path, seeds_path, tracking_method="eudx", out_dir=out_dir
+            pam_path, mask_path, seeds_path, use_binary_mask=True, out_dir=tmp_path
         )
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
 
-        # Test tracking with pam with sh and deterministic getter
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
-                tracking_method="deterministic",
-                out_dir=out_dir,
-            )
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
 
-        # Test tracking with pam with sh and probabilistic getter
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
-                tracking_method="probabilistic",
-                out_dir=out_dir,
-            )
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
+    # Test tracking with pam with sh
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    lf_track_pam.run(
+        pam_path, gfa_path, seeds_path, tracking_method="eudx", out_dir=tmp_path
+    )
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
 
-        # Test tracking with pam with sh and closest peaks getter
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
-                tracking_method="closestpeaks",
-                out_dir=out_dir,
-            )
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_false(is_tractogram_empty(tractogram_path))
+    # Test tracking with pam with sh and deterministic getter
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        lf_track_pam.run(
+            pam_path,
+            gfa_path,
+            seeds_path,
+            tracking_method="deterministic",
+            out_dir=tmp_path,
+        )
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
 
-        # Test that tracking returns seeds
-        lf_track_pam = LocalFiberTrackingPAMFlow()
-        lf_track_pam._force_overwrite = True
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=descoteaux07_legacy_msg,
-                category=PendingDeprecationWarning,
-            )
-            lf_track_pam.run(
-                pam_path,
-                gfa_path,
-                seeds_path,
-                tracking_method="deterministic",
-                save_seeds=True,
-                out_dir=out_dir,
-            )
-        tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
-        assert_true(tractogram_has_seeds(tractogram_path))
-        assert_true(seeds_are_same_space_as_streamlines(tractogram_path))
+    # Test tracking with pam with sh and probabilistic getter
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        lf_track_pam.run(
+            pam_path,
+            gfa_path,
+            seeds_path,
+            tracking_method="probabilistic",
+            out_dir=tmp_path,
+        )
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
+
+    # Test tracking with pam with sh and closest peaks getter
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        lf_track_pam.run(
+            pam_path,
+            gfa_path,
+            seeds_path,
+            tracking_method="closestpeaks",
+            out_dir=tmp_path,
+        )
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_false(is_tractogram_empty(tractogram_path))
+
+    # Test that tracking returns seeds
+    lf_track_pam = LocalFiberTrackingPAMFlow()
+    lf_track_pam._force_overwrite = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=descoteaux07_legacy_msg,
+            category=PendingDeprecationWarning,
+        )
+        lf_track_pam.run(
+            pam_path,
+            gfa_path,
+            seeds_path,
+            tracking_method="deterministic",
+            save_seeds=True,
+            out_dir=tmp_path,
+        )
+    tractogram_path = lf_track_pam.last_generated_outputs["out_tractogram"]
+    assert_true(tractogram_has_seeds(tractogram_path))
+    assert_true(seeds_are_same_space_as_streamlines(tractogram_path))
 
 
 def is_tractogram_empty(tractogram_path):

--- a/dipy/workflows/tests/test_viz.py
+++ b/dipy/workflows/tests/test_viz.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -27,7 +24,7 @@ skip_it = use_xvfb == "skip"
 
 @pytest.mark.skipif(skip_it or not has_fury, reason="Requires FURY")
 @set_random_number_generator()
-def test_horizon_flow(rng):
+def test_horizon_flow(tmp_path, rng):
     s1 = 10 * np.array(
         [[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0]], dtype="f8"
     )
@@ -63,123 +60,122 @@ def test_horizon_flow(rng):
     tractograms = [sft]
     images = None
 
-    with TemporaryDirectory() as out_dir:
-        horizon(
-            tractograms=tractograms,
-            images=images,
-            cluster=True,
-            cluster_thr=5,
-            random_colors=False,
-            length_lt=np.inf,
-            length_gt=0,
-            clusters_lt=np.inf,
-            clusters_gt=0,
-            world_coords=True,
-            interactive=False,
-            out_png=str(Path(out_dir) / "horizon-flow.png"),
-        )
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        cluster=True,
+        cluster_thr=5,
+        random_colors=False,
+        length_lt=np.inf,
+        length_gt=0,
+        clusters_lt=np.inf,
+        clusters_gt=0,
+        world_coords=True,
+        interactive=False,
+        out_png=str(tmp_path / "horizon-flow.png"),
+    )
 
-        buan_colors = np.ones(streamlines.get_data().shape)
+    buan_colors = np.ones(streamlines.get_data().shape)
 
-        horizon(
-            tractograms=tractograms,
-            buan=True,
-            buan_colors=buan_colors,
-            world_coords=True,
-            interactive=False,
-            out_png=str(Path(out_dir) / "buan.png"),
-        )
+    horizon(
+        tractograms=tractograms,
+        buan=True,
+        buan_colors=buan_colors,
+        world_coords=True,
+        interactive=False,
+        out_png=str(tmp_path / "buan.png"),
+    )
 
-        data = 255 * rng.random((197, 233, 189))
+    data = 255 * rng.random((197, 233, 189))
 
-        images = [(data, affine, "test/test.nii.gz")]
+    images = [(data, affine, "test/test.nii.gz")]
 
-        horizon(
-            tractograms=tractograms,
-            images=images,
-            cluster=True,
-            cluster_thr=5,
-            random_colors=False,
-            length_lt=np.inf,
-            length_gt=0,
-            clusters_lt=np.inf,
-            clusters_gt=0,
-            world_coords=True,
-            interactive=False,
-            out_png=str(Path(out_dir) / "horizon-flow-nii-images.png"),
-        )
+    horizon(
+        tractograms=tractograms,
+        images=images,
+        cluster=True,
+        cluster_thr=5,
+        random_colors=False,
+        length_lt=np.inf,
+        length_gt=0,
+        clusters_lt=np.inf,
+        clusters_gt=0,
+        world_coords=True,
+        interactive=False,
+        out_png=str(tmp_path / "horizon-flow-nii-images.png"),
+    )
 
-        fimg = Path(out_dir) / "test.nii.gz"
-        ftrk = Path(out_dir) / "test.trk"
-        fnpy = Path(out_dir) / "test.npy"
+    fimg = tmp_path / "test.nii.gz"
+    ftrk = tmp_path / "test.trk"
+    fnpy = tmp_path / "test.npy"
 
-        save_nifti(fimg, data, affine)
-        dimensions = data.shape
-        nii_header = create_nifti_header(affine, dimensions, vox_size)
-        sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
-        save_tractogram(sft, ftrk, bbox_valid_check=False)
+    save_nifti(fimg, data, affine)
+    dimensions = data.shape
+    nii_header = create_nifti_header(affine, dimensions, vox_size)
+    sft = StatefulTractogram(streamlines, nii_header, space=Space.RASMM)
+    save_tractogram(sft, ftrk, bbox_valid_check=False)
 
-        pvalues = rng.uniform(low=0, high=1, size=(10,))
-        np.save(fnpy, pvalues)
+    pvalues = rng.uniform(low=0, high=1, size=(10,))
+    np.save(fnpy, pvalues)
 
-        input_files = [ftrk, fimg]
+    input_files = [ftrk, fimg]
 
-        npt.assert_equal(len(input_files), 2)
+    npt.assert_equal(len(input_files), 2)
 
-        hz_flow = HorizonFlow()
+    hz_flow = HorizonFlow()
 
-        hz_flow.run(
-            input_files=input_files,
-            stealth=True,
-            out_dir=out_dir,
-            out_stealth_png="tmp_x.png",
-        )
+    hz_flow.run(
+        input_files=input_files,
+        stealth=True,
+        out_dir=tmp_path,
+        out_stealth_png="tmp_x.png",
+    )
 
-        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
-        npt.assert_raises(
-            ValueError, hz_flow.run, input_files=input_files, bg_color=(0.2, 0.2)
-        )
+    npt.assert_equal((tmp_path / "tmp_x.png").exists(), True)
+    npt.assert_raises(
+        ValueError, hz_flow.run, input_files=input_files, bg_color=(0.2, 0.2)
+    )
 
-        hz_flow.run(
-            input_files=input_files,
-            stealth=True,
-            bg_color=[
-                0.5,
-            ],
-            out_dir=out_dir,
-            out_stealth_png="tmp_x.png",
-        )
-        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
+    hz_flow.run(
+        input_files=input_files,
+        stealth=True,
+        bg_color=[
+            0.5,
+        ],
+        out_dir=tmp_path,
+        out_stealth_png="tmp_x.png",
+    )
+    npt.assert_equal((tmp_path / "tmp_x.png").exists(), True)
 
-        input_files = [ftrk, fnpy]
+    input_files = [ftrk, fnpy]
 
-        npt.assert_equal(len(input_files), 2)
+    npt.assert_equal(len(input_files), 2)
 
-        hz_flow.run(
-            input_files=input_files,
-            stealth=True,
-            bg_color=[
-                0.5,
-            ],
-            buan=True,
-            buan_thr=0.5,
-            buan_highlight=(1, 1, 0),
-            out_dir=out_dir,
-            out_stealth_png="tmp_x.png",
-        )
-        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
+    hz_flow.run(
+        input_files=input_files,
+        stealth=True,
+        bg_color=[
+            0.5,
+        ],
+        buan=True,
+        buan_thr=0.5,
+        buan_highlight=(1, 1, 0),
+        out_dir=tmp_path,
+        out_stealth_png="tmp_x.png",
+    )
+    npt.assert_equal((tmp_path / "tmp_x.png").exists(), True)
 
-        npt.assert_raises(
-            ValueError, hz_flow.run, input_files=input_files, roi_colors=(0.2, 0.2)
-        )
+    npt.assert_raises(
+        ValueError, hz_flow.run, input_files=input_files, roi_colors=(0.2, 0.2)
+    )
 
-        hz_flow.run(
-            input_files=input_files,
-            stealth=True,
-            roi_colors=[
-                0.5,
-            ],
-            out_dir=out_dir,
-            out_stealth_png="tmp_x.png",
-        )
-        npt.assert_equal(Path(Path(out_dir) / "tmp_x.png").exists(), True)
+    hz_flow.run(
+        input_files=input_files,
+        stealth=True,
+        roi_colors=[
+            0.5,
+        ],
+        out_dir=tmp_path,
+        out_stealth_png="tmp_x.png",
+    )
+    npt.assert_equal((tmp_path / "tmp_x.png").exists(), True)

--- a/dipy/workflows/tests/test_workflow.py
+++ b/dipy/workflows/tests/test_workflow.py
@@ -1,6 +1,4 @@
 import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
 import time
 
 import numpy.testing as npt
@@ -10,31 +8,30 @@ from dipy.workflows.segment import MedianOtsuFlow
 from dipy.workflows.workflow import Workflow
 
 
-def test_force_overwrite():
-    with TemporaryDirectory() as out_dir:
-        data_path, _, _ = get_fnames(name="small_25")
-        mo_flow = MedianOtsuFlow(output_strategy="absolute")
+def test_force_overwrite(tmp_path):
+    data_path, _, _ = get_fnames(name="small_25")
+    mo_flow = MedianOtsuFlow(output_strategy="absolute")
 
-        # Generate the first results
-        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
-        mask_file = mo_flow.last_generated_outputs["out_mask"]
-        first_time = os.path.getmtime(mask_file)
+    # Generate the first results
+    mo_flow.run(data_path, out_dir=tmp_path, vol_idx=[0])
+    mask_file = mo_flow.last_generated_outputs["out_mask"]
+    first_time = os.path.getmtime(mask_file)
 
-        # re-run with no force overwrite, modified time should not change
-        mo_flow.run(data_path, out_dir=out_dir)
-        mask_file = mo_flow.last_generated_outputs["out_mask"]
-        second_time = os.path.getmtime(mask_file)
-        assert first_time == second_time
+    # re-run with no force overwrite, modified time should not change
+    mo_flow.run(data_path, out_dir=tmp_path)
+    mask_file = mo_flow.last_generated_outputs["out_mask"]
+    second_time = os.path.getmtime(mask_file)
+    assert first_time == second_time
 
-        # re-run with force overwrite, modified time should change
-        mo_flow = MedianOtsuFlow(output_strategy="absolute", force=True)
-        # Make sure that at least one second elapsed, so that time-stamp is
-        # different (sometimes measured in whole seconds)
-        time.sleep(1)
-        mo_flow.run(data_path, out_dir=out_dir, vol_idx=[0])
-        mask_file = mo_flow.last_generated_outputs["out_mask"]
-        third_time = os.path.getmtime(mask_file)
-        assert third_time != second_time
+    # re-run with force overwrite, modified time should change
+    mo_flow = MedianOtsuFlow(output_strategy="absolute", force=True)
+    # Make sure that at least one second elapsed, so that time-stamp is
+    # different (sometimes measured in whole seconds)
+    time.sleep(1)
+    mo_flow.run(data_path, out_dir=tmp_path, vol_idx=[0])
+    mask_file = mo_flow.last_generated_outputs["out_mask"]
+    third_time = os.path.getmtime(mask_file)
+    assert third_time != second_time
 
 
 def test_get_sub_runs():
@@ -47,7 +44,7 @@ def test_run():
     npt.assert_raises(Exception, wf.run, None)
 
 
-def test_missing_file():
+def test_missing_file(tmp_path):
     # The function is invoking a dummy workflow with a non-existent file.
     # So, an OSError will be raised.
 
@@ -66,5 +63,4 @@ def test_missing_file():
             _ = self.get_io_iterator()
 
     dummyflow = TestMissingFile()
-    with TemporaryDirectory() as tempdir:
-        npt.assert_raises(OSError, dummyflow.run, str(Path(tempdir) / "dummy_file.txt"))
+    npt.assert_raises(OSError, dummyflow.run, str(tmp_path / "dummy_file.txt"))


### PR DESCRIPTION
# Description

Prefer using the `pytest` `tmp_path` and `tmp_path_factory` fixtures in tests.

## Motivation and Context

- Makes the code more readable as no additional context (and the associated indentation) required by the use of `TemporaryDirectory` is needed.
- Simplifies path manipulation as they return a `pathlib.Path` object and thus, no recurrent casting to `Path` is necessary.
- Increases consistency in temporary directory naming, and thus, eases maintenance.

## How Has This Been Tested?

Will rely on CI builds.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
