### PR TITLE
STYLE: Delete unused variables from `segment` module Cython code

### DIFF
--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -514,7 +514,6 @@ cdef class QuickBundles:
             cnp.npy_intp k
             double dist
             NearestCluster nearest_cluster
-            float aabb[6]
 
         nearest_cluster.id = -1
         nearest_cluster.dist = consts.BIGGEST_DOUBLE

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -583,7 +583,7 @@ cdef void _icm_ising(double[:, :, :, :] nloglike, double beta,
         cnp.npy_intp ny = nloglike.shape[1]
         cnp.npy_intp nz = nloglike.shape[2]
         cnp.npy_intp nclasses = nloglike.shape[3]
-        cnp.npy_intp x, y, z, xx, yy, zz, i, j, k
+        cnp.npy_intp x, y, z, xx, yy, zz, i, k
         double min_energy = NPY_INFINITY
         double this_energy = NPY_INFINITY
         cnp.npy_short best_class


### PR DESCRIPTION
## Description

Delete unused variables from `segment` module Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/segment/clusteringspeed.pyx:520:19:
'aabb' defined but unused (try prefixing with underscore?)
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/32512937731/job/96868025924?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
