### PR TITLE
Restrict tar extraction to the destination directory

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -505,8 +505,8 @@ def _make_fetcher(
         A message to print to screen when fetching takes place. Default (None)
         is to print nothing
     unzip : bool, optional
-        Whether to unzip the file(s) after downloading them. Supports zip, gz,
-        and tar.gz files.
+        Whether to unzip the file(s) after downloading them. Supports zip,
+        tar.gz, and tar.bz2 files.
     use_headers : bool, optional
         Whether to use headers when downloading files.
 
@@ -537,16 +537,14 @@ def _make_fetcher(
                 p = Path(f)
                 if p.suffix in (".gz", ".bz2"):
                     if p.with_suffix("").suffix == ".tar":
-                        ar = tarfile.open(Path(folder) / f)
-                        ar.extractall(path=folder)
-                        ar.close()
+                        with tarfile.open(Path(folder) / f) as ar:
+                            ar.extractall(path=folder, filter="data")
                     else:
                         raise ValueError("File extension is not recognized")
                 elif p.suffix == ".zip":
-                    z = zipfile.ZipFile(Path(folder) / f, "r")
-                    files[str(f)] += (tuple(z.namelist()),)
-                    z.extractall(folder)
-                    z.close()
+                    with zipfile.ZipFile(Path(folder) / f, "r") as z:
+                        files[str(f)] += (tuple(z.namelist()),)
+                        z.extractall(folder)
                 else:
                     raise ValueError("File extension is not recognized")
 

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -1,11 +1,14 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import importlib
+import io
 import logging
 import os
 from pathlib import Path
 import shutil
+import tarfile
 import tempfile
 from threading import Thread
+import zipfile
 
 import pytest
 
@@ -139,6 +142,76 @@ def test_make_fetcher_http(tmp_path):
     finally:
         server.shutdown()
         os.chdir(original_cwd)
+
+
+def test_make_fetcher_tar_member_cannot_escape_folder(tmp_path):
+    """A tar member with a parent-directory path is not extracted outside `folder`.
+
+    Regression test for CVE-2007-4559: extractall() without a filter honours
+    "../" in member names and writes outside the destination.
+    """
+    served = tmp_path / "served"
+    served.mkdir()
+    archive = served / "payload.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        benign = tarfile.TarInfo("good.txt")
+        benign.size = 3
+        tar.addfile(benign, io.BytesIO(b"ok\n"))
+        escaping = tarfile.TarInfo("../escaped.txt")
+        escaping.size = 4
+        tar.addfile(escaping, io.BytesIO(b"bad\n"))
+
+    dest = tmp_path / "dest"
+    server, base_url, original_cwd = _free_port_server(str(served))
+    try:
+        fetch = _make_fetcher(
+            "escaping_fetcher",
+            str(dest),
+            base_url,
+            [archive.name],
+            [archive.name],
+            md5_list=[_get_file_md5(archive)],
+            unzip=True,
+        )
+        with pytest.raises(tarfile.OutsideDestinationError):
+            fetch()
+    finally:
+        server.shutdown()
+        os.chdir(original_cwd)
+
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_make_fetcher_zip_member_cannot_escape_folder(tmp_path):
+    """zipfile drops the parent-directory prefix, so the member stays inside."""
+    served = tmp_path / "served"
+    served.mkdir()
+    archive = served / "payload.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("good.txt", "ok\n")
+        zf.writestr("../escaped.txt", "bad\n")
+
+    dest = tmp_path / "dest"
+    server, base_url, original_cwd = _free_port_server(str(served))
+    try:
+        fetch = _make_fetcher(
+            "zip_fetcher",
+            str(dest),
+            base_url,
+            [archive.name],
+            [archive.name],
+            md5_list=[_get_file_md5(archive)],
+            unzip=True,
+        )
+        files, _ = fetch()
+    finally:
+        server.shutdown()
+        os.chdir(original_cwd)
+
+    assert not (tmp_path / "escaped.txt").exists()
+    assert (dest / "good.txt").is_file()
+    assert (dest / "escaped.txt").is_file()
+    assert files[archive.name][-1] == ("good.txt", "../escaped.txt")
 
 
 def test_fetch_data_http(tmp_path):


### PR DESCRIPTION
One of the extraction problems from #3933.

`_make_fetcher` extracts downloaded tar archives with a bare `tarfile.extractall()`. Members are not checked against the destination, so an archive entry like `../escaped.txt` is written **outside** the target folder:

```python
with tarfile.open(tar_path) as tf:
    tf.extractall(path=out)              # current behaviour
# -> escaped.txt now exists in out's parent

with tarfile.open(tar_path) as tf:
    tf.extractall(path=out, filter="data")   # this PR
# -> tarfile.OutsideDestinationError: '../escaped.txt' would be extracted to ...
# -> only good.txt lands in out/
```

`filter="data"` is the extraction filter Python added for exactly this (CVE-2007-4559); it becomes the default in 3.14, and dipy already requires >=3.12, so no version guard is needed. The fetchers pull archives from remote URLs, so this is the path that matters.

Also switched the tar and zip handles to context managers — both were closed by hand, so an error mid-extraction leaked the handle.

Scoped deliberately: #3933 lists a dozen findings across `fetcher.py` and its tests, and the test-side ones (mkstemp handles, hardcoded ports, `os.chdir` without `try/finally`) already look fixed on main — `_free_port_server` binds port 0 and the `check_md5` tests close their descriptors. Happy to take more of the list if you point me at what is still live.

`ruff check` and `ruff format --check` clean on the changed file under the pinned 0.15.12.
