### PR TITLE
STYLE: Use underscores for unused loop control variables in Cython

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -298,8 +298,8 @@ def _firdn_vector(double[:] f, double[:] h, double[:] out):
     cdef cnp.npy_intp klen = len(h)
     cdef cnp.npy_intp outLen = (n + klen) // 2
     cdef double ss
-    cdef cnp.npy_intp i, k, limInf, limSup, x = 0, ox = 0, ks = 0
-    for i in range(outLen):
+    cdef cnp.npy_intp k, limInf, limSup, x = 0, ox = 0, ks = 0
+    for _ in range(outLen):
         ss = 0
         limInf = _int_max(0, x - klen + 1)
         limSup = 1 + _int_min(n - 1, x)

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -317,13 +317,12 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         """
         cdef double data_support = 0
         cdef double max_posterior = 0
-        cdef int tries
 
         self.position[0] = seed_point[0]
         self.position[1] = seed_point[1]
         self.position[2] = seed_point[2]
 
-        for tries in range(self.rejection_sampling_nbr_sample):
+        for _ in range(self.rejection_sampling_nbr_sample):
             self.initialize_candidate(seed_direction)
             data_support = self.calculate_data_support()
             if data_support > max_posterior:
@@ -334,7 +333,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
 
         # Initialization is successful if a suitable candidate can be sampled
         # within the trial limit
-        for tries in range(self.rejection_sampling_max_try):
+        for _ in range(self.rejection_sampling_max_try):
             self.initialize_candidate(seed_direction)
             if (random() * max_posterior <= self.calculate_data_support()):
                 self.last_val = self.last_val_cand
@@ -359,7 +358,6 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         cdef double max_posterior = 0
         cdef double data_support = 0
         cdef double[3] tangent
-        cdef int tries
         cdef cnp.npy_intp i
 
         self.prepare_propagator(self.step_size)
@@ -384,7 +382,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         self.frame[0][1] = tangent[1]
         self.frame[0][2] = tangent[2]
 
-        for tries in range(self.rejection_sampling_nbr_sample):
+        for _ in range(self.rejection_sampling_nbr_sample):
             self.k1, self.k2 = random_point_within_circle(self.max_curvature)
             data_support = self.calculate_data_support()
             if data_support > max_posterior:
@@ -395,7 +393,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
 
         # Propagation is successful if a suitable candidate can be sampled
         # within the trial limit
-        for tries in range(self.rejection_sampling_max_try):
+        for _ in range(self.rejection_sampling_max_try):
             self.k1, self.k2 = random_point_within_circle(self.max_curvature)
             if random() * max_posterior <= self.calculate_data_support():
                 self.last_val = self.last_val_cand

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -440,14 +440,13 @@ cdef int initialize_ptt(TrackerParameters params,
     """
     cdef double data_support = 0
     cdef double max_posterior = 0
-    cdef int tries
 
     # position
     stream_data[19] = seed_point[0]
     stream_data[20] = seed_point[1]
     stream_data[21] = seed_point[2]
 
-    for tries in range(params.ptt.rejection_sampling_nbr_sample):
+    for _ in range(params.ptt.rejection_sampling_nbr_sample):
         initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
         data_support = calculate_ptt_data_support(params, stream_data, pmf_gen)
         if data_support > max_posterior:
@@ -458,7 +457,7 @@ cdef int initialize_ptt(TrackerParameters params,
 
     # Initialization is successful if a suitable candidate can be sampled
     # within the trial limit
-    for tries in range(params.ptt.rejection_sampling_max_try):
+    for _ in range(params.ptt.rejection_sampling_max_try):
         initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
         if (random_float(rng) * max_posterior <= calculate_ptt_data_support(params, stream_data, pmf_gen)):
             stream_data[22] = stream_data[23]  # last_val = last_val_cand
@@ -996,7 +995,6 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
     cdef double max_posterior = 0
     cdef double data_support = 0
     cdef double[3] tangent
-    cdef int tries
     cdef int i
 
     if stream_data[0] == 0:
@@ -1029,7 +1027,7 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
     stream_data[2] = tangent[1]
     stream_data[3] = tangent[2]
 
-    for tries in range(params.ptt.rejection_sampling_nbr_sample):
+    for _ in range(params.ptt.rejection_sampling_nbr_sample):
         # k1, k2
         stream_data[24], stream_data[25] = \
             random_point_within_circle(params.max_curvature, rng)
@@ -1040,7 +1038,7 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
     # Compensation for underestimation of max posterior estimate
     max_posterior = pow(2.0 * max_posterior, params.ptt.data_support_exponent)
 
-    for tries in range(params.ptt.rejection_sampling_max_try):
+    for _ in range(params.ptt.rejection_sampling_max_try):
         # k1, k2
         stream_data[24], stream_data[25] = \
             random_point_within_circle(params.max_curvature, rng)

--- a/dipy/utils/tests/test_fast_numpy.pyx
+++ b/dipy/utils/tests/test_fast_numpy.pyx
@@ -66,7 +66,7 @@ def test_cross():
     cdef double[:] vec2
     cdef double[:] out
     out = np.zeros(3, dtype=np.double)
-    for i in range(10):
+    for _ in range(10):
         vec1 = np.random.random(3).astype(np.double)
         vec2 = np.random.random(3).astype(np.double)
         out2 = np.cross(vec1, vec2).astype(np.double)


### PR DESCRIPTION
## Description

Use underscores for unused loop control variables in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/denoise/denspeed.pyx:303:9: Loop
control variable 'i' not used within the loop body (if this is intended,
start the name with an underscore)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
