### PR TITLE
BF: Make a `cinit` variable be an instance variable

### DIFF
--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -27,7 +27,7 @@ cdef class EuDXDirectionGetter(DirectionGetter):
         int initialized
 
     def __cinit__(self):
-        initialized = False
+        self.initialized = False
         self.qa_thr = 0.0239
         self.ang_thr = 60
         self.total_weight = .5


### PR DESCRIPTION
## Description

Make a `cinit` variable be an instance variable: prepend `self` to it, otherwise the variable appears unused.

## Motivation and Context

Seems to be a bug.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
