### PR TITLE
BF: Make FORCE simulation generation reproducible via a seed

### DIFF
--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -18,6 +18,7 @@ from dipy.sims._force_core import (
     DEFAULT_TWO_FIBER_MIN_ANGLE,
 )
 from dipy.sims.force import (
+    DEFAULT_FORCE_SEED,
     DEFAULT_NUM_ODI_VALUES,
     DEFAULT_ODI_RANGE,
     generate_force_simulations,
@@ -266,6 +267,7 @@ def _find_cached_simulation(
         Path to the cached ``.npz`` file, or None if no match found.
     """
     registry = _load_cache_registry(cache_dir)
+    legacy_seed_cache_reported = False
     for entry in registry:
         if entry["num_simulations"] != num_simulations:
             continue
@@ -277,6 +279,15 @@ def _find_cached_simulation(
             continue
         if not _min_angles_match(entry, min_crossing_angles):
             continue
+        if "seed" not in entry and seed is not None:
+            candidate = cache_dir / entry["filename"]
+            if candidate.exists() and not legacy_seed_cache_reported:
+                logger.info(
+                    f"Cached FORCE simulations at {candidate} predate seed "
+                    "tracking and cannot guarantee reproducibility. A new "
+                    "seeded library will be generated."
+                )
+                legacy_seed_cache_reported = True
         if not _seed_matches(entry, seed):
             continue
         candidate = cache_dir / entry["filename"]
@@ -810,7 +821,7 @@ class FORCEModel(ReconstModel):
         num_simulations=500000,
         output_path=None,
         num_cpus=1,
-        seed=2298,
+        seed=DEFAULT_FORCE_SEED,
         wm_threshold=0.5,
         tortuosity=False,
         odi_range=DEFAULT_ODI_RANGE,
@@ -851,8 +862,8 @@ class FORCEModel(ReconstModel):
             Seed for reproducible library generation (see
             :func:`~dipy.sims.force.generate_force_simulations`). Identical
             seeds yield identical libraries for any ``num_cpus``. The seed
-            is part of the cache key. When None, every run uses fresh
-            entropy.
+            is part of the cache key. When None, each newly generated library
+            uses fresh entropy; a matching cached library may still be reused.
         wm_threshold : float, optional
             Minimum WM fraction to include fiber labels.
         tortuosity : bool, optional

--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -761,7 +761,7 @@ class FORCEModel(ReconstModel):
     ):
         r"""
         FORCE (FORward matching for Complex microstructure Estimation) model
-        :footcite:p:`Shah2025`.
+        :footcite:p:`Shah2026`.
 
         FORCE is a forward modeling paradigm that reframes how diffusion data
         is analyzed. Instead of inverting the measured signal, FORCE simulates

--- a/dipy/reconst/force.py
+++ b/dipy/reconst/force.py
@@ -216,6 +216,19 @@ def _min_angles_match(entry, min_crossing_angles):
     )
 
 
+def _seed_matches(entry, seed):
+    """Check whether a registry *entry*'s generation seed matches the request.
+
+    Entries written before the seed became part of the cache key carry no
+    ``seed`` field; like entries generated with ``seed=None``, they only
+    match requests with ``seed=None``.
+    """
+    entry_seed = entry.get("seed")
+    if entry_seed is None or seed is None:
+        return entry_seed is None and seed is None
+    return int(entry_seed) == int(seed)
+
+
 def _find_cached_simulation(
     cache_dir,
     gtab,
@@ -224,6 +237,7 @@ def _find_cached_simulation(
     odi_range,
     num_odi_values,
     min_crossing_angles,
+    seed,
 ):
     """Search the registry for a simulation matching the given parameters.
 
@@ -243,6 +257,8 @@ def _find_cached_simulation(
         Resolved number of ODI grid points.
     min_crossing_angles : tuple
         ``(two_fiber_min_angle, three_fiber_min_angle)`` in degrees.
+    seed : int or None
+        Generation seed requested for the library.
 
     Returns
     -------
@@ -261,6 +277,8 @@ def _find_cached_simulation(
             continue
         if not _min_angles_match(entry, min_crossing_angles):
             continue
+        if not _seed_matches(entry, seed):
+            continue
         candidate = cache_dir / entry["filename"]
         if candidate.exists():
             return str(candidate)
@@ -276,6 +294,7 @@ def _register_cached_simulation(
     odi_range,
     num_odi_values,
     min_crossing_angles,
+    seed,
 ):
     """Add a new entry to the cache registry.
 
@@ -297,6 +316,8 @@ def _register_cached_simulation(
         Resolved number of ODI grid points.
     min_crossing_angles : tuple
         ``(two_fiber_min_angle, three_fiber_min_angle)`` in degrees.
+    seed : int or None
+        Generation seed used for the library.
     """
 
     # Convert numpy types to plain Python for JSON serialisation
@@ -322,6 +343,7 @@ def _register_cached_simulation(
         "num_odi_values": int(num_odi_values),
         "two_fiber_min_angle": float(min_crossing_angles[0]),
         "three_fiber_min_angle": float(min_crossing_angles[1]),
+        "seed": None if seed is None else int(seed),
         "filename": filename,
     }
 
@@ -788,6 +810,7 @@ class FORCEModel(ReconstModel):
         num_simulations=500000,
         output_path=None,
         num_cpus=1,
+        seed=2298,
         wm_threshold=0.5,
         tortuosity=False,
         odi_range=DEFAULT_ODI_RANGE,
@@ -806,8 +829,8 @@ class FORCEModel(ReconstModel):
         simulations are cached in ``~/.dipy/force_simulations/`` (or
         ``$DIPY_HOME``). A registry file (``cache_registry.json``) keeps
         track of the bvals, bvecs, diffusivity configuration, ODI grid,
-        minimum crossing angles and number of simulations for each cached
-        file. If a cached simulation that matches
+        minimum crossing angles, seed and number of simulations for each
+        cached file. If a cached simulation that matches
         the current gradient table (within tolerance) and diffusivity
         configuration already exists, it is loaded from disk and generation
         is skipped.
@@ -824,6 +847,12 @@ class FORCEModel(ReconstModel):
             ``~/.dipy/force_simulations/`` and uses caching.
         num_cpus : int, optional
             Number of CPU cores for parallel processing.
+        seed : int or None, optional
+            Seed for reproducible library generation (see
+            :func:`~dipy.sims.force.generate_force_simulations`). Identical
+            seeds yield identical libraries for any ``num_cpus``. The seed
+            is part of the cache key. When None, every run uses fresh
+            entropy.
         wm_threshold : float, optional
             Minimum WM fraction to include fiber labels.
         tortuosity : bool, optional
@@ -893,6 +922,7 @@ class FORCEModel(ReconstModel):
             resolved_odi_range, num_odi_values=num_odi_values
         )
         min_crossing_angles = (float(two_fiber_min_angle), float(three_fiber_min_angle))
+        resolved_seed = None if seed is None else int(seed)
 
         # --- Cache logic when no explicit output_path is given ----------
         if output_path is None and use_cache:
@@ -905,6 +935,7 @@ class FORCEModel(ReconstModel):
                 resolved_odi_range,
                 resolved_num_odi,
                 min_crossing_angles,
+                resolved_seed,
             )
             if cached is not None:
                 if verbose:
@@ -918,6 +949,7 @@ class FORCEModel(ReconstModel):
             self.gtab,
             num_simulations=num_simulations,
             num_cpus=num_cpus,
+            seed=resolved_seed,
             wm_threshold=wm_threshold,
             tortuosity=tortuosity,
             odi_range=resolved_odi_range,
@@ -957,6 +989,7 @@ class FORCEModel(ReconstModel):
                 resolved_odi_range,
                 resolved_num_odi,
                 min_crossing_angles,
+                resolved_seed,
             )
             if verbose:
                 print(f"[FORCE] Cached simulations to {cache_dir / filename}")

--- a/dipy/reconst/tests/test_force.py
+++ b/dipy/reconst/tests/test_force.py
@@ -17,6 +17,7 @@ from dipy.reconst.force import (
     SignalIndex,
     _fwhm_kde_batch,
     _odi_grid_matches,
+    _seed_matches,
     _weighted_percentile,
     compute_microstructure_uncertainty_ambiguity,
     compute_uncertainty_ambiguity,
@@ -351,6 +352,21 @@ def test_odi_grid_matches_legacy_and_exact():
     assert not _odi_grid_matches(entry, (0.01, 0.3), 19)  # diff range, same grid
 
 
+def test_seed_matches_legacy_and_exact():
+    """Cache matching on the generation seed, incl. legacy (keyless) entries."""
+    # A legacy entry (written before the seed was part of the key) was not
+    # generated reproducibly, so it only satisfies seed=None requests.
+    legacy = {"num_simulations": 100}
+    assert _seed_matches(legacy, None)
+    assert not _seed_matches(legacy, 2298)
+
+    # A modern entry matches only its exact seed.
+    entry = {"seed": 2298}
+    assert _seed_matches(entry, 2298)
+    assert not _seed_matches(entry, 42)
+    assert not _seed_matches(entry, None)
+
+
 def _registry(dipy_home):
     path = dipy_home / "force_simulations" / "cache_registry.json"
     return json.load(open(path)) if path.exists() else []
@@ -389,6 +405,35 @@ def test_force_cache_keys_on_odi_grid(tmp_path, monkeypatch):
     gen(num_odi_values=5)
     assert ((0.01, 0.3), 5) in entries()
     assert len(entries()) == 3
+
+
+def test_force_cache_keys_on_seed(tmp_path, monkeypatch):
+    """The simulation cache is keyed on the generation seed."""
+    monkeypatch.setenv("DIPY_HOME", str(tmp_path))
+    gtab = _make_gtab([1000])
+
+    def gen(**kwargs):
+        model = FORCEModel(gtab)
+        model.generate(num_simulations=60, num_cpus=1, verbose=False, **kwargs)
+        return model
+
+    # 1. the default seed (2298) is recorded in the registry.
+    first = gen()
+    assert [e["seed"] for e in _registry(tmp_path)] == [2298]
+
+    # 2. re-running with the default seed hits the cache (no new entry) and
+    # serves the identical library.
+    again = gen()
+    assert len(_registry(tmp_path)) == 1
+    npt.assert_array_equal(again.simulations["signals"], first.simulations["signals"])
+
+    # 3. a different seed is a distinct library, not a cache hit.
+    other = gen(seed=42)
+    assert len(_registry(tmp_path)) == 2
+    assert {e["seed"] for e in _registry(tmp_path)} == {2298, 42}
+    assert not np.array_equal(
+        other.simulations["signals"], first.simulations["signals"]
+    )
 
 
 def test_cache_registry_separates_min_crossing_angles(tmp_path, monkeypatch):

--- a/dipy/reconst/tests/test_force.py
+++ b/dipy/reconst/tests/test_force.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_almost_equal, assert_array_less
 from dipy.core.gradients import gradient_table
 from dipy.data import default_sphere
 from dipy.reconst.force import (
+    DEFAULT_FORCE_SEED,
     DEFAULT_NUM_ODI_VALUES,
     DEFAULT_ODI_RANGE,
     FORCEModel,
@@ -358,11 +359,11 @@ def test_seed_matches_legacy_and_exact():
     # generated reproducibly, so it only satisfies seed=None requests.
     legacy = {"num_simulations": 100}
     assert _seed_matches(legacy, None)
-    assert not _seed_matches(legacy, 2298)
+    assert not _seed_matches(legacy, DEFAULT_FORCE_SEED)
 
     # A modern entry matches only its exact seed.
-    entry = {"seed": 2298}
-    assert _seed_matches(entry, 2298)
+    entry = {"seed": DEFAULT_FORCE_SEED}
+    assert _seed_matches(entry, DEFAULT_FORCE_SEED)
     assert not _seed_matches(entry, 42)
     assert not _seed_matches(entry, None)
 
@@ -417,9 +418,9 @@ def test_force_cache_keys_on_seed(tmp_path, monkeypatch):
         model.generate(num_simulations=60, num_cpus=1, verbose=False, **kwargs)
         return model
 
-    # 1. the default seed (2298) is recorded in the registry.
+    # 1. the default seed is recorded in the registry.
     first = gen()
-    assert [e["seed"] for e in _registry(tmp_path)] == [2298]
+    assert [e["seed"] for e in _registry(tmp_path)] == [DEFAULT_FORCE_SEED]
 
     # 2. re-running with the default seed hits the cache (no new entry) and
     # serves the identical library.
@@ -430,10 +431,46 @@ def test_force_cache_keys_on_seed(tmp_path, monkeypatch):
     # 3. a different seed is a distinct library, not a cache hit.
     other = gen(seed=42)
     assert len(_registry(tmp_path)) == 2
-    assert {e["seed"] for e in _registry(tmp_path)} == {2298, 42}
+    assert {e["seed"] for e in _registry(tmp_path)} == {DEFAULT_FORCE_SEED, 42}
     assert not np.array_equal(
         other.simulations["signals"], first.simulations["signals"]
     )
+
+
+def test_force_cache_reports_seedless_legacy_entry(tmp_path, monkeypatch):
+    """A legacy cache miss explains why a seeded library is regenerated."""
+    monkeypatch.setenv("DIPY_HOME", str(tmp_path))
+    gtab = _make_gtab([1000])
+
+    FORCEModel(gtab).generate(
+        num_simulations=10,
+        num_cpus=1,
+        seed=None,
+        compute_dti=False,
+        verbose=False,
+    )
+
+    registry_path = tmp_path / "force_simulations" / "cache_registry.json"
+    registry = _registry(tmp_path)
+    registry[0].pop("seed")
+    with open(registry_path, "w") as f:
+        json.dump(registry, f)
+
+    messages = []
+    monkeypatch.setattr("dipy.reconst.force.logger.info", messages.append)
+    FORCEModel(gtab).generate(
+        num_simulations=10,
+        num_cpus=1,
+        compute_dti=False,
+        verbose=False,
+    )
+
+    assert any(
+        "predate seed tracking" in message
+        and "new seeded library will be generated" in message
+        for message in messages
+    )
+    assert _registry(tmp_path)[-1]["seed"] == DEFAULT_FORCE_SEED
 
 
 def test_cache_registry_separates_min_crossing_angles(tmp_path, monkeypatch):

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -11,7 +11,7 @@ from real diffusion MRI data.
 
 References
 ----------
-:footcite:p:`Shah2025`
+:footcite:p:`Shah2026`
 """
 
 import ast

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -148,29 +148,21 @@ def smallest_shell_bval(bvals, *, b0_threshold=50, shell_tolerance=50, n=1):
     return min_shells, shell_mask
 
 
-@warning_for_keywords(from_version="1.13.0")
-def init_worker(*, base_seed=None):
+def init_worker():
     """Initialize a ProcessPoolExecutor worker with a unique RNG state.
 
-    With ``base_seed=None``, seed = PID + high-resolution time so every
-    worker has a different stream. With an explicit ``base_seed`` -- passed
-    through ``initializer=partial(init_worker, base_seed=...)``, since the
-    parameter is keyword-only -- seed = base_seed + PID, so workers differ
-    but the run is reproducible for a fixed worker count.
-
-    Parameters
-    ----------
-    base_seed : int, optional
-        Base seed for reproducible worker initialization.
+    Seeds the global :mod:`numpy.random` and :mod:`random` states from the
+    PID and high-resolution time so forked workers do not inherit identical
+    streams from the parent. Reproducibility does not rely on this state:
+    when :func:`generate_force_simulations` is given a ``seed``, every batch
+    reseeds itself from ``(seed, batch_index)`` in the batch worker,
+    independently of the number of workers.
     """
     import random
     import time
 
-    if base_seed is not None:
-        seed = (int(base_seed) + os.getpid()) % (2**32)
-    else:
-        # Unique per process and run: PID + high-resolution time
-        seed = (os.getpid() * (2**16) + int(time.perf_counter_ns())) % (2**32)
+    # Unique per process and run: PID + high-resolution time
+    seed = (os.getpid() * (2**16) + int(time.perf_counter_ns())) % (2**32)
     np.random.seed(seed)
     random.seed(seed)
 
@@ -184,6 +176,7 @@ def _create_memmap(output_dir, name, dtype, shape):
 def _generate_batch_worker(
     start_idx,
     batch_size,
+    batch_seed,
     sphere,
     evecs,
     bingham,
@@ -198,10 +191,16 @@ def _generate_batch_worker(
 ):
     """Worker function for parallel batch generation.
 
-    Opens memmaps by path in each process and writes directly.
+    Opens memmaps by path in each process and writes directly. When
+    ``batch_seed`` is not None, the global NumPy RNG is reseeded with it so
+    the batch's random draws are deterministic regardless of which worker
+    process executes it.
     """
     from dipy.sims._force_core import create_mixed_signal, set_diffusivity_ranges
     from dipy.sims._multi_tensor_omp import multi_tensor
+
+    if batch_seed is not None:
+        np.random.seed(batch_seed)
 
     # Unpack memmap info
     (
@@ -435,6 +434,7 @@ def generate_force_simulations(
     output_dir=None,
     num_cpus=1,
     batch_size=1000,
+    seed=2298,
     wm_threshold=0.5,
     tortuosity=False,
     odi_range=DEFAULT_ODI_RANGE,
@@ -469,6 +469,12 @@ def generate_force_simulations(
         (e.g. ``-2`` = all minus one). ``0`` raises ``ValueError``.
     batch_size : int, optional
         Batch size for processing.
+    seed : int or None, optional
+        Seed for reproducible simulation generation. Each batch draws from
+        an independent random stream derived from ``(seed, batch_index)``,
+        so identical seeds yield identical libraries for any ``num_cpus``.
+        Note that changing ``batch_size`` changes the batch layout and
+        therefore the library. When None, every run uses fresh entropy.
     wm_threshold : float, optional
         Minimum WM fraction to include fiber labels.
     tortuosity : bool, optional
@@ -614,11 +620,20 @@ def generate_force_simulations(
     remainder = num_simulations % batch_size
     total_batches = num_batches_full + (1 if remainder > 0 else 0)
 
+    # Derive one independent stream per batch so results depend only on
+    # (seed, batch_index) — not on num_cpus or worker scheduling — while
+    # every batch still draws different random values.
     batch_specs = []
     current_start = 0
     for batch_idx in range(total_batches):
         bs = batch_size if batch_idx < num_batches_full else remainder
-        batch_specs.append((current_start, bs))
+        if seed is None:
+            batch_seed = None
+        else:
+            batch_seed = int(
+                np.random.SeedSequence([int(seed), batch_idx]).generate_state(1)[0]
+            )
+        batch_specs.append((current_start, bs, batch_seed))
         current_start += bs
 
     # Pack memmap info for workers
@@ -685,10 +700,11 @@ def generate_force_simulations(
     if num_cpus == 1:
         # Serial in-process path — no subprocess spawned, safe on all platforms
         init_worker()
-        for start_idx, bs in batch_specs:
+        for start_idx, bs, batch_seed in batch_specs:
             batch_done = _generate_batch_worker(
                 start_idx,
                 bs,
+                batch_seed,
                 target_sphere,
                 evecs,
                 dispersion_sf,
@@ -713,6 +729,7 @@ def generate_force_simulations(
                         _generate_batch_worker,
                         start_idx,
                         bs,
+                        batch_seed,
                         target_sphere,
                         evecs,
                         dispersion_sf,
@@ -725,7 +742,7 @@ def generate_force_simulations(
                         diffusivity_config,
                         min_crossing_angles,
                     ): (start_idx, bs)
-                    for start_idx, bs in batch_specs
+                    for start_idx, bs, batch_seed in batch_specs
                 }
                 for future in as_completed(futures):
                     batch_done = future.result()
@@ -737,10 +754,11 @@ def generate_force_simulations(
                 "Falling back to serial execution."
             )
             init_worker()
-            for start_idx, bs in batch_specs:
+            for start_idx, bs, batch_seed in batch_specs:
                 batch_done = _generate_batch_worker(
                     start_idx,
                     bs,
+                    batch_seed,
                     target_sphere,
                     evecs,
                     dispersion_sf,
@@ -768,6 +786,7 @@ def generate_force_simulations(
                     _generate_batch_worker,
                     start_idx,
                     bs,
+                    batch_seed,
                     target_sphere,
                     evecs,
                     dispersion_sf,
@@ -780,7 +799,7 @@ def generate_force_simulations(
                     diffusivity_config,
                     min_crossing_angles,
                 ): (start_idx, bs)
-                for start_idx, bs in batch_specs
+                for start_idx, bs, batch_seed in batch_specs
             }
 
             for future in as_completed(futures):

--- a/dipy/sims/force.py
+++ b/dipy/sims/force.py
@@ -32,7 +32,7 @@ from dipy.sims._force_core import (
     DEFAULT_TWO_FIBER_MIN_ANGLE,
 )
 from dipy.sims.voxel import all_tensor_evecs
-from dipy.utils.deprecator import warning_for_keywords
+from dipy.utils.deprecator import deprecated_params, warning_for_keywords
 from dipy.utils.logging import logger
 from dipy.utils.multiproc import determine_num_processes
 
@@ -42,6 +42,7 @@ from dipy.utils.multiproc import determine_num_processes
 # autoscale the number of grid points to any custom ``odi_range``.
 DEFAULT_ODI_RANGE = (0.01, 0.3)
 DEFAULT_NUM_ODI_VALUES = 10
+DEFAULT_FORCE_SEED = 2298
 
 
 @warning_for_keywords(from_version="1.13.0")
@@ -148,15 +149,19 @@ def smallest_shell_bval(bvals, *, b0_threshold=50, shell_tolerance=50, n=1):
     return min_shells, shell_mask
 
 
-def init_worker():
+@warning_for_keywords(from_version="1.13.0")
+@deprecated_params("base_seed", since="1.13.0", until="2.0.0")
+def init_worker(*, base_seed=None):
     """Initialize a ProcessPoolExecutor worker with a unique RNG state.
 
     Seeds the global :mod:`numpy.random` and :mod:`random` states from the
     PID and high-resolution time so forked workers do not inherit identical
-    streams from the parent. Reproducibility does not rely on this state:
-    when :func:`generate_force_simulations` is given a ``seed``, every batch
-    reseeds itself from ``(seed, batch_index)`` in the batch worker,
-    independently of the number of workers.
+    streams from the parent.
+
+    Parameters
+    ----------
+    base_seed : int or None, optional
+        Deprecated and ignored.
     """
     import random
     import time
@@ -189,13 +194,7 @@ def _generate_batch_worker(
     diffusivity_cfg,
     min_crossing_angles,
 ):
-    """Worker function for parallel batch generation.
-
-    Opens memmaps by path in each process and writes directly. When
-    ``batch_seed`` is not None, the global NumPy RNG is reseeded with it so
-    the batch's random draws are deterministic regardless of which worker
-    process executes it.
-    """
+    """Worker function for parallel batch generation."""
     from dipy.sims._force_core import create_mixed_signal, set_diffusivity_ranges
     from dipy.sims._multi_tensor_omp import multi_tensor
 
@@ -434,7 +433,7 @@ def generate_force_simulations(
     output_dir=None,
     num_cpus=1,
     batch_size=1000,
-    seed=2298,
+    seed=DEFAULT_FORCE_SEED,
     wm_threshold=0.5,
     tortuosity=False,
     odi_range=DEFAULT_ODI_RANGE,
@@ -620,9 +619,6 @@ def generate_force_simulations(
     remainder = num_simulations % batch_size
     total_batches = num_batches_full + (1 if remainder > 0 else 0)
 
-    # Derive one independent stream per batch so results depend only on
-    # (seed, batch_index) — not on num_cpus or worker scheduling — while
-    # every batch still draws different random values.
     batch_specs = []
     current_start = 0
     for batch_idx in range(total_batches):
@@ -697,32 +693,43 @@ def generate_force_simulations(
     # Run simulations with progress bar
     pbar = tqdm(total=num_simulations, desc="Simulating", disable=not verbose)
 
+    def run_serial():
+        """Run batches in-process without altering the caller's NumPy RNG."""
+        state = np.random.get_state()
+        try:
+            if seed is None:
+                init_worker()
+            for start_idx, bs, batch_seed in batch_specs:
+                batch_done = _generate_batch_worker(
+                    start_idx,
+                    bs,
+                    batch_seed,
+                    target_sphere,
+                    evecs,
+                    dispersion_sf,
+                    odi_list,
+                    bvals,
+                    bvecs,
+                    wm_threshold,
+                    tortuosity,
+                    memmap_info,
+                    diffusivity_config,
+                    min_crossing_angles,
+                )
+                pbar.update(batch_done)
+        finally:
+            np.random.set_state(state)
+
     if num_cpus == 1:
         # Serial in-process path — no subprocess spawned, safe on all platforms
-        init_worker()
-        for start_idx, bs, batch_seed in batch_specs:
-            batch_done = _generate_batch_worker(
-                start_idx,
-                bs,
-                batch_seed,
-                target_sphere,
-                evecs,
-                dispersion_sf,
-                odi_list,
-                bvals,
-                bvecs,
-                wm_threshold,
-                tortuosity,
-                memmap_info,
-                diffusivity_config,
-                min_crossing_angles,
-            )
-            pbar.update(batch_done)
+        run_serial()
     elif sys.platform == "win32":
         if _main_is_guarded():
             ctx = mp.get_context("spawn")
             with ProcessPoolExecutor(
-                max_workers=num_cpus, initializer=init_worker, mp_context=ctx
+                max_workers=num_cpus,
+                initializer=init_worker if seed is None else None,
+                mp_context=ctx,
             ) as executor:
                 futures = {
                     executor.submit(
@@ -753,25 +760,7 @@ def generate_force_simulations(
                 "protected with `if __name__ == '__main__':`. "
                 "Falling back to serial execution."
             )
-            init_worker()
-            for start_idx, bs, batch_seed in batch_specs:
-                batch_done = _generate_batch_worker(
-                    start_idx,
-                    bs,
-                    batch_seed,
-                    target_sphere,
-                    evecs,
-                    dispersion_sf,
-                    odi_list,
-                    bvals,
-                    bvecs,
-                    wm_threshold,
-                    tortuosity,
-                    memmap_info,
-                    diffusivity_config,
-                    min_crossing_angles,
-                )
-                pbar.update(batch_done)
+            run_serial()
     else:
         # fork: workers are copies of the parent — __main__ is NOT re-run,
         # so no `if __name__ == '__main__':` guard is needed in the caller's
@@ -779,7 +768,9 @@ def generate_force_simulations(
         # (no GUI/ObjC).
         ctx = mp.get_context("fork")
         with ProcessPoolExecutor(
-            max_workers=num_cpus, initializer=init_worker, mp_context=ctx
+            max_workers=num_cpus,
+            initializer=init_worker if seed is None else None,
+            mp_context=ctx,
         ) as executor:
             futures = {
                 executor.submit(

--- a/dipy/sims/tests/test_force.py
+++ b/dipy/sims/tests/test_force.py
@@ -309,13 +309,10 @@ def _library_crossing_angles(sims, num_fibers):
     return np.asarray(angles)
 
 
-def test_generate_force_simulations_default_min_crossing_angles(monkeypatch):
+def test_generate_force_simulations_default_min_crossing_angles():
     """By default the library holds no crossing below 30 (two) or 60 (three) degrees."""
     from dipy.sims.force import generate_force_simulations
 
-    monkeypatch.setattr(
-        "dipy.sims.force.init_worker", lambda *a, **k: np.random.seed(0)
-    )
     gtab = _make_gtab([1000, 2000])
     sims = generate_force_simulations(
         gtab, num_simulations=300, batch_size=100, num_cpus=1, verbose=False
@@ -328,13 +325,10 @@ def test_generate_force_simulations_default_min_crossing_angles(monkeypatch):
     assert three.min() >= 60.0
 
 
-def test_generate_force_simulations_relaxed_min_crossing_angles(monkeypatch):
+def test_generate_force_simulations_relaxed_min_crossing_angles():
     """Lowering the limits lets shallow crossings into the library."""
     from dipy.sims.force import generate_force_simulations
 
-    monkeypatch.setattr(
-        "dipy.sims.force.init_worker", lambda *a, **k: np.random.seed(0)
-    )
     gtab = _make_gtab([1000, 2000])
     sims = generate_force_simulations(
         gtab,
@@ -351,6 +345,82 @@ def test_generate_force_simulations_relaxed_min_crossing_angles(monkeypatch):
     assert two.size and three.size
     assert two.min() < 30.0
     assert three.min() < 60.0
+
+
+def test_generate_force_simulations_seed_reproducible():
+    """Identical seeds reproduce the library; different seeds do not."""
+    from dipy.sims.force import generate_force_simulations
+
+    gtab = _make_gtab([1000])
+    kwargs = {
+        "num_simulations": 40,
+        "batch_size": 10,
+        "num_cpus": 1,
+        "compute_dti": False,
+        "verbose": False,
+    }
+
+    sims_a = generate_force_simulations(gtab, seed=42, **kwargs)
+    sims_b = generate_force_simulations(gtab, seed=42, **kwargs)
+    for key in ("signals", "labels", "num_fibers", "wm_fraction", "nd"):
+        np.testing.assert_array_equal(sims_a[key], sims_b[key])
+
+    # The default seed is applied when none is given, so two default runs
+    # are also identical.
+    sims_c = generate_force_simulations(gtab, **kwargs)
+    sims_d = generate_force_simulations(gtab, **kwargs)
+    np.testing.assert_array_equal(sims_c["signals"], sims_d["signals"])
+
+    # A different seed yields a different library.
+    sims_e = generate_force_simulations(gtab, seed=43, **kwargs)
+    assert not np.array_equal(sims_a["signals"], sims_e["signals"])
+
+    # seed=None draws fresh entropy on every run.
+    sims_f = generate_force_simulations(gtab, seed=None, **kwargs)
+    sims_g = generate_force_simulations(gtab, seed=None, **kwargs)
+    assert not np.array_equal(sims_f["signals"], sims_g["signals"])
+
+
+def test_generate_force_simulations_seed_independent_of_num_cpus():
+    """The same seed gives the same library for any worker count."""
+    from dipy.sims.force import generate_force_simulations
+
+    gtab = _make_gtab([1000])
+    kwargs = {
+        "num_simulations": 40,
+        "batch_size": 10,
+        "seed": 42,
+        "compute_dti": False,
+        "verbose": False,
+    }
+
+    serial = generate_force_simulations(gtab, num_cpus=1, **kwargs)
+    parallel = generate_force_simulations(gtab, num_cpus=2, **kwargs)
+    for key in ("signals", "labels", "num_fibers", "wm_fraction", "nd"):
+        np.testing.assert_array_equal(serial[key], parallel[key])
+
+
+def test_generate_force_simulations_batches_draw_distinct_streams():
+    """Each batch draws from its own stream, so batches are not clones."""
+    from dipy.sims.force import generate_force_simulations
+
+    gtab = _make_gtab([1000])
+    sims = generate_force_simulations(
+        gtab,
+        num_simulations=40,
+        batch_size=10,
+        num_cpus=1,
+        compute_dti=False,
+        verbose=False,
+    )
+
+    batches = sims["signals"].reshape(4, 10, -1)
+    for i in range(len(batches)):
+        for j in range(i + 1, len(batches)):
+            assert not np.array_equal(batches[i], batches[j]), (
+                f"Batches {i} and {j} are identical – the same seed was "
+                "propagated to every batch"
+            )
 
 
 @pytest.mark.parametrize(

--- a/dipy/sims/tests/test_force.py
+++ b/dipy/sims/tests/test_force.py
@@ -4,14 +4,30 @@ import numpy as np
 import pytest
 
 from dipy.sims.force import (
+    DEFAULT_FORCE_SEED,
     DEFAULT_NUM_ODI_VALUES,
     DEFAULT_ODI_RANGE,
     dispersion_lut,
     get_default_diffusivity_config,
+    init_worker,
     resolve_num_odi_values,
     smallest_shell_bval,
     validate_diffusivity_config,
 )
+
+
+def test_init_worker_base_seed_deprecated():
+    """The removed base_seed argument remains available during deprecation."""
+    import random
+
+    numpy_state = np.random.get_state()
+    random_state = random.getstate()
+    try:
+        with pytest.warns(DeprecationWarning, match='"base_seed" was deprecated'):
+            init_worker(base_seed=42)
+    finally:
+        np.random.set_state(numpy_state)
+        random.setstate(random_state)
 
 
 def test_dispersion_lut_structure():
@@ -379,6 +395,51 @@ def test_generate_force_simulations_seed_reproducible():
     sims_f = generate_force_simulations(gtab, seed=None, **kwargs)
     sims_g = generate_force_simulations(gtab, seed=None, **kwargs)
     assert not np.array_equal(sims_f["signals"], sims_g["signals"])
+
+
+@pytest.mark.parametrize("seed", [DEFAULT_FORCE_SEED, None])
+def test_generate_force_simulations_preserves_numpy_rng_state(seed):
+    """Serial generation does not alter the caller's global NumPy RNG."""
+    from dipy.sims.force import generate_force_simulations
+
+    state = np.random.get_state()
+    try:
+        np.random.seed(1234)
+        expected = np.random.random(5)
+        np.random.seed(1234)
+
+        generate_force_simulations(
+            _make_gtab([1000]),
+            num_simulations=10,
+            batch_size=10,
+            num_cpus=1,
+            seed=seed,
+            compute_dti=False,
+            verbose=False,
+        )
+
+        np.testing.assert_array_equal(np.random.random(5), expected)
+    finally:
+        np.random.set_state(state)
+
+
+def test_seeded_serial_generation_skips_worker_initialization(monkeypatch):
+    """A deterministic batch seed makes worker initialization unnecessary."""
+    from dipy.sims.force import generate_force_simulations
+
+    def fail_if_called():
+        pytest.fail("init_worker should not run for seeded serial generation")
+
+    monkeypatch.setattr("dipy.sims.force.init_worker", fail_if_called)
+    generate_force_simulations(
+        _make_gtab([1000]),
+        num_simulations=10,
+        batch_size=10,
+        num_cpus=1,
+        seed=42,
+        compute_dti=False,
+        verbose=False,
+    )
 
 
 def test_generate_force_simulations_seed_independent_of_num_cpus():

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -3520,7 +3520,7 @@ class ReconstForceFlow(Workflow):
         """Workflow for FORCE microstructure reconstruction.
 
         Performs FORCE (FORward matching for Complex microstructure Estimation)
-        reconstruction :footcite:p:`Shah2025` on the files by 'globing'
+        reconstruction :footcite:p:`Shah2026` on the files by 'globing'
         ``input_files`` and saves the FORCE metrics in a directory specified
         by ``out_dir``.
 

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -67,6 +67,7 @@ from dipy.reconst.shm import (
     sph_harm_lookup,
 )
 from dipy.segment.tissue import TissueClassifierHMRF
+from dipy.sims.force import DEFAULT_FORCE_SEED
 from dipy.utils.deprecator import deprecated_params, warning_for_keywords
 from dipy.utils.logging import logger
 from dipy.workflows.workflow import Workflow
@@ -3487,7 +3488,7 @@ class ReconstForceFlow(Workflow):
         gm_d_iso_range=None,
         csf_d=None,
         num_cpus=-1,
-        seed=2298,
+        seed=DEFAULT_FORCE_SEED,
         use_cache=True,
         compute_kurtosis=False,
         engine="serial",

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -3487,6 +3487,7 @@ class ReconstForceFlow(Workflow):
         gm_d_iso_range=None,
         csf_d=None,
         num_cpus=-1,
+        seed=2298,
         use_cache=True,
         compute_kurtosis=False,
         engine="serial",
@@ -3584,6 +3585,9 @@ class ReconstForceFlow(Workflow):
         num_cpus : int, optional
             Number of CPU cores for simulation generation. Use -1 to use
             all available cores.
+        seed : int, optional
+            Random seed for reproducible simulation-library generation.
+            Identical seeds yield identical libraries for any ``num_cpus``.
         use_cache : bool, optional
             Load cached simulations if available.
         compute_kurtosis : bool, optional
@@ -3765,6 +3769,7 @@ class ReconstForceFlow(Workflow):
             model.generate(
                 num_simulations=num_simulations,
                 num_cpus=num_cpus,
+                seed=seed,
                 use_cache=use_cache,
                 compute_dki=compute_kurtosis,
                 wm_threshold=wm_threshold,

--- a/doc/examples/reconst_force.py
+++ b/doc/examples/reconst_force.py
@@ -3,7 +3,7 @@
 Reconstruction with FORCE (FORward matching for Complex microstructure Estimation)
 ==================================================================================
 
-FORCE :footcite:p:`Shah2025` is a forward-modeling paradigm that reframes how
+FORCE :footcite:p:`Shah2026` is a forward-modeling paradigm that reframes how
 diffusion MRI data are analyzed. Instead of inverting the measured signal,
 FORCE simulates a large library of biologically plausible intra-voxel fiber
 configurations and tissue compositions. It then identifies the best-matching

--- a/doc/examples/tracking_introduction_eudx.py
+++ b/doc/examples/tracking_introduction_eudx.py
@@ -77,7 +77,7 @@ white_matter = (labels == 1) | (labels == 2)
 #
 # The first thing we need to begin fiber tracking is a way of getting
 # directions from this diffusion data set. Here, we use the FORCE model
-# :footcite:p:`Shah2025` to estimate fiber orientations. FORCE is a
+# :footcite:p:`Shah2026` to estimate fiber orientations. FORCE is a
 # forward-modeling approach that simulates a library of biologically
 # plausible fiber configurations and matches each voxel's signal to its
 # nearest library entry. We then extract discrete peaks from the FORCE fit

--- a/doc/reconstruction_models_list.rst
+++ b/doc/reconstruction_models_list.rst
@@ -67,7 +67,7 @@
      - :bdg-success:`Yes`
      - :bdg-success:`Yes`
      - Tested from 500 s/mm^2 to 5500 s/mm^2, with as low as 20 directions single shell and 378 directions multi shell
-     - :cite:t:`Shah2025`
+     - :cite:t:`Shah2026`
    * - :ref:`IVIM <sphx_glr_examples_built_reconstruction_reconst_ivim.py>`
      - :bdg-danger:`No`
      - :bdg-success:`Yes`

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1662,13 +1662,13 @@
   url       = {https://doi.org/10.1016/j.neuroimage.2012.06.005}
 }
 
-@article{Shah2025,
+@article{Shah2026,
   author    = {Atharva Jaydeep Shah and Rafael Neto Henriques and Alonso Ramirez-Manzanares and Patryk Filipiak and Steven Baete and Kaustav Deka and Maharshi Gor and Serge Koudoro and Eleftherios Garyfallidis},
   title     = {{FORCE: FORward matching for Complex microstructure Estimation}},
   journal   = {Research Square (Preprint)},
-  year      = {2025},
-  doi       = {10.21203/rs.3.rs-8151109/v1},
-  url       = {https://www.researchsquare.com/article/rs-10766894/latest},
+  year      = {2026},
+  doi       = {10.21203/rs.3.rs-10766894/v1},
+  url       = {https://doi.org/10.21203/rs.3.rs-10766894/v1},
   note      = {Under review at Nature Portfolio}
 }
 


### PR DESCRIPTION
## Description


`generate_force_simulations` could not be made reproducible through the public API: the documented `base_seed` path of `init_worker` was never wired up, and its `base_seed + PID` scheme would not have been reproducible across runs even if it were.

## Motivation and Context

Fixes #4092.

- **`dipy/sims/force.py`**: `generate_force_simulations` gains a `seed` parameter (default `2298`). Seeding is per *batch*, not per worker: each batch reseeds itself from a stream derived via `np.random.SeedSequence([seed, batch_index])` at the top of `_generate_batch_worker`. Identical seeds therefore yield bit-identical libraries independently of `num_cpus` or worker scheduling, while every batch still draws distinct random values. `seed=None` keeps the previous fresh-entropy behavior. The dead `base_seed` branch of `init_worker` is removed and its docstring corrected.
- **`dipy/reconst/force.py`**: `FORCEModel.generate` gains `seed=2298` and threads it through. The simulation cache registry records the seed as part of the cache key (`_seed_matches`); legacy entries without a `seed` field were not generated reproducibly, so they only match `seed=None` requests.
- **`dipy/workflows/reconst.py`**: `--seed` exposed on the FORCE workflow.

## How Has This Been Tested?

Ran the issue's reproducer: two identical calls now return identical libraries, `num_cpus=1` vs `num_cpus=4` are bit-identical, different seeds diverge, and within a run all 2000 signal rows are unique (no batch is a clone of another, guarding against the same seed being propagated to every worker).

New tests cover: same-seed/default-seed reproducibility, different-seed divergence, `seed=None` entropy, CPU-count independence (1 vs 2 workers), distinct per-batch streams, and cache keying on the seed (hit on repeat, miss on a different seed, legacy-entry handling).



## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [X] I have added tests that cover my changes (if applicable).
- [X] All new and existing tests pass locally.
- [X] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
