### PR TITLE
STYLE: Use two whitespaces before inline comments in Cython

### DIFF
--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -171,7 +171,7 @@ cdef class EnhancementKernel:
 
         lookuptablelocal = np.zeros((OR1, OR2, N, N, N))
         x = np.zeros(3)
-        y = np.zeros(3) # constant at (0,0,0)
+        y = np.zeros(3)  # constant at (0,0,0)
 
         with nogil:
 

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -122,7 +122,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
 
         self.k_small = 0.0001
         self.rejection_sampling_max_try = 100
-        self.rejection_sampling_nbr_sample = 10 # Adaptively set in Trekker.
+        self.rejection_sampling_nbr_sample = 10  # Adaptively set in Trekker.
 
         ProbabilisticDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
                                        pmf_threshold=pmf_threshold, **kwargs)

--- a/dipy/reconst/quick_squash.pyx
+++ b/dipy/reconst/quick_squash.pyx
@@ -91,9 +91,9 @@ def quick_squash(obj_arr, mask=None, fill=0):
             common_shape = e.shape
             dtype = e.dtype
             break
-        else: # something other than scalar or array
+        else:  # something other than scalar or array
             return obj_arr
-    else: # Nothing outside mask / all None
+    else:  # Nothing outside mask / all None
         return obj_arr
     # Check rest of values to confirm common type / shape, and collect dtypes
     last_dtype = dtype
@@ -109,7 +109,7 @@ def quick_squash(obj_arr, mask=None, fill=0):
             if not issubclass(t, np.generic) and not t in SCALAR_TYPES:
                 return obj_arr
             dtype = np.dtype(t)
-        else: # search_for == ARRAY:
+        else:  # search_for == ARRAY:
             if not t == cnp.ndarray:
                 return obj_arr
             if not e.shape == common_shape:

--- a/dipy/reconst/vec_val_sum.pyx
+++ b/dipy/reconst/vec_val_sum.pyx
@@ -71,7 +71,7 @@ def vec_val_vect(vecs, vals):
     valr = np.array(vals.reshape((N, cols)), dtype=float)
     out = np.zeros((N, rows, rows))
     with nogil:
-        for t in range(N): # loop over the early dimensions
+        for t in range(N):  # loop over the early dimensions
             vec = vecr[t]
             val = valr[t]
             out_vec = out[t]

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -73,7 +73,7 @@ cdef void aabb_creation(Data2D streamline, float* aabb) noexcept nogil:
             if min_[d] > streamline[n, d]:
                 min_[d] = streamline[n, d]
 
-        aabb[d + 3] = (max_[d] - min_[d]) / 2.0 # radius
+        aabb[d + 3] = (max_[d] - min_[d]) / 2.0  # radius
         aabb[d] = min_[d] + aabb[d + 3]  # center
 
 

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -292,11 +292,11 @@ def cut_plane(tracks, ref):
                 # q = track[q_no]
                 # r = track[q_no+1]
                 # float* versions of above: p == this_ref_p
-                this_trk_p = next_trk_p # q
-                next_trk_p = asfp(track[q_no+1]) # r
+                this_trk_p = next_trk_p  # q
+                next_trk_p = asfp(track[q_no+1])  # r
                 #if np.inner(normal,q-p)*np.inner(normal,r-p) <= 0:
-                csub_3vecs(this_trk_p, this_ref_p, qMp) # q-p
-                csub_3vecs(next_trk_p, this_ref_p, rMp) # r-p
+                csub_3vecs(this_trk_p, this_ref_p, qMp)  # q-p
+                csub_3vecs(next_trk_p, this_ref_p, rMp)  # r-p
                 if (cinner_3vecs(normal, qMp) * cinner_3vecs(normal, rMp)) <=0:
                     #if np.inner((r-q),normal) != 0:
                     csub_3vecs(next_trk_p, this_trk_p, rMq)
@@ -315,7 +315,7 @@ def cut_plane(tracks, ref):
                             csub_3vecs(hit, this_ref_p, hitMp)
                             # |h-p|
                             lhp = cnorm_3vec(hitMp)
-                            delta = rMq # just renaming
+                            delta = rMq  # just renaming
                             # |r-q| == |delta|
                             ld = cnorm_3vec(delta)
                             """ # Summary of stuff in comments
@@ -720,8 +720,8 @@ cdef inline void min_distances(cnp.npy_intp t1_len,
                 min_t2t1[t2_pi]=delta2
             if delta2 < min_t1t2[t1_pi]:
                 min_t1t2[t1_pi]=delta2
-            t2_pt += 3 # to next point in track 2
-        t1_pt += 3 # to next point in track 1
+            t2_pt += 3  # to next point in track 2
+        t1_pt += 3  # to next point in track 1
     # sqrt to get Euclidean distance from squared distance
     for t1_pi from 0<= t1_pi < t1_len:
         min_t1t2[t1_pi]=sqrt(min_t1t2[t1_pi])
@@ -1308,26 +1308,26 @@ cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, f
 
     if fabs(a) < epsilon_float:
         #segment runs parallel to cylinder axis
-        if c>0.:  return 0. # segment lies outside cylinder
+        if c>0.:  return 0.  # segment lies outside cylinder
         if md < 0.:
-            t[0]=-mn/nn # intersect against p endcap
+            t[0]=-mn/nn  # intersect against p endcap
         elif md > dd :
-            t[0]=(nd-mn)/nn # intersect against q endcap
+            t[0]=(nd-mn)/nn  # intersect against q endcap
         else:
-            t[0]=0. # lies inside cylinder
+            t[0]=0.  # lies inside cylinder
         return 1
 
     b=dd*mn -nd*md
     discr=b*b-a*c
-    if discr < 0.: return 0. # no real roots ; no intersection
+    if discr < 0.: return 0.  # no real roots ; no intersection
 
     t[0]=(-b-sqrt(discr))/a
     t[1]=(-b+sqrt(discr))/a
-    if t[0]<0. or t[0] > 1. : return 0. # intersection lies outside segment
+    if t[0]<0. or t[0] > 1. : return 0.  # intersection lies outside segment
 
     if md + t[0]* nd < 0.:
         #intersection outside cylinder on 'p' side
-        if nd <= 0. : return 0. # segment pointing away from endcap
+        if nd <= 0. : return 0.  # segment pointing away from endcap
         t[0]=-md/nd
         #keep intersection if Dot(S(t)-p,S(t)-p) <= r^2
         if k+2*t[0]*(mn+t[0]*nn) <=0.:
@@ -1335,7 +1335,7 @@ cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, f
 
     elif md+t[0]*nd > dd :
         #intersection outside cylinder on 'q' side
-        if nd >= 0.: return 0. # segment pointing away from endcap
+        if nd >= 0.: return 0.  # segment pointing away from endcap
         t[0]= (dd-md)/nd
         #keep intersection if Dot(S(t)-q,S(t)-q) <= r^2
         if k+dd-2*md+t[0]*(2*(mn-nd)+t[0]*nn) <= 0.:

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -185,9 +185,9 @@ cdef cnp.npy_intp _propagation_direction(double *point,
                                          double *direction,
                                          double total_weight) noexcept nogil:
     cdef:
-        double total_w = 0 # total weighting useful for interpolation
-        cnp.npy_intp delta = 0 # store delta function (stopping function) result
-        double new_direction[3] # new propagation direction
+        double total_w = 0  # total weighting useful for interpolation
+        cnp.npy_intp delta = 0  # store delta function (stopping function) result
+        double new_direction[3]  # new propagation direction
         double w[8]
         double qa_tmp[PEAK_NO]
         double ind_tmp[PEAK_NO]
@@ -236,7 +236,7 @@ cdef cnp.npy_intp _propagation_direction(double *point,
         for i from 0 <= i < 3:
             new_direction[i] += w[m] * direction[i]
     # if less than half the volume is time to stop propagating
-    if total_w < total_weight: # termination
+    if total_w < total_weight:  # termination
         return 0
     # all good return normalized weighted next direction
     normd = new_direction[0]**2 + new_direction[1]**2 + new_direction[2]**2
@@ -272,7 +272,7 @@ cdef cnp.npy_intp _initial_direction(double* seed,double *qa,
     if qa_tmp < qa_thr:
         return 0
     # Find the correct direction from the indices
-    ind_tmp = ind[off] # similar to ind[point] in numpy syntax
+    ind_tmp = ind[off]  # similar to ind[point] in numpy syntax
     # Return initial direction through odf_vertices by ind
     for i from 0 <= i < 3:
         direction[i] = odf_vertices[3 * <cnp.npy_intp>ind_tmp + i]
@@ -394,7 +394,7 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
                  break
             # propagate
             ps2[i] = tmp
-            point[i] = ps2[i] # to be changed
+            point[i] = ps2[i]  # to be changed
         # add track point
         if d == 1:
             track.insert(0, point.copy())
@@ -461,7 +461,7 @@ cdef int initialize_ptt(TrackerParameters params,
         for tries in range(params.ptt.rejection_sampling_max_try):
             initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
             if (random_float(rng) * max_posterior <= calculate_ptt_data_support(params, stream_data, pmf_gen)):
-                stream_data[22] = stream_data[23] # last_val = last_val_cand
+                stream_data[22] = stream_data[23]  # last_val = last_val_cand
                 return 0
         return 1
 
@@ -1047,7 +1047,7 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
         stream_data[24], stream_data[25] = \
             random_point_within_circle(params.max_curvature, rng)
         if random_float(rng) * max_posterior < calculate_ptt_data_support(params, stream_data, pmf_gen):
-            stream_data[22] = stream_data[23] # last_val = last_val_cand
+            stream_data[22] = stream_data[23]  # last_val = last_val_cand
             # Propagation is successful if a suitable candidate can be sampled
             # within the trial limit
             # update the point and return

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -437,7 +437,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
                 if v < 0:
                     v = 0
                 elif v >= vd[cno]:
-                    v = vd[cno]-1 # last index for this dimension
+                    v = vd[cno]-1  # last index for this dimension
                 out_pt[cno] = v
             # calculate element number in flattened tcs array
             el_no = out_pt[0] * yz + out_pt[1] * vd[2] + out_pt[2]


### PR DESCRIPTION
## Description

Use two whitespaces before inline comments in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/denoise/enhancement_kernel.pyx:174:24:
E261 at least two spaces before inline comment
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
