### PR TITLE
BF: Hide the injected `rng` from the pytest-visible signature

### DIFF
--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -96,21 +96,19 @@ def set_random_number_generator(seed_v=1234):
     def _set_random_number_generator(func):
         @wraps(func)
         def _set_random_number_generator_wrapper(*args, **kwargs):
-            rng = np.random.default_rng(seed_v)
-            kwargs["rng"] = rng
-
-            sig = inspect.signature(func)
-            params = sig.parameters
-
-            # If the wrapped test expects pytestconfig, preserve it as the
-            # first positional argument when present.
-            if "pytestconfig" in params and args:
-                return func(*args, **kwargs)
-
+            kwargs["rng"] = np.random.default_rng(seed_v)
             return func(*args, **kwargs)
 
-        _set_random_number_generator_wrapper.__wrapped__ = func
-        _set_random_number_generator_wrapper.__signature__ = inspect.signature(func)
+        # `pytest` builds a test's fixture request from the signature it can
+        # see, so the wrapper must advertise the parameters the test owns
+        # (`tmp_path`, `pytestconfig`, ...) while hiding `rng`, which this
+        # decorator supplies. Leaving `rng` visible makes `pytest` look for a
+        # fixture of that name and fail at setup with `fixture 'rng' not
+        # found`, unless the test happens to give `rng` a default value.
+        sig = inspect.signature(func)
+        _set_random_number_generator_wrapper.__signature__ = sig.replace(
+            parameters=[p for name, p in sig.parameters.items() if name != "rng"]
+        )
         return _set_random_number_generator_wrapper
 
     return _set_random_number_generator

--- a/dipy/testing/tests/test_decorators.py
+++ b/dipy/testing/tests/test_decorators.py
@@ -1,12 +1,18 @@
 """Testing decorators module."""
 
+import inspect
 import warnings
 
+import numpy as np
 from numpy.testing import assert_equal, assert_raises
 
 import dipy
 from dipy.testing import assert_true
-from dipy.testing.decorators import doctest_skip_parser, warning_for_keywords
+from dipy.testing.decorators import (
+    doctest_skip_parser,
+    set_random_number_generator,
+    warning_for_keywords,
+)
 
 
 def test_skipper():
@@ -135,3 +141,33 @@ def test_warning_for_keywords():
 
     # Restore the original version
     dipy.__version__ = original_version
+
+
+@set_random_number_generator(1234)
+def test_set_random_number_generator_seeds_rng(rng=None):
+    assert_true(isinstance(rng, np.random.Generator))
+    assert_equal(rng.random(), np.random.default_rng(1234).random())
+
+
+@set_random_number_generator()
+def test_set_random_number_generator_with_tmp_path_fixture(tmp_path, rng):
+    # `rng` deliberately carries no default value here: the decorator supplies
+    # it, so `pytest` must resolve `tmp_path` and leave `rng` alone.
+    assert_true(isinstance(rng, np.random.Generator))
+    assert_true(tmp_path.is_dir())
+
+
+@set_random_number_generator()
+def test_set_random_number_generator_with_pytestconfig_fixture(pytestconfig, rng):
+    assert_true(isinstance(rng, np.random.Generator))
+    assert_true(pytestconfig is not None)
+
+
+def test_set_random_number_generator_hides_rng_from_signature():
+    @set_random_number_generator()
+    def func(tmp_path, rng):
+        return tmp_path, rng
+
+    parameters = inspect.signature(func).parameters
+    assert_true("tmp_path" in parameters)
+    assert_true("rng" not in parameters)


### PR DESCRIPTION
## Description

`set_random_number_generator()` advertises the wrapped test's full signature to `pytest` (`decorators.py:113`), `rng` included — the parameter the decorator injects. `pytest` reads that as a fixture request, so a test declaring `rng` without a default errors at setup with `fixture 'rng' not found`. This hides `rng` and leaves the test's own fixtures to resolve.

## Motivation and Context

`DIPY Test` has failed on every push to `master` since #4093 merged on 2026-08-19 — 8 of those 9 runs for this reason, the 9th a runner shutdown. One error out of 1,566 collected tests, 19 of 20 jobs green.

#4093 gave `rng` a default in 214 signatures so `pytest` would ignore it, and missed two of the 235 call sites: `test_default_Cnn1DDenoiser_flow(pytestconfig, rng)` and `test_horizon_flow(tmp_path, rng)`. Only `coverage` installs TensorFlow, which is why one cell of twenty caught it. The second site is latent — `optional_package("fury", max_version="1.0.0")` rejects the FURY 2.0.0 CI installs, so it never runs.

`set_random_number_generator` is also the only decorator in that module with no test of its own.

## How Has This Been Tested?

Four tests added; three fail on `master` (two `fixture 'rng' not found`, one on the signature assertion), the fourth controls the `rng=None` form.

I also diffed the `pytest`-visible signature of all 232 decorated tests, `master` vs branch: `rng` disappears everywhere, nothing else moves.

Scoped local runs, macOS / Python 3.13: 746 passed / 0 failed on `master`, 750 / 0 here, per-package counts identical bar the four new tests. `align`, and parts of `tracking`, `io` and `workflows`, stall on data fetches here on unmodified `master`; neither TensorFlow nor FURY installs, so neither real call site runs locally.

Adding `rng=None` to those two tests would also green the CI — happy to swap.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally. *(scoped — see above; `dipy/align` cannot run on this machine)*
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
