### PR TITLE
BF: Fix CLI help text assigned to wrong dipy_fit_dki arguments

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -276,6 +276,23 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
                 "in the run method is same as the doc string."
             )
 
+        documented_args = [param[0] for param in self.doc]
+        if documented_args != args:
+            mismatches = "\n".join(
+                f"  position {i}: run() declares {arg!r}, "
+                f"doc string documents {documented!r}"
+                for i, (arg, documented) in enumerate(zip(args, documented_args))
+                if arg != documented
+            )
+            raise ValueError(
+                f"{self.prog}: Parameter names in the doc string and run "
+                "method do not match. Doc string parameters are paired "
+                "with the run method signature by position, so a mismatch "
+                "assigns the wrong help text and default value to a "
+                "command line argument. Please ensure that both list the "
+                f"same parameters in the same order.\n{mismatches}"
+            )
+
         for i, arg in enumerate(args):
             prefix = ""
             is_optional = i >= len_args - len_defaults

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -270,27 +270,22 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
 
         if len_args != len(self.doc):
             raise ValueError(
-                self.prog + ": Number of parameters in the "
-                "doc string and run method does not match. "
-                "Please ensure that the number of parameters "
-                "in the run method is same as the doc string."
+                f"{self.prog}: the docstring documents {len(self.doc)} parameters "
+                f"but there are {len_args} command line arguments. Every argument "
+                "must be documented."
             )
 
         documented_args = [param[0] for param in self.doc]
         if documented_args != args:
             mismatches = "\n".join(
-                f"  position {i}: run() declares {arg!r}, "
-                f"doc string documents {documented!r}"
+                f"  argument {i}: {arg!r} is documented as {documented!r}"
                 for i, (arg, documented) in enumerate(zip(args, documented_args))
                 if arg != documented
             )
             raise ValueError(
-                f"{self.prog}: Parameter names in the doc string and run "
-                "method do not match. Doc string parameters are paired "
-                "with the run method signature by position, so a mismatch "
-                "assigns the wrong help text and default value to a "
-                "command line argument. Please ensure that both list the "
-                f"same parameters in the same order.\n{mismatches}"
+                f"{self.prog}: docstring parameters are matched to command line "
+                "arguments by position, so both must list the same names in the "
+                f"same order.\n{mismatches}"
             )
 
         for i, arg in enumerate(args):

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -1284,7 +1284,7 @@ class ConcatenateTractogramFlow(Workflow):
 
         Parameters
         ----------
-        tractogram_list : variable string or Path
+        tractogram_files : variable string or Path
             The stateful tractogram filenames to concatenate
         reference : string or Path, optional
             Reference anatomy for tck/vtk/fib/dpy file.

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -1689,9 +1689,7 @@ class ReconstDkiFlow(Workflow):
         out_dir : string or Path, optional
             Output directory.
         out_dt_tensor : string, optional
-            Name of the tensors volume to be saved.
-        out_dk_tensor : string, optional
-            Name of the tensors volume to be saved.
+            Name of the diffusion tensor volume to be saved.
         out_fa : string, optional
             Name of the fractional anisotropy volume to be saved.
         out_ga : string, optional
@@ -1710,6 +1708,8 @@ class ReconstDkiFlow(Workflow):
             Name of the eigenvectors volume to be saved.
         out_eval : string, optional
             Name of the eigenvalues to be saved.
+        out_dk_tensor : string, optional
+            Name of the kurtosis tensor volume to be saved.
         out_mk : string, optional
             Name of the mean kurtosis to be saved.
         out_ak : string, optional
@@ -2124,7 +2124,7 @@ class ReconstRUMBAFlow(Workflow):
             FA threshold to compute the WM response function.
         extract_pam_values : bool, optional
             Save or not to save pam volumes as single nifti files.
-        sh_order : int, optional
+        sh_order_max : int, optional
             Spherical harmonics order (l) used in the RUMBA fit.
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -1,13 +1,18 @@
+import inspect
 from pathlib import Path
 import sys
 
 import numpy.testing as npt
 
+from dipy.utils.optpkg import optional_package
 from dipy.workflows.base import (
     IntrospectiveArgumentParser,
     add_default_args_to_docstring,
+    get_args_default,
     none_or_dtype,
 )
+from dipy.workflows.cli import cli_flows
+from dipy.workflows.docstring_parser import NumpyDocString
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import (
     DummyCombinedWorkflow,
@@ -323,3 +328,34 @@ def test_add_default_args_to_docstring():
         "multiple lines of description.",
         "(default: 0.3)",
     ]
+
+
+def test_workflow_docstring_matches_signature():
+    # ``IntrospectiveArgumentParser.add_workflow`` pairs the ``run`` method
+    # signature with the doc string ``Parameters`` section by position, so an
+    # entry that is missing, extra or out of order silently assigns the wrong
+    # help text and default value to a command line argument.
+    mismatched = []
+    for cli_name, (mod_name, flow_name) in cli_flows.items():
+        mod, have_mod, _ = optional_package(mod_name)
+        if not have_mod:
+            continue
+
+        run_method = getattr(mod, flow_name).run
+        args, _ = get_args_default(run_method)
+        npds = NumpyDocString(inspect.getdoc(run_method))
+        documented_args = [param[0] for param in npds["Parameters"]]
+
+        if documented_args != args:
+            mismatched.append(
+                f"{cli_name} ({mod_name}.{flow_name}):"
+                f"\n  run() declares    {args}"
+                f"\n  doc string lists  {documented_args}"
+            )
+
+    npt.assert_equal(
+        mismatched,
+        [],
+        err_msg="Doc string parameters do not match the run method "
+        "signature:\n" + "\n".join(mismatched),
+    )

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -331,10 +331,10 @@ def test_add_default_args_to_docstring():
 
 
 def test_workflow_docstring_matches_signature():
-    # ``IntrospectiveArgumentParser.add_workflow`` pairs the ``run`` method
-    # signature with the doc string ``Parameters`` section by position, so an
-    # entry that is missing, extra or out of order silently assigns the wrong
-    # help text and default value to a command line argument.
+    # ``IntrospectiveArgumentParser.add_workflow`` documents each command line
+    # argument with the docstring ``Parameters`` entry in the same position, so
+    # an entry that is missing, extra or out of order silently attaches the
+    # wrong help text and default value to an argument.
     mismatched = []
     for cli_name, (mod_name, flow_name) in cli_flows.items():
         mod, have_mod, _ = optional_package(mod_name)
@@ -349,13 +349,13 @@ def test_workflow_docstring_matches_signature():
         if documented_args != args:
             mismatched.append(
                 f"{cli_name} ({mod_name}.{flow_name}):"
-                f"\n  run() declares    {args}"
-                f"\n  doc string lists  {documented_args}"
+                f"\n  arguments  {args}"
+                f"\n  documented {documented_args}"
             )
 
     npt.assert_equal(
         mismatched,
         [],
-        err_msg="Doc string parameters do not match the run method "
-        "signature:\n" + "\n".join(mismatched),
+        err_msg="Docstring parameters do not match the command line "
+        "arguments:\n" + "\n".join(mismatched),
     )


### PR DESCRIPTION
## Description

`dipy_fit_dki --help` prints the wrong description, and the wrong default value, for ten of its output arguments. `--out_fa` is described as the kurtosis tensor output, `--out_ga` as fractional anisotropy, `--out_rgb` as geodesic anisotropy, and so on through `--out_dk_tensor`.

`IntrospectiveArgumentParser.add_workflow` pairs the `run` method signature with the doc string `Parameters` section **by position** — the flag name comes from the signature, while the type and help text come from `self.doc[i]`:

```python
args, defaults = get_args_default(workflow.run)
...
for i, arg in enumerate(args):
    typestr = self.doc[i][1]
    help_msg = _strip_rst_markup("\n".join(self.doc[i][2]))
    _args = [f"{prefix}{arg}"]
```

The only guard was a length check, so an out-of-order entry was accepted silently.

`ReconstDkiFlow.run` declares `out_dk_tensor` after `out_eval`, but documented it immediately after `out_dt_tensor`, shifting the ten entries in between by one position.

The wrong default is shown too: `add_default_args_to_docstring` appends `(default: ...)` by matching on the **parameter name**, while the entry is rendered by **position**. So `--out_fa` advertises `(default: dki_tensors.nii.gz)` while argparse's real default is `fa.nii.gz`.

Replaying DIPY's own `NumpyDocString` parser and the pairing logic above against `ReconstDkiFlow` on current `master`:

```
CLI flag           help text taken from   first line of that help
--out_dt_tensor    out_dt_tensor          Name of the tensors volume to be saved.
--out_fa           out_dk_tensor          Name of the tensors volume to be saved.       <-- wrong
--out_ga           out_fa                 Name of the fractional anisotropy volume      <-- wrong
--out_rgb          out_ga                 Name of the geodesic anisotropy volume        <-- wrong
--out_md           out_rgb                Name of the color fa volume to be saved.      <-- wrong
--out_ad           out_md                 Name of the mean diffusivity volume           <-- wrong
--out_rd           out_ad                 Name of the axial diffusivity volume          <-- wrong
--out_mode         out_rd                 Name of the radial diffusivity volume         <-- wrong
--out_evec         out_mode               Name of the mode volume to be saved.          <-- wrong
--out_eval         out_evec               Name of the eigenvectors volume               <-- wrong
--out_dk_tensor    out_eval               Name of the eigenvalues to be saved.          <-- wrong
--out_mk           out_mk                 Name of the mean kurtosis to be saved.
```

### Changes

- **`workflows/base.py`** — added a name/order check beside the existing length check in `add_workflow`, so this class of drift raises an error naming the offending positions instead of producing misleading help. This matches the adjacent length check, which already raises.
- **`workflows/reconst.py`** — moved the `out_dk_tensor` entry to its position in the signature. Also gave the two tensor outputs descriptions that tell them apart: both read *"Name of the tensors volume to be saved"*, which is what allowed the shift to go unnoticed. `out_dt_tensor` saves `lower_triangular(dkfit.quadratic_form)` (diffusion tensor) and `out_dk_tensor` saves `dkfit.kt` (kurtosis tensor).
- **`workflows/reconst.py`** — `ReconstRUMBAFlow` still documented `sh_order`, renamed to `sh_order_max` in 1.9 via `@deprecated_params`. This flow is not in `cli_flows`, so that one is a documentation fix only.
- **`workflows/io.py`** — `ConcatenateTractogramFlow` documented `tractogram_list`; the signature declares `tractogram_files`.
- **`workflows/tests/test_iap.py`** — regression test.

## Motivation and Context

Users reading `dipy_fit_dki --help` are told the wrong thing about ten output options, including wrong default filenames. Because the pairing is positional and only the count was validated, nothing flagged it.

I found this while checking every workflow `run` doc string against its signature; `dipy_fit_dki` and `dipy_concatenate_tractograms` were the two CLI-registered flows affected.

I did not open an issue first — happy to file one if you would prefer that for tracking.

## How Has This Been Tested?

Added `test_workflow_docstring_matches_signature` in `dipy/workflows/tests/test_iap.py`. It walks the `cli_flows` registry and asserts each `run` doc string lists the same parameters in the same order as the signature, resolving modules with `optional_package` the same way `cli.py` does so absent optional dependencies do not fail the run.

- Fails on unpatched `master`, reporting 2 workflows (`dipy_fit_dki`, `dipy_concatenate_tractograms`)
- Passes with this change, 61 workflows checked
- `ruff format` reports no changes needed; `ruff check` adds no new findings (the 28 pre-existing findings in `reconst.py` are identical before and after)
- `codespell` clean

**One caveat, in the interest of full disclosure:** I could not execute the pytest suite locally. DIPY's compiled extensions fail to import in my environment on Python 3.14 with `KeyError: '__reduce_cython__'`, and I could not build from source on this machine. I validated the test's comparison logic against the repository source by driving DIPY's own `NumpyDocString` parser and the `cli_flows` registry directly, which is how I confirmed the fail-before / pass-after result above. CI here is the authoritative check, and I will fix anything it turns up.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally. *(see the caveat above — not run locally)*
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure

### One note on the new check

`add_workflow` now raises on a name mismatch as well as a count mismatch. That is deliberate — it makes the failure loud at parser-construction time rather than silently misinforming users — but it does mean a third-party workflow whose doc string has drifted would now raise where it previously did not. If you would rather this warn than raise, say the word and I will switch it.
