### PR TITLE
STYLE: Delete unused variables from `reconst` module Cython code

### DIFF
--- a/dipy/reconst/_force_search.pyx
+++ b/dipy/reconst/_force_search.pyx
@@ -143,7 +143,6 @@ cdef void knn_inner_product_streaming(
     """
     cdef size_t n_queries = queries.shape[0]
     cdef size_t n_database = database.shape[0]
-    cdef size_t d = queries.shape[1]
 
     cdef size_t chunk_start, chunk_end, chunk_size
     cdef size_t batch_size
@@ -254,7 +253,6 @@ def search_inner_product(
     """
     cdef cnp.npy_intp n_queries = queries.shape[0]
     cdef cnp.npy_intp n_database = database.shape[0]
-    cdef cnp.npy_intp d = queries.shape[1]
 
     if queries.shape[1] != database.shape[1]:
         raise ValueError(

--- a/dipy/reconst/dkispeed.pyx
+++ b/dipy/reconst/dkispeed.pyx
@@ -498,7 +498,6 @@ def mean_kurtosis_analytical(double[:, :] dki_params_flat,
         cnp.npy_intp n_voxels = dki_params_flat.shape[0]
         cnp.npy_intp v
         double[:] MK = np.zeros(n_voxels, dtype=np.float64)
-        double[:] evals = np.zeros(3, dtype=np.float64)
         double[:, :] evecs = np.zeros((3, 3), dtype=np.float64)
         double[:] kt = np.zeros(15, dtype=np.float64)
         double L1, L2, L3

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -324,7 +324,6 @@ def local_maxima(double[:] odf, cnp.uint16_t[:, :] edges):
 
     """
     cdef:
-        cnp.ndarray[cnp.npy_intp] wpeak
         double[::1] out_values
         cnp.npy_intp[::1] out_indices
 
@@ -605,7 +604,7 @@ def argmax_from_countarrs(cnp.ndarray vals,
         cnp.uint32_t *vertinds_ptr
         cnp.uint32_t *counts_ptr
         cnp.uint32_t *adj_ptr
-        cnp.uint32_t vals_size, vert_size
+        cnp.uint32_t vals_size
     if not (cnp.PyArray_ISCONTIGUOUS(cvals) and
             cnp.PyArray_ISCONTIGUOUS(cvertinds) and
             cnp.PyArray_ISCONTIGUOUS(cadj_counts) and


### PR DESCRIPTION
## Description

Delete unused variables from `reconst` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/reconst/_force_search.pyx:146:17: 'd'
defined but unused (try prefixing with underscore?)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
