### PR TITLE
STYLE: Remove multiple spaces after/before operator in Cython code

### DIFF
--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -797,7 +797,7 @@ cdef class RigidIsoScalingTransform3D(Transform):
         J[0, 0] = (-sc * ca * sb) * px * scale + (sc * sa) * py * scale + \
                   (sc * ca * cb) * pz * scale
         J[1, 0] = (cc * ca * sb) * px * scale + (-cc * sa) * py * scale + \
-                  (-cc * ca * cb) * pz  * scale
+                  (-cc * ca * cb) * pz * scale
         J[2, 0] = (sa * sb) * px * scale + ca * py * scale + \
                   (-sa * cb) * pz * scale
 
@@ -808,7 +808,7 @@ cdef class RigidIsoScalingTransform3D(Transform):
         J[2, 1] = (-ca * cb) * px * scale + (-ca * sb) * pz * scale
 
         J[0, 2] = (-sc * cb - cc * sa * sb) * px * scale + \
-                  (-cc * ca) * py  * scale + \
+                  (-cc * ca) * py * scale + \
                   (-sc * sb + cc * sa * cb) * pz * scale
         J[1, 2] = (cc * cb - sc * sa * sb) * px * scale + \
                   (-sc * ca) * py * scale + \

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -243,14 +243,14 @@ cdef void _trilinear_interpolation_iso(double *X,
     # the initial rectangular box for more on trilinear have a look here
     # https://en.wikipedia.org/wiki/Trilinear_interpolation
     # http://local.wasp.uwa.edu.au/~pbourke/miscellaneous/interpolation/index.html
-    W[0]=nd[0] * nd[1] * nd[2]
-    W[1]= d[0] * nd[1] * nd[2]
-    W[2]=nd[0] *  d[1] * nd[2]
-    W[3]=nd[0] * nd[1] *  d[2]
-    W[4]= d[0] *  d[1] * nd[2]
-    W[5]=nd[0] *  d[1] *  d[2]
-    W[6]= d[0] * nd[1] *  d[2]
-    W[7]= d[0] *  d[1] *  d[2]
+    W[0] = nd[0] * nd[1] * nd[2]
+    W[1] = d[0] * nd[1] * nd[2]
+    W[2] = nd[0] * d[1] * nd[2]
+    W[3] = nd[0] * nd[1] * d[2]
+    W[4] = d[0] * d[1] * nd[2]
+    W[5] = nd[0] * d[1] * d[2]
+    W[6] = d[0] * nd[1] * d[2]
+    W[7] = d[0] * d[1] * d[2]
     # indices
     # the indices give you the indices of the neighboring voxels (the corners
     # of the box) e.g. the qa coordinates

--- a/dipy/denoise/_bias_correction.pyx
+++ b/dipy/denoise/_bias_correction.pyx
@@ -265,7 +265,7 @@ def compute_tukey_weights(
     then applies the Tukey bisquare function::
 
         weights[i] *= (1 - (r_i / (c * MAD))^2)^2   if |r_i| < c * MAD
-        weights[i]  = 0                               otherwise
+        weights[i] = 0                               otherwise
 
     where ``MAD = median(|residuals|) / 0.6745``.
 

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -281,7 +281,7 @@ cdef cnp.npy_intp copy_block_3d(double * dest,
 
     for i in range(I):
         for j in range(J):
-            memcpy(&dest[i * J * K  + j * K], &source[i + min_i, j + min_j, min_k], K * sizeof(double))
+            memcpy(&dest[i * J * K + j * K], &source[i + min_i, j + min_j, min_k], K * sizeof(double))
 
     return 1
 

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -209,7 +209,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
             if fabs(self.k2) < self.k_small:
                 self.k2 = self.k_small
 
-            tmp_arclength  = arclength * arclength / 2.0
+            tmp_arclength = arclength * arclength / 2.0
 
             self.propagator[0] = arclength
             self.propagator[1] = self.k1 * tmp_arclength

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1500,7 +1500,7 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) noexcep
 
 
 @cython.cdivision(True)
-cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out) noexcept nogil:
+cdef inline void track_direct_flip_3dist(float *a1, float *b1,float *c1,float *a2, float *b2, float *c2, float *out) noexcept nogil:
     """ Calculate the euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
@@ -1833,7 +1833,7 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
     return C
 
 
-cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out):
+cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float *c1,float *a2, float *b2, float *c2, float *out):
     """ Calculate the average squared euclidean distance between two 3pt tracks
     both direct and flip are given as output
 

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -582,7 +582,7 @@ cdef void prepare_ptt_propagator(TrackerParameters params,
         if fabs(stream_data[25]) < params.ptt.k_small:  # k2
             stream_data[25] = params.ptt.k_small
 
-        tmp_arclength  = arclength * arclength / 2.0
+        tmp_arclength = arclength * arclength / 2.0
 
         # stream_data[10:18] -> propagator
         stream_data[11] = stream_data[24] * tmp_arclength


### PR DESCRIPTION
## Description

Remove multiople spaces after/before operator in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/transforms.pyx:800:39: E221
multiple spaces before operator
```

and similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
