### PR TITLE
STYLE: Remove whitespace before closing bracket in Cython code

### DIFF
--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -21,7 +21,7 @@ cdef extern from "dpy_math.h" nogil:
     double fabs(double x)
     double cos(double x)
     double sin(double x)
-    float acos(float x )
+    float acos(float x)
     double sqrt(double x)
     double DPY_PI
 

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -18,7 +18,7 @@ cdef extern from "dpy_math.h" nogil:
     double floor(double x)
     float sqrt(float x)
     float fabs(float x)
-    float acos(float x )
+    float acos(float x)
     bint dpy_isnan(double x)
     double dpy_log2(double x)
 

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -37,7 +37,7 @@ from libc.stdio cimport printf
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double x)
-    float acos(float x )
+    float acos(float x)
     double sqrt(double x)
     double DPY_PI
 

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -262,7 +262,7 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
         # update position
         for j in range(3):
             point[j] += voxdir[j] * params.inv_voxel_size[j] * params.step_size
-        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts + i )* 3])
+        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts + i)* 3])
 
         status_forward = sc.check_point_c(point, &rng)
         if (status_forward == ENDPOINT or
@@ -296,7 +296,7 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
         # update position
         for j in range(3):
             point[j] += voxdir[j] * params.inv_voxel_size[j] * params.step_size
-        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts - i )* 3])
+        fast_numpy.copy_point(point, &stream[(params.max_nbr_pts - i)* 3])
 
         status_backward = sc.check_point_c(point, &rng)
         if (status_backward == ENDPOINT or


### PR DESCRIPTION
## Description

Remove whitespace before closing bracket in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/tracking/tractogen.pyx:265:69: E202
whitespace before ')'
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
