### PR TITLE
STYLE: Add missing whitespace around modulo operator in Cython code

### DIFF
--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -65,10 +65,10 @@ cdef class Transform:
         """
         n = theta.shape[0]
         if n != self.number_of_parameters:
-            raise ValueError("Invalid number of parameters: %d"%(n,))
+            raise ValueError("Invalid number of parameters: %d" % (n,))
         m = x.shape[0]
         if m < self.dim:
-            raise ValueError("Invalid point dimension: %d"%(m,))
+            raise ValueError("Invalid point dimension: %d" % (m,))
         J = np.zeros((self.dim, n))
         ret = self._jacobian(theta, x, J)
         return np.asarray(J)
@@ -102,7 +102,7 @@ cdef class Transform:
         """
         n = len(theta)
         if n != self.number_of_parameters:
-            raise ValueError("Invalid number of parameters: %d"%(n,))
+            raise ValueError("Invalid number of parameters: %d" % (n,))
         T = np.eye(self.dim + 1)
         self._param_to_matrix(theta, T)
         return np.asarray(T)


### PR DESCRIPTION
## Description

Add missing whitespace around modulo operator in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/transforms.pyx:68:64: E228
missing whitespace around modulo operator
```
and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
