### PR TITLE
STYLE: Fix over-indentation in Cython code

### DIFF
--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -437,15 +437,15 @@ cpdef double iterate_residual_displacement_field_ssd_3d(
                         if max_displacement < opt:
                             max_displacement = opt
                     elif sigmasq < 1e-9:
-                            nrm2 = g[0] ** 2 + g[1] ** 2 + g[2] ** 2
-                            if nrm2 < 1e-9:
-                                disp[s, r, c, 0] = 0
-                                disp[s, r, c, 1] = 0
-                                disp[s, r, c, 2] = 0
-                            else:
-                                disp[s, r, c, 0] = (b[0]) / nrm2
-                                disp[s, r, c, 1] = (b[1]) / nrm2
-                                disp[s, r, c, 2] = (b[2]) / nrm2
+                        nrm2 = g[0] ** 2 + g[1] ** 2 + g[2] ** 2
+                        if nrm2 < 1e-9:
+                            disp[s, r, c, 0] = 0
+                            disp[s, r, c, 1] = 0
+                            disp[s, r, c, 2] = 0
+                        else:
+                            disp[s, r, c, 0] = (b[0]) / nrm2
+                            disp[s, r, c, 1] = (b[1]) / nrm2
+                            disp[s, r, c, 2] = (b[2]) / nrm2
                     else:
                         tau = sigmasq * lambda_param * nn
                         y[0] = b[0] + sigmasq * lambda_param * y[0]

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -415,55 +415,55 @@ cdef int initialize_ptt(TrackerParameters params,
                         double* seed_point,
                         double* seed_direction,
                         RNGState* rng) noexcept nogil:
-        """Sample an initial curve by rejection sampling.
+    """Sample an initial curve by rejection sampling.
 
-        Parameters
-        ----------
-        params : TrackerParameters
-            PTT tracking parameters.
-        stream_data : double*
-            Streamline data persitant across tracking steps.
-        pmf_gen : PmfGen
-            Orientation data.
-        seed_point : double[3]
-            Initial point
-        seed_direction : double[3]
-            Initial direction
-        rng : RNGState*
-            Random number generator state. (Threadsafe)
+    Parameters
+    ----------
+    params : TrackerParameters
+        PTT tracking parameters.
+    stream_data : double*
+        Streamline data persitant across tracking steps.
+    pmf_gen : PmfGen
+        Orientation data.
+    seed_point : double[3]
+        Initial point
+    seed_direction : double[3]
+        Initial direction
+    rng : RNGState*
+        Random number generator state. (Threadsafe)
 
-        Returns
-        -------
-        status : int
-            Returns 0 if the initialization was successful, or
-            1 otherwise.
-        """
-        cdef double data_support = 0
-        cdef double max_posterior = 0
-        cdef int tries
+    Returns
+    -------
+    status : int
+        Returns 0 if the initialization was successful, or
+        1 otherwise.
+    """
+    cdef double data_support = 0
+    cdef double max_posterior = 0
+    cdef int tries
 
-        # position
-        stream_data[19] = seed_point[0]
-        stream_data[20] = seed_point[1]
-        stream_data[21] = seed_point[2]
+    # position
+    stream_data[19] = seed_point[0]
+    stream_data[20] = seed_point[1]
+    stream_data[21] = seed_point[2]
 
-        for tries in range(params.ptt.rejection_sampling_nbr_sample):
-            initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
-            data_support = calculate_ptt_data_support(params, stream_data, pmf_gen)
-            if data_support > max_posterior:
-                max_posterior = data_support
+    for tries in range(params.ptt.rejection_sampling_nbr_sample):
+        initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
+        data_support = calculate_ptt_data_support(params, stream_data, pmf_gen)
+        if data_support > max_posterior:
+            max_posterior = data_support
 
-        # Compensation for underestimation of max posterior estimate
-        max_posterior = pow(2.0 * max_posterior, params.ptt.data_support_exponent)
+    # Compensation for underestimation of max posterior estimate
+    max_posterior = pow(2.0 * max_posterior, params.ptt.data_support_exponent)
 
-        # Initialization is successful if a suitable candidate can be sampled
-        # within the trial limit
-        for tries in range(params.ptt.rejection_sampling_max_try):
-            initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
-            if (random_float(rng) * max_posterior <= calculate_ptt_data_support(params, stream_data, pmf_gen)):
-                stream_data[22] = stream_data[23]  # last_val = last_val_cand
-                return 0
-        return 1
+    # Initialization is successful if a suitable candidate can be sampled
+    # within the trial limit
+    for tries in range(params.ptt.rejection_sampling_max_try):
+        initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
+        if (random_float(rng) * max_posterior <= calculate_ptt_data_support(params, stream_data, pmf_gen)):
+            stream_data[22] = stream_data[23]  # last_val = last_val_cand
+            return 0
+    return 1
 
 
 cdef void initialize_ptt_candidate(TrackerParameters params,


### PR DESCRIPTION
## Description

Fix over-indentation in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/sumsqdiff.pyx:440:29: E117
over-indented
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
