### PR TITLE
STYLE: Mark docstrings as raw to interpret escape sequences in Cython

### DIFF
--- a/dipy/reconst/dirspeed.pyx
+++ b/dipy/reconst/dirspeed.pyx
@@ -31,7 +31,7 @@ cdef cnp.uint16_t peak_directions_c(
     cnp.uint16_t[:] mapping,
     cnp.uint16_t[:] index
 ) noexcept nogil:
-    """Get the directions of odf peaks.
+    r"""Get the directions of odf peaks.
 
     Peaks are defined as points on the odf that are greater than at least one
     neighbor and greater than or equal to all neighbors. Peaks are sorted in

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -96,7 +96,7 @@ def remove_similar_vertices(
     bint return_index=False,
     bint remove_antipodal=True
 ):
-    """Remove vertices that are less than `theta` degrees from any other
+    r"""Remove vertices that are less than `theta` degrees from any other
 
     Returns vertices that are at least theta degrees from any other vertex.
     Vertex v and -v are considered the same so if v and -v are both in


### PR DESCRIPTION
## Description

Mark docstrings as raw so that escape sequences used in math expressions can be interpreted correctly in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/reconst/dirspeed.pyx:69:46: W605
invalid escape sequence '\i'
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
