### PR TITLE
STYLE: Delete unused variables from `align` module Cython code

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -111,7 +111,7 @@ def _bundle_minimum_distance_matrix(double [:, ::1] static,
     """
 
     cdef:
-        cnp.npy_intp i=0, j=0, mov_i=0, mov_j=0
+        cnp.npy_intp i=0, j=0
         int threads_to_use = -1
 
     threads_to_use = determine_num_threads(num_threads)
@@ -317,7 +317,7 @@ def _bundle_minimum_distance_asymmetric(double [:, ::1] static,
 
     cdef:
         cnp.npy_intp i=0, j=0
-        double sum_i=0, sum_j=0, tmp=0
+        double sum_i=0, tmp=0
         double inf = np.finfo("f8").max
         double dist=0
         double * min_j
@@ -382,8 +382,6 @@ def distance_matrix_mdf(streamlines_a, streamlines_b):
         cnp.npy_intp i, j, lentA, lentB
     # preprocess tracks
     cdef:
-        cnp.npy_intp longest_track_len = 0, track_len
-        longest_track_lenA, longest_track_lenB
         cnp.ndarray[object, ndim=1] tracksA64
         cnp.ndarray[object, ndim=1] tracksB64
         cnp.ndarray[cnp.double_t, ndim=2] DM
@@ -406,12 +404,9 @@ def distance_matrix_mdf(streamlines_a, streamlines_b):
     cdef:
         cnp.float64_t *t1_ptr
         cnp.float64_t *t2_ptr
-        cnp.float64_t *min_buffer
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float64_t, ndim=2] t1, t2
-        cnp.npy_intp t1_len, t2_len
-        double d[2]
     t_len = tracksA64[0].shape[0]
 
     for i from 0 <= i < lentA:

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -182,7 +182,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
         cnp.npy_intp firstc, lastc, firstr, lastr, firsts, lasts
         cnp.npy_intp s, r, c, it, sides, sider, sidec
         double cnt
-        cnp.npy_intp ssss, sss, ss, rr, cc, prev_ss, prev_rr, prev_cc
+        cnp.npy_intp sss, ss, rr, cc, prev_ss, prev_rr, prev_cc
         double Imean, Jmean, IJprods, Isq, Jsq
         double[:, :, :, :] temp = np.zeros((2, nr, nc, 5), dtype=np.float64)
         floating[:, :, :, :] factors = np.zeros((ns, nr, nc, 5),

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -289,10 +289,10 @@ class ParzenJointHistogram:
         if not self.setup_called:
             self.setup(sval, mval)
 
-        energy = _compute_pdfs_sparse(sval, mval, self.smin, self.sdelta,
-                                      self.mmin, self.mdelta, self.nbins,
-                                      self.padding, self.joint,
-                                      self.smarginal, self.mmarginal)
+        _compute_pdfs_sparse(sval, mval, self.smin, self.sdelta,
+                             self.mmin, self.mdelta, self.nbins,
+                             self.padding, self.joint,
+                             self.smarginal, self.mmarginal)
 
     def update_gradient_dense(self, theta, transform, static, moving,
                               grid2world, mgradient, smask=None, mmask=None):

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -198,7 +198,6 @@ cpdef double iterate_residual_displacement_field_ssd_2d(
     ----------
     .. footbibliography::
     """
-    ftype = np.asarray(delta_field).dtype
     cdef:
         int NUM_NEIGHBORS = 4
         int* dRow = [-1, 0, 1,  0]
@@ -212,7 +211,7 @@ cpdef double iterate_residual_displacement_field_ssd_2d(
         double* y = [0, 0]
         double* A = [0, 0, 0]
 
-        double xx, yy, opt, nrm2, delta, sigmasq, max_displacement, det
+        double xx, yy, opt, nrm2, sigmasq, max_displacement, det
 
     max_displacement = 0
 
@@ -220,7 +219,6 @@ cpdef double iterate_residual_displacement_field_ssd_2d(
 
         for r in range(nrows):
             for c in range(ncols):
-                delta = delta_field[r, c]
                 sigmasq = sigmasq_field[r, c] if sigmasq_field is not None else 1
                 if target is None:
                     b[0] = delta_field[r, c] * grad[r, c, 0]
@@ -368,7 +366,6 @@ cpdef double iterate_residual_displacement_field_ssd_3d(
     ----------
     .. footbibliography::
     """
-    ftype = np.asarray(delta_field).dtype
     cdef:
         int NUM_NEIGHBORS = 6
         int* dSlice = [-1, 0, 0, 0,  0, 1]
@@ -382,8 +379,7 @@ cpdef double iterate_residual_displacement_field_ssd_3d(
         double* b = [0, 0, 0]
         double* d = [0, 0, 0]
         double* y = [0, 0, 0]
-        double* A = [0, 0, 0, 0, 0, 0]
-        double xx, yy, zz, opt, nrm2, delta, sigmasq, max_displacement
+        double xx, yy, zz, opt, nrm2, sigmasq, max_displacement
         cnp.npy_intp dr, ds, dc, s, r, c
     max_displacement = 0
 
@@ -395,7 +391,6 @@ cpdef double iterate_residual_displacement_field_ssd_3d(
                     g[0] = grad[s, r, c, 0]
                     g[1] = grad[s, r, c, 1]
                     g[2] = grad[s, r, c, 2]
-                    delta = delta_field[s, r, c]
                     sigmasq = sigmasq_field[s, r, c] if sigmasq_field is not None else 1
                     if target is None:
                         b[0] = delta_field[s, r, c] * g[0]
@@ -708,7 +703,6 @@ cpdef compute_residual_displacement_field_ssd_2d(
                     b[1] = target[r, c, 1]
                 y[0] = 0  # reset y
                 y[1] = 0
-                nn=0
                 for k in range(NUM_NEIGHBORS):
                     dr = r + dRow[k]
                     if dr < 0 or dr >= nrows:

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -70,7 +70,7 @@ cdef class Transform:
         if m < self.dim:
             raise ValueError("Invalid point dimension: %d" % (m,))
         J = np.zeros((self.dim, n))
-        ret = self._jacobian(theta, x, J)
+        self._jacobian(theta, x, J)
         return np.asarray(J)
 
     def get_identity_parameters(self):

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -959,7 +959,7 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
         cnp.npy_intp nslices = out_shape[0]
         cnp.npy_intp nrows = out_shape[1]
         cnp.npy_intp ncols = out_shape[2]
-        cnp.npy_intp i, j, k, inside
+        cnp.npy_intp i, j, k
         double di, dj, dk, dii, djj, dkk
         floating[:] tmp = np.zeros((3,), dtype=np.asarray(d).dtype)
         floating[:, :, :, :] out = np.zeros(shape=(nslices, nrows, ncols, 3),
@@ -988,8 +988,7 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
                             <double>k, <double>i, <double>j, 1, affine_idx_in)
                         dj = _apply_affine_3d_x2(
                             <double>k, <double>i, <double>j, 1, affine_idx_in)
-                        inside = _interpolate_vector_3d[floating](d, dk, di,
-                                                                  dj, &tmp[0])
+                        _interpolate_vector_3d[floating](d, dk, di, dj, &tmp[0])
                         dkk = tmp[0]
                         dii = tmp[1]
                         djj = tmp[2]
@@ -1303,7 +1302,6 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
         double[:, :] out = np.zeros(shape=(n, 3), dtype=np.float64)
         double[:, :] _points = np.array(points, dtype=np.float64)
         double[:, :] in2grid
-        int inside
         floating[:] tmp = np.zeros(shape=(3,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
@@ -1340,7 +1338,7 @@ def warp_coordinates_3d(points,  floating[:, :, :, :] d1,
                 gz = z
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_3d[floating](d1, gx, gy, gz, &tmp[0])
+            _interpolate_vector_3d[floating](d1, gx, gy, gz, & tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -1379,7 +1377,6 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
         double[:, :] out = np.zeros(shape=(n, 2), dtype=np.float64)
         double[:, :] _points = np.array(points, dtype=np.float64)
         double[:, :] in2grid
-        int inside
         floating[:] tmp = np.zeros(shape=(2,), dtype=np.asarray(d1).dtype)
     # in2grid maps points to displacement's grid
     if in2world is None:  # then points are already in world coordinates
@@ -1410,7 +1407,7 @@ def warp_coordinates_2d(points,  floating[:, :, :] d1,
                 gy = y
 
             # Interpolate deformation field at (gx, gy, gz)
-            inside = _interpolate_vector_2d[floating](d1, gx, gy, &tmp[0])
+            _interpolate_vector_2d[floating](d1, gx, gy, & tmp[0])
 
             # Warp input point
             wx += tmp[0]
@@ -1649,13 +1646,8 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
         cnp.npy_intp nslices = ref_shape[0]
         cnp.npy_intp nrows = ref_shape[1]
         cnp.npy_intp ncols = ref_shape[2]
-        cnp.npy_intp nsVol = volume.shape[0]
-        cnp.npy_intp nrVol = volume.shape[1]
-        cnp.npy_intp ncVol = volume.shape[2]
-        cnp.npy_intp i, j, k, ii, jj, kk
-        int inside
-        double dkk, dii, djj, tmp0, tmp1
-        double alpha, beta, gamma, calpha, cbeta, cgamma
+        cnp.npy_intp i, j, k
+        double dkk, dii, djj
         floating[:, :, :] out = np.zeros(shape=(nslices, nrows, ncols),
                                          dtype=np.asarray(volume).dtype)
 
@@ -1675,8 +1667,7 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
                         dkk = <double>k
                         dii = <double>i
                         djj = <double>j
-                    inside = _interpolate_scalar_3d[floating](volume, dkk,
-                        dii, djj, &out[k, i, j])
+                    _interpolate_scalar_3d[floating](volume, dkk, dii, djj, &out[k, i, j])
     return np.asarray(out)
 
 
@@ -1904,12 +1895,8 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
         cnp.npy_intp nslices = ref_shape[0]
         cnp.npy_intp nrows = ref_shape[1]
         cnp.npy_intp ncols = ref_shape[2]
-        cnp.npy_intp nsVol = volume.shape[0]
-        cnp.npy_intp nrVol = volume.shape[1]
-        cnp.npy_intp ncVol = volume.shape[2]
-        double dkk, dii, djj, tmp0, tmp1
-        double alpha, beta, gamma, calpha, cbeta, cgamma
-        cnp.npy_intp k, i, j, kk, ii, jj
+        double dkk, dii, djj
+        cnp.npy_intp k, i, j
         number[:, :, :] out = np.zeros((nslices, nrows, ncols),
                                         dtype=np.asarray(volume).dtype)
 
@@ -2134,11 +2121,8 @@ def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
     cdef:
         cnp.npy_intp nrows = ref_shape[0]
         cnp.npy_intp ncols = ref_shape[1]
-        cnp.npy_intp nrVol = image.shape[0]
-        cnp.npy_intp ncVol = image.shape[1]
-        cnp.npy_intp i, j, ii, jj
-        double dii, djj, tmp0
-        double alpha, beta, calpha, cbeta
+        cnp.npy_intp i, j
+        double dii, djj
         floating[:, :] out = np.zeros(shape=(nrows, ncols),
                                       dtype=np.asarray(image).dtype)
 
@@ -2360,11 +2344,8 @@ def transform_2d_affine_nn(number[:, :] image, int[:] ref_shape,
     cdef:
         cnp.npy_intp nrows = ref_shape[0]
         cnp.npy_intp ncols = ref_shape[1]
-        cnp.npy_intp nrVol = image.shape[0]
-        cnp.npy_intp ncVol = image.shape[1]
-        double dii, djj, tmp0
-        double alpha, beta, calpha, cbeta
-        cnp.npy_intp i, j, ii, jj
+        double dii, djj
+        cnp.npy_intp i, j
         number[:, :] out = np.zeros((nrows, ncols),
                                     dtype=np.asarray(image).dtype)
 
@@ -2415,7 +2396,6 @@ def resample_displacement_field_3d(floating[:, :, :, :] field,
         cnp.npy_intp trows = out_shape[1]
         cnp.npy_intp tcols = out_shape[2]
         cnp.npy_intp k, i, j
-        int inside
         double dkk, dii, djj
         floating[:, :, :, :] expanded = np.zeros((tslices, trows, tcols, 3),
                                                  dtype=ftype)
@@ -2459,7 +2439,6 @@ def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
         cnp.npy_intp trows = out_shape[0]
         cnp.npy_intp tcols = out_shape[1]
         cnp.npy_intp i, j
-        int inside
         double dii, djj
         floating[:, :, :] expanded = np.zeros((trows, tcols, 2), dtype=ftype)
 
@@ -2467,8 +2446,7 @@ def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
         for j in range(tcols):
             dii = i*factors[0]
             djj = j*factors[1]
-            inside = _interpolate_vector_2d[floating](field, dii, djj,
-                                                      &expanded[i, j, 0])
+            _interpolate_vector_2d[floating](field, dii, djj, &expanded[i, j, 0])
     return np.asarray(expanded)
 
 
@@ -2516,7 +2494,6 @@ def create_random_displacement_2d(int[:] from_shape,
                                           dtype=np.int32)
         double[:, :, :] output = np.zeros(tuple(from_shape) + (2,),
                                           dtype=np.float64)
-        cnp.npy_intp dom_size = from_shape[0]*from_shape[1]
 
     if not is_valid_affine(from_grid2world, 2):
         raise ValueError("Invalid 'from' affine transform matrix")
@@ -2605,7 +2582,6 @@ def create_random_displacement_3d(int[:] from_shape,
                                              dtype=np.int32)
         double[:, :, :, :] output = np.zeros(tuple(from_shape) + (3,),
                                              dtype=np.float64)
-        cnp.npy_intp dom_size = from_shape[0]*from_shape[1]*from_shape[2]
 
     if not is_valid_affine(from_grid2world, 3):
         raise ValueError("Invalid 'from' affine transform matrix")
@@ -3068,7 +3044,7 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
     cdef:
         cnp.npy_intp nrows = out.shape[0]
         cnp.npy_intp ncols = out.shape[1]
-        cnp.npy_intp i, j, k, in_flag
+        cnp.npy_intp i, j, in_flag
         double tmp
         double[:] x = np.empty(shape=(2,), dtype=np.float64)
         double[:] dx = np.empty(shape=(2,), dtype=np.float64)


### PR DESCRIPTION
## Description

Delete unused variables from `align` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/bundlemin.pyx:115:32: 'mov_i'
defined but unused (try prefixing with underscore?)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
