### PR TITLE
STYLE: Honor object in variable name

### DIFF
--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -206,26 +206,26 @@ def io_tractogram(tmp_path, extension):
 @pytest.mark.parametrize("space,origin", list(itertools.product(SPACES, ORIGINS)))
 def test_vtk_matching_space(tmp_path, space, origin):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
-    sfs = load_tractogram(
+    sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.vtk"],
         FILEPATH_DIX["gs_volume.nii"],
         from_space=Space.LPSMM,
     )
-    sfs.to_rasmm()
-    sfs.to_center()
-    ref_coords = sfs.streamlines._data.copy()
+    sft.to_rasmm()
+    sft.to_center()
+    ref_coords = sft.streamlines._data.copy()
 
-    save_tractogram(sfs, tmp_path / "tmp.vtk", to_space=space, to_origin=origin)
-    sfs = load_tractogram(
+    save_tractogram(sft, tmp_path / "tmp.vtk", to_space=space, to_origin=origin)
+    sft = load_tractogram(
         tmp_path / "tmp.vtk",
         FILEPATH_DIX["gs_volume.nii"],
         from_space=space,
         from_origin=origin,
     )
 
-    sfs.to_rasmm()
-    sfs.to_center()
-    save_coords = sfs.streamlines._data.copy()
+    sft.to_rasmm()
+    sft.to_center()
+    save_coords = sft.streamlines._data.copy()
     npt.assert_almost_equal(ref_coords, save_coords, decimal=5)
 
 


### PR DESCRIPTION
## Description

Honor object in variable name: use `sft` as a name for a `StatefulTractogram` object. Increases consistency with the rest of the code.

## Motivation and Context

Style.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
