### PR TITLE
STYLE: Delete unused variables from `core` module Cython code

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -187,7 +187,6 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
     """
     cdef:
         double w[8]
-        double values[24]
         cnp.npy_intp index[24]
         cnp.npy_intp off, i, j
         double *ds=<double *> cnp.PyArray_DATA(data)


### PR DESCRIPTION
## Description

Delete unused variables from `core` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/core/interpolation.pyx:190:16:
'values' defined but unused (try prefixing with underscore)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
