### PR TITLE
STYLE: Remove excess blank lines in Cython code

### DIFF
--- a/dipy/align/bundlemin.pyx
+++ b/dipy/align/bundlemin.pyx
@@ -53,7 +53,6 @@ cdef double min_direct_flip_dist(double *a,double *b,
         cnp.npy_intp i=0, j=0
         double sub=0, subf=0, distf=0, dist=0, tmprow=0, tmprowf=0
 
-
     for i in range(rows):
         tmprow = 0
         tmprowf = 0
@@ -272,7 +271,6 @@ def _bundle_minimum_distance(double [:, ::1] static,
         restore_default_num_threads()
 
     return dist
-
 
 
 def _bundle_minimum_distance_asymmetric(double [:, ::1] static,

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -363,7 +363,6 @@ def trilinear_interpolate4d(floating[:, :, :, :] data,
     return out
 
 
-
 def nearestneighbor_interpolate(data, point):
     index = tuple(np.round(point).astype(int))
     return data[index]

--- a/dipy/core/math.pyx
+++ b/dipy/core/math.pyx
@@ -11,7 +11,6 @@ operations used throughout DIPY core modules.
 """
 
 
-
 from dipy.align.fused_types cimport floating
 
 

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -22,7 +22,6 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 
 
-
 def nlmeans_3d_classic(arr, mask=None, sigma=None, patch_radius=1,
                block_radius=5, rician=True, num_threads=None):
     """ Non-local means for denoising 3D images

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -29,7 +29,6 @@ cdef class BootDirectionGetter(DirectionGetter):
         object model
         object sphere
 
-
     def __init__(self, data, model, max_angle, sphere=default_sphere,
                  max_attempts=5, sh_order=0, b_tol=20, **kwargs):
         cdef:
@@ -70,7 +69,6 @@ cdef class BootDirectionGetter(DirectionGetter):
         self.vox_data = np.empty(self.data.shape[3])
         self.pmf = np.empty(sphere.vertices.shape[0])
 
-
     @classmethod
     def from_data(cls, data, model, max_angle, sphere=default_sphere,
                   sh_order=0, max_attempts=5, b_tol=20, **kwargs):
@@ -104,7 +102,6 @@ cdef class BootDirectionGetter(DirectionGetter):
         return cls(data, model, max_angle, sphere=sphere, max_attempts=max_attempts, sh_order=sh_order,
                    b_tol=b_tol, **kwargs)
 
-
     cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(self,
                                                              double[::1] point):
         """Returns best directions at seed location to start tracking.
@@ -126,7 +123,6 @@ cdef class BootDirectionGetter(DirectionGetter):
 
         return peak_directions(pmf, self.sphere, **self._pf_kwargs)[0]
 
-
     cpdef double[:] get_pmf(self, double[::1] point):
         """Produces an ODF from a SH bootstrap sample"""
         if trilinear_interpolate4d_c(self.data,
@@ -138,7 +134,6 @@ cdef class BootDirectionGetter(DirectionGetter):
                 np.asarray(self.vox_data)[self.dwi_mask], self.H, self.R)
             self.pmf = self.model.fit(np.asarray(self.vox_data)).odf(self.sphere)
         return self.pmf
-
 
     cpdef double[:] get_pmf_no_boot(self, double[::1] point):
 
@@ -157,7 +152,6 @@ cdef class BootDirectionGetter(DirectionGetter):
 
         for i in range(len_pmf):
             self.pmf[i] = 0.0
-
 
     cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         """Attempt direction getting on a few bootstrap samples.

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -59,7 +59,6 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         # The vertices need to be in a contiguous array
         self.vertices = self.sphere.vertices.copy()
 
-
     cdef int get_direction_c(self, double[::1] point, double[::1] direction):
         """Samples a pmf to updates ``direction`` array with a new direction.
 
@@ -85,7 +84,6 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
 
         _len = self.len_pmf
         pmf = self._get_pmf(point)
-
 
         if norm(&direction[0]) == 0:
             return 1

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -60,7 +60,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
     cdef double[3]    voxel_size
     cdef double[3]    inv_voxel_size
 
-
     def __init__(self, pmf_gen, max_angle, sphere, pmf_threshold=None,
                  double probe_length=0.5, double probe_radius=0,
                  int probe_quality=3, int probe_count=1,
@@ -127,7 +126,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         ProbabilisticDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
                                        pmf_threshold=pmf_threshold, **kwargs)
 
-
     cdef void initialize_candidate(self, double[:] init_dir):
         """"Initialize the parallel transport frame.
 
@@ -177,7 +175,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                 self.last_val += self.pmf_gen.get_pmf_value_c(position,
                                                               self.frame[0])
 
-
     cdef void prepare_propagator(self, double arclength) nogil:
         """Prepare the propagator.
 
@@ -221,7 +218,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
             self.propagator[6] = -self.k2 * arclength
             self.propagator[7] = -self.k1 * self.k2 * tmp_arclength
             self.propagator[8] = (1 - self.k2 * self.k2 * tmp_arclength)
-
 
     cdef double calculate_data_support(self):
         """Calculates data support for the candidate probe."""
@@ -302,7 +298,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
             likelihood = pow(likelihood, self.data_support_exponent)
 
         return likelihood
-
 
     cdef int initialize(self, double[:] seed_point, double[:] seed_direction):
         """Sample an initial curve by rejection sampling.
@@ -407,7 +402,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                 return 0
 
         return 1
-
 
     # @cython.boundscheck(False)
     # @cython.wraparound(False)

--- a/dipy/reconst/dkispeed.pyx
+++ b/dipy/reconst/dkispeed.pyx
@@ -63,7 +63,6 @@ cdef inline int get_kt_index(int key) noexcept nogil:
         return 0
 
 
-
 cdef inline bint positive_evals_single(double L1, double L2, double L3,
                                         double er=2e-7) noexcept nogil:
     """Check if all eigenvalues are significantly larger than zero.
@@ -85,7 +84,6 @@ cdef inline bint positive_evals_single(double L1, double L2, double L3,
         True if all three eigenvalues exceed ``er``, False otherwise.
     """
     return L1 > er and L2 > er and L3 > er
-
 
 
 cdef double carlson_rf_single(double x, double y, double z,
@@ -145,7 +143,6 @@ cdef double carlson_rf_single(double x, double y, double z,
                            (E2 * E2) / 24.0 - 3.0 / 44.0 * E2 * E3)
 
     return RF
-
 
 
 cdef double carlson_rd_single(double x, double y, double z,
@@ -218,7 +215,6 @@ cdef double carlson_rd_single(double x, double y, double z,
     return RD
 
 
-
 cdef double F2m_single(double a, double b, double c, double er=2.5e-2) noexcept nogil:
     """Compute function F2 for a single voxel.
 
@@ -286,7 +282,6 @@ cdef double F2m_single(double a, double b, double c, double er=2.5e-2) noexcept 
     return F2
 
 
-
 cdef double F1m_single(double a, double b, double c, double er=2.5e-2) noexcept nogil:
     """Compute function F1 for a single voxel.
 
@@ -348,7 +343,6 @@ cdef double F1m_single(double a, double b, double c, double er=2.5e-2) noexcept 
     return F1
 
 
-
 cdef double G1m_single(double a, double b, double c, double er=2.5e-2) noexcept nogil:
     """Compute function G1 for a single voxel.
 
@@ -388,7 +382,6 @@ cdef double G1m_single(double a, double b, double c, double er=2.5e-2) noexcept 
     L2 = b
     G1 = (L1 + 2.0 * L2) * (L1 + 2.0 * L2) / (24.0 * L2 * L2)
     return G1
-
 
 
 cdef double G2m_single(double a, double b, double c, double er=2.5e-2) noexcept nogil:
@@ -432,7 +425,6 @@ cdef double G2m_single(double a, double b, double c, double er=2.5e-2) noexcept 
     return G2
 
 
-
 cdef double Wrotate_element_single(double[:] kt, int indi, int indj,
                                     int indk, int indl,
                                     double[:, :] B) noexcept nogil:
@@ -468,7 +460,6 @@ cdef double Wrotate_element_single(double[:] kt, int indi, int indj,
                     Wre = Wre + multiplyB * kt[idx]
 
     return Wre
-
 
 
 def mean_kurtosis_analytical(double[:, :] dki_params_flat,
@@ -558,7 +549,6 @@ def mean_kurtosis_analytical(double[:, :] dki_params_flat,
     return np.asarray(MK)
 
 
-
 def axial_kurtosis_analytical(double[:, :] dki_params_flat,
                                double min_kurtosis=-3.0/7.0,
                                double max_kurtosis=10.0):
@@ -617,7 +607,6 @@ def axial_kurtosis_analytical(double[:, :] dki_params_flat,
             AK[v] = ak_val
 
     return np.asarray(AK)
-
 
 
 def radial_kurtosis_analytical(double[:, :] dki_params_flat,
@@ -683,7 +672,6 @@ def radial_kurtosis_analytical(double[:, :] dki_params_flat,
             RK[v] = rk_val
 
     return np.asarray(RK)
-
 
 
 def kurtosis_fractional_anisotropy_c(double[:, :] dki_params_flat):

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -94,7 +94,6 @@ cdef class EuDXDirectionGetter(DirectionGetter):
 
         return res
 
-
     @cython.initializedcheck(False)
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -114,8 +114,6 @@ cdef CentroidNode* create_empty_node(Shape centroid_shape, float threshold) nogi
     return node
 
 
-
-
 cdef class QuickBundlesX:
 
     def __init__(self, features_shape, levels_thresholds, Metric metric):
@@ -399,7 +397,6 @@ cdef class ClustersCentroid(Clusters):
             free_memview_2d(self.centroids[i].features)
             free_memview_2d(self._updated_centroids[i].features)
 
-
         free(self.centroids)
         self.centroids = NULL
         free(self._updated_centroids)
@@ -532,7 +529,6 @@ cdef class QuickBundles:
             if dist < nearest_cluster.dist:
                 nearest_cluster.dist = dist
                 nearest_cluster.id = k
-
 
         return nearest_cluster
 

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -32,7 +32,6 @@ class ConstantObservationModel:
         """
         pass
 
-
     def initialize_param_uniform(self, image, nclasses):
         r""" Initializes the means and variances uniformly
 
@@ -61,7 +60,6 @@ class ConstantObservationModel:
         _initialize_param_uniform(image, mu, sigma)
 
         return np.array(mu), np.array(sigma)
-
 
     def seg_stats(self, input_image, seg_image, cnp.npy_intp nclass):
         r""" Mean and standard variation for N desired  tissue classes
@@ -122,7 +120,6 @@ class ConstantObservationModel:
 
         return mu, var
 
-
     def negloglikelihood(self, image, mu, sigmasq, cnp.npy_intp nclasses):
         r""" Computes the gaussian negative log-likelihood of each class at
         each voxel of `image` assuming a gaussian distribution with means and
@@ -153,7 +150,6 @@ class ConstantObservationModel:
             _negloglikelihood(image, mu, sigmasq, l, nloglike)
 
         return nloglike
-
 
     def prob_image(self, img, cnp.npy_intp nclasses, mu, sigmasq, P_L_N):
         r""" Conditional probability of the label given the image
@@ -193,7 +189,6 @@ class ConstantObservationModel:
             P_L_Y[:, :, :, l] = P_L_Y[:, :, :, l] / P_L_Y_norm
 
         return P_L_Y
-
 
     def update_param(self, image, P_L_Y, mu, cnp.npy_intp nclasses):
         r""" Updates the means and the variances in each iteration for all
@@ -423,7 +418,6 @@ class IteratedConditionalModes:
 
         return seg
 
-
     def icm_ising(self, nloglike, beta, seg):
         r""" Executes one iteration of the ICM algorithm for MRF MAP
         estimation. The prior distribution of the MRF is a Gibbs
@@ -457,7 +451,6 @@ class IteratedConditionalModes:
         _icm_ising(nloglike, beta, seg, energy, new_seg)
 
         return new_seg, energy
-
 
     def prob_neighborhood(self, seg, beta, cnp.npy_intp nclasses):
         r""" Conditional probability of the label given the neighborhood

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -79,13 +79,11 @@ cdef void _fixed_step(double * point, double * direction, double step_size) noex
         point[i] += direction[i] * step_size
 
 
-
 cdef class DirectionGetter:
 
     cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(
             self, double[::1] point):
         pass
-
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -357,9 +357,6 @@ def cut_plane(tracks, ref):
     return Hit[1:]
 
 
-
-
-
 def most_similar_track_mam(tracks,metric="avg"):
     """ Find the most similar track in a bundle
     using distances calculated from Zhang et. al 2008.
@@ -642,8 +639,6 @@ def bundles_distances_mdf(tracksA, tracksB):
     return DM
 
 
-
-
 cdef cnp.float32_t inf = np.inf
 
 @cython.cdivision(True)
@@ -727,7 +722,6 @@ cdef inline void min_distances(cnp.npy_intp t1_len,
         min_t1t2[t1_pi]=sqrt(min_t1t2[t1_pi])
     for t2_pi from 0<= t2_pi < t2_len:
         min_t2t1[t2_pi]=sqrt(min_t2t1[t2_pi])
-
 
 
 def mam_distances(xyz1,xyz2,metric="all"):
@@ -956,7 +950,6 @@ cdef float clee_perpendicular_distance(float *start0, float *end0,float *start1,
 
     csub_3vecs(end1,start1,tmp)
     l1 = cinner_3vecs(tmp, tmp)
-
 
     #csub_3vecs(end0,start0,k0)
 
@@ -1537,14 +1530,10 @@ cdef inline void track_direct_flip_3dist(float *a1, float *b1,float *c1,float *a
     #out[1]=(tmp1f+tmp2+tmp3f)/3.0
 
 
-
-
 ctypedef struct LSC_Cluster:
     long *indices
     float *hidden
     long N
-
-
 
 
 @cython.boundscheck(False)
@@ -1706,7 +1695,6 @@ def local_skeleton_clustering(tracks, d_thr=10):
 
             free(alld)
             free(flip)
-
 
     #Copy results to a dictionary
 
@@ -1968,7 +1956,6 @@ def larch_3split(tracks, indices=None, thr=10.):
             C[lenC]["N"]=1
             C[lenC]["indices"]=[it]
 
-
     return C
 
 
@@ -2033,7 +2020,6 @@ def larch_3merge(C,thr=10.):
             del C2[c]
 
     return C2
-
 
 
 def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,

--- a/dipy/tracking/propspeed.pxd
+++ b/dipy/tracking/propspeed.pxd
@@ -36,7 +36,6 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
                                                  RNGState* rng) noexcept nogil
 
 
-
 cdef cnp.npy_intp _propagation_direction(double *point, double* prev, double* qa,
                                 double *ind, double *odf_vertices,
                                 double qa_thr, double ang_thr,

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -807,7 +807,6 @@ cdef TrackerStatus probabilistic_propagator(double* point,
         double last_cdf, cos_sim
         cnp.npy_intp len_pmf=pmf_gen.pmf.shape[0]
 
-
     if norm(direction) == 0:
         return TrackerStatus.FAIL
     normalize(direction)
@@ -1040,7 +1039,6 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
 
     # Compensation for underestimation of max posterior estimate
     max_posterior = pow(2.0 * max_posterior, params.ptt.data_support_exponent)
-
 
     for tries in range(params.ptt.rejection_sampling_max_try):
         # k1, k2

--- a/dipy/tracking/tests/test_tractogen.pyx
+++ b/dipy/tracking/tests/test_tractogen.pyx
@@ -17,7 +17,6 @@ from dipy.tracking.utils import (connectivity_matrix, random_seeds_from_mask,
                                  seeds_from_mask, seeds_directions_pairs)
 
 
-
 def get_fast_tracking_performances(params, *, nbr_seeds=1000, nbr_threads=0):
     """
     Generate streamlines and return performances on the DiSCo dataset.
@@ -170,7 +169,6 @@ def test_tracking_step_size():
             dists.extend(np.linalg.norm(sl[0:-1] - sl[1:], axis=1))
         return dists
 
-
     for step_size in [0.02, 0.5, 1]:
         params = generate_tracking_parameters("det",
                                               max_len=500,
@@ -189,7 +187,6 @@ def test_return_all():
     """This tests that the number of streamlines equals the number of seeds
     when return_all=True.
     """
-
 
     fnames = get_fnames(name="disco1", include_optional=True)
     sphere = HemiSphere.from_sphere(get_sphere(name="repulsion724"))


### PR DESCRIPTION

## Description

Remove excess blank lines in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/bundlemin.pyx:57:5: E303 too many
blank lines (2)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
