### PR TITLE
STYLE: Comply with blank lines after class or function def in Cython

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -163,6 +163,7 @@ def mul_3vecs(vec1, vec2):
                <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
 
+
 cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) noexcept nogil:
     cdef cnp.npy_intp i
     for i from 0<=i<3:
@@ -174,6 +175,7 @@ def mul_3vec(a, vec):
     cmul_3vec(a, <float *> cnp.PyArray_DATA(fvec),
               <float *> cnp.PyArray_DATA(vec_out))
     return vec_out
+
 
 cdef inline void cmul_3vec(float a, float *vec, float *vec_out) noexcept nogil:
     cdef cnp.npy_intp i
@@ -1265,6 +1267,7 @@ def intersect_segment_cylinder(sa,sb,p,q,r):
     tmp = cintersect_segment_cylinder(csa,csb,cp, cq, cr, ct)
 
     return tmp, ct[0], ct[1]
+
 
 cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, float r, float *t):
     """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -39,6 +39,8 @@ def _get_default_threads():
         return default_threads
     else:
         return 1
+
+
 default_threads = _get_default_threads()
 
 


### PR DESCRIPTION
## Description

Comply with the required two blank lines after class or function definition in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/utils/omp.pyx:42:1: E305 expected 2
blank lines after class or function definition, found 0
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
