### PR TITLE
STYLE: Use one whitespace after number sign in Cython inline comments

### DIFF
--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -54,7 +54,7 @@ cdef class BootDirectionGetter(DirectionGetter):
             if hasattr(model, "sh_order"):
                 self.sh_order = model.sh_order
             else:
-                self.sh_order = 4 #  DEFAULT Value
+                self.sh_order = 4  # DEFAULT Value
 
         self.dwi_mask = model.gtab.b0s_mask == 0
         x, y, z = model.gtab.gradients[self.dwi_mask].T

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -96,7 +96,7 @@ cdef CentroidNode* create_empty_node(Shape centroid_shape, float threshold) nogi
     # otherwise during assignment CPython will try to call _PYX_XDEC_MEMVIEW on it and segfault.
     cdef CentroidNode* node = <CentroidNode*> calloc(1, sizeof(CentroidNode))
     node.centroid = create_memview_2d(centroid_shape.size, centroid_shape.dims)
-    #node.updated_centroid = <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]> calloc(centroid_shape.size, sizeof(float))
+        # node.updated_centroid = <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]> calloc(centroid_shape.size, sizeof(float))
 
     node.father = NULL
     node.children = NULL

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -8,7 +8,7 @@ from libc.math cimport sqrt, acos
 from dipy.segment.cythonutils cimport tuple2shape, shape2tuple, same_shape
 from dipy.segment.featurespeed cimport IdentityFeature
 
-DEF biggest_double = 1.7976931348623157e+308  #  np.finfo('f8').max
+DEF biggest_double = 1.7976931348623157e+308  # np.finfo('f8').max
 
 import math
 cdef double PI = math.pi

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1295,8 +1295,8 @@ cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, f
     dd=cinner_3vecs(d,d)
 
     #test if segment fully outside either endcap of cylinder
-    if md < 0. and md + nd < 0.:  return 0 #segment outside p side
-    if md > dd and md + nd > dd:  return 0 #segment outside q side
+    if md < 0. and md + nd < 0.:  return 0  # segment outside p side
+    if md > dd and md + nd > dd:  return 0  # segment outside q side
 
     nn=cinner_3vecs(n,n)
     mn=cinner_3vecs(m,n)
@@ -1676,7 +1676,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
                     i_k=k
 
             if m_d < cd_thr:
-                if flip[i_k]==1:#correct if flipping is needed
+                if flip[i_k]==1:  # correct if flipping is needed
                     for i from 0<=i<rows:
                         for j from 0<=j<3:
                             cluster[i_k].hidden[i*3+j]+=ptr[(rows-1-i)*3+j]
@@ -1688,7 +1688,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
                 cluster[i_k].indices=<long *>realloc(cluster[i_k].indices,cluster[i_k].N*sizeof(long))
                 cluster[i_k].indices[cluster[i_k].N-1]=cit
 
-            else:#New cluster added
+            else:  # New cluster added
                 lenC+=1
                 cluster=<LSC_Cluster *>realloc(cluster,lenC*sizeof(LSC_Cluster))
                 cluster[lenC-1].indices=<long *>realloc(NULL,sizeof(long))

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -146,7 +146,7 @@ cdef cnp.npy_intp _nearest_direction(double* dx,
             odfv[j]=odf_vertices[3 * <cnp.npy_intp>ind[i] + j]
         # calculate the absolute dot product between dx and odf_vertices
         curr_dot = dx[0] * odfv[0] + dx[1] * odfv[1] + dx[2] * odfv[2]
-        if curr_dot < 0: #abs check
+        if curr_dot < 0:  # abs check
             curr_dot = -curr_dot
         # maximum dot means minimum angle
         # store the maximum dot and the corresponding index from the


### PR DESCRIPTION
## Description

Use one whitespace after number sign in Cython inline comments. Take advantage of the commit to add two whitespaces before the sign where appropriate in the modified lines in anticipation of E261 errors.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/direction/bootstrap_direction_getter.pyx:58:35:
E262 inline comment should start with '# '
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
