### PR TITLE
RF: Delete unused block in `align` module Cython code

### DIFF
--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -2458,17 +2458,8 @@ def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
     cdef:
         cnp.npy_intp trows = out_shape[0]
         cnp.npy_intp tcols = out_shape[1]
-        cnp.npy_intp i, j
-        int inside
-        double dii, djj
         floating[:, :, :] expanded = np.zeros((trows, tcols, 2), dtype=ftype)
 
-    for i in range(trows):
-        for j in range(tcols):
-            dii = i*factors[0]
-            djj = j*factors[1]
-            inside = _interpolate_vector_2d[floating](field, dii, djj,
-                                                      &expanded[i, j, 0])
     return np.asarray(expanded)
 
 


### PR DESCRIPTION
## Description

Delete unused block in `align` module Cython code: statements have no effect.

## Motivation and Context

Statements have no effect.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
