### PR TITLE
STYLE: Comply with blank lines between functions and classes in Cython

### DIFF
--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -15,6 +15,7 @@ cdef extern from "dpy_math.h" nogil:
 cdef inline int ifloor(double x) nogil:
     return int(floor(x))
 
+
 def quantize_positive_2d(floating[:, :] v, int num_levels):
     """Quantize a 2D image to num_levels quantization levels.
 
@@ -353,6 +354,7 @@ def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
                 variances[i] = INF64
     return np.asarray(means), np.asarray(variances)
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -442,6 +444,7 @@ def compute_em_demons_step_2d(floating[:,:] delta_field,
                         out[i, j, 0] = prod * gradient_moving[i, j, 0] / den
                         out[i, j, 1] = prod * gradient_moving[i, j, 1] / den
     return np.asarray(out), energy
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -22,6 +22,7 @@ cdef extern from "dpy_math.h" nogil:
     double sin(double)
     double log(double)
 
+
 class ParzenJointHistogram:
     def __init__(self, nbins):
         r""" Computes joint histogram and derivatives with Parzen windows

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -380,6 +380,7 @@ cdef class EnhancementKernel:
 
 cdef double PI = 3.1415926535897932
 
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef double [:] euler_angles(double [:] inp) noexcept nogil:
@@ -424,6 +425,7 @@ cdef double [:] euler_angles(double [:] inp) noexcept nogil:
         output[1] = atan2(y, x)
 
     return output
+
 
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -70,6 +70,7 @@ def convolve(odfs_sh, kernel, sh_order_max, test_mode=False, num_threads=None, n
 
     return output_sh
 
+
 def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=True):
     """Perform the shift-twist convolution with the ODF data and
     the lookup-table of the kernel.
@@ -108,6 +109,7 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, normalize=Tr
         output = np.multiply(output, np.amax(odfs_sf)/np.amax(output))
 
     return output
+
 
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -216,6 +216,7 @@ cdef cnp.npy_intp search_descending_c(cython.floating* arr, cnp.npy_intp size, d
 
     return left
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def search_descending(cython.floating[::1] a, double relative_threshold):
@@ -286,6 +287,7 @@ cdef long local_maxima_c(double[:] odf, cnp.uint16_t[:, :] edges, double[::1] ou
     free(wpeak)
 
     return count
+
 
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -16,6 +16,7 @@ cdef extern from "dpy_math.h" nogil:
     double dpy_rint(double x)
     double fabs(double)
 
+
 @cython.cdivision(True)
 cdef inline double _stepsize(double point, double increment) noexcept nogil:
     """Compute the step size to the closest boundary in units of increment."""

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -154,6 +154,7 @@ cdef inline void cadd_3vecs(float *vec1, float *vec2, float *vec_out) noexcept n
     for i from 0<=i<3:
         vec_out[i] = vec1[i]+vec2[i]
 
+
 def mul_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
@@ -168,6 +169,7 @@ cdef inline void cmul_3vecs(float *vec1, float *vec2, float *vec_out) noexcept n
     cdef cnp.npy_intp i
     for i from 0<=i<3:
         vec_out[i] = vec1[i]*vec2[i]
+
 
 def mul_3vec(a, vec):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec = as_float_3vec(vec)
@@ -471,6 +473,7 @@ def most_similar_track_mam(tracks,metric="avg"):
         track2others[j] = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
     return si, track2others
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def bundles_distances_mam(tracksA, tracksB, metric="avg"):
@@ -646,6 +649,7 @@ def bundles_distances_mdf(tracksA, tracksB):
 
 cdef cnp.float32_t inf = np.inf
 
+
 @cython.cdivision(True)
 cdef inline cnp.float32_t czhang(cnp.npy_intp t1_len,
                                  cnp.float32_t *track1_ptr,
@@ -685,6 +689,7 @@ cdef inline cnp.float32_t czhang(cnp.npy_intp t1_len,
         else:
             dist_val=mean_t1t2
     return dist_val
+
 
 @cython.cdivision(True)
 cdef inline void min_distances(cnp.npy_intp t1_len,
@@ -1738,6 +1743,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
 
     return C
 
+
 def local_skeleton_clustering_3pts(tracks, d_thr=10):
     """ Does a first pass clustering
 
@@ -2094,6 +2100,7 @@ def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
         return True
     else:
         return False
+
 
 def track_roi_intersection_check(cnp.ndarray[float,ndim=2] track, cnp.ndarray[float,ndim=2] roi, double sq_dist_thr):
     """ Check if a track is intersecting a region of interest


### PR DESCRIPTION
## Description

Comply with the two-blank-line rule between functions and classes in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/expectmax.pyx:18:1: E302 expected
2 blank lines, found 1
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
