### PR TITLE
BF: reorient b-vectors after motion correction

### DIFF
--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -11,7 +11,11 @@ from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
 from dipy.align.reslice import reslice
 from dipy.align.streamlinear import slr_with_qbx
 from dipy.align.streamwarp import bundlewarp
-from dipy.core.gradients import gradient_table, mask_non_weighted_bvals
+from dipy.core.gradients import (
+    gradient_table,
+    mask_non_weighted_bvals,
+    reorient_bvecs,
+)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti, save_nifti, save_qa_metric
 from dipy.io.stateful_tractogram import StatefulTractogram
@@ -986,6 +990,7 @@ class MotionCorrectionFlow(Workflow):
         out_dir="",
         out_moved="moved.nii.gz",
         out_affine="affine.txt",
+        out_bvecs="moved.bvec",
     ):
         """
         Parameters
@@ -1012,6 +1017,8 @@ class MotionCorrectionFlow(Workflow):
             Name for the saved transformed image.
         out_affine : string, optional
             Name for the saved affine matrix.
+        out_bvecs : string, optional
+            Name for the saved reoriented b-vectors.
         """
         if tuple(level_iters) == (1000, 500, 100):
             logger.info(
@@ -1023,7 +1030,7 @@ class MotionCorrectionFlow(Workflow):
 
         io_it = self.get_io_iterator()
 
-        for dwi, bval, bvec, omoved, oafffine in io_it:
+        for dwi, bval, bvec, omoved, oafffine, obvecs in io_it:
             # Load the data from the input files and store into objects.
             logger.info(f"Loading {dwi}")
             data, affine = load_nifti(dwi)
@@ -1047,6 +1054,10 @@ class MotionCorrectionFlow(Workflow):
                 data=data, gtab=gtab, affine=affine, level_iters=level_iters
             )
 
+            reoriented_gtab = reorient_bvecs(
+                gtab, reg_affines[..., ~gtab.b0s_mask], atol=bvecs_tol
+            )
+
             # Saving the corrected image file
             save_nifti(omoved, reg_img.get_fdata(), affine)
             # Write the affine matrix array to disk
@@ -1055,6 +1066,8 @@ class MotionCorrectionFlow(Workflow):
                 for affine_slice in reg_affines:
                     np.savetxt(outfile, affine_slice, fmt="%-7.2f")
                     outfile.write("# New slice\n")
+            np.savetxt(obvecs, reoriented_gtab.bvecs.T, fmt="%.8f")
+            logger.info(f"Reoriented b-vectors saved as {obvecs}")
 
 
 class BundleWarpFlow(Workflow):

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -9,6 +9,7 @@ import pytest
 from dipy.align.tests.test_imwarp import get_synthetic_warped_circle
 from dipy.align.tests.test_parzenhist import setup_random_transform
 from dipy.align.transforms import regtransforms
+from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.image import load_nifti, load_nifti_data, save_nifti
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
@@ -817,6 +818,19 @@ def test_motion_correction(tmp_path):
     npt.assert_equal(corrected.shape, data.shape)
     npt.assert_equal(corrected.min(), data.min())
     npt.assert_equal(corrected.max(), data.max())
+
+    bvecs_path = motion_correction_flow.last_generated_outputs["out_bvecs"]
+    new_bvecs = np.loadtxt(bvecs_path)
+    gtab = gradient_table(bvals[:10], bvecs=bvecs[:10])
+
+    npt.assert_equal(new_bvecs.shape, (3, 10))
+    npt.assert_allclose(new_bvecs[:, gtab.b0s_mask], 0, atol=1e-12)
+    npt.assert_allclose(
+        np.linalg.norm(new_bvecs[:, ~gtab.b0s_mask], axis=0), 1.0, atol=1e-6
+    )
+    npt.assert_(
+        not np.allclose(new_bvecs.T[~gtab.b0s_mask], gtab.bvecs[~gtab.b0s_mask])
+    )
 
 
 def test_syn_registration_flow(tmp_path):


### PR DESCRIPTION
## Description

`MotionCorrectionFlow` registers every diffusion-weighted volume to the mean b0 with a pipeline ending in a full affine, then saves the rotated volumes and the transforms. It never rotated the gradient directions, so the b-vectors coming out of the workflow still described the data as acquired, not as corrected.

This PR wires `dipy.core.gradients.reorient_bvecs` into the workflow and saves the corrected directions as a new `out_bvecs` output (default `moved.bvec`), one direction per column in the usual bvec layout. `reorient_bvecs` expects one transform per diffusion-weighted volume, ordered as in `gtab.bvecs[~gtab.b0s_mask]`, so the b0 transforms are excluded from the array returned by `register_dwi_series`.

## Motivation and Context

Leemans and Jones showed that not rotating the gradient table after motion correction biases rotationally invariant measures such as FA and MD, and produces characteristic biases in tractography. The failure is silent: FA maps look plausible and tractography runs to completion, only the orientations are wrong.

`reorient_bvecs` already implements this correction and cites the same reference, but had no callers anywhere in the codebase, so users of `dipy_motion_correction` had no corrected b-vectors to feed downstream.

## How Has This Been Tested?

Extended the existing workflow test `dipy/workflows/tests/test_align.py::test_motion_correction`, which now also checks that:

- the b-vector file is written with one direction per column (shape `(3, n)`),
- b0 volumes keep a null direction,
- diffusion-weighted directions stay unit norm after rotation,
- the written directions actually differ from the nominal ones (the reorientation happened).

python -m pytest dipy/workflows/tests/test_align.py::test_motion_correction -q
1 passed


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure