### PR TITLE
STYLE: Delete unused variables from `tracking` module Cython code

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -947,8 +947,6 @@ cdef float clee_perpendicular_distance(float *start0, float *end0, float *start1
     csub_3vecs(end0, start0, k0)
     l0 = cinner_3vecs(k0, k0)
 
-    csub_3vecs(end1, start1, tmp)
-
     # csub_3vecs(end0,start0,k0)
 
     # u1 = np.inner(start1-start0,k0)/l0

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -227,7 +227,7 @@ def cut_plane(tracks, ref):
     """
     cdef:
         cnp.npy_intp n_hits, hit_no, max_hit_len
-        float alpha, beta, lrq, rcd, lhp, ld
+        float alpha, beta, rcd, lhp, ld
         cnp.ndarray[cnp.float32_t, ndim=2] ref32
         cnp.ndarray[cnp.float32_t, ndim=2] track
         object hits
@@ -508,7 +508,7 @@ def bundles_distances_mam(tracksA, tracksB, metric="avg"):
         raise ValueError("Metric should be one of avg, min, max")
     # preprocess tracks
     cdef:
-        cnp.npy_intp longest_track_len = 0, track_len
+        cnp.npy_intp track_len
         cnp.npy_intp longest_track_lenA = 0, longest_track_lenB = 0
         cnp.ndarray[object, ndim=1] tracksA32
         cnp.ndarray[object, ndim=1] tracksB32
@@ -591,8 +591,6 @@ def bundles_distances_mdf(tracksA, tracksB):
         cnp.npy_intp i, j, lentA, lentB
     # preprocess tracks
     cdef:
-        cnp.npy_intp longest_track_len = 0, track_len
-        longest_track_lenA, longest_track_lenB
         cnp.ndarray[object, ndim=1] tracksA32
         cnp.ndarray[object, ndim=1] tracksB32
         cnp.ndarray[cnp.double_t, ndim=2] DM
@@ -617,11 +615,9 @@ def bundles_distances_mdf(tracksA, tracksB):
     cdef:
         cnp.float32_t *t1_ptr
         cnp.float32_t *t2_ptr
-        cnp.float32_t *min_buffer
     # cycle over tracks
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=2] t1, t2
-        cnp.npy_intp t1_len, t2_len
         float d[2]
     t_len = tracksA32[0].shape[0]
 
@@ -940,9 +936,7 @@ cdef float clee_perpendicular_distance(float *start0, float *end0, float *start1
     """
 
     cdef:
-        float l0, l1, ltmp, u1, u2, lperp1, lperp2
-        float *s_tmp
-        float *e_tmp
+        float l0, u1, u2, lperp1, lperp2
         float k0[3]
         float ps[3]
         float pe[3]
@@ -954,7 +948,6 @@ cdef float clee_perpendicular_distance(float *start0, float *end0, float *start1
     l0 = cinner_3vecs(k0, k0)
 
     csub_3vecs(end1, start1, tmp)
-    l1 = cinner_3vecs(tmp, tmp)
 
     # csub_3vecs(end0,start0,k0)
 
@@ -1039,11 +1032,8 @@ cdef float clee_angle_distance(float *start0, float *end0, float *start1, float 
 
     cdef:
         float l0, l1, ltmp, cos_theta_squared
-        float *s_tmp
-        float *e_tmp
         float k0[3]
         float k1[3]
-        float tmp[3]
 
     csub_3vecs(end0, start0, k0)
     l0 = cinner_3vecs(k0, k0)
@@ -1363,8 +1353,6 @@ def point_segment_sq_distance(a, b, c):
         float *ca
         float *cb
         float *cc
-        float cr
-        float ct[2]
 
     ca = asfp(a)
     cb = asfp(b)
@@ -1614,7 +1602,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
         cnp.ndarray[cnp.float32_t, ndim=2] track
         LSC_Cluster *cluster
         long lent = 0, lenC = 0, dim = 0, points=0
-        long i=0, j=0, c=0, i_k=0, rows=0, cit=0
+        long i=0, j=0, i_k=0, rows=0, cit=0
         float *ptr
         float *hid
         float *alld

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -212,8 +212,6 @@ cdef class FBCMeasures:
         # prepare numpy arrays for speed
         streamlines = np.zeros((num_fibers, max_length, dim),
                                dtype=np.float64) * np.nan
-        streamlines_tangents = np.zeros((num_fibers, max_length, dim),
-                                        dtype=np.float64)
         streamlines_nearestp = np.zeros((num_fibers, max_length),
                                         dtype=np.int32)
         streamline_scores = np.zeros((num_fibers, max_length),
@@ -226,15 +224,6 @@ cdef class FBCMeasures:
                     streamlines[line_id, point_id, dims] = \
                         py_streamlines[line_id][point_id][dims]
         self.streamline_points = streamlines
-
-        # compute tangents
-        for line_id in range(num_fibers):
-            for point_id in range(streamlines_length[line_id] - 1):
-                tangent = np.subtract(streamlines[line_id, point_id + 1],
-                                      streamlines[line_id, point_id])
-                streamlines_tangents[line_id, point_id] = \
-                    np.divide(tangent,
-                              np.sqrt(np.dot(tangent, tangent)))
 
         # estimate which kernel LUT index corresponds to angles
         tree = KDTree(kernel.get_orientations())

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -170,7 +170,6 @@ cdef class FBCMeasures:
             cnp.npy_intp num_fibers, max_length, dim
             double [:, :, :] streamlines
             int [:] streamlines_length
-            double [:, :, :] streamlines_tangent
             int [:, :] streamlines_nearestp
             double [:, :] streamline_scores
             cnp.npy_intp line_id = 0
@@ -178,10 +177,9 @@ cdef class FBCMeasures:
             cnp.npy_intp line_id2 = 0
             cnp.npy_intp point_id2 = 0
             cnp.npy_intp dims
-            double score
             double [:] score_mp
             int [:] xd_mp, yd_mp, zd_mp
-            cnp.npy_intp xd, yd, zd, N, hn
+            cnp.npy_intp N, hn
             double [:, :, :, :, ::1] lut
             cnp.npy_intp threads_to_use = -1
 

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -206,7 +206,6 @@ cdef _pft_tracker(DirectionGetter dg,
         int strl_array_len
         double max_wm_pve, current_wm_pve
         double point[3]
-        void (*step)(double* , double*, double) noexcept nogil
 
     copy_point(seed, point)
     copy_point(seed, &streamline[0, 0])

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -321,13 +321,12 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
         double *pverts = <double*> cnp.PyArray_DATA(odf_vertices)
         cnp.npy_intp *pstr = <cnp.npy_intp *> cnp.PyArray_STRIDES(qa)
         cnp.npy_intp *qa_shape = <cnp.npy_intp *> cnp.PyArray_DIMS(qa)
-        cnp.npy_intp *pvstr = <cnp.npy_intp *> cnp.PyArray_STRIDES(odf_vertices)
-        cnp.npy_intp d, i, j, cnt
+        cnp.npy_intp d, i, cnt
         double direction[3]
         double dx[3]
         double idirection[3]
         double ps2[3]
-        double tmp, ftmp
+        double tmp
     if not cnp.PyArray_CHKFLAGS(seed, cnp.NPY_ARRAY_C_CONTIGUOUS):
         raise ValueError("seed is not C contiguous")
     if not cnp.PyArray_CHKFLAGS(qa, cnp.NPY_ARRAY_C_CONTIGUOUS):
@@ -502,7 +501,6 @@ cdef void initialize_ptt_candidate(TrackerParameters params,
     cdef double fod_amp
     cdef int count
     cdef int i
-    cdef double* pmf
 
     # Initialize Frame
     stream_data[1] = init_dir[0]
@@ -621,7 +619,6 @@ cdef double calculate_ptt_data_support(TrackerParameters params,
     cdef double[3] new_position
     cdef double likelihood
     cdef int c, i, j, q
-    cdef double* pmf
 
     prepare_ptt_propagator(params, stream_data, params.ptt.probe_step_size)
 

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -34,7 +34,6 @@ cdef class BinaryStoppingCriterion(StoppingCriterion):
     cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
         cdef:
             unsigned char result
-            int err
             int voxel[3]
 
         voxel[0] = <int>dpy_rint(point[0])

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -247,10 +247,9 @@ cdef void c_set_number_of_points_from_arraysequence(Streamline points,
                                                     long nb_points,
                                                     Streamline out) noexcept nogil:
     cdef:
-        cnp.npy_intp i, j, k
+        cnp.npy_intp i
         cnp.npy_intp offset, length
         cnp.npy_intp offset_out = 0
-        double dn, sum_dn_sqr
 
     for i in range(offsets.shape[0]):
         offset = offsets[i]
@@ -492,7 +491,6 @@ cdef cnp.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
         cnp.npy_intp D = streamline.shape[1]
         cnp.npy_intp nb_points = 0
         cnp.npy_intp d, prev, next, curr
-        double segment_length
 
     # Copy first point since it is always kept.
     for d in range(D):

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -401,7 +401,6 @@ def track_counts(tracks, vol_dims, vox_sizes=(1, 1, 1), return_elements=True):
     cdef cnp.ndarray[cnp.npy_intp, ndim=1] tcs = \
         np.zeros((n_voxels,), dtype=np.intp)
     # pointer to output track indices
-    cdef cnp.npy_intp i
     if return_elements:
         el_inds = {}
     # cython numpy pointer to individual track array


### PR DESCRIPTION
## Description

Delete unused variables from `tracking` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/tracking/distances.pyx:226:26: 'lrq'
defined but unused (try prefixing with underscore?)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
