### PR TITLE
STYLE: Stick to canonical indentation multiplicity in Cython code

### DIFF
--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -180,9 +180,9 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                         # loop over kernel x,y,z,orient --> x and r
                         for x in range(int_max(cx - hn, 0),
                                        int_min(cx + hn + 1, ny - 1)):
-                             for y in range(int_max(cy - hn, 0),
+                            for y in range(int_max(cy - hn, 0),
                                             int_min(cy + hn + 1, ny - 1)):
-                                 for z in range(int_max(cz - hn, 0),
+                                for z in range(int_max(cz - hn, 0),
                                                 int_min(cz + hn + 1, nz - 1)):
                                     voxcount[corient, cx, cy, cz] += 1.0
                                     for orient in range(0, OR2):

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -38,7 +38,7 @@ cdef class BootDirectionGetter(DirectionGetter):
             double[:, :] B
 
         if max_attempts < 1:
-             raise ValueError("max_attempts must be greater than 0.")
+            raise ValueError("max_attempts must be greater than 0.")
 
         if b_tol <= 0:
             raise ValueError("b_tol must be greater than 0.")

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -427,7 +427,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
             double average_voxel_size = 0
 
         if not fixedstep > 0:
-           raise ValueError("PTT only supports fixed step size.")
+            raise ValueError("PTT only supports fixed step size.")
 
         self.step_size = step_size
         for i in range(3):

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -96,7 +96,7 @@ cdef CentroidNode* create_empty_node(Shape centroid_shape, float threshold) nogi
     # otherwise during assignment CPython will try to call _PYX_XDEC_MEMVIEW on it and segfault.
     cdef CentroidNode* node = <CentroidNode*> calloc(1, sizeof(CentroidNode))
     node.centroid = create_memview_2d(centroid_shape.size, centroid_shape.dims)
-        #node.updated_centroid = <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]> calloc(centroid_shape.size, sizeof(float))
+    #node.updated_centroid = <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]> calloc(centroid_shape.size, sizeof(float))
 
     node.father = NULL
     node.children = NULL

--- a/dipy/segment/cythonutils.pxd
+++ b/dipy/segment/cythonutils.pxd
@@ -21,9 +21,9 @@ ctypedef fused Data:
     Data7D
 
 cdef struct Shape:
-   Py_ssize_t ndim
-   Py_ssize_t dims[MAX_NDIM]
-   Py_ssize_t size
+    Py_ssize_t ndim
+    Py_ssize_t dims[MAX_NDIM]
+    Py_ssize_t size
 
 
 cdef Shape shape_from_memview(Data data) noexcept nogil

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -100,40 +100,40 @@ cdef class DirectionGetter:
                                     StreamlineStatus stream_status,
                                     int fixedstep
                                     ):
-       cdef:
-           cnp.npy_intp i
-           cnp.npy_intp len_streamlines = streamline.shape[0]
-           double point[3]
-           double voxdir[3]
-           void (*step)(double*, double*, double) noexcept nogil
+        cdef:
+            cnp.npy_intp i
+            cnp.npy_intp len_streamlines = streamline.shape[0]
+            double point[3]
+            double voxdir[3]
+            void (*step)(double*, double*, double) noexcept nogil
 
-       if fixedstep > 0:
-           step = _fixed_step
-       else:
-           step = _step_to_boundary
+        if fixedstep > 0:
+            step = _fixed_step
+        else:
+            step = _step_to_boundary
 
-       copy_point(&seed[0], point)
-       copy_point(&seed[0], &streamline[0,0])
+        copy_point(&seed[0], point)
+        copy_point(&seed[0], &streamline[0,0])
 
-       stream_status = TRACKPOINT
-       for i in range(1, len_streamlines):
-           if self.get_direction_c(point, direction):
-               break
-           for j in range(3):
-               voxdir[j] = direction[j] / voxel_size[j]
-           step(point, voxdir, step_size)
-           copy_point(point, &streamline[i, 0])
-           stream_status = stopping_criterion.check_point_c(point)
-           if stream_status == TRACKPOINT:
-               continue
-           elif (stream_status == ENDPOINT or
+        stream_status = TRACKPOINT
+        for i in range(1, len_streamlines):
+            if self.get_direction_c(point, direction):
+                break
+            for j in range(3):
+                voxdir[j] = direction[j] / voxel_size[j]
+            step(point, voxdir, step_size)
+            copy_point(point, &streamline[i, 0])
+            stream_status = stopping_criterion.check_point_c(point)
+            if stream_status == TRACKPOINT:
+                continue
+            elif (stream_status == ENDPOINT or
                  stream_status == INVALIDPOINT or
                  stream_status == OUTSIDEIMAGE):
-               break
-       else:
-           # maximum length of streamline has been reached, return everything
-           i = streamline.shape[0]
-       return i, stream_status
+                break
+        else:
+            # maximum length of streamline has been reached, return everything
+            i = streamline.shape[0]
+        return i, stream_status
 
     def get_direction(self, double[::1] point, double[::1] direction):
         return self.get_direction_c(point, direction)

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1,4 +1,4 @@
- # A type of -*- python -*- file
+# A type of -*- python -*- file
 """ Optimized track distances, similarities and distanch clustering algorithms
 """
 
@@ -1687,7 +1687,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
                         for j from 0<=j<3:
                             cluster[i_k].hidden[i*3+j]+=ptr[(rows-1-i)*3+j]
                 else:
-                     for i from 0<=i<rows:
+                    for i from 0<=i<rows:
                         for j from 0<=j<3:
                             cluster[i_k].hidden[i*3+j]+=ptr[i*3+j]
                 cluster[i_k].N+=1

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -362,8 +362,8 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
             # check for boundaries
             tmp = ps[i] + step_sz * dx[i]
             if tmp > qa_shape[i] - 1 or tmp < 0.:
-                 d = 0
-                 break
+                d = 0
+                break
             # propagate
             ps[i] = tmp
             point[i] = ps[i]
@@ -390,8 +390,8 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
             # check for boundaries
             tmp=ps2[i] + step_sz*dx[i]
             if tmp > qa_shape[i] - 1 or tmp < 0.:
-                 d = 0
-                 break
+                d = 0
+                break
             # propagate
             ps2[i] = tmp
             point[i] = ps2[i] # to be changed

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -19,7 +19,7 @@ cdef class StoppingCriterion:
         return self.check_point_c(&point[0])
 
     cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
-         pass
+        pass
 
 
 cdef class BinaryStoppingCriterion(StoppingCriterion):

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -172,9 +172,9 @@ cdef inline void c_get_closest_edge(cnp.double_t* p,
                                     cnp.double_t* direction,
                                     cnp.double_t* edge,
                                     double eps=1.) noexcept nogil:
-     edge[0] = floor(p[0] + eps) if direction[0] >= 0.0 else ceil(p[0] - eps)
-     edge[1] = floor(p[1] + eps) if direction[1] >= 0.0 else ceil(p[1] - eps)
-     edge[2] = floor(p[2] + eps) if direction[2] >= 0.0 else ceil(p[2] - eps)
+    edge[0] = floor(p[0] + eps) if direction[0] >= 0.0 else ceil(p[0] - eps)
+    edge[1] = floor(p[1] + eps) if direction[1] >= 0.0 else ceil(p[1] - eps)
+    edge[2] = floor(p[2] + eps) if direction[2] >= 0.0 else ceil(p[2] - eps)
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
## Description

Stick to canonical indentation multiplicity in Cython code: use 4 whitespaces per indentation level.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/denoise/shift_twist_convolution.pyx:183:30:
E111 indentation is not a multiple of 4
```

and
```
/home/runner/work/dipy/dipy/dipy/tracking/direction_getter.pyx:134:12:
E114 indentation is not a multiple of 4 (comment)
```

and
```
/home/runner/work/dipy/dipy/dipy/segment/clusteringspeed.pyx:99:9: E116
unexpected indentation (comment)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
