### PR TITLE
STYLE: Lint Cython files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.21.0
+    hooks:
+    -   id: cython-lint
+    -   id: double-quote-cython-strings
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,3 +253,6 @@ filterwarnings = [
     "ignore:.*np.find_common_type is deprecated.*:DeprecationWarning:scipy",
     "ignore:.*`product` is deprecated.*:DeprecationWarning:h5py"
 ]
+
+[tool.cython-lint]
+max-line-length = 88


### PR DESCRIPTION
## Description

Lint Cython files using the `MarcoGorelli/cython-lint` pre-commit hook. Add the corresponding hook to `.pre-commit-config.yaml` so that the linting takes place before every commit/necessary changes can be shown by the corresponding CI.

## Motivation and Context

Improves readability and consistncy of the Cython code.

## How Has This Been Tested?

Relying on the GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
