### PR TITLE
STYLE: Avoid outer scope variable shadowing

### DIFF
--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -560,10 +560,10 @@ def generate_force_simulations(
     # Create memmaps for large arrays
     memmap_paths = {}
 
-    def create_mm(name, dt, shape):
-        mm, path = _create_memmap(Path(output_dir), name, dt, shape)
-        memmap_paths[name] = path
-        return mm
+    def create_mm(_name, dt, shape):
+        _mm, _path = _create_memmap(Path(output_dir), _name, dt, shape)
+        memmap_paths[_name] = _path
+        return _mm
 
     signals_mm = create_mm("signals", dtype, (num_simulations, n_bvals))
     labels_mm = create_mm("labels", label_dtype, (num_simulations, n_dirs))


### PR DESCRIPTION
## Description

Avoid outer scope variable shadowing. Fixes:
```
Shadows name 'name' from outer scope
```

and
```
Shadows name 'mm' from outer scope
```

and
```
Shadows name 'path' from outer scope
```

raised by local IDE.

## Motivation and Context

Bad practice.

## How Has This Been Tested?

Relying on CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
