### PR TITLE
STYLE: Delete unused variables from `denoise` module Cython code

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -91,7 +91,6 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
     cdef:
         cnp.npy_intp i, j, k, I, J, K
         double[:, :, ::1] out = np.zeros_like(arr)
-        double summ = 0
         cnp.npy_intp P = patch_radius
         cnp.npy_intp B = block_radius
         int threads_to_use = -1
@@ -151,7 +150,7 @@ cdef double process_block(double[:, :, ::1] arr,
     """
 
     cdef:
-        cnp.npy_intp m, n, o, M, N, O, patch_vol_size, a, b, c, cnt, step
+        cnp.npy_intp m, n, o, patch_vol_size, a, b, c, cnt
         double summ, d, w, sumw, sum_out, x, sigm
         double * W
         double * cache
@@ -229,7 +228,6 @@ def add_padding_reflection(double[:, :, ::1] arr, padding):
     cdef:
         double[:, :, ::1] final
         cnp.npy_intp i, j, k
-        cnp.npy_intp B = padding
         cnp.npy_intp[::1] indices_i = correspond_indices(arr.shape[0], padding)
         cnp.npy_intp[::1] indices_j = correspond_indices(arr.shape[1], padding)
         cnp.npy_intp[::1] indices_k = correspond_indices(arr.shape[2], padding)
@@ -337,7 +335,6 @@ def _upfir_vector(double[:] f, double[:] h, double[:] out):
 
 
 def _firdn_matrix(double[:, :] F, double[:] h, double[:, :] out):
-    cdef cnp.npy_intp n = F.shape[0]
     cdef cnp.npy_intp m = F.shape[1]
     cdef cnp.npy_intp j
     for j in range(m):
@@ -345,7 +342,6 @@ def _firdn_matrix(double[:, :] F, double[:] h, double[:, :] out):
 
 
 def _upfir_matrix(double[:, :] F, double[:] h, double[:, :] out):
-    cdef cnp.npy_intp n = F.shape[0]
     cdef cnp.npy_intp m = F.shape[1]
     for j in range(m):
         _upfir_vector(F[:, j], h, out[:, j])
@@ -934,7 +930,6 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
     cdef double epsilon = 1e-5
     cdef double mean_ratio_threshold = 0.95
     cdef double variance_ratio_min = 0.5 + 1e-7
-    cdef double variance_ratio_max = 1.0 / variance_ratio_min
 
     # Output arrays
     cdef double[:, :, :] denoised_image = np.zeros_like(image)
@@ -943,18 +938,9 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
     cdef double[:, :, :] accumulated_estimates = np.zeros_like(image)
     cdef double[:, :, :] weight_counts = np.zeros_like(image)
 
-    # Thread-local working memory (allocated per thread to avoid race conditions)
-    cdef double *thread_weighted_averages = NULL
-    cdef int block_volume = block_size * block_size * block_size
-
     # Loop variables
     cdef int center_y, center_x, center_z
-    cdef int neighbor_y, neighbor_x, neighbor_z
-    cdef int offset_y, offset_x, offset_z
-    cdef double mean_ratio, variance_ratio
-    cdef double patch_distance, similarity_weight, max_weight, total_weight
     cdef double current_mean, current_variance
-    cdef double neighbor_mean, neighbor_variance
     cdef int thread_id
 
     # Set number of threads

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -73,7 +73,7 @@ cdef class EnhancementKernel:
                 theta = np.pi * rng.random(n_pts)
                 phi = 2 * np.pi * rng.random(n_pts)
                 hsph_initial = HemiSphere(theta=theta, phi=phi)
-                sphere, potential = disperse_charges(hsph_initial, 5000)
+                sphere, _ = disperse_charges(hsph_initial, 5000)
         else:
             # use default
             sphere = get_sphere(name="repulsion100")
@@ -165,9 +165,6 @@ cdef class EnhancementKernel:
             double [:] x
             double [:] y
             cdef double [:, :, :, :, :] lookuptablelocal
-            double kmax = self.kernelmax
-            double l1norm
-            double kernelval
 
         lookuptablelocal = np.zeros((OR1, OR2, N, N, N))
         x = np.zeros(3)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -153,7 +153,6 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
         cnp.npy_intp ny = odfs.shape[1]
         cnp.npy_intp nz = odfs.shape[2]
         cnp.npy_intp threads_to_use = -1
-        cnp.npy_intp all_cores = openmp.omp_get_num_procs()
         cnp.npy_intp corient, orient, cx, cy, cz, x, y, z
         cnp.npy_intp expectedvox
         cnp.npy_intp edgeNormalization = True


### PR DESCRIPTION
## Description

Delete unused variables from `denoise` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/denoise/denspeed.pyx:94:16: 'summ'
defined but unused (try prefixing with underscore?)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
