### PR TITLE
STYLE: Remove unused import from `denoise` module Cython code

### DIFF
--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -2,7 +2,6 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 
-cimport safe_openmp as openmp
 from cython.parallel import prange
 
 from dipy.reconst.shm import sh_to_sf, sf_to_sh


### PR DESCRIPTION
## Description

Remove unused import statement from `denoise` module Cython code.

Fixes:
```
dipy/denoise/shift_twist_convolution.pyx:5:9: 'openmp' imported but
unused
```

Left behind in commits 4b7aee4 and 0c5ffe2.

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [ ] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
