### PR TITLE
OPT: multi-thread 2D and 3D image gradients

### DIFF
--- a/benchmarks/registration/README.md
+++ b/benchmarks/registration/README.md
@@ -34,7 +34,6 @@ The current evaluator computes:
 ```text
 ncc
 mse
-mi
 nmi
 ```
 

--- a/benchmarks/registration/README.md
+++ b/benchmarks/registration/README.md
@@ -27,7 +27,8 @@ either backend:
 3. Fill holes and keep the largest connected mask component.
 4. Rigidly prealign the moving image to the fixed image.
 5. Run DIPY SyN and ANTsPy SyN from the same prealigned inputs.
-6. Evaluate both warped outputs with framework-independent metrics.
+6. Evaluate both warped outputs inside the fixed brain mask with
+   framework-independent metrics.
 
 The current evaluator computes:
 

--- a/benchmarks/registration/README.md
+++ b/benchmarks/registration/README.md
@@ -1,0 +1,92 @@
+# Registration Benchmark
+
+## Purpose
+
+This folder contains a small benchmarking framework for comparing DIPY and
+ANTsPy SyN registration on the same fixed/moving image pairs.
+
+The benchmark is designed to keep dataset-specific logic separate from the
+registration pipeline. Dataset adapters should produce a generic pair CSV, and the
+main benchmark script consumes only:
+
+```text
+fixed_path,moving_path
+```
+
+An optional `pair_id` column can be provided to control output folder names.
+
+---
+
+## Pipeline
+
+For each pair, `run_benchmark.py` applies the same preprocessing before running
+either backend:
+
+1. Reslice both images by the same downsampling factor.
+2. Skull-strip both images with SynthSeg.
+3. Fill holes and keep the largest connected mask component.
+4. Rigidly prealign the moving image to the fixed image.
+5. Run DIPY SyN and ANTsPy SyN from the same prealigned inputs.
+6. Evaluate both warped outputs with framework-independent metrics.
+
+The current evaluator computes:
+
+```text
+ncc
+mse
+mi
+nmi
+```
+
+Metrics are written per pair and progressively aggregated into:
+
+```text
+benchmark_results.json
+```
+
+This file contains run metadata, per-sample metrics, and overall summary
+statistics.
+
+---
+
+## Configuration
+
+Benchmark parameters are stored in YAML files under `configs/`.
+
+Each configuration is split into:
+
+```text
+registration  shared benchmark intent and common parameter values
+dipy          DIPY-specific parameters
+ants          ANTsPy-specific parameters
+```
+
+The parameter mapping follows the notes in
+[DIPY vs ANTs SyN: Fair Comparison Guide](dipy_ants_syn_comparison.md).
+
+---
+
+## Dataset Adapters
+
+Dataset-specific code should live under `datasets/` and produce the generic
+pair CSV consumed by `run_benchmark.py`.
+
+An OASIS-2 example adapter is available at
+[datasets/oasis2](datasets/oasis2/README.md).
+
+---
+
+## Usage
+
+Run a small benchmark from `benchmarks/registration`:
+
+```powershell
+python run_benchmark.py `
+  --pairs data/oasis2_pairs.csv `
+  --config configs/syn_cc_default.yaml `
+  --out-dir outputs/oasis2_syn_cc_ds2 `
+  --downsample-factor 2 `
+  --n 5
+```
+
+Use `--use-cuda` to run SynthSeg with CUDA.

--- a/benchmarks/registration/configs/syn_cc_default.yaml
+++ b/benchmarks/registration/configs/syn_cc_default.yaml
@@ -1,0 +1,23 @@
+name: syn_cc_default
+description: Initial SyN-only cross-correlation benchmark configuration.
+
+registration:
+  metric: CC
+  level_iters: [20, 20, 10]
+  grad_step: 0.25
+  cc_radius: 4
+  initial_transform: Identity
+  convergence_tol: 1.0e-7
+  convergence_window: 8
+
+dipy:
+  metric_class: CCMetric
+  update_field_sigma: 2.0
+  ss_sigma_factor: 0.5
+  inv_iter: 20
+  inv_tol: 1.0e-3
+
+ants:
+  syn_metric: CC
+  flow_sigma: 2.0
+  total_sigma: 0.0

--- a/benchmarks/registration/datasets/oasis2/README.md
+++ b/benchmarks/registration/datasets/oasis2/README.md
@@ -1,0 +1,64 @@
+# OASIS-2 Pair Generation
+
+## Purpose
+
+This folder contains the OASIS-2-specific pair generator used as an example
+dataset adapter for the registration benchmark.
+
+The benchmark itself is dataset-agnostic. This adapter only creates a CSV with:
+
+```text
+fixed_path,moving_path
+```
+
+An optional `pair_id` column may also be included.
+
+---
+
+## Dataset Layout
+
+The raw OASIS-2 data is organized as session folders:
+
+```text
+OAS2_RAW_PART1/
+  OAS2_0001_MR1/
+    RAW/
+      mpr-1.nifti.hdr
+      mpr-1.nifti.img
+      mpr-2.nifti.hdr
+      mpr-2.nifti.img
+      ...
+```
+
+For each valid session, the adapter creates one monomodal intra-session pair:
+
+```text
+fixed  = RAW/mpr-1.nifti.hdr
+moving = RAW/mpr-2.nifti.hdr
+```
+
+The CSV stores the `.hdr` path and requires the matching `.img` file to exist.
+
+---
+
+## Usage
+
+From `benchmarks/registration`:
+
+```powershell
+python datasets/oasis2/make_pairs.py `
+  --root /path/to/OAS2_RAW_PART1/OAS2_RAW_PART1 `
+  --out data/oasis2_pairs.csv
+```
+
+OASIS-2 data access and download links are available from the
+[official OASIS-2 page](https://sites.wustl.edu/oasisbrains/home/oasis-2/).
+
+---
+
+## Citations
+
+Marcus, D. S., Fotenos, A. F., Csernansky, J. G., Morris, J. C., & Buckner,
+R. L. (2010). Open Access Series of Imaging Studies (OASIS): Longitudinal MRI
+data in nondemented and demented older adults. *Journal of Cognitive
+Neuroscience, 22*, 2677-2684. https://doi.org/10.1162/jocn.2009.21407

--- a/benchmarks/registration/datasets/oasis2/__init__.py
+++ b/benchmarks/registration/datasets/oasis2/__init__.py
@@ -1,0 +1,1 @@
+"""OASIS-2 dataset adapter for registration benchmark pair generation."""

--- a/benchmarks/registration/datasets/oasis2/make_pairs.py
+++ b/benchmarks/registration/datasets/oasis2/make_pairs.py
@@ -1,0 +1,104 @@
+"""Create fixed/moving registration pairs from the OASIS-2 raw layout.
+
+This module contains the dataset-specific logic needed to discover the
+intra-session OASIS-2 pairs used for the initial benchmark:
+
+    fixed  = RAW/mpr-1.nifti.hdr
+    moving = RAW/mpr-2.nifti.hdr
+
+Example, from benchmarks/registration:
+
+    python datasets/oasis2/make_pairs.py \
+        --root /path/to/OAS2_RAW_PART1/OAS2_RAW_PART1 \
+        --out data/oasis2_pairs.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+import re
+
+SESSION_DIR_RE = re.compile(r"^(OAS2_\d+)_MR(\d+)$")
+DEFAULT_FIELDS = [
+    "pair_id",
+    "fixed_path",
+    "moving_path",
+]
+
+
+def has_analyze_pair(hdr_path: Path) -> bool:
+    """Return True when the .hdr file and its matching .img file exist."""
+    return hdr_path.exists() and hdr_path.with_suffix(".img").exists()
+
+
+def iter_oasis2_mpr1_mpr2_pairs(root: Path):
+    """Yield one mpr-2 to mpr-1 pair for each valid OASIS-2 session folder."""
+    for session_dir in sorted(root.iterdir()):
+        if not session_dir.is_dir():
+            continue
+
+        match = SESSION_DIR_RE.match(session_dir.name)
+        if match is None:
+            continue
+
+        raw_dir = session_dir / "RAW"
+        fixed_path = raw_dir / "mpr-1.nifti.hdr"
+        moving_path = raw_dir / "mpr-2.nifti.hdr"
+
+        if not has_analyze_pair(fixed_path) or not has_analyze_pair(moving_path):
+            continue
+
+        yield {
+            "pair_id": f"{session_dir.name}_mpr2_to_mpr1",
+            "fixed_path": str(fixed_path),
+            "moving_path": str(moving_path),
+        }
+
+
+def write_pairs_csv(rows: list[dict], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=DEFAULT_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build generic registration pairs from OASIS-2 RAW folders."
+    )
+    parser.add_argument(
+        "--root",
+        required=True,
+        type=Path,
+        help="Path containing OAS2_*_MR* session folders.",
+    )
+    parser.add_argument(
+        "--out",
+        default=Path("data/oasis2_pairs.csv"),
+        type=Path,
+        help="Output CSV path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = args.root.expanduser().resolve()
+
+    if not root.exists():
+        raise FileNotFoundError(f"OASIS-2 root does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"OASIS-2 root is not a directory: {root}")
+
+    rows = list(iter_oasis2_mpr1_mpr2_pairs(root))
+    write_pairs_csv(rows, args.out)
+
+    print(f"Found {len(rows)} OASIS-2 mpr-2 to mpr-1 pairs")
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registration/dipy_ants_syn_comparison.md
+++ b/benchmarks/registration/dipy_ants_syn_comparison.md
@@ -1,0 +1,261 @@
+# DIPY vs ANTs SyN: Fair Comparison Guide
+
+## Purpose
+
+This document summarizes the current working understanding of the parameter correspondences and implementation differences between DIPY's `SymmetricDiffeomorphicRegistration` and ANTs/ANTsPy SyN registration. It is intended as a guide for designing fair benchmarks and for discussing remaining uncertainties.
+
+The focus here is **SyN-only deformable registration**, not affine, rigid, or full multi-stage registration pipelines.
+
+---
+
+## Scope and Working Assumptions
+
+DIPY and ANTs expose SyN registration through substantially different interfaces:
+
+* **DIPY** uses a dedicated class for SyN-like registration: `SymmetricDiffeomorphicRegistration`.
+* **ANTsPy** uses a single high-level `registration()` function whose behavior depends on `type_of_transform`.
+
+For fair SyN-only comparisons, the closest ANTs mode is generally:
+
+```python
+ants.registration(..., type_of_transform="SyNOnly")
+```
+
+rather than:
+
+```python
+ants.registration(..., type_of_transform="SyN")
+```
+
+because ANTsPy `"SyN"` includes an affine stage before the deformable SyN stage, whereas DIPY's `SymmetricDiffeomorphicRegistration` only performs the nonlinear symmetric diffeomorphic optimization.
+
+---
+
+## Parameter Equivalences
+
+| DIPY                      | ANTs / ANTsPy                                               | Notes                                                                                                                      |
+| ------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `level_iters`             | `reg_iterations`                                            | Both control the number of nonlinear SyN iterations per pyramid level.                                                     |
+| `step_length`             | `grad_step`                                                 | Both control the update magnitude, but the update normalization/composition details may differ.                                |
+| `static` in `optimize()`  | `fixed`                                                     | Reference image.                                                                                                           |
+| `moving` in `optimize()`  | `moving`                                                    | Image to be registered to the reference.                                                                                   |
+| `prealign`                | `initial_transform`                                         | Both used for prealignment, can be set to identity for fair comparison |
+| `CCMetric(radius=...)`    | `syn_sampling` when `syn_metric="CC"`                       | In CC, `syn_sampling` corresponds to the local neighborhood radius.                                                        |
+| `opt_tol`                 | ANTs convergence threshold hardcoded to `1e-7`                     | Need to inspect ITK/ANTs convergence formula before claiming direct equivalence.                                           |
+| DIPY `energy_window = 12` | ANTs convergence window hardcoded to 8. | Both relate to convergence monitoring, but formulas and interpretation need confirmation.                                  |
+
+
+---
+
+## Pyramid Construction: Smoothing and Scaling
+
+### ANTs / ANTsPy
+
+For the SyN stage, ANTsPy computes scalar smoothing sigmas and nominal shrink factors from the number of pyramid levels:
+
+```text
+iterations_i      = reg_iterations[i]
+smoothing_sigma_i = L - 1 - i
+shrink_factor_i   = 2 ** (L - 1 - i)
+```
+
+Example:
+
+```text
+reg_iterations = [40, 20, 20]
+L = 3
+smoothing sigmas = [2, 1, 0]
+shrink factors   = [4, 2, 1]
+```
+
+Later, ANTs converts the nominal shrink factor into per-dimension integer shrink factors, taking image spacing into account. The goal is to keep the downsampled image spacing as close as possible to isotropic while using integer shrink factors.
+
+### DIPY
+
+DIPY constructs a `ScaleSpace` object. For each pyramid level, it starts from the same conceptual scale progression:
+
+```text
+scale_i = 2 ** i
+```
+
+but then computes per-dimension scaling using the minimum input spacing:
+
+```text
+scaling[d] = 2**i * min_spacing / input_spacing[d]
+```
+
+This gives:
+
+```text
+output_spacing[d] = input_spacing[d] * scaling[d]
+                  = 2**i * min_spacing
+```
+
+Therefore, DIPY allows non-integer per-dimension scaling values and effectively forces the target spacing at each level to be isotropic in physical units.
+
+For smoothing, DIPY computes voxel-unit Gaussian sigmas as:
+
+```text
+sigma[d] = sigma_factor * (output_spacing[d] / input_spacing[d] - 1)
+```
+
+For isotropic data, this simplifies to:
+
+```text
+sigma_i = sigma_factor * (2**i - 1)
+```
+
+Thus, DIPY's default smoothing can be much weaker than ANTs' default smoothing. For three isotropic levels and `sigma_factor = 0.2`, DIPY gives fine-to-coarse sigmas:
+
+```text
+[0, 0.2, 0.6]
+```
+
+whereas ANTs uses:
+
+```text
+[0, 1, 2]
+```
+
+fine-to-coarse.
+
+---
+
+## Update Smoothing and Deformation Regularization
+
+### ANTs
+
+ANTs separates deformation regularization into two explicit SyN parameters:
+
+```text
+SyN[grad_step, flow_sigma, total_sigma]
+```
+
+* `flow_sigma` smooths the **update field**, i.e. the incremental displacement estimated at the current iteration before it is composed into the running deformation.
+* `total_sigma` smooths the **accumulated total field**, i.e. the running deformation after update composition.
+
+### DIPY
+
+DIPY's `SymmetricDiffeomorphicRegistration` does not expose direct equivalents of either `flow_sigma` or `total_sigma`.
+
+Instead, update smoothing is implemented inside metric classes, before the update field is normalized and composed by the SyN optimizer. These parameters are therefore at most conceptually similar to ANTs' `flow_sigma`, not `total_sigma`.
+
+There is currently no direct DIPY equivalent of ANTs' `total_sigma`.
+
+---
+
+## Masks
+
+ANTs supports explicit metric masks:
+
+```text
+mask
+moving_mask
+mask_all_stages
+```
+
+These can restrict where the metric is evaluated during optimization.
+
+DIPY `SymmetricDiffeomorphicRegistration` does not expose equivalent fixed/moving metric masks. The closest related mechanism is `metric.mask0`, used by `ScaleSpace` to keep zero-valued regions zero after smoothing. This is not equivalent to ANTs' fixed/moving registration masks.
+
+---
+
+## Other ANTs Features Without Direct DIPY Equivalents
+
+| ANTs parameter                  | Relevance to SyN                                           | DIPY equivalent                                              |
+| ------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
+| `restrict_transformation`       | Can restrict deformation components along selected axes    | No built-in equivalent                                       |
+| `multivariate_extras`           | Adds weighted extra metrics during deformable optimization | No built-in equivalent; would require custom combined metric |
+| `use_legacy_histogram_matching` | Legacy intensity preprocessing option; not recommended     | No direct equivalent                                         |
+
+---
+
+## Intensity Preprocessing / Normalization
+
+Current working summary:
+
+* ANTs/ITK appears to build a 256-bin histogram, estimate intensity bounds using lower and upper quantiles, and use those bounds for min/max-like normalization before constructing coarser smoothed levels.
+* DIPY performs direct min/max normalization to `[0, 1]` in `ScaleSpace`, and does this again after smoothing at each coarse level.
+
+---
+
+## Inverse Field Computation
+
+Both DIPY and ANTs/ITK SyN maintain inverse displacement fields during optimization.
+
+### DIPY
+
+DIPY exposes inverse-field inversion parameters directly:
+
+```text
+inv_iter = 20
+inv_tol  = 1e-3
+```
+
+These are passed to the displacement-field inversion routine during optimization.
+
+### ANTs / ITK SyN
+
+ANTs/ITK SyN also uses iterative inverse displacement field estimation. The apparent internal settings are:
+
+```text
+maximum inverse iterations = 20
+mean error tolerance       = 0.001
+max error tolerance        = 0.1
+```
+
+ANTsPy `registration()` does not expose these inverse-field inversion parameters.
+
+---
+
+## Potential Implementation Detail to Verify
+
+There may be a possible issue in DIPY's `CCMetric.compute_backward()`:
+
+```text
+compute_backward() assigns the returned energy to a local variable `energy`, whereas compute_forward() stores it as `self.energy`.
+```
+
+If true, `get_energy()` after the backward computation may not reflect the backward energy.
+
+---
+
+## Recommended Benchmarking Strategy
+
+1. **Start with SyN-only comparisons**
+
+   * ANTs: `type_of_transform="SyNOnly"`
+   * DIPY: `SymmetricDiffeomorphicRegistration`
+
+2. **Use the same metric family where possible**
+
+   * Best first comparison: ANTs `syn_metric="CC"` vs DIPY `CCMetric`.
+   * Map `syn_sampling` to `CCMetric.radius`.
+
+3. **Control pyramid levels explicitly**
+
+   * Match `reg_iterations` and `level_iters`.
+   * Be aware that smoothing and scaling schedules are still not identical.
+
+4. **Minimize convergence stopping differences initially**
+
+   * Consider forcing full iteration execution by setting very strict or very permissive convergence thresholds, depending on interface possibilities.
+   * Revisit convergence once other differences are controlled.
+
+5. **Set ANTs `total_sigma=0` for fairer comparison**
+
+   * DIPY does not expose a corresponding total-field smoothing parameter.
+
+6. **Treat update smoothing carefully**
+
+   * For CC, compare ANTs `flow_sigma` with DIPY `CCMetric.sigma_diff`, but remember this is only conceptual.
+
+7. **Avoid masks, multivariate metrics, and restricted transforms in the first benchmark**
+
+   * These have no direct DIPY equivalents.
+
+---
+
+## Open Questions
+
+* Why exactly does the SyN formulation update forward-to-middle fields and maintain inverse fields for warping, instead of directly optimizing pull fields?

--- a/benchmarks/registration/dipy_ants_syn_comparison.md
+++ b/benchmarks/registration/dipy_ants_syn_comparison.md
@@ -202,18 +202,6 @@ ANTsPy `registration()` does not expose these inverse-field inversion parameters
 
 ---
 
-## Potential Implementation Detail to Verify
-
-There may be a possible issue in DIPY's `CCMetric.compute_backward()`:
-
-```text
-compute_backward() assigns the returned energy to a local variable `energy`, whereas compute_forward() stores it as `self.energy`.
-```
-
-If true, `get_energy()` after the backward computation may not reflect the backward energy.
-
----
-
 ## Recommended Benchmarking Strategy
 
 1. **Start with SyN-only comparisons**

--- a/benchmarks/registration/dipy_ants_syn_comparison.md
+++ b/benchmarks/registration/dipy_ants_syn_comparison.md
@@ -99,12 +99,6 @@ For smoothing, DIPY computes voxel-unit Gaussian sigmas as:
 sigma[d] = sigma_factor * (output_spacing[d] / input_spacing[d] - 1)
 ```
 
-For isotropic data, this simplifies to:
-
-```text
-sigma_i = sigma_factor * (2**i - 1)
-```
-
 Thus, DIPY's default smoothing can be much weaker than ANTs' default smoothing. For three isotropic levels and `sigma_factor = 0.2`, DIPY gives fine-to-coarse sigmas:
 
 ```text
@@ -117,7 +111,7 @@ whereas ANTs uses:
 [0, 1, 2]
 ```
 
-fine-to-coarse.
+fine-to-coarse. For Affine Registration, DIPY does accept the smoothing sigmas as a list, allowing for using the same smoothing scheme as ANTs for example.
 
 ---
 

--- a/benchmarks/registration/evaluate.py
+++ b/benchmarks/registration/evaluate.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import nibabel as nib
 from nibabel.processing import resample_from_to
 import numpy as np
+from scipy.stats import pearsonr
+from skimage.metrics import mean_squared_error, normalized_mutual_information
 
 EPS = 1e-8
 
@@ -25,71 +27,23 @@ def same_grid(a: nib.Nifti1Image, b: nib.Nifti1Image) -> bool:
     return a.shape == b.shape and np.allclose(a.affine, b.affine, atol=1e-4)
 
 
-def normalize_in_mask(data: np.ndarray, mask: np.ndarray) -> np.ndarray:
-    out = np.zeros_like(data, dtype=np.float32)
-    values = data[mask].astype(np.float64)
-    out[mask] = (
-        (values - values.min()) / max(values.max() - values.min(), EPS)
-    ).astype(np.float32)
-    return out
-
-
-def ncc(x: np.ndarray, y: np.ndarray, mask: np.ndarray) -> float:
-    xv = x[mask].astype(np.float64)
-    yv = y[mask].astype(np.float64)
-    xv -= xv.mean()
-    yv -= yv.mean()
-    return float(np.dot(xv, yv) / max(np.linalg.norm(xv) * np.linalg.norm(yv), EPS))
-
-
-def mse(x: np.ndarray, y: np.ndarray, mask: np.ndarray) -> float:
-    diff = x[mask].astype(np.float64) - y[mask].astype(np.float64)
-    return float(np.mean(diff * diff))
-
-
-def mutual_information(
-    x: np.ndarray,
-    y: np.ndarray,
-    mask: np.ndarray,
-    bins: int = 64,
-) -> float:
-    hist, _, _ = np.histogram2d(x[mask].ravel(), y[mask].ravel(), bins=bins)
-    pxy = hist / max(hist.sum(), EPS)
-    px = pxy.sum(axis=1)
-    py = pxy.sum(axis=0)
-    nz = pxy > 0
-    independent = np.maximum(px[:, None] * py[None, :], EPS)
-    return float(np.sum(pxy[nz] * np.log(pxy[nz] / independent[nz])))
-
-
-def normalized_mutual_information(
-    x: np.ndarray,
-    y: np.ndarray,
-    mask: np.ndarray,
-    bins: int = 64,
-) -> float:
-    hist, _, _ = np.histogram2d(x[mask].ravel(), y[mask].ravel(), bins=bins)
-    pxy = hist / max(hist.sum(), EPS)
-    px = pxy.sum(axis=1)
-    py = pxy.sum(axis=0)
-    hx = -np.sum(px[px > 0] * np.log(px[px > 0]))
-    hy = -np.sum(py[py > 0] * np.log(py[py > 0]))
-    hxy = -np.sum(pxy[pxy > 0] * np.log(pxy[pxy > 0]))
-    return float((hx + hy) / max(hxy, EPS))
+def normalized_values(data: np.ndarray) -> np.ndarray:
+    values = data.astype(np.float64).ravel()
+    return (values - values.min()) / max(values.max() - values.min(), EPS)
 
 
 def evaluate_candidate(
     fixed: np.ndarray,
     candidate: np.ndarray,
-    mask: np.ndarray,
 ) -> dict[str, float]:
-    fixed_n = normalize_in_mask(fixed, mask)
-    candidate_n = normalize_in_mask(candidate, mask)
+    fixed_values = normalized_values(fixed)
+    candidate_values = normalized_values(candidate)
     return {
-        "ncc": ncc(fixed_n, candidate_n, mask),
-        "mse": mse(fixed_n, candidate_n, mask),
-        "mi": mutual_information(fixed_n, candidate_n, mask),
-        "nmi": normalized_mutual_information(fixed_n, candidate_n, mask),
+        "ncc": float(pearsonr(fixed_values, candidate_values)[0]),
+        "mse": float(mean_squared_error(fixed_values, candidate_values)),
+        "nmi": float(
+            normalized_mutual_information(fixed_values, candidate_values, bins=64)
+        ),
     }
 
 
@@ -121,16 +75,11 @@ def evaluate_registration(
         "ants": ants_warped,
         "dipy": dipy_warped,
     }
-    mask = np.isfinite(fixed) & (fixed > 0)
-    for candidate in candidates.values():
-        mask &= np.isfinite(candidate)
-    if not mask.any():
-        raise ValueError("Evaluation mask is empty.")
 
     output = {
         "pair_id": pair_id,
         "metrics": {
-            name: evaluate_candidate(fixed, candidate, mask)
+            name: evaluate_candidate(fixed, candidate)
             for name, candidate in candidates.items()
         },
     }

--- a/benchmarks/registration/evaluate.py
+++ b/benchmarks/registration/evaluate.py
@@ -35,9 +35,10 @@ def normalized_values(data: np.ndarray) -> np.ndarray:
 def evaluate_candidate(
     fixed: np.ndarray,
     candidate: np.ndarray,
+    mask: np.ndarray,
 ) -> dict[str, float]:
-    fixed_values = normalized_values(fixed)
-    candidate_values = normalized_values(candidate)
+    fixed_values = normalized_values(fixed[mask])
+    candidate_values = normalized_values(candidate[mask])
     return {
         "ncc": float(pearsonr(fixed_values, candidate_values)[0]),
         "mse": float(mean_squared_error(fixed_values, candidate_values)),
@@ -51,15 +52,19 @@ def evaluate_registration(
     pair_id: str,
     fixed_path: str | Path,
     moving_path: str | Path,
+    fixed_mask_path: str | Path,
     warped_ants_path: str | Path,
     warped_dipy_path: str | Path,
     out_json: str | Path,
 ) -> dict:
     fixed_img, fixed = load_image(fixed_path)
     moving_img, moving = load_image(moving_path)
+    mask_img, fixed_mask = load_image(fixed_mask_path)
     ants_img, ants_warped = load_image(warped_ants_path)
     dipy_img, dipy_warped = load_image(warped_dipy_path)
 
+    if not same_grid(fixed_img, mask_img):
+        raise ValueError("Fixed mask is not on the fixed image grid.")
     if not same_grid(fixed_img, ants_img):
         raise ValueError("ANTs warped image is not on the fixed image grid.")
     if not same_grid(fixed_img, dipy_img):
@@ -75,11 +80,17 @@ def evaluate_registration(
         "ants": ants_warped,
         "dipy": dipy_warped,
     }
+    mask = fixed_mask > 0
+    mask &= np.isfinite(fixed)
+    for candidate in candidates.values():
+        mask &= np.isfinite(candidate)
+    if not mask.any():
+        raise ValueError("Evaluation mask is empty.")
 
     output = {
         "pair_id": pair_id,
         "metrics": {
-            name: evaluate_candidate(fixed, candidate)
+            name: evaluate_candidate(fixed, candidate, mask)
             for name, candidate in candidates.items()
         },
     }
@@ -97,6 +108,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--pair-id", required=True)
     parser.add_argument("--fixed", required=True)
     parser.add_argument("--moving", required=True)
+    parser.add_argument("--fixed-mask", required=True)
     parser.add_argument("--warped-ants", required=True)
     parser.add_argument("--warped-dipy", required=True)
     parser.add_argument("--out-json", required=True)
@@ -109,6 +121,7 @@ def main() -> None:
         pair_id=args.pair_id,
         fixed_path=args.fixed,
         moving_path=args.moving,
+        fixed_mask_path=args.fixed_mask,
         warped_ants_path=args.warped_ants,
         warped_dipy_path=args.warped_dipy,
         out_json=args.out_json,

--- a/benchmarks/registration/evaluate.py
+++ b/benchmarks/registration/evaluate.py
@@ -1,0 +1,170 @@
+"""Evaluate registration outputs with framework-independent metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import nibabel as nib
+from nibabel.processing import resample_from_to
+import numpy as np
+
+EPS = 1e-8
+
+
+def load_image(path: str | Path) -> tuple[nib.Nifti1Image, np.ndarray]:
+    img = nib.load(str(path))
+    data = np.squeeze(img.get_fdata(dtype=np.float32))
+    if data.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got shape {data.shape}: {path}")
+    return img, data
+
+
+def same_grid(a: nib.Nifti1Image, b: nib.Nifti1Image) -> bool:
+    return a.shape == b.shape and np.allclose(a.affine, b.affine, atol=1e-4)
+
+
+def normalize_in_mask(data: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    out = np.zeros_like(data, dtype=np.float32)
+    values = data[mask].astype(np.float64)
+    out[mask] = (
+        (values - values.min()) / max(values.max() - values.min(), EPS)
+    ).astype(np.float32)
+    return out
+
+
+def ncc(x: np.ndarray, y: np.ndarray, mask: np.ndarray) -> float:
+    xv = x[mask].astype(np.float64)
+    yv = y[mask].astype(np.float64)
+    xv -= xv.mean()
+    yv -= yv.mean()
+    return float(np.dot(xv, yv) / max(np.linalg.norm(xv) * np.linalg.norm(yv), EPS))
+
+
+def mse(x: np.ndarray, y: np.ndarray, mask: np.ndarray) -> float:
+    diff = x[mask].astype(np.float64) - y[mask].astype(np.float64)
+    return float(np.mean(diff * diff))
+
+
+def mutual_information(
+    x: np.ndarray,
+    y: np.ndarray,
+    mask: np.ndarray,
+    bins: int = 64,
+) -> float:
+    hist, _, _ = np.histogram2d(x[mask].ravel(), y[mask].ravel(), bins=bins)
+    pxy = hist / max(hist.sum(), EPS)
+    px = pxy.sum(axis=1)
+    py = pxy.sum(axis=0)
+    nz = pxy > 0
+    independent = np.maximum(px[:, None] * py[None, :], EPS)
+    return float(np.sum(pxy[nz] * np.log(pxy[nz] / independent[nz])))
+
+
+def normalized_mutual_information(
+    x: np.ndarray,
+    y: np.ndarray,
+    mask: np.ndarray,
+    bins: int = 64,
+) -> float:
+    hist, _, _ = np.histogram2d(x[mask].ravel(), y[mask].ravel(), bins=bins)
+    pxy = hist / max(hist.sum(), EPS)
+    px = pxy.sum(axis=1)
+    py = pxy.sum(axis=0)
+    hx = -np.sum(px[px > 0] * np.log(px[px > 0]))
+    hy = -np.sum(py[py > 0] * np.log(py[py > 0]))
+    hxy = -np.sum(pxy[pxy > 0] * np.log(pxy[pxy > 0]))
+    return float((hx + hy) / max(hxy, EPS))
+
+
+def evaluate_candidate(
+    fixed: np.ndarray,
+    candidate: np.ndarray,
+    mask: np.ndarray,
+) -> dict[str, float]:
+    fixed_n = normalize_in_mask(fixed, mask)
+    candidate_n = normalize_in_mask(candidate, mask)
+    return {
+        "ncc": ncc(fixed_n, candidate_n, mask),
+        "mse": mse(fixed_n, candidate_n, mask),
+        "mi": mutual_information(fixed_n, candidate_n, mask),
+        "nmi": normalized_mutual_information(fixed_n, candidate_n, mask),
+    }
+
+
+def evaluate_registration(
+    pair_id: str,
+    fixed_path: str | Path,
+    moving_path: str | Path,
+    warped_ants_path: str | Path,
+    warped_dipy_path: str | Path,
+    out_json: str | Path,
+) -> dict:
+    fixed_img, fixed = load_image(fixed_path)
+    moving_img, moving = load_image(moving_path)
+    ants_img, ants_warped = load_image(warped_ants_path)
+    dipy_img, dipy_warped = load_image(warped_dipy_path)
+
+    if not same_grid(fixed_img, ants_img):
+        raise ValueError("ANTs warped image is not on the fixed image grid.")
+    if not same_grid(fixed_img, dipy_img):
+        raise ValueError("DIPY warped image is not on the fixed image grid.")
+
+    if not same_grid(fixed_img, moving_img):
+        moving = np.squeeze(
+            resample_from_to(moving_img, fixed_img, order=1).get_fdata(dtype=np.float32)
+        )
+
+    candidates = {
+        "baseline": moving,
+        "ants": ants_warped,
+        "dipy": dipy_warped,
+    }
+    mask = np.isfinite(fixed) & (fixed > 0)
+    for candidate in candidates.values():
+        mask &= np.isfinite(candidate)
+    if not mask.any():
+        raise ValueError("Evaluation mask is empty.")
+
+    output = {
+        "pair_id": pair_id,
+        "metrics": {
+            name: evaluate_candidate(fixed, candidate, mask)
+            for name, candidate in candidates.items()
+        },
+    }
+
+    out_json = Path(out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open("w") as f:
+        json.dump(output, f, indent=2)
+
+    return output
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate registration outputs.")
+    parser.add_argument("--pair-id", required=True)
+    parser.add_argument("--fixed", required=True)
+    parser.add_argument("--moving", required=True)
+    parser.add_argument("--warped-ants", required=True)
+    parser.add_argument("--warped-dipy", required=True)
+    parser.add_argument("--out-json", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    evaluate_registration(
+        pair_id=args.pair_id,
+        fixed_path=args.fixed,
+        moving_path=args.moving,
+        warped_ants_path=args.warped_ants,
+        warped_dipy_path=args.warped_dipy,
+        out_json=args.out_json,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registration/run_benchmark.py
+++ b/benchmarks/registration/run_benchmark.py
@@ -1,0 +1,400 @@
+"""Run the registration benchmark pipeline for a CSV of fixed/moving pairs.
+
+Pipeline:
+
+1. Reslice both images by the same downsampling factor.
+2. Skull-strip both images with SynthSeg.
+3. Fill holes and keep the largest connected mask component.
+4. Rigidly prealign the moving image to the fixed image.
+5. Run DIPY SyN and ANTs SyN from the same prealigned inputs.
+6. Evaluate both warped outputs with framework-independent metrics.
+
+Example, from benchmarks/registration:
+
+    python run_benchmark.py \
+        --pairs data/oasis2_pairs.csv \
+        --config configs/syn_cc_default.yaml \
+        --out-dir outputs/oasis2_syn_cc_ds2 \
+        --downsample-factor 2 \
+        --n 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+import random
+import statistics
+
+from evaluate import evaluate_registration
+import nibabel as nib
+import numpy as np
+from runners.ants_syn import run_ants_syn
+from runners.dipy_syn import run_dipy_syn
+from scipy.ndimage import binary_fill_holes, label
+import yaml
+
+from dipy.align.imaffine import (
+    AffineRegistration,
+    MutualInformationMetric,
+    transform_centers_of_mass,
+)
+from dipy.align.reslice import reslice
+from dipy.align.transforms import RigidTransform3D, TranslationTransform3D
+
+_SYNTHSEG_MODEL = None
+METRIC_NAMES = ("ncc", "mse", "mi", "nmi")
+
+
+def load_yaml(path: str | Path) -> dict:
+    with Path(path).open() as f:
+        return yaml.safe_load(f)
+
+
+def read_pairs(path: str | Path) -> list[dict[str, str]]:
+    with Path(path).open(newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    required = {"fixed_path", "moving_path"}
+    missing = required - set(rows[0]) if rows else required
+    if missing:
+        raise ValueError(f"Pair CSV is missing columns: {sorted(missing)}")
+    return rows
+
+
+def sample_pairs(
+    rows: list[dict[str, str]], n: int | None, seed: int
+) -> list[dict[str, str]]:
+    if n is None:
+        return rows
+    if n > len(rows):
+        raise ValueError(f"Requested n={n}, but only found {len(rows)} pairs.")
+    return random.Random(seed).sample(rows, n)
+
+
+def get_pair_id(row: dict[str, str], index: int) -> str:
+    pair_id = row.get("pair_id", "").strip()
+    return pair_id or f"pair_{index:04d}"
+
+
+def reslice_by_factor(in_path: str | Path, out_path: str | Path, factor: float) -> Path:
+    in_path = Path(in_path)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if factor == 1:
+        return in_path
+    if out_path.exists():
+        print(f"Reusing resliced image: {out_path}")
+        return out_path
+
+    print(f"Reslicing image: {in_path}")
+    img = nib.load(str(in_path))
+    data = np.squeeze(np.asarray(img.dataobj, dtype=np.float32))
+    if data.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got {data.shape}: {in_path}")
+
+    zooms = img.header.get_zooms()[:3]
+    new_zooms = tuple(float(zoom) * factor for zoom in zooms)
+    data_rs, affine_rs = reslice(data, img.affine, zooms, new_zooms)
+
+    out_img = nib.Nifti1Image(data_rs.astype(np.float32), affine_rs)
+    nib.save(out_img, str(out_path))
+    return out_path
+
+
+def keep_largest_component(mask: np.ndarray) -> np.ndarray:
+    components, n_components = label(mask)
+    if n_components <= 1:
+        return mask.astype(bool)
+
+    counts = np.bincount(components.ravel())
+    counts[0] = 0
+    return components == int(counts.argmax())
+
+
+def get_synthseg_model(use_cuda: bool):
+    global _SYNTHSEG_MODEL
+    if _SYNTHSEG_MODEL is None:
+        from dipy.nn.torch.synthseg import SynthSeg
+
+        _SYNTHSEG_MODEL = SynthSeg(verbose=False, use_cuda=use_cuda)
+    return _SYNTHSEG_MODEL
+
+
+def skull_strip(
+    in_path: str | Path,
+    out_img_path: str | Path,
+    *,
+    use_cuda: bool,
+) -> Path:
+    out_img_path = Path(out_img_path)
+    if out_img_path.exists():
+        print(f"Reusing skull-stripped image: {out_img_path}")
+        return out_img_path
+
+    print(f"Skull stripping image: {in_path}")
+    out_img_path.parent.mkdir(parents=True, exist_ok=True)
+    img = nib.load(str(in_path))
+    data = np.squeeze(img.get_fdata(dtype=np.float32))
+    if data.ndim != 3:
+        raise ValueError(f"SynthSeg expects a 3D image, got {data.shape}: {in_path}")
+
+    data = np.nan_to_num(data, nan=0.0, posinf=0.0, neginf=0.0)
+
+    _, _, mask = get_synthseg_model(use_cuda).predict(data, img.affine)
+    mask = binary_fill_holes(mask.astype(bool))
+    mask = keep_largest_component(mask)
+    brain = data * mask
+
+    brain_img = nib.Nifti1Image(brain.astype(np.float32), img.affine)
+    nib.save(brain_img, str(out_img_path))
+
+    return out_img_path
+
+
+def rigid_prealign(
+    fixed_path: str | Path, moving_path: str | Path, out_path: str | Path
+) -> Path:
+    out_path = Path(out_path)
+    if out_path.exists():
+        print(f"Reusing rigid prealignment: {out_path}")
+        return out_path
+
+    print("Running rigid prealignment")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fixed_img = nib.load(str(fixed_path))
+    moving_img = nib.load(str(moving_path))
+    fixed = fixed_img.get_fdata(dtype=np.float32)
+    moving = moving_img.get_fdata(dtype=np.float32)
+
+    center = transform_centers_of_mass(
+        fixed, fixed_img.affine, moving, moving_img.affine
+    )
+
+    metric = MutualInformationMetric(nbins=32, sampling_proportion=None)
+    affreg = AffineRegistration(
+        metric=metric,
+        level_iters=[10000, 1000, 100],
+        sigmas=[3.0, 1.0, 0.0],
+        factors=[4, 2, 1],
+    )
+
+    translation = affreg.optimize(
+        fixed,
+        moving,
+        TranslationTransform3D(),
+        params0=None,
+        static_grid2world=fixed_img.affine,
+        moving_grid2world=moving_img.affine,
+        starting_affine=center.affine,
+    )
+
+    rigid = affreg.optimize(
+        fixed,
+        moving,
+        RigidTransform3D(),
+        params0=None,
+        static_grid2world=fixed_img.affine,
+        moving_grid2world=moving_img.affine,
+        starting_affine=translation.affine,
+    )
+
+    prealigned = rigid.transform(moving)
+
+    nib.save(
+        nib.Nifti1Image(
+            prealigned.astype(np.float32), fixed_img.affine, fixed_img.header
+        ),
+        str(out_path),
+    )
+
+    return out_path
+
+
+def prepare_pair(
+    row: dict[str, str],
+    pair_out: Path,
+    *,
+    downsample_factor: float,
+    use_cuda: bool,
+) -> tuple[Path, Path]:
+    prepared_out = pair_out / "prepared"
+    inputs_out = prepared_out / "inputs"
+    skullstrip_out = prepared_out / "skullstrip"
+
+    print("Preparing inputs")
+    fixed_resliced = reslice_by_factor(
+        row["fixed_path"],
+        inputs_out / "fixed_resliced.nii.gz",
+        downsample_factor,
+    )
+    moving_resliced = reslice_by_factor(
+        row["moving_path"],
+        inputs_out / "moving_resliced.nii.gz",
+        downsample_factor,
+    )
+
+    fixed_brain = skull_strip(
+        fixed_resliced,
+        skullstrip_out / "fixed_brain.nii.gz",
+        use_cuda=use_cuda,
+    )
+    moving_brain = skull_strip(
+        moving_resliced,
+        skullstrip_out / "moving_brain.nii.gz",
+        use_cuda=use_cuda,
+    )
+
+    moving_prealigned = rigid_prealign(
+        fixed_brain,
+        moving_brain,
+        pair_out / "prealign" / "moving_rigid_to_fixed.nii.gz",
+    )
+    return fixed_brain, moving_prealigned
+
+
+def gains_vs_baseline(metrics: dict) -> dict:
+    baseline = metrics["baseline"]
+    return {
+        method: {metric: values[metric] - baseline[metric] for metric in METRIC_NAMES}
+        for method, values in metrics.items()
+        if method != "baseline"
+    }
+
+
+def summarize(samples: list[dict]) -> dict:
+    methods = sorted({method for sample in samples for method in sample["metrics"]})
+    summary = {}
+
+    for method in methods:
+        method_summary = {"n": len(samples)}
+        for metric in METRIC_NAMES:
+            values = [
+                sample["metrics"][method][metric]
+                for sample in samples
+                if method in sample["metrics"]
+            ]
+            method_summary[metric] = {
+                "mean": statistics.mean(values),
+                "std": statistics.stdev(values) if len(values) > 1 else 0.0,
+            }
+
+            if method == "baseline":
+                continue
+
+            gain_values = [
+                sample["gains_vs_baseline"][method][metric]
+                for sample in samples
+                if method in sample["gains_vs_baseline"]
+            ]
+            method_summary[f"{metric}_gain_vs_baseline"] = {
+                "mean": statistics.mean(gain_values),
+                "std": statistics.stdev(gain_values) if len(gain_values) > 1 else 0.0,
+            }
+        summary[method] = method_summary
+
+    return summary
+
+
+def write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def run_pair(
+    pair_id: str,
+    row: dict[str, str],
+    out_dir: Path,
+    config: dict,
+    args: argparse.Namespace,
+) -> dict:
+    pair_out = out_dir / pair_id
+    fixed, moving = prepare_pair(
+        row,
+        pair_out,
+        downsample_factor=args.downsample_factor,
+        use_cuda=args.use_cuda,
+    )
+
+    print("Running DIPY SyN")
+    dipy_result = run_dipy_syn(fixed, moving, pair_out / "dipy", config)
+
+    print("Running ANTs SyN")
+    ants_result = run_ants_syn(fixed, moving, pair_out / "ants", config)
+
+    print("Evaluating registration outputs")
+    return evaluate_registration(
+        pair_id=pair_id,
+        fixed_path=fixed,
+        moving_path=moving,
+        warped_ants_path=ants_result["warped_image"],
+        warped_dipy_path=dipy_result["warped_image"],
+        out_json=pair_out / "evaluation.json",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run DIPY vs ANTs registration benchmark."
+    )
+    parser.add_argument("--pairs", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument(
+        "--out-dir", default=Path("outputs/registration_benchmark"), type=Path
+    )
+    parser.add_argument("--n", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--downsample-factor", type=float, default=1.0)
+    parser.add_argument("--use-cuda", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_yaml(args.config)
+    pairs = sample_pairs(read_pairs(args.pairs), args.n, args.seed)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {
+        "metadata": {
+            "pairs_file": str(args.pairs),
+            "config_file": str(args.config),
+            "config": config,
+            "n_pairs": len(pairs),
+            "seed": args.seed,
+            "downsample_factor": args.downsample_factor,
+        },
+        "samples": [],
+        "summary": {},
+    }
+
+    for index, row in enumerate(pairs, start=1):
+        pair_id = get_pair_id(row, index)
+        print(f"\n=== {pair_id} ===")
+        if not row.get("pair_id", "").strip():
+            print(f"fixed:  {row['fixed_path']}")
+            print(f"moving: {row['moving_path']}")
+
+        evaluation = run_pair(pair_id, row, args.out_dir, config, args)
+        results["samples"].append(
+            {
+                "pair_id": pair_id,
+                "fixed_path": row["fixed_path"],
+                "moving_path": row["moving_path"],
+                "metrics": evaluation["metrics"],
+                "gains_vs_baseline": gains_vs_baseline(evaluation["metrics"]),
+            }
+        )
+        results["summary"] = summarize(results["samples"])
+        write_json(args.out_dir / "benchmark_results.json", results)
+
+    print(f"\nDone. Results saved in: {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registration/run_benchmark.py
+++ b/benchmarks/registration/run_benchmark.py
@@ -127,11 +127,13 @@ def get_synthseg_model(use_cuda: bool):
 def skull_strip(
     in_path: str | Path,
     out_img_path: str | Path,
+    out_mask_path: str | Path,
     *,
     use_cuda: bool,
 ) -> Path:
     out_img_path = Path(out_img_path)
-    if out_img_path.exists():
+    out_mask_path = Path(out_mask_path)
+    if out_img_path.exists() and out_mask_path.exists():
         print(f"Reusing skull-stripped image: {out_img_path}")
         return out_img_path
 
@@ -151,6 +153,9 @@ def skull_strip(
 
     brain_img = nib.Nifti1Image(brain.astype(np.float32), img.affine)
     nib.save(brain_img, str(out_img_path))
+
+    mask_img = nib.Nifti1Image(mask.astype(np.uint8), img.affine)
+    nib.save(mask_img, str(out_mask_path))
 
     return out_img_path
 
@@ -241,11 +246,13 @@ def prepare_pair(
     fixed_brain = skull_strip(
         fixed_resliced,
         skullstrip_out / "fixed_brain.nii.gz",
+        skullstrip_out / "fixed_mask.nii.gz",
         use_cuda=use_cuda,
     )
     moving_brain = skull_strip(
         moving_resliced,
         skullstrip_out / "moving_brain.nii.gz",
+        skullstrip_out / "moving_mask.nii.gz",
         use_cuda=use_cuda,
     )
 
@@ -332,6 +339,7 @@ def run_pair(
         pair_id=pair_id,
         fixed_path=fixed,
         moving_path=moving,
+        fixed_mask_path=pair_out / "prepared" / "skullstrip" / "fixed_mask.nii.gz",
         warped_ants_path=ants_result["warped_image"],
         warped_dipy_path=dipy_result["warped_image"],
         out_json=pair_out / "evaluation.json",

--- a/benchmarks/registration/run_benchmark.py
+++ b/benchmarks/registration/run_benchmark.py
@@ -45,7 +45,7 @@ from dipy.align.reslice import reslice
 from dipy.align.transforms import RigidTransform3D, TranslationTransform3D
 
 _SYNTHSEG_MODEL = None
-METRIC_NAMES = ("ncc", "mse", "mi", "nmi")
+METRIC_NAMES = ("ncc", "mse", "nmi")
 
 
 def load_yaml(path: str | Path) -> dict:

--- a/benchmarks/registration/runners/__init__.py
+++ b/benchmarks/registration/runners/__init__.py
@@ -1,0 +1,1 @@
+"""Registration backend runners used by the benchmark scripts."""

--- a/benchmarks/registration/runners/ants_syn.py
+++ b/benchmarks/registration/runners/ants_syn.py
@@ -1,0 +1,75 @@
+"""Run ANTsPy SyN registration for one fixed/moving image pair."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import ants
+import yaml
+
+
+def load_config(path: str | Path) -> dict:
+    with Path(path).open() as f:
+        return yaml.safe_load(f)
+
+
+def run_ants_syn(
+    fixed_path: str | Path,
+    moving_path: str | Path,
+    out_dir: str | Path,
+    config: dict,
+) -> dict:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fixed = ants.image_read(str(fixed_path))
+    moving = ants.image_read(str(moving_path))
+
+    registration_cfg = config["registration"]
+    ants_cfg = config["ants"]
+
+    reg = ants.registration(
+        fixed=fixed,
+        moving=moving,
+        type_of_transform="SyNOnly",
+        initial_transform=registration_cfg["initial_transform"],
+        syn_metric=ants_cfg["syn_metric"],
+        syn_sampling=registration_cfg["cc_radius"],
+        reg_iterations=registration_cfg["level_iters"],
+        grad_step=registration_cfg["grad_step"],
+        flow_sigma=ants_cfg["flow_sigma"],
+        total_sigma=ants_cfg["total_sigma"],
+        singleprecision=ants_cfg["singleprecision"],
+        use_legacy_histogram_matching=ants_cfg["use_legacy_histogram_matching"],
+        outprefix=str(out_dir / "ants_"),
+        verbose=True,
+    )
+
+    warped_path = out_dir / "warped_ants.nii.gz"
+    ants.image_write(reg["warpedmovout"], str(warped_path))
+
+    return {"warped_image": str(warped_path)}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run ANTsPy SyN registration.")
+    parser.add_argument("--fixed", required=True)
+    parser.add_argument("--moving", required=True)
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--config", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_ants_syn(
+        fixed_path=args.fixed,
+        moving_path=args.moving,
+        out_dir=args.out_dir,
+        config=load_config(args.config),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registration/runners/ants_syn.py
+++ b/benchmarks/registration/runners/ants_syn.py
@@ -40,8 +40,8 @@ def run_ants_syn(
         grad_step=registration_cfg["grad_step"],
         flow_sigma=ants_cfg["flow_sigma"],
         total_sigma=ants_cfg["total_sigma"],
-        singleprecision=ants_cfg["singleprecision"],
-        use_legacy_histogram_matching=ants_cfg["use_legacy_histogram_matching"],
+        singleprecision=True,
+        use_legacy_histogram_matching=False,
         outprefix=str(out_dir / "ants_"),
         verbose=True,
     )

--- a/benchmarks/registration/runners/ants_syn.py
+++ b/benchmarks/registration/runners/ants_syn.py
@@ -51,8 +51,8 @@ def run_ants_syn(
         grad_step=registration_cfg["grad_step"],
         flow_sigma=ants_cfg["flow_sigma"],
         total_sigma=ants_cfg["total_sigma"],
-        singleprecision=ants_cfg["singleprecision"],
-        use_legacy_histogram_matching=ants_cfg["use_legacy_histogram_matching"],
+        singleprecision=False,
+        use_legacy_histogram_matching=False,
         verbose=True,
     )
 

--- a/benchmarks/registration/runners/ants_syn.py
+++ b/benchmarks/registration/runners/ants_syn.py
@@ -14,6 +14,17 @@ def load_config(path: str | Path) -> dict:
         return yaml.safe_load(f)
 
 
+def remove_transform_files(registration_result: dict) -> None:
+    transform_paths = [
+        *registration_result.get("fwdtransforms", []),
+        *registration_result.get("invtransforms", []),
+    ]
+    for transform_path in set(transform_paths):
+        path = Path(transform_path)
+        if path.exists():
+            path.unlink()
+
+
 def run_ants_syn(
     fixed_path: str | Path,
     moving_path: str | Path,
@@ -40,14 +51,14 @@ def run_ants_syn(
         grad_step=registration_cfg["grad_step"],
         flow_sigma=ants_cfg["flow_sigma"],
         total_sigma=ants_cfg["total_sigma"],
-        singleprecision=True,
-        use_legacy_histogram_matching=False,
-        outprefix=str(out_dir / "ants_"),
+        singleprecision=ants_cfg["singleprecision"],
+        use_legacy_histogram_matching=ants_cfg["use_legacy_histogram_matching"],
         verbose=True,
     )
 
     warped_path = out_dir / "warped_ants.nii.gz"
     ants.image_write(reg["warpedmovout"], str(warped_path))
+    remove_transform_files(reg)
 
     return {"warped_image": str(warped_path)}
 

--- a/benchmarks/registration/runners/dipy_syn.py
+++ b/benchmarks/registration/runners/dipy_syn.py
@@ -1,0 +1,100 @@
+"""Run DIPY SyN registration for one fixed/moving image pair."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import yaml
+
+from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
+from dipy.align.metrics import CCMetric
+
+
+def load_config(path: str | Path) -> dict:
+    with Path(path).open() as f:
+        return yaml.safe_load(f)
+
+
+def as_3d(data: np.ndarray, path: str | Path) -> np.ndarray:
+    data = np.squeeze(data)
+    if data.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got {data.shape}: {path}")
+    return data
+
+
+def run_dipy_syn(
+    fixed_path: str | Path,
+    moving_path: str | Path,
+    out_dir: str | Path,
+    config: dict,
+) -> dict:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fixed_img = nib.load(str(fixed_path))
+    moving_img = nib.load(str(moving_path))
+
+    fixed = as_3d(fixed_img.get_fdata(dtype=np.float32), fixed_path)
+    moving = as_3d(moving_img.get_fdata(dtype=np.float32), moving_path)
+
+    registration_cfg = config["registration"]
+    dipy_cfg = config["dipy"]
+
+    metric = CCMetric(
+        3,
+        radius=registration_cfg["cc_radius"],
+        sigma_diff=dipy_cfg["update_field_sigma"],
+    )
+
+    sdr = SymmetricDiffeomorphicRegistration(
+        metric,
+        level_iters=registration_cfg["level_iters"],
+        step_length=registration_cfg["grad_step"],
+        ss_sigma_factor=dipy_cfg["ss_sigma_factor"],
+        opt_tol=registration_cfg["convergence_tol"],
+        inv_iter=dipy_cfg["inv_iter"],
+        inv_tol=dipy_cfg["inv_tol"],
+    )
+    sdr.energy_window = registration_cfg["convergence_window"]
+
+    mapping = sdr.optimize(
+        fixed,
+        moving,
+        static_grid2world=fixed_img.affine,
+        moving_grid2world=moving_img.affine,
+        prealign=None,
+    )
+
+    warped = mapping.transform(moving)
+
+    warped_path = out_dir / "warped_dipy.nii.gz"
+
+    nib.save(nib.Nifti1Image(warped.astype(np.float32), fixed_img.affine), warped_path)
+
+    return {"warped_image": str(warped_path)}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DIPY SyN registration.")
+    parser.add_argument("--fixed", required=True)
+    parser.add_argument("--moving", required=True)
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--config", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_dipy_syn(
+        fixed_path=args.fixed,
+        moving_path=args.moving,
+        out_dir=args.out_dir,
+        config=load_config(args.config),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dipy/align/tests/test_vector_fields.py
+++ b/dipy/align/tests/test_vector_fields.py
@@ -1765,6 +1765,38 @@ def test_gradient_3d(rng):
 
 
 @set_random_number_generator(1234)
+def test_gradient_threading(rng):
+    """Threaded dense gradients match one-thread gradients."""
+    for shape in ((32, 29), (16, 15, 14)):
+        dim = len(shape)
+        img_world2grid = np.eye(dim + 1)
+        img_spacing = np.ones(dim)
+        out_grid2world = np.eye(dim + 1)
+
+        for dtype in (np.float32, np.float64):
+            img = rng.normal(size=shape).astype(dtype)
+            serial, serial_inside = vfu.gradient(
+                img,
+                img_world2grid,
+                img_spacing,
+                shape,
+                out_grid2world,
+                num_threads=1,
+            )
+            threaded, threaded_inside = vfu.gradient(
+                img,
+                img_world2grid,
+                img_spacing,
+                shape,
+                out_grid2world,
+                num_threads=2,
+            )
+
+            assert_array_equal(threaded, serial)
+            assert_array_equal(threaded_inside, serial_inside)
+
+
+@set_random_number_generator(1234)
 def test_compose_vector_fields_threading(rng):
     """Threaded composition matches one-thread composition and statistics."""
     cases = (

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -2847,9 +2847,113 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
     return np.asarray(s)
 
 
+cdef void _gradient_3d_slice(floating[:, :, :] img,
+                             double[:, :] img_world2grid,
+                             double[:] img_spacing,
+                             double[:, :] out_grid2world,
+                             floating[:, :, :, :] out,
+                             int[:, :, :] inside,
+                             cnp.npy_intp k,
+                             cnp.npy_intp nrows,
+                             cnp.npy_intp ncols) noexcept nogil:
+    r"""Compute the image gradient for one slice of a 3D output volume.
+
+    This performs the inner two loops of :func:`_gradient_3d` for one output
+    volume slice. It was added so the outer slice loop can run with ``prange``
+    while the temporary interpolation arrays remain local to each worker.
+
+    Parameters
+    ----------
+    img : array, shape (S, R, C)
+        the input volume whose gradient will be computed
+    img_world2grid : array, shape (4, 4)
+        the space-to-grid transform matrix associated to img
+    img_spacing : array, shape (3,)
+        the spacing between voxels (voxel size along each axis) of the input
+        volume
+    out_grid2world : array, shape (4, 4)
+        the grid-to-space transform associated to the sampling grid
+    out : array, shape (S', R', C', 3)
+        the buffer in which to store the image gradient
+    inside : array, shape (S', R', C')
+        the buffer in which to store the flags indicating whether the sample
+        point lies inside (=1) or outside (=0) the image grid
+    k : int
+        index of the output slice to compute.
+    nrows : int
+        number of rows in the output slice.
+    ncols : int
+        number of columns in the output slice.
+
+    Returns
+    -------
+    out : array, shape (S', R', C', 3)
+        on output, slice ``k`` contains the image gradient.
+    inside : array, shape (S', R', C')
+        on output, slice ``k`` contains the inside-image flags.
+    """
+    cdef:
+        cnp.npy_intp i, j, in_flag
+        double tmp
+        double x[3]
+        double dx[3]
+        double h[3]
+        double q[3]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    h[2] = 0.5 * img_spacing[2]
+    for i in range(nrows):
+        for j in range(ncols):
+            inside[k, i, j] = 1
+            # Compute coordinates of index (k, i, j) in physical space
+            x[0] = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, out_grid2world)
+            x[1] = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, out_grid2world)
+            x[2] = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, out_grid2world)
+            dx[0] = x[0]
+            dx[1] = x[1]
+            dx[2] = x[2]
+            for p in range(3):
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] - h[p]
+                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                    q[1], q[2], &out[k, i, j, p])
+                if in_flag == 0:
+                    out[k, i, j, p] = 0
+                    inside[k, i, j] = 0
+                    continue
+                tmp = out[k, i, j, p]
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] + h[p]
+                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                            img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                                        q[1], q[2], &out[k, i, j, p])
+                if in_flag == 0:
+                    out[k, i, j, p] = 0
+                    inside[k, i, j] = 0
+                    continue
+                out[k, i, j, p] = ((out[k, i, j, p] - tmp) /
+                                    img_spacing[p])
+                dx[p] = x[p]
+
+
 def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                  double[:] img_spacing, double[:, :] out_grid2world,
-                 floating[:, :, :, :] out, int[:, :, :] inside):
+                 floating[:, :, :, :] out, int[:, :, :] inside,
+                 *, num_threads=None):
     r""" Gradient of a 3D image in physical space coordinates
 
     Each grid cell (i, j, k) in the sampling grid (determined by
@@ -2883,65 +2987,26 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
     inside : array, shape (S', R', C')
         the buffer in which to store the flags indicating whether the sample
         point lies inside (=1) or outside (=0) the image grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
     """
     cdef:
         cnp.npy_intp nslices = out.shape[0]
         cnp.npy_intp nrows = out.shape[1]
         cnp.npy_intp ncols = out.shape[2]
-        cnp.npy_intp i, j, k, in_flag
-        double tmp
-        double[:] x = np.empty(shape=(3,), dtype=np.float64)
-        double[:] dx = np.empty(shape=(3,), dtype=np.float64)
-        double[:] h = np.empty(shape=(3,), dtype=np.float64)
-        double[:] q = np.empty(shape=(3,), dtype=np.float64)
+        cnp.npy_intp k
+        int threads_to_use
+
+    threads_to_use = determine_num_threads(num_threads)
+
     with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        h[2] = 0.5 * img_spacing[2]
-        for k in range(nslices):
-            for i in range(nrows):
-                for j in range(ncols):
-                    inside[k, i, j] = 1
-                    # Compute coordinates of index (k, i, j) in physical space
-                    x[0] = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, out_grid2world)
-                    x[1] = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, out_grid2world)
-                    x[2] = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, out_grid2world)
-                    dx[:] = x[:]
-                    for p in range(3):
-                        # Compute coordinates of point dx on img's grid
-                        dx[p] = x[p] - h[p]
-                        q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
-                        if in_flag == 0:
-                            out[k, i, j, p] = 0
-                            inside[k, i, j] = 0
-                            continue
-                        tmp = out[k, i, j, p]
-                        # Compute coordinates of point dx on img's grid
-                        dx[p] = x[p] + h[p]
-                        q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                                   img_world2grid)
-                        # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                                                q[1], q[2], &out[k, i, j, p])
-                        if in_flag == 0:
-                            out[k, i, j, p] = 0
-                            inside[k, i, j] = 0
-                            continue
-                        out[k, i, j, p] = ((out[k, i, j, p] - tmp) /
-                                           img_spacing[p])
-                        dx[p] = x[p]
+        for k in prange(
+            nslices, schedule="static", num_threads=threads_to_use
+        ):
+            _gradient_3d_slice[floating](
+                img, img_world2grid, img_spacing, out_grid2world,
+                out, inside, k, nrows, ncols)
 
 
 def _sparse_gradient_3d(floating[:, :, :] img,
@@ -3029,9 +3094,97 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                 dx[p] = sample_points[i, p]
 
 
+cdef void _gradient_2d_row(floating[:, :] img,
+                           double[:, :] img_world2grid,
+                           double[:] img_spacing,
+                           double[:, :] out_grid2world,
+                           floating[:, :, :] out,
+                           int[:, :] inside,
+                           cnp.npy_intp i,
+                           cnp.npy_intp ncols) noexcept nogil:
+    r"""Compute the image gradient for one row of a 2D output image.
+
+    This performs the inner loop of :func:`_gradient_2d` for one output image
+    row. It was added so the outer row loop can run with ``prange`` while the
+    temporary interpolation arrays remain local to each worker.
+
+    Parameters
+    ----------
+    img : array, shape (R, C)
+        the input image whose gradient will be computed
+    img_world2grid : array, shape (3, 3)
+        the space-to-grid transform matrix associated to img
+    img_spacing : array, shape (2,)
+        the spacing between pixels (pixel size along each axis) of the input
+        image
+    out_grid2world : array, shape (3, 3)
+        the grid-to-space transform associated to the sampling grid
+    out : array, shape (S', R', 2)
+        the buffer in which to store the image gradient
+    inside : array, shape (S', R')
+        the buffer in which to store the flags indicating whether the sample
+        point lies inside (=1) or outside (=0) the image grid
+    i : int
+        index of the output row to compute.
+    ncols : int
+        number of columns in the output row.
+
+    Returns
+    -------
+    out : array, shape (R', C', 2)
+        on output, row ``i`` contains the image gradient.
+    inside : array, shape (R', C')
+        on output, row ``i`` contains the inside-image flags.
+    """
+    cdef:
+        cnp.npy_intp j, in_flag
+        double tmp
+        double x[2]
+        double dx[2]
+        double h[2]
+        double q[2]
+
+    h[0] = 0.5 * img_spacing[0]
+    h[1] = 0.5 * img_spacing[1]
+    for j in range(ncols):
+        inside[i, j] = 1
+        # Compute coordinates of index (i, j) in physical space
+        x[0] = _apply_affine_2d_x0(<double>i, <double>j, 1, out_grid2world)
+        x[1] = _apply_affine_2d_x1(<double>i, <double>j, 1, out_grid2world)
+        dx[0] = x[0]
+        dx[1] = x[1]
+        for p in range(2):
+            # Compute coordinates of point dx on img's grid
+            dx[p] = x[p] - h[p]
+            q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+            q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_2d[floating](img, q[0],
+                                            q[1], &out[i, j, p])
+            if in_flag == 0:
+                out[i, j, p] = 0
+                inside[i, j] = 0
+                continue
+            tmp = out[i, j, p]
+            # Compute coordinates of point dx on img's grid
+            dx[p] = x[p] + h[p]
+            q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
+            q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
+            # Interpolate img at q
+            in_flag = _interpolate_scalar_2d[floating](img, q[0],
+                                            q[1], &out[i, j, p])
+            if in_flag == 0:
+                out[i, j, p] = 0
+                inside[i, j] = 0
+                continue
+            out[i, j, p] = (out[i, j, p] - tmp) / img_spacing[p]
+            dx[p] = x[p]
+
+
 def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                  double[:] img_spacing, double[:, :] out_grid2world,
-                 floating[:, :, :] out, int[:, :] inside):
+                 floating[:, :, :] out, int[:, :] inside,
+                 *, num_threads=None):
     r""" Gradient of a 2D image in physical space coordinates
 
     Each grid cell (i, j) in the sampling grid (determined by
@@ -3064,52 +3217,25 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
     inside : array, shape (S', R')
         the buffer in which to store the flags indicating whether the sample
         point lies inside (=1) or outside (=0) the image grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
     """
     cdef:
         cnp.npy_intp nrows = out.shape[0]
         cnp.npy_intp ncols = out.shape[1]
-        cnp.npy_intp i, j, k, in_flag
-        double tmp
-        double[:] x = np.empty(shape=(2,), dtype=np.float64)
-        double[:] dx = np.empty(shape=(2,), dtype=np.float64)
-        double[:] h = np.empty(shape=(2,), dtype=np.float64)
-        double[:] q = np.empty(shape=(2,), dtype=np.float64)
+        cnp.npy_intp i
+        int threads_to_use
+
+    threads_to_use = determine_num_threads(num_threads)
+
     with nogil:
-        h[0] = 0.5 * img_spacing[0]
-        h[1] = 0.5 * img_spacing[1]
-        for i in range(nrows):
-            for j in range(ncols):
-                inside[i, j] = 1
-                # Compute coordinates of index (i, j) in physical space
-                x[0] = _apply_affine_2d_x0(<double>i, <double>j, 1, out_grid2world)
-                x[1] = _apply_affine_2d_x1(<double>i, <double>j, 1, out_grid2world)
-                dx[:] = x[:]
-                for p in range(2):
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] - h[p]
-                    q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                    q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                                                    q[1], &out[i, j, p])
-                    if in_flag == 0:
-                        out[i, j, p] = 0
-                        inside[i, j] = 0
-                        continue
-                    tmp = out[i, j, p]
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] + h[p]
-                    q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
-                    q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                                                    q[1], &out[i, j, p])
-                    if in_flag == 0:
-                        out[i, j, p] = 0
-                        inside[i, j] = 0
-                        continue
-                    out[i, j, p] = (out[i, j, p] - tmp) / img_spacing[p]
-                    dx[p] = x[p]
+        for i in prange(
+            nrows, schedule="static", num_threads=threads_to_use
+        ):
+            _gradient_2d_row[floating](
+                img, img_world2grid, img_spacing, out_grid2world,
+                out, inside, i, ncols)
 
 
 def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
@@ -3189,7 +3315,7 @@ def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
 
 
 def gradient(img, img_world2grid, img_spacing, out_shape,
-             out_grid2world):
+             out_grid2world, *, num_threads=None):
     r""" Gradient of an image in physical space
 
     Parameters
@@ -3205,6 +3331,9 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
         the number of (slices), rows and columns of the sampling grid
     out_grid2world : array, shape (dim+1, dim+1)
         the grid-to-space transform associated to the sampling grid
+    num_threads : int or None, optional
+        Number of OpenMP threads to use. If None, use DIPY's default thread
+        count.
 
     Returns
     -------
@@ -3235,7 +3364,15 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
         img_spacing = img_spacing.astype(np.float64)
     if out_grid2world.dtype != np.float64:
         out_grid2world = out_grid2world.astype(np.float64)
-    jd_grad(img, img_world2grid, img_spacing, out_grid2world, out, inside)
+    jd_grad(
+        img,
+        img_world2grid,
+        img_spacing,
+        out_grid2world,
+        out,
+        inside,
+        num_threads=num_threads,
+    )
     return np.asarray(out), np.asarray(inside)
 
 


### PR DESCRIPTION
## Description

Parallelizes dense 2D and 3D image-gradient computation using OpenMP through Cython's `prange`.

The outer loop processes independent rows in 2D and slices in 3D. This follows a nearly identical procedure to PR #4083, which introduced parallel 2D and 3D image warping.

Sparse gradient computation remains unchanged.

## Motivation and Context

Image gradients are repeatedly computed during dense registration. Since the gradient at each output voxel is independent, this operation can be safely parallelized.

This work revisits and reimplements the optimization originally proposed in PR #1599, adapting it to DIPY's current codebase and existing OpenMP conventions.

This improves affine registration methods using dense image gradients while preserving the existing numerical behaviour. SyN currently computes image gradients separately using `numpy.gradient`. A future contribution could investigate sharing or extending the parallel gradient implementation for SyN, provided that boundary behaviour and numerical equivalence are preserved and the performance benefit is demonstrated.

## How Has This Been Tested?

A threading test was added for dense 2D and 3D gradients. It verifies that running with two threads produces exactly the same gradient values and inside-image masks as running with one thread, for both `float32` and `float64` inputs.

A preliminary 3D affine-registration experiment was also performed using the images from [DIPY's affine-registration tutorial](https://github.com/dipy/dipy/blob/master/doc/examples/affine_registration_3d.py). The results from this PR were compared against `main` using four OpenMP threads.

| Timing | `main` | This PR |
|---|---:|---:|
| Total registration | 3.498 s | 3.102 s |
| Gradient computation | 1.120 s | 0.292 s |

The parallel gradient computation was approximately **3.84× faster**, and the complete registration was approximately **1.13× faster**. Both runs produced the same final NMI value (`1.176528`) and performed the same number of gradient calls.

The gradient computation shows a significant speedup, but gradients are only one part of affine registration. Other operations remain unchanged, and parallel execution introduces some thread-management overhead. Therefore, the improvement in total registration time is smaller.

These are preliminary results from one data sample on one machine, rather than a comprehensive performance benchmark. A more complete experiment should probably need to be done to prove the extra complexity in the code is worth it.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
