### PR TITLE
STYLE: Add blank lines where required by linter in Cython code

### DIFF
--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -33,6 +33,7 @@ cdef class Feature:
         """ Is this feature invariant to the sequence's ordering """
         def __get__(Feature self):
             return bool(self.is_order_invariant)
+
         def __set__(self, int value):
             self.is_order_invariant = bool(value)
 

--- a/dipy/tracking/tests/test_propspeed.pyx
+++ b/dipy/tracking/tests/test_propspeed.pyx
@@ -31,6 +31,7 @@ def test_tracker_deterministic():
     cdef RNGState rng
 
     seed_rng(&rng, 12345)
+
     class SillyModel(SphHarmModel):
         sh_order_max = 4
 


### PR DESCRIPTION
## Description

Add blank lines where required by linter in Cython code.

Fixes:
```
dipy/segment/featurespeed.pyx:36:9: E301 expected 1 blank line, found 0
``

and
```
dipy/tracking/tests/test_propspeed.pyx:34:5: E306 expected 1 blank line before a nested definition, found 0
```

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
