### PR TITLE
STYLE: Rely on `pathlib.Path` instance methods for path operations

### DIFF
--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -2,7 +2,6 @@
 
 import gzip
 import json
-from os.path import dirname, exists
 from pathlib import Path
 import pickle
 
@@ -160,7 +159,7 @@ def loads_compat(byte_data):
     return pickle.loads(byte_data, encoding="latin1")
 
 
-DATA_DIR = Path(dirname(__file__)) / "files"
+DATA_DIR = Path(__file__).resolve().parent / "files"
 SPHERE_FILES = {
     "symmetric362": Path(DATA_DIR) / "evenly_distributed_sphere_362.npz",
     "symmetric642": Path(DATA_DIR) / "evenly_distributed_sphere_642.npz",
@@ -462,7 +461,7 @@ def load_sdp_constraints(model_name, *, order=None):
 
     path = Path(DATA_DIR) / file
 
-    if not exists(path):
+    if not path.exists():
         raise ValueError(f"Constraints file '{file}' not found.")
 
     try:

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -2370,7 +2370,7 @@ def get_fnames(*, name="small_64D", include_optional=False):
         filepath_dix = {}
         files, folder = fetch_real_data_io()
         for filename in files:
-            filepath_dix[filename] = os.path.join(folder, filename)
+            filepath_dix[filename] = folder / filename
 
         return filepath_dix
     if name in ["disco", "disco1", "disco2", "disco3"]:

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -19,6 +19,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 import gc
 import multiprocessing as mp
 import os
+from pathlib import Path
 import sys
 import tempfile
 
@@ -172,7 +173,7 @@ def init_worker(base_seed=None):
 
 def _create_memmap(output_dir, name, dtype, shape):
     """Create a memory-mapped file."""
-    path = os.path.join(output_dir, f"{name}.mmap")
+    path = output_dir / f"{name}.mmap"
     return np.memmap(path, mode="w+", dtype=dtype, shape=shape), path
 
 
@@ -454,7 +455,7 @@ def generate_force_simulations(
         Gradient table with b-values and b-vectors.
     num_simulations : int, optional
         Number of simulated voxels.
-    output_dir : str, optional
+    output_dir : str or Path, optional
         Directory for output files. If None, uses a temporary directory.
     num_cpus : int or None, optional
         Number of CPU cores for parallel processing.
@@ -560,7 +561,7 @@ def generate_force_simulations(
     memmap_paths = {}
 
     def create_mm(name, dt, shape):
-        mm, path = _create_memmap(output_dir, name, dt, shape)
+        mm, path = _create_memmap(Path(output_dir), name, dt, shape)
         memmap_paths[name] = path
         return mm
 
@@ -889,7 +890,7 @@ def generate_force_simulations(
 
     for path in memmap_paths.values():
         try:
-            if os.path.exists(path):
+            if path.exists():
                 os.remove(path)
         except OSError:
             pass

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -1,5 +1,3 @@
-import os.path as op
-
 import nibabel as nib
 import numpy as np
 import numpy.testing as npt
@@ -12,8 +10,6 @@ from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti_data
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 import dipy.tracking.life as life
-
-THIS_DIR = op.dirname(__file__)
 
 
 def test_streamline_gradients():

--- a/dipy/workflows/tests/test_reconst.py
+++ b/dipy/workflows/tests/test_reconst.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
@@ -101,8 +100,8 @@ def reconst_flow_core(flow, *, use_multishell_data=None, **kwargs):
             bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
             bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
             gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
-            bval_path = Path(out_dir) / os.path.basename(bval_path)
-            bvec_path = Path(out_dir) / os.path.basename(bvec_path)
+            bval_path = Path(out_dir) / bval_path.name
+            bvec_path = Path(out_dir) / bvec_path.name
             np.savetxt(bval_path, bvals_2s)
             np.savetxt(bvec_path, bvecs_2s)
 

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -1,4 +1,3 @@
-import os
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
 import warnings
@@ -179,8 +178,8 @@ def test_fwdti():
         bvals_2s = np.concatenate((bvals, bvals * 1.5), axis=0)
         bvecs_2s = np.concatenate((bvecs, bvecs), axis=0)
         gtab_2s = gradient_table(bvals_2s, bvecs=bvecs_2s)
-        fbvals = pjoin(out_dir, os.path.basename(fbvals))
-        fbvecs = pjoin(out_dir, os.path.basename(fbvecs))
+        fbvals = pjoin(out_dir, fbvals.name)
+        fbvecs = pjoin(out_dir, fbvecs.name)
         np.savetxt(fbvals, bvals_2s)
         np.savetxt(fbvecs, bvecs_2s)
 

--- a/doc/examples/combined_workflow_creation.py
+++ b/doc/examples/combined_workflow_creation.py
@@ -10,8 +10,6 @@ First create your ``CombinedWorkflow`` class. Your ``CombinedWorkflow`` class
 file is usually located in the ``dipy/workflows`` directory.
 """
 
-import os
-
 from dipy.workflows.combined_workflow import CombinedWorkflow
 
 ###############################################################################
@@ -82,9 +80,9 @@ class DenoiseAndSegment(CombinedWorkflow):
 
         for fnames in io_it:
             in_fname = fnames[0]
-            _out_denoised = os.path.basename(fnames[1])
-            _out_mask = os.path.basename(fnames[2])
-            _out_masked = os.path.basename(fnames[3])
+            _out_denoised = fnames[1].name
+            _out_mask = fnames[2].name
+            _out_masked = fnames[3].name
 
             nl_flow = NLMeansFlow()
             self.run_sub_flow(

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -16,8 +16,6 @@ Read :ref:`faq`
 
 """
 
-import os
-
 import nibabel as nib
 import numpy as np
 
@@ -44,7 +42,7 @@ from dipy.tracking.utils import density_map
 fetch_file_formats()
 bundles_filename, ref_anat_filename = get_file_formats()
 for filename in bundles_filename:
-    print(os.path.basename(filename))
+    print(filename.name)
 reference_anatomy = nib.load(ref_anat_filename)
 
 ###############################################################################
@@ -111,7 +109,7 @@ print(is_header_compatible(reference_anatomy, bundles_filename[0]))
 
 nifti_header = create_nifti_header(affine, dimensions, voxel_sizes)
 nib.save(nib.Nifti1Image(np.zeros(dimensions), affine, nifti_header), "fake.nii.gz")
-nib.save(reference_anatomy, os.path.basename(ref_anat_filename))
+nib.save(reference_anatomy, ref_anat_filename.name)
 
 ###############################################################################
 # Once loaded, no matter the original file format, the stateful tractogram is

--- a/doc/examples/tracking_disco_phantom.py
+++ b/doc/examples/tracking_disco_phantom.py
@@ -13,8 +13,6 @@ See
 for detailed examples of those algorithms.
 """
 
-import os
-
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.ndimage import binary_erosion
@@ -45,7 +43,7 @@ print("Downloading data...")
 # Prepare the synthetic DiSCo data for tractography. The ground-truth
 # connectome will be use to evaluate tractography performances.
 fnames = get_fnames(name="disco1")
-disco1_fnames = [os.path.basename(f) for f in fnames]
+disco1_fnames = [f.name for f in fnames]
 
 GT_connectome_fname = fnames[
     disco1_fnames.index("DiSCo1_Connectivity_Matrix_Cross-Sectional_Area.txt")


### PR DESCRIPTION
## Description

Rely on `pathlib.Path` instance methods for path operations.

Increases consistency across the code base as `pathlib` was adopted for path manipulation in commit 3c6ede0.

Remove the `THIS_DIR` global variable with no usage from LiFE testing.

## Motivation and Context

Left behind these across other commits.

## How Has This Been Tested?

Relying on Cis.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
