### PR TITLE
FIX: Unpack SynthSeg `predict()` return tuple in test

### DIFF
--- a/dipy/nn/tests/test_synthseg.py
+++ b/dipy/nn/tests/test_synthseg.py
@@ -100,7 +100,9 @@ def test_input_shapes(monkeypatch):
         npt.assert_equal(labels.shape, shape)
         npt.assert_equal(mask.shape, shape)
 
-        probabilities = synthseg_model.predict(input_arr, np.eye(4), return_prob=True)
+        probabilities, _, _ = synthseg_model.predict(
+            input_arr, np.eye(4), return_prob=True
+        )
         npt.assert_equal(probabilities.shape, model_shape + (33,))
 
 

--- a/dipy/nn/tests/test_synthseg.py
+++ b/dipy/nn/tests/test_synthseg.py
@@ -38,6 +38,7 @@ def teardown_module(module):
 
 
 @pytest.mark.skipif(not have_torch, reason="Requires Torch")
+@pytest.mark.filterwarnings("ignore:The finalized brain mask may differ.*:UserWarning")
 def test_default_weights():
     file_path = get_fnames(name="synthseg_test_data")
     input_arr = np.load(file_path)["input"][0]
@@ -55,6 +56,7 @@ def test_default_weights():
 
 
 @pytest.mark.skipif(not have_torch, reason="Requires Torch")
+@pytest.mark.filterwarnings("ignore:The finalized brain mask may differ.*:UserWarning")
 def test_default_weights_batch():
     file_path = get_fnames(name="synthseg_test_data")
     data = np.load(file_path)
@@ -76,6 +78,8 @@ def test_default_weights_batch():
 
 
 @pytest.mark.skipif(not have_torch, reason="Requires Torch")
+@pytest.mark.filterwarnings("ignore:The finalized brain mask may differ.*:UserWarning")
+@pytest.mark.filterwarnings("ignore:The probability maps are returned.*:UserWarning")
 def test_input_shapes(monkeypatch):
     synthseg_model = synthseg.SynthSeg()
 
@@ -107,6 +111,7 @@ def test_input_shapes(monkeypatch):
 
 
 @pytest.mark.skipif(not have_torch, reason="Requires Torch")
+@pytest.mark.filterwarnings("ignore:The finalized brain mask may differ.*:UserWarning")
 def test_default_weights_labels():
     file_path = get_fnames(name="synthseg_test_data")
     input_arr = np.load(file_path)["input"][0]


### PR DESCRIPTION
## Description

Unpack SynthSeg `predict()` return tuple in test: when `return_prob=True`, `predict()` returns a tuple of three values. The test must unpack this tuple before accessing the shape attribute.

## Motivation and Context

Test failing in CIs.

## How Has This Been Tested?

Relying on CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [X] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
