### PR TITLE
STYLE: Remove unused package import statements from Cython code

### DIFF
--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -3,7 +3,7 @@ cimport numpy as cnp
 cimport cython
 
 from safe_openmp cimport have_openmp
-from cython.parallel import parallel, prange, threadid
+from cython.parallel import prange
 
 from scipy.spatial import KDTree
 from scipy.interpolate import interp1d


### PR DESCRIPTION
## Description

Remove unused package import statements from Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/tracking/fbcmeasures.pyx:6:29:
  'parallel' imported but unused
/home/runner/work/dipy/dipy/dipy/tracking/fbcmeasures.pyx:6:47:
  'threadid' imported but unused
```

raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
