### PR TITLE
STYLE: Rename variable to void shadowing built-in name

### DIFF
--- a/dipy/io/tests/test_surface.py
+++ b/dipy/io/tests/test_surface.py
@@ -86,11 +86,11 @@ def test_vtk_matching_space(space, origin):
 
 @pytest.mark.skipif(not have_vtk, reason="Requires VTK")
 @pytest.mark.parametrize(
-    "type,fname,space,origin",
+    "_type,fname,space,origin",
     list(itertools.product(FOLDERS_GII, FILENAMES_GII, SPACES, ORIGINS)),
 )
-def test_gifti_matching_space(type, fname, space, origin):
-    if type == "gzip_base64":
+def test_gifti_matching_space(_type, fname, space, origin):
+    if _type == "gzip_base64":
         fname += ".gz"
     sfs = load_surface(FILEPATH_DIX[fname], FILEPATH_DIX["anat.nii.gz"])
     sfs.to_rasmm()


### PR DESCRIPTION
## Description

Rename varable to avoid shadowing buit-in name. Fixes:
```
Shadows built-in name 'type'
```

## Motivation and Context

Avoid bad practices.

## How Has This Been Tested?

Relying on CI.


## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
