### PR TITLE
Polyxios adoption

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       runs-on: '["ubuntu-latest", ]'
       coverage: true
       enable-viz-tests: true
-      extra-depends: scikit-learn scipy statsmodels pandas tables fury tensorflow==2.18 torch
+      extra-depends: scikit-learn scipy statsmodels pandas tables fury polyxios tensorflow==2.18 torch
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test_viz.yml
+++ b/.github/workflows/test_viz.yml
@@ -24,5 +24,5 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
-      extra-depends: scikit_learn vtk fury scipy
+      extra-depends: scikit_learn vtk fury polyxios scipy
       enable-viz-tests: true

--- a/dipy/io/stateful_surface.py
+++ b/dipy/io/stateful_surface.py
@@ -13,10 +13,46 @@ from dipy.io.utils import (
     is_header_compatible,
     is_reference_info_valid,
 )
-from dipy.io.vtk import convert_to_polydata
+from dipy.utils.optpkg import optional_package
+
+px, have_polyxios, setup_module = optional_package("polyxios", min_version="0.2.0")
 
 logger = logging.getLogger("StatefulSurface")
 logger.setLevel(level=logging.INFO)
+
+
+def convert_to_polydata(vertices, triangles, data_per_point=None):
+    """Convert vertices and triangles to a polyxios PolyData.
+
+    Parameters
+    ----------
+    vertices : numpy.ndarray
+        An array of shape (n_vertices, 3) containing the vertex coordinates.
+    triangles : numpy.ndarray
+        An array of shape (n_triangles, 3) containing the vertex indices
+        of the triangles.
+    data_per_point : dict, optional
+        A dictionary where keys are array names and values are numpy arrays
+        of shape (n_vertices, ...) representing data associated with each
+        vertex.
+
+    Returns
+    -------
+    polydata : polyxios.PolyData
+    """
+    vertices = np.asarray(vertices, dtype=np.float64)
+    triangles = np.asarray(triangles, dtype=np.int32)
+
+    vertex_attrs = {}
+    if data_per_point is not None:
+        for name, array in data_per_point.items():
+            array = np.asarray(array)
+            if len(array) != len(vertices):
+                raise ValueError("Array length does not match number of points.")
+            vertex_attrs[name] = array
+
+    element_groups = [("triangle", triangles.reshape(-1, 3))] if triangles.size else []
+    return px.make_polydata(vertices, element_groups, vertex_attrs=vertex_attrs)
 
 
 def set_sfs_logger_level(log_level):
@@ -378,6 +414,7 @@ class StatefulSurface:
         return self._vertices.copy()
 
     def get_polydata(self):
+        """Build a polyxios PolyData from the surface."""
         return convert_to_polydata(self._vertices, self._faces, self._data_per_vertex)
 
     @vertices.setter

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from pathlib import Path
 import time
 
 import nibabel as nib
@@ -16,9 +17,152 @@ from dipy.io.utils import (
     is_header_compatible,
     split_filename_extension,
 )
-from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines
 from dipy.testing.decorators import warning_for_keywords
+from dipy.tracking.streamline import transform_streamlines
 from dipy.utils.logging import logger
+from dipy.utils.optpkg import optional_package
+
+px, have_polyxios, setup_module = optional_package("polyxios", min_version="0.2.0")
+
+if have_polyxios:
+    from polyxios._element_types import ELEMENT_TYPES
+
+
+def _polyxios_format(filename):
+    """Name the codec for a suffix polyxios does not register, else None.
+
+    A ``.fib`` file is a legacy VTK file that tractography tools happen to
+    name differently. polyxios picks its codec from the extension and only
+    registers ``.vtk``, so that one has to be asked for by name.
+    """
+    return ".vtk" if Path(filename).suffix.lower() == ".fib" else None
+
+
+def convert_to_polydata_lines(lines):
+    """Convert a list of lines to a polyxios PolyData.
+
+    Parameters
+    ----------
+    lines : list
+        list of 2D arrays or ArraySequence, each of shape (n_points, 3).
+
+    Returns
+    -------
+    polydata : polyxios.PolyData
+        One ``poly_line`` element per input line, in the order given.
+    """
+    lines = [np.asarray(line, dtype=np.float64) for line in lines]
+    lengths = np.array([len(line) for line in lines], dtype=np.int64)
+
+    if len(lines):
+        vertices = np.concatenate(lines, axis=0)
+    else:
+        vertices = np.empty((0, 3), dtype=np.float64)
+
+    idx_dtype = np.int64 if len(vertices) >= 2**31 else np.int32
+    offsets = np.zeros(len(lengths) + 1, dtype=idx_dtype)
+    offsets[1:] = np.cumsum(lengths)
+
+    return px.PolyData(
+        vertices=vertices,
+        connectivity=np.arange(len(vertices), dtype=idx_dtype),
+        offsets=offsets,
+        element_types=np.full(len(lengths), ELEMENT_TYPES["poly_line"], dtype=np.uint8),
+    )
+
+
+def get_polydata_lines(polydata):
+    """Get the lines of a polyxios PolyData as a list of coordinate arrays.
+
+    Parameters
+    ----------
+    polydata : polyxios.PolyData
+
+    Returns
+    -------
+    lines : list of numpy.ndarray
+        One array of shape (n_points, 3) per line.
+
+    Notes
+    -----
+    A PolyData holding no line element falls back to its raw connectivity,
+    which is what keeps a tractogram saved as ``.vtp`` readable: the polyxios
+    VTP writer files every element under ``Polys``.
+
+    """
+    vertices = polydata.vertices
+    indices = polydata.lines
+    if indices is None:
+        offsets = polydata.offsets
+        indices = [
+            polydata.connectivity[offsets[i] : offsets[i + 1]]
+            for i in range(len(polydata.element_types))
+        ]
+    return [vertices[idx] for idx in indices]
+
+
+@warning_for_keywords()
+def save_vtk_streamlines(streamlines, filename, *, to_lps=True, binary=False):
+    """Save streamlines as polydata to a supported format file.
+
+    File formats can be VTK, VTP and FIB.
+
+    Parameters
+    ----------
+    streamlines : list
+        list of 2D arrays or ArraySequence
+    filename : string or Path
+        output filename (.vtk, .vtp or .fib)
+    to_lps : bool
+        Default to True, will follow the vtk file convention for streamlines
+        Will be supported by MITKDiffusion and MI-Brain
+    binary : bool
+        save the file as binary
+
+    """
+    if to_lps:
+        to_lps = np.eye(4)
+        to_lps[0, 0] = -1
+        to_lps[1, 1] = -1
+        streamlines = transform_streamlines(streamlines, to_lps)
+
+    fmt = _polyxios_format(filename)
+    opts = {"binary": binary}
+    if (fmt or Path(filename).suffix.lower()) == ".vtk":
+        opts["vtk_version"] = "4.2"
+
+    px.write(convert_to_polydata_lines(streamlines), str(filename), fmt=fmt, **opts)
+
+
+@warning_for_keywords()
+def load_vtk_streamlines(filename, *, to_lps=True):
+    """Load streamlines from polydata.
+
+    Load formats can be VTK, VTP and FIB.
+
+    Parameters
+    ----------
+    filename : string or Path
+        input filename (.vtk, .vtp or .fib)
+    to_lps : bool
+        Default to True, will follow the vtk file convention for streamlines
+        Will be supported by MITK-Diffusion and MI-Brain
+
+    Returns
+    -------
+    output :  list
+         list of 2D arrays
+
+    """
+    polydata = px.read(str(filename), fmt=_polyxios_format(filename))
+    lines = get_polydata_lines(polydata)
+    if to_lps:
+        to_lps = np.eye(4)
+        to_lps[0, 0] = -1
+        to_lps[1, 1] = -1
+        return transform_streamlines(lines, to_lps)
+
+    return lines
 
 
 @warning_for_keywords()

--- a/dipy/io/surface.py
+++ b/dipy/io/surface.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
+from dataclasses import replace
 import gzip
-import logging
 from pathlib import Path
 import time
 
@@ -14,22 +14,83 @@ from dipy.io.utils import (
     get_reference_info,
     split_filename_extension,
 )
-from dipy.io.vtk import (
-    get_polydata_triangles,
-    get_polydata_vertices,
-    load_polydata,
-    save_polydata,
-)
 from dipy.testing.decorators import warning_for_keywords
+from dipy.utils.logging import logger
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
+px, have_polyxios, setup_module = optional_package("polyxios", min_version="0.2.0")
 
-if have_vtk:
-    import vtk
-    import vtk.util.numpy_support as ns
+COLOR_ARRAY_NAME = "colors"
+
+
+def load_polydata(file_name):
+    """Load a polydata from a supported format file.
+
+    Supported file formats are OBJ, VTK, VTP, PLY and STL.
+
+    Parameters
+    ----------
+    file_name : string or Path
+
+    Returns
+    -------
+    output : polyxios.PolyData
+
+    """
+    return px.read(str(file_name))
+
+
+@warning_for_keywords()
+def save_polydata(polydata, file_name, *, binary=False, color_array_name=None):
+    """Save a polydata to a supported format file.
+
+    Save formats can be OBJ, VTK, VTP, PLY and STL.
+
+    Parameters
+    ----------
+    polydata : polyxios.PolyData
+        The polydata object to be saved.
+    file_name : string or Path
+        The output filename (.obj, .vtk, .vtp, .ply and .stl)
+    binary : bool, optional
+        Save the file in binary format.
+    color_array_name : str, optional
+        Name of the vertex attribute holding the colors. It is written under
+        the name readers pick colors up from, so that it survives the
+        round-trip. Every other vertex attribute is written under its own.
+    """
+    if color_array_name is not None and color_array_name in polydata.vertex_attrs:
+        vertex_attrs = dict(polydata.vertex_attrs)
+        vertex_attrs[COLOR_ARRAY_NAME] = vertex_attrs.pop(color_array_name)
+        polydata = replace(polydata, vertex_attrs=vertex_attrs)
+
+    opts = {"binary": binary}
+    if Path(file_name).suffix.lower() == ".vtk":
+        opts["vtk_version"] = "4.2"
+
+    px.write(polydata, str(file_name), **opts)
+
+
+def get_polydata_vertices(polydata):
+    """Get the (n_vertices, 3) vertex coordinates of a polyxios PolyData."""
+    return polydata.vertices
+
+
+def get_polydata_triangles(polydata):
+    """Get the (n_triangles, 3) vertex indices of a polyxios PolyData.
+
+    A surface element that is not a triangle is triangulated: a quad splits
+    in two, a polygon is fanned.
+    """
+    triangles = polydata.faces
+    if triangles is None:
+        return np.empty((0, 3), dtype=np.int32)
+    return triangles
+
+
+def get_polydata_vertex_attrs(polydata):
+    """Get every per-vertex array of a polyxios PolyData, keyed by name."""
+    return dict(polydata.vertex_attrs)
 
 
 def load_surface(
@@ -85,20 +146,20 @@ def load_surface(
     vtk_ext = [".vtk", ".vtp", ".obj", ".stl", ".ply"]
     freesurfer_ext = [".gii", ".gii.gz", ".pial", ".nofix", ".orig", ".smoothwm", ".T1"]
 
-    name, ext = split_filename_extension(fname)
+    _, ext = split_filename_extension(fname)
     if ext.lower() not in freesurfer_ext + vtk_ext:
-        logging.error("Input extension is not one of the supported format.")
+        logger.error("Input extension is not one of the supported format.")
         return False
 
     if to_space not in Space:
-        logging.error(
+        logger.error(
             f"Space MUST be one of the {len(Space)} choices:"
             f" {list(Space.__members__.keys())}."
         )
         return False
 
     if to_origin not in Origin:
-        logging.error(
+        logger.error(
             f"Origin MUST be one of the {len(Origin)} choices:"
             f" {list(Origin.__members__.keys())}."
         )
@@ -108,7 +169,7 @@ def load_surface(
         if ext in [".gii", ".gii.gz"]:
             reference = fname
         else:
-            logging.error(
+            logger.error(
                 'Reference must be provided, "same" is only available for GII file.'
             )
             return False
@@ -126,25 +187,14 @@ def load_surface(
         data = load_polydata(fname)
         vertices = get_polydata_vertices(data)
         faces = get_polydata_triangles(data)
-        vertex_data = data.GetPointData()
-        scalar_names = [
-            vertex_data.GetArrayName(i) for i in range(vertex_data.GetNumberOfArrays())
-        ]
-        if scalar_names:
-            for name in scalar_names:
-                scalar = data.GetPointData().GetScalars(name)
-                if name in data_per_vertex:
-                    logging.warning(
-                        f"Scalar {name} already in data_per_vertex, overwriting"
-                    )
-                data_per_vertex[name] = ns.vtk_to_numpy(scalar)
+        data_per_vertex = get_polydata_vertex_attrs(data) or None
     else:
         data = load_pial(fname, return_meta=True)
         data, metadata = data[0:2], data[2]
 
         data = (apply_freesurfer_transform(data[0], reference, inv=True), data[1])
         if from_space is not None or from_origin is not None:
-            logging.warning(
+            logger.warning(
                 "from_space and from_origin are ignored when loading pial files."
             )
         from_space = Space.RASMM
@@ -167,7 +217,7 @@ def load_surface(
     elif isinstance(metadata, nib.filebasedimages.FileBasedHeader):
         sfs.gii_header = metadata
 
-    logging.debug(
+    logger.debug(
         f"Load {fname} with {len(sfs)} vertices in {round(time.time() - timer, 3)}"
         f" seconds."
     )
@@ -214,7 +264,8 @@ def save_surface(
             NIFTI standard, default (center of the voxel)
             TRACKVIS standard (corner of the voxel)
     legacy_vtk_format : bool, optional
-        Whether to save the file in legacy VTK format or not.
+        Kept for backward compatibility and ignored: polyxios always writes
+        the classic VTK 4.2 layout, which every VTK reader takes.
     bbox_valid_check : bool, optional
         Verification for negative voxel coordinates or values above the
         volume dimensions. Default is True, to enforce valid file.
@@ -250,9 +301,9 @@ def save_surface(
         sfs.to_space(to_space)
         sfs.to_origin(to_origin)
 
+        color_array_name = None
         if sfs.data_per_vertex is not None:
             # Check if rgb, colors, colors, etc. are available
-            color_array_name = None
             for key in ["rgb", "colors", "color"]:
                 if key in sfs.data_per_vertex:
                     color_array_name = key
@@ -261,26 +312,10 @@ def save_surface(
                     color_array_name = key.upper()
                     break
 
-        polydata = sfs.get_polydata()
-        if color_array_name is not None:
-            color_array = sfs.data_per_vertex[color_array_name]
-            if len(color_array) != polydata.GetNumberOfPoints():
-                raise ValueError("Array length does not match number of vertices.")
-            vtk_array = ns.numpy_to_vtk(
-                np.array(color_array), deep=True, array_type=vtk.VTK_UNSIGNED_CHAR
-            )
-            vtk_array.SetName("RGB")
-
-            if "normal" in color_array_name.lower():
-                polydata.GetPointData().SetNormals(vtk_array)
-            else:
-                try:
-                    polydata.GetPointData().SetScalars(vtk_array)
-                except ValueError:
-                    polydata.GetPointData().AddArray(vtk_array)
-
         save_polydata(
-            polydata, fname, legacy_vtk_format=legacy_vtk_format, color_array_name="RGB"
+            sfs.get_polydata(),
+            fname,
+            color_array_name=color_array_name,
         )
     elif ext in [".gii", ".gii.gz"]:
         if not hasattr(sfs, "gii_header") and ref_gii is None:
@@ -320,7 +355,7 @@ def save_surface(
             metadata = sfs.fs_metadata
 
         if to_space is not None or to_origin is not None:
-            logging.warning(
+            logger.warning(
                 "to_space and to_origin are ignored when loading pial files."
             )
         sfs.to_space(Space.RASMM)
@@ -330,7 +365,7 @@ def save_surface(
 
         save_pial(fname, vertices, sfs.faces, metadata=metadata)
     else:
-        logging.error("Output extension is not one of the supported format.")
+        logger.error("Output extension is not one of the supported format.")
 
     sfs.to_space(old_space)
     sfs.to_origin(old_origin)
@@ -358,7 +393,7 @@ def load_pial(fname, *, return_meta=False):
     except ValueError:
         try:
             data = nib.freesurfer.read_geometry(fname, read_metadata=False)
-            logging.warning("No metadata found, please use a pial file with metadata.")
+            logger.warning("No metadata found, please use a pial file with metadata.")
         except ValueError:
             raise ValueError(f"{fname} provided does not have geometry data.") from None
 

--- a/dipy/io/tests/test_stateful_surface.py
+++ b/dipy/io/tests/test_stateful_surface.py
@@ -12,9 +12,8 @@ from dipy.io.utils import Origin, Space, recursive_compare
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
+_, have_polyxios, _ = optional_package("polyxios", min_version="0.2.0")
+
 SPACES = [Space.LPSMM, Space.RASMM, Space.VOXMM, Space.VOX]
 ORIGINS = [Origin.NIFTI, Origin.TRACKVIS]
 
@@ -240,7 +239,7 @@ def test_random_space_transformations(rng=None):
     npt.assert_array_almost_equal(initial_vertices, sfs.vertices, decimal=5)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("space, origin", list(itertools.product(SPACES, ORIGINS)))
 def test_space_origin_gold_standard(space, origin):
     fname = FILEPATH_DIX[f"gs_mesh_{space.value.lower()}_{origin.value.lower()}.ply"]
@@ -281,7 +280,7 @@ def test_equivalent_gii():
     npt.assert_allclose(vertices, sfs.vertices, atol=1e-3, rtol=1e-6)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_create_from_sfs():
     sfs_1 = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -308,7 +307,7 @@ def test_create_from_sfs():
         )
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_init_dtype_dict_attributes():
     sfs = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -325,7 +324,7 @@ def test_init_dtype_dict_attributes():
         npt.assert_(False, msg=e)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_set_dtype_dict_attributes():
     sfs = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -346,7 +345,7 @@ def test_set_dtype_dict_attributes():
         npt.assert_(False, msg="dtype_dict should be identical after set.")
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_set_partial_dtype_dict_attributes():
     sfs = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -373,7 +372,7 @@ def test_set_partial_dtype_dict_attributes():
         )
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_non_existing_dtype_dict_attributes():
     sfs = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -395,7 +394,7 @@ def test_non_existing_dtype_dict_attributes():
         npt.assert_(True)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_from_sfs_dtype_dict_attributes():
     sfs = load_surface(
         FILEPATH_DIX["gs_mesh_rasmm_center.ply"], FILEPATH_DIX["gs_volume.nii"]
@@ -422,7 +421,7 @@ def test_from_sfs_dtype_dict_attributes():
         npt.assert_(False, msg="from_sfs() should not modify the dtype_dict.")
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("extension", ["vtk", "gii", "pial"])
 def test_save_load_many_times(tmp_path, extension):
     # Load initial surface

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -16,9 +16,8 @@ from dipy.io.utils import is_header_compatible, recursive_compare
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
+_, have_polyxios, _ = optional_package("polyxios", min_version="0.2.0")
+
 is_big_endian = "big" in sys.byteorder.lower()
 
 
@@ -63,7 +62,7 @@ def test_direct_trx_loading():
     npt.assert_allclose(sft.streamlines._data, tmp_points_vox, rtol=1e-04, atol=1e-06)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("ext, space", list(itertools.product(EXTENSIONS, SPACES)))
 def test_space_gold_standard(ext, space):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
@@ -246,7 +245,7 @@ def test_empty_sft_case():
     assert is_header_compatible(sft_1, sft_2)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires FURY")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("ext", EXTENSIONS)
 def test_iterative_saving_loading(tmp_path, ext):
     # VTK/FIB in the gold standard dataset are in LPSMM space.

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -7,15 +7,19 @@ import pytest
 
 from dipy.data import get_fnames
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
-from dipy.io.streamline import load_tractogram, load_trk, save_tractogram, save_trk
+from dipy.io.streamline import (
+    load_tractogram,
+    load_trk,
+    load_vtk_streamlines,
+    save_tractogram,
+    save_trk,
+    save_vtk_streamlines,
+)
 from dipy.io.utils import Origin, Space, create_nifti_header
-from dipy.io.vtk import load_vtk_streamlines, save_vtk_streamlines
 from dipy.tracking.streamline import Streamlines
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
+_, have_polyxios, _ = optional_package("polyxios", min_version="0.2.0")
 
 FILEPATH_DIX = None
 SPACES = [Space.RASMM, Space.LPSMM, Space.VOXMM, Space.VOX]
@@ -202,7 +206,7 @@ def io_tractogram(tmp_path, extension):
     npt.assert_array_almost_equal(sft.streamlines[1], STREAMLINE, decimal=4)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("space,origin", list(itertools.product(SPACES, ORIGINS)))
 def test_vtk_matching_space(tmp_path, space, origin):
     # VTK/FIB in the gold standard dataset are in LPSMM space.
@@ -234,13 +238,13 @@ def test_io_ext_non_vtk(tmp_path, ext):
     io_tractogram(tmp_path, ext)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("ext", ["vtk", "vtp"])
 def test_io_vtk(tmp_path, ext):
     io_tractogram(tmp_path, ext)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_low_io_vtk(tmp_path):
     fname = tmp_path / "test.fib"
 

--- a/dipy/io/tests/test_surface.py
+++ b/dipy/io/tests/test_surface.py
@@ -11,9 +11,7 @@ from dipy.io.surface import load_surface, save_surface
 from dipy.io.utils import Origin, Space
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
+_, have_polyxios, _ = optional_package("polyxios", min_version="0.2.0")
 
 FOLDERS_GII = ["ascii", "base64", "gzip_base64"]
 FILENAMES_GII = ["pial.L.surf.gii", "smoothwm.L.surf.gii"]
@@ -37,7 +35,7 @@ def setup_module():
         return
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_pial_load_save(tmp_path):
     data_raw = nib.freesurfer.read_geometry(FILEPATH_DIX["naf_lh.pial"])
 
@@ -54,7 +52,7 @@ def test_pial_load_save(tmp_path):
     npt.assert_almost_equal(data_raw[0], data_save[0], decimal=5)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize("space,origin", list(itertools.product(SPACES, ORIGINS)))
 def test_vtk_matching_space(tmp_path, space, origin):
     sfs = load_surface(
@@ -78,7 +76,7 @@ def test_vtk_matching_space(tmp_path, space, origin):
     npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize(
     "_type,fname,space,origin",
     list(itertools.product(FOLDERS_GII, FILENAMES_GII, SPACES, ORIGINS)),
@@ -105,7 +103,7 @@ def test_gifti_matching_space(tmp_path, _type, fname, space, origin):
     npt.assert_almost_equal(ref_vertices, save_vertices, decimal=5)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 @pytest.mark.parametrize(
     "dataset,hemisphere,type", list(itertools.product(FOLDERS, HEMISPHERES, TYPES))
 )

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -25,10 +25,7 @@ from dipy.io.utils import (
 from dipy.testing.decorators import set_random_number_generator
 from dipy.utils.optpkg import optional_package
 
-vtk, have_vtk, setup_module = optional_package(
-    "vtk", min_version="9.0.0", max_version="9.1.0"
-)
-
+_, have_polyxios, _ = optional_package("polyxios", min_version="0.2.0")
 
 FILEPATH_DIX = None
 
@@ -49,7 +46,7 @@ def teardown_module():
     FILEPATH_DIX = (None,)
 
 
-@pytest.mark.skipif(not have_vtk, reason="Requires VTK")
+@pytest.mark.skipif(not have_polyxios, reason="Requires polyxios")
 def test_equivalence_lpsmm_sft_sfs():
     sft = load_tractogram(
         FILEPATH_DIX["gs_streamlines.vtk"],

--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -1,281 +1,47 @@
-import numpy as np
+"""Deprecated. Polydata IO now lives beside the formats that use it.
 
-from dipy.testing.decorators import warning_for_keywords
-from dipy.tracking.streamline import transform_streamlines
-from dipy.utils.optpkg import optional_package
+VTK formats (.vtk, .vtp, .fib) are handled directly by :mod:`dipy.io.streamline`
+for tractograms and :mod:`dipy.io.surface` for surfaces, both through polyxios.
+This module only re-exports them and is removed in DIPY 2.0.
+"""
 
-fury, have_fury, setup_module = optional_package(
-    "fury", min_version="0.10.0", max_version="1.0.0"
+import warnings
+
+from dipy.io.stateful_surface import convert_to_polydata
+from dipy.io.streamline import (
+    convert_to_polydata_lines,
+    get_polydata_lines,
+    load_vtk_streamlines,
+    save_vtk_streamlines,
+)
+from dipy.io.surface import (
+    get_polydata_triangles,
+    get_polydata_vertex_attrs,
+    get_polydata_vertices,
+    load_polydata,
+    save_polydata,
 )
 
-vtk, have_vtk, _ = optional_package("vtk")
+__all__ = [
+    "convert_to_polydata",
+    "convert_to_polydata_lines",
+    "get_polydata_lines",
+    "get_polydata_triangles",
+    "get_polydata_vertex_attrs",
+    "get_polydata_vertices",
+    "load_polydata",
+    "load_vtk_streamlines",
+    "save_polydata",
+    "save_vtk_streamlines",
+]
 
-if have_fury:
-    import fury.io
-    import fury.utils
-
-if have_vtk:
-    import vtk
-    import vtk.util.numpy_support as ns
-
-    DATATYPE_DICT = {
-        np.dtype("int8"): vtk.VTK_CHAR,
-        np.dtype("uint8"): vtk.VTK_UNSIGNED_CHAR,
-        np.dtype("int16"): vtk.VTK_SHORT,
-        np.dtype("uint16"): vtk.VTK_UNSIGNED_SHORT,
-        np.dtype("int32"): vtk.VTK_INT,
-        np.dtype("uint32"): vtk.VTK_UNSIGNED_INT,
-        np.dtype("int64"): vtk.VTK_LONG_LONG,
-        np.dtype("uint64"): vtk.VTK_UNSIGNED_LONG_LONG,
-        np.dtype("float32"): vtk.VTK_FLOAT,
-        np.dtype("float64"): vtk.VTK_DOUBLE,
-    }
-
-
-def load_polydata(file_name):
-    """Load a vtk polydata to a supported format file.
-
-    Supported file formats are OBJ, VTK, VTP, FIB, PLY, STL and XML
-
-    Parameters
-    ----------
-    file_name : string or Path
-
-    Returns
-    -------
-    output : vtkPolyData
-
-    """
-    return fury.io.load_polydata(str(file_name))
-
-
-@warning_for_keywords()
-def save_polydata(
-    polydata, file_name, *, binary=False, color_array_name=None, legacy_vtk_format=False
-):
-    """Save a vtk polydata to a supported format file.
-
-    Save formats can be VTK, VTP, FIB, PLY, STL and XML.
-    Color array can be saved as well either by being already in the polydata
-    or by passing it as an argument (color_array).
-
-    Parameters
-    ----------
-    polydata : vtkPolyData
-        The polydata object to be saved.
-    file_name : string or Path
-        The output filename (.vtk, .fib, .ply, .stl and .xml)
-    binary : bool, optional
-        Save the file in binary format.
-    color_array_name : str, optional
-        Name of the color array to save.
-    legacy_vtk_format : bool, optional
-        Use legacy VTK file format. Only applied when fury >= 2.0
-        is installed.
-    """
-    # use kwargs for backward compatibility with fury < 2.0
-    kwargs = {}
-    if fury.__version__.split(".")[0] >= "2":
-        kwargs.update({"legacy_vtk_format": legacy_vtk_format})
-
-    fury.io.save_polydata(
-        polydata=polydata,
-        file_name=str(file_name),
-        binary=binary,
-        color_array_name=color_array_name,
-        **kwargs,
-    )
-
-
-@warning_for_keywords()
-def save_vtk_streamlines(streamlines, filename, *, to_lps=True, binary=False):
-    """Save streamlines as vtk polydata to a supported format file.
-
-    File formats can be OBJ, VTK, VTP, FIB, PLY, STL and XML
-
-    Parameters
-    ----------
-    streamlines : list
-        list of 2D arrays or ArraySequence
-    filename : string or Path
-        output filename (.obj, .vtk, .fib, .ply, .stl and .xml)
-    to_lps : bool
-        Default to True, will follow the vtk file convention for streamlines
-        Will be supported by MITKDiffusion and MI-Brain
-    binary : bool
-        save the file as binary
-
-    """
-    if to_lps:
-        # ras (mm) to lps (mm)
-        to_lps = np.eye(4)
-        to_lps[0, 0] = -1
-        to_lps[1, 1] = -1
-        streamlines = transform_streamlines(streamlines, to_lps)
-
-    polydata, _ = fury.utils.lines_to_vtk_polydata(streamlines)
-    save_polydata(polydata, file_name=filename, binary=binary)
-
-
-@warning_for_keywords()
-def load_vtk_streamlines(filename, *, to_lps=True):
-    """Load streamlines from vtk polydata.
-
-    Load formats can be VTK, FIB
-
-    Parameters
-    ----------
-    filename : string or Path
-        input filename (.vtk or .fib)
-    to_lps : bool
-        Default to True, will follow the vtk file convention for streamlines
-        Will be supported by MITK-Diffusion and MI-Brain
-
-    Returns
-    -------
-    output :  list
-         list of 2D arrays
-
-    """
-    polydata = load_polydata(filename)
-    lines = fury.utils.get_polydata_lines(polydata)
-    if to_lps:
-        to_lps = np.eye(4)
-        to_lps[0, 0] = -1
-        to_lps[1, 1] = -1
-        return transform_streamlines(lines, to_lps)
-
-    return lines
-
-
-def get_polydata_triangles(polydata, dtype=None):
-    """Get triangles from a vtkPolyData object.
-
-    Parameters
-    ----------
-    polydata : vtkPolyData
-        The polydata object from which to extract triangles.
-    dtype : data-type, optional
-        The desired data type for the output triangles. If None, the default
-        data type will be used.
-    Returns
-    -------
-    triangles : numpy.ndarray
-        An array of shape (n_triangles, 3) containing the vertex indices
-        of the triangles.
-
-    """
-    vtk_polys = ns.vtk_to_numpy(polydata.GetPolys().GetData())
-    if len(vtk_polys) == 0:
-        nbr_cells = polydata.GetNumberOfCells()
-        triangles = []
-        for i in range(nbr_cells):
-            ids = polydata.GetCell(i).GetPointIds()
-            for j in range(ids.GetNumberOfIds() - 2):
-                triangles.append([ids.GetId(j), ids.GetId(j + 1), ids.GetId(j + 2)])  # noqa: PERF401
-        triangles = np.array(triangles)
-    else:
-        if not (vtk_polys[::4] == 3).all():
-            raise ValueError("Not all polygons are triangles")
-        triangles = np.vstack([vtk_polys[1::4], vtk_polys[2::4], vtk_polys[3::4]]).T
-    if dtype is not None:
-        return triangles.astype(dtype)
-    return triangles
-
-
-def get_polydata_vertices(polydata, dtype=None):
-    """Get vertices from a vtkPolyData object.
-
-    Parameters
-    ----------
-    polydata : vtkPolyData
-        The polydata object from which to extract vertices.
-    dtype : data-type, optional
-        The desired data type for the output vertices. If None, the default
-        data type will be used.
-    Returns
-    -------
-    vertices : numpy.ndarray
-        An array of shape (n_vertices, 3) containing the vertex coordinates.
-
-    """
-    vertices = ns.vtk_to_numpy(polydata.GetPoints().GetData())
-    if dtype is not None:
-        return vertices.astype(dtype)
-    return vertices
-
-
-def convert_to_polydata(vertices, triangles, data_per_point=None):
-    """Convert vertices and triangles to a vtkPolyData object.
-
-    Parameters
-    ----------
-    vertices : numpy.ndarray
-        An array of shape (n_vertices, 3) containing the vertex coordinates.
-    triangles : numpy.ndarray
-        An array of shape (n_triangles, 3) containing the vertex indices
-        of the triangles.
-    data_per_point : dict, optional
-        A dictionary where keys are array names and values are numpy arrays
-        of shape (n_vertices, ...) representing data associated with each
-        vertex.
-
-    Returns
-    -------
-    polydata : vtkPolyData
-        The resulting vtkPolyData object.
-    """
-    vtk_points = vtk.vtkPoints()
-    vtk_points.SetData(ns.numpy_to_vtk(vertices, deep=True))
-
-    vtk_triangles = np.hstack(np.c_[np.ones(len(triangles)).astype(int) * 3, triangles])
-    vtk_triangles = ns.numpy_to_vtkIdTypeArray(vtk_triangles, deep=True)
-    vtk_cells = vtk.vtkCellArray()
-    vtk_cells.SetCells(len(triangles), vtk_triangles)
-
-    polydata = vtk.vtkPolyData()
-    polydata.SetPoints(vtk_points)
-    polydata.SetPolys(vtk_cells)
-
-    if data_per_point is not None:
-        for name, array in data_per_point.items():
-            if len(array) != polydata.GetNumberOfPoints():
-                raise ValueError("Array length does not match number of points.")
-            vtk_array = _numpy_to_vtk_array(np.array(array), name=name)
-
-            if "normal" in name.lower():
-                polydata.GetPointData().SetNormals(vtk_array)
-            else:
-                polydata.GetPointData().AddArray(vtk_array)
-
-    return polydata
-
-
-def _numpy_to_vtk_array(array, name=None, dtype=None, deep=True):
-    """Convert a numpy array to a vtk array.
-
-    Parameters
-    ----------
-    array : numpy.ndarray
-        The input numpy array.
-    name : str, optional
-        The name to assign to the vtk array.
-    dtype : data-type, optional
-        The desired data type for the vtk array. If None, the default data
-        type of the numpy array will be used.
-    deep : bool, optional
-        If True, a deep copy of the data is made.
-
-    Returns
-    -------
-    vtk_array : vtkDataArray
-        The resulting vtk array.
-    """
-    if dtype is not None:
-        vtk_dtype = DATATYPE_DICT[np.dtype(dtype)]
-    else:
-        vtk_dtype = DATATYPE_DICT[np.dtype(array.dtype)]
-    vtk_array = ns.numpy_to_vtk(np.asarray(array), deep=True, array_type=vtk_dtype)
-    if name is not None:
-        vtk_array.SetName(name)
-    return vtk_array
+warnings.warn(
+    "dipy.io.vtk is deprecated and will be removed in DIPY 2.0. VTK formats "
+    "(.vtk, .vtp, .fib) are handled directly by dipy.io.streamline for "
+    "tractograms and dipy.io.surface for surfaces, both through polyxios. "
+    "Import from those modules instead.\n"
+    "* deprecated from version: 1.13\n"
+    "* Will be removed as of version: 2.0",
+    FutureWarning,
+    stacklevel=2,
+)

--- a/dipy/io/vtk.py
+++ b/dipy/io/vtk.py
@@ -5,43 +5,50 @@ for tractograms and :mod:`dipy.io.surface` for surfaces, both through polyxios.
 This module only re-exports them and is removed in DIPY 2.0.
 """
 
-import warnings
+import importlib
 
-from dipy.io.stateful_surface import convert_to_polydata
-from dipy.io.streamline import (
-    convert_to_polydata_lines,
-    get_polydata_lines,
-    load_vtk_streamlines,
-    save_vtk_streamlines,
-)
-from dipy.io.surface import (
-    get_polydata_triangles,
-    get_polydata_vertex_attrs,
-    get_polydata_vertices,
-    load_polydata,
-    save_polydata,
-)
+from dipy.utils.deprecator import deprecate_with_version
 
-__all__ = [
-    "convert_to_polydata",
-    "convert_to_polydata_lines",
-    "get_polydata_lines",
-    "get_polydata_triangles",
-    "get_polydata_vertex_attrs",
-    "get_polydata_vertices",
-    "load_polydata",
-    "load_vtk_streamlines",
-    "save_polydata",
-    "save_vtk_streamlines",
-]
+_NEW_LOCATIONS = {
+    "convert_to_polydata": "dipy.io.stateful_surface",
+    "convert_to_polydata_lines": "dipy.io.streamline",
+    "get_polydata_lines": "dipy.io.streamline",
+    "get_polydata_triangles": "dipy.io.surface",
+    "get_polydata_vertex_attrs": "dipy.io.surface",
+    "get_polydata_vertices": "dipy.io.surface",
+    "load_polydata": "dipy.io.surface",
+    "load_vtk_streamlines": "dipy.io.streamline",
+    "save_polydata": "dipy.io.surface",
+    "save_vtk_streamlines": "dipy.io.streamline",
+}
 
-warnings.warn(
-    "dipy.io.vtk is deprecated and will be removed in DIPY 2.0. VTK formats "
-    "(.vtk, .vtp, .fib) are handled directly by dipy.io.streamline for "
-    "tractograms and dipy.io.surface for surfaces, both through polyxios. "
-    "Import from those modules instead.\n"
-    "* deprecated from version: 1.13\n"
-    "* Will be removed as of version: 2.0",
-    FutureWarning,
-    stacklevel=2,
-)
+__all__ = list(_NEW_LOCATIONS)
+
+
+def __getattr__(name):
+    """Resolve a deprecated re-export from its new location.
+
+    Parameters
+    ----------
+    name : str
+        Name of the attribute being looked up on this module.
+
+    Returns
+    -------
+    callable
+        The re-exported function, wrapped so that calling it warns.
+
+    Raises
+    ------
+    AttributeError
+        If `name` is not one of the deprecated re-exports.
+    """
+    if name not in _NEW_LOCATIONS:
+        raise AttributeError(f"module 'dipy.io.vtk' has no attribute {name!r}")
+
+    module = _NEW_LOCATIONS[name]
+    return deprecate_with_version(
+        f"dipy.io.vtk is deprecated. Import '{name}' from {module} instead.",
+        since="1.13.0",
+        until="2.0.0",
+    )(getattr(importlib.import_module(module), name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ optional = [
     "scikit-image",
     "boto3",
     "numexpr",
+    "polyxios>=0.2.0",
 ]
 
 [project.urls]

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -37,3 +37,4 @@ cvxpy
 scikit-image
 boto3
 numexpr
+polyxios>=0.2.0

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -11,3 +11,4 @@ cvxpy
 scikit-image
 boto3
 numexpr
+polyxios>=0.2.0


### PR DESCRIPTION
## Description

This PR aims to provide the gateway for `polyxios` to replace `vtk` based file IO operations.

## Motivation and Context

DIPY currently uses VTK library to simply load_polydata from vtk based files. It brings a huge load for just that, while polyxios is super light weight and can handle all the popular vtk formats.

So, for DIPY 1.13.0 release we will keep `vtk.py`  with polyxios being used as backend but doing imports from `dipy.io.vtk` will trigger a deprecation warning.

## How Has This Been Tested?

All the existing test cases around these functionality works as it was. Causing no change in the user behavior.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
