### PR TITLE
STYLE: Remove unused imports from Cyhon code (continuation)

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -4,11 +4,10 @@ cimport cython
 cimport numpy as cnp
 
 import numpy as np
-import warnings
 
 from libc.math cimport floor
 
-from scipy.interpolate import Rbf, RBFInterpolator
+from scipy.interpolate import RBFInterpolator
 
 from dipy.align.fused_types cimport floating, number
 

--- a/dipy/core/tests/test_math.pyx
+++ b/dipy/core/tests/test_math.pyx
@@ -1,6 +1,5 @@
 
 
-cimport numpy as cnp
 import numpy as np
 import numpy.testing as npt
 

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -9,7 +9,6 @@ discrete distribution (pmf) at each step of the tracking.
 """
 from random import random
 
-import numpy as np
 cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -18,7 +18,6 @@ References
 
 cimport numpy as cnp
 from libc.math cimport M_PI, pow, sin, cos, fabs
-from libc.stdlib cimport malloc, free
 
 from dipy.direction.probabilistic_direction_getter cimport \
         ProbabilisticDirectionGetter

--- a/dipy/reconst/_force_heap.pyx
+++ b/dipy/reconst/_force_heap.pyx
@@ -8,8 +8,6 @@ Uses Cython with OpenMP (prange) for parallel heap operations.
 
 cimport cython
 from cython.parallel cimport prange
-from libc.stdlib cimport malloc, free
-from libc.string cimport memcpy
 from libc.stdint cimport int64_t
 
 

--- a/dipy/reconst/_force_search.pyx
+++ b/dipy/reconst/_force_search.pyx
@@ -29,7 +29,6 @@ cdef extern from "force_src/distances.h" namespace "faiss" nogil:
 
 # Import heap functions from local module
 from dipy.reconst._force_heap cimport (
-    select_top_k_parallel,
     heap_init_parallel,
     heap_update_batch_parallel,
     heap_finalize_parallel

--- a/dipy/reconst/dirspeed.pyx
+++ b/dipy/reconst/dirspeed.pyx
@@ -12,7 +12,6 @@ cimport numpy as cnp
 import cython
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
-from libc.math cimport cos, M_PI, INFINITY
 
 from dipy.core.math cimport f_max, f_array_min
 from dipy.reconst.recspeed cimport local_maxima_c, search_descending_c, remove_similar_vertices_c

--- a/dipy/reconst/dkispeed.pyx
+++ b/dipy/reconst/dkispeed.pyx
@@ -10,7 +10,6 @@ This module contains Cython-optimized versions of computationally intensive
 DKI functions, particularly the mean kurtosis calculation.
 """
 
-cimport cython
 import numpy as np
 cimport numpy as cnp
 from libc.math cimport sqrt, fabs, atan, log

--- a/dipy/sims/_force_core.pyx
+++ b/dipy/sims/_force_core.pyx
@@ -12,8 +12,6 @@ Low-level signal generation for multi-compartment diffusion simulations.
 import numpy as np
 cimport numpy as cnp
 
-from libc.math cimport exp
-
 ctypedef cnp.float64_t DTYPE_t
 ctypedef cnp.uint8_t LABEL_t
 

--- a/dipy/sims/_multi_tensor_omp.pyx
+++ b/dipy/sims/_multi_tensor_omp.pyx
@@ -11,7 +11,6 @@ computation with optional OpenMP parallelization.
 """
 
 import numpy as np
-cimport numpy as cnp
 from libc.math cimport exp
 
 

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -9,7 +9,6 @@
 # cython: embedsignature=True
 
 cimport cython
-from cython.parallel import prange
 
 import numpy as np
 cimport numpy as cnp
@@ -32,8 +31,7 @@ from dipy.tracking.tractogen cimport prepare_pmf
 from dipy.tracking.tracker_parameters cimport TrackerParameters, TrackerStatus
 
 from libc.stdlib cimport malloc, free
-from libc.math cimport M_PI, pow, sin, cos, fabs
-from libc.stdio cimport printf
+from libc.math cimport pow, sin, cos, fabs
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double x)

--- a/dipy/tracking/tests/test_tractogen.pyx
+++ b/dipy/tracking/tests/test_tractogen.pyx
@@ -7,7 +7,7 @@ from scipy.stats import pearsonr
 from dipy.core.sphere import HemiSphere
 from dipy.data import get_fnames, get_sphere
 from dipy.direction.peaks import peaks_from_positions
-from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen
+from dipy.direction.pmf import SimplePmfGen
 from dipy.reconst.shm import sh_to_sf
 from dipy.tracking.tractogen import generate_tractogram
 from dipy.tracking.stopping_criterion import BinaryStoppingCriterion

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -4,7 +4,6 @@
 # cython: Nonecheck=False
 
 cimport ctime
-cimport cython
 from cython.parallel import prange
 import numpy as np
 cimport numpy as cnp
@@ -22,10 +21,7 @@ from dipy.tracking.stopping_criterion cimport (StreamlineStatus,
                                                VALIDSTREAMLIME,
                                                INVALIDSTREAMLIME)
 from dipy.tracking.tracker_parameters cimport (TrackerParameters,
-                                               TrackerStatus,
-                                               func_ptr)
-
-from nibabel.streamlines import ArraySequence as Streamlines
+                                               TrackerStatus)
 
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, memset
@@ -66,7 +62,7 @@ def generate_tractogram(double[:,::1] seed_positions,
 
     Yields
     ------
-    streamlines : Streamlines
+    streamlines : nibabel.streamlines.ArraySequence
         Streamlines generated from the seed points.
     seeds : ndarray, optional
         seed points associated with the generated streamlines.

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -5,7 +5,6 @@
 
 from dipy.utils.deprecator import deprecate_with_version
 
-from libc.stdio cimport printf
 cimport numpy as cnp
 
 


### PR DESCRIPTION
## Description

Remove unused imports from Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/direction/probabilistic_direction_getter.pyx:12:8:
'np' imported but unused
```

and other similar errors raised in:

Left behind in commit 4b7aee4.

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
