### PR TITLE
STYLE: Fix logical statement indentation spread across lines in Cython

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -519,8 +519,11 @@ class ParzenJointHistogram:
             raise ValueError("Dimensions of gradients and points are different")
 
         nsamples = sval.shape[0]
-        if ((mgradient.shape[0] != nsamples) or (mval.shape[0] != nsamples)
-            or sample_points.shape[0] != nsamples):
+        if (
+            mgradient.shape[0] != nsamples
+            or mval.shape[0] != nsamples
+            or sample_points.shape[0] != nsamples
+        ):
             raise ValueError("Number of points and gradients are different.")
 
         if mgradient.dtype not in [np.float32, np.float64]:

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -675,8 +675,12 @@ cdef void _process_block_complete(double[:, :, :] image,
                     mean_ratio = current_mean / neighbor_mean
                     variance_ratio = current_variance / neighbor_variance
 
-                    if (mean_ratio < mean_ratio_threshold or mean_ratio > (1.0 / mean_ratio_threshold) or
-                        variance_ratio < variance_ratio_min or variance_ratio > variance_ratio_max):
+                    if (
+                        mean_ratio < mean_ratio_threshold
+                        or mean_ratio > (1.0 / mean_ratio_threshold)
+                        or variance_ratio < variance_ratio_min
+                        or variance_ratio > variance_ratio_max
+                    ):
                         continue
 
                     # Compute patch distance

--- a/dipy/direction/pmf.pyx
+++ b/dipy/direction/pmf.pyx
@@ -229,9 +229,11 @@ cdef class SimplePeakGen(PmfGen):
                 "peak_indices and peak_values must be 4D arrays"
             )
 
-        if (indices_arr.shape[0] != values_arr.shape[0] or
+        if (
+            indices_arr.shape[0] != values_arr.shape[0] or
             indices_arr.shape[1] != values_arr.shape[1] or
-            indices_arr.shape[2] != values_arr.shape[2]):
+            indices_arr.shape[2] != values_arr.shape[2]
+        ):
             raise ValueError(
                 "peak_indices and peak_values must have matching spatial dimensions"
             )
@@ -465,9 +467,11 @@ cdef class SimplePeakGen(PmfGen):
             for i in range(3):
                 xyz[i] = index[m * 3 + i]
 
-            if (xyz[0] < 0 or xyz[0] >= self.peak_shape[0] or
-                xyz[1] < 0 or xyz[1] >= self.peak_shape[1] or
-                xyz[2] < 0 or xyz[2] >= self.peak_shape[2]):
+            if (
+                xyz[0] < 0 or xyz[0] >= self.peak_shape[0]
+                or xyz[1] < 0 or xyz[1] >= self.peak_shape[1]
+                or xyz[2] < 0 or xyz[2] >= self.peak_shape[2]
+            ):
                 continue
 
             out_valid[m] = 1

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -108,9 +108,11 @@ cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
 
         newdir = self.vertices[idx]
         # Update direction and return 0 for error
-        if (direction[0] * newdir[0]
+        if (
+            direction[0] * newdir[0]
             + direction[1] * newdir[1]
-            + direction[2] * newdir[2] > 0):
+            + direction[2] * newdir[2] > 0
+        ):
             copy_point(&newdir[0], &direction[0])
         else:
             newdir[0] = newdir[0] * -1
@@ -174,9 +176,11 @@ cdef class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
 
             newdir = self.vertices[max_idx]
             # Update direction and return 0 for error
-            if (direction[0] * newdir[0]
+            if (
+                direction[0] * newdir[0]
                 + direction[1] * newdir[1]
-                + direction[2] * newdir[2] > 0):
+                + direction[2] * newdir[2] > 0
+            ):
                 copy_point(&newdir[0], &direction[0])
             else:
                 newdir[0] = newdir[0] * -1

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -188,8 +188,7 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         """
         cdef double tmp_arclength
 
-        if (fabs(self.k1) < self.k_small
-            and fabs(self.k2) < self.k_small):
+        if fabs(self.k1) < self.k_small and fabs(self.k2) < self.k_small:
             self.propagator[0] = arclength
             self.propagator[1] = 0
             self.propagator[2] = 0

--- a/dipy/reconst/quick_squash.pyx
+++ b/dipy/reconst/quick_squash.pyx
@@ -77,8 +77,7 @@ def quick_squash(obj_arr, mask=None, fill=0):
     # Find first valid value
     for i in range(N):
         e = flat_obj[i]
-        if ((have_mask and flat_mask[i] == 0) or
-            (not have_mask and e is None)):
+        if ((have_mask and flat_mask[i] == 0) or (not have_mask and e is None)):
             continue
         t = type(e)
         if issubclass(t, np.generic) or t in SCALAR_TYPES:
@@ -101,8 +100,7 @@ def quick_squash(obj_arr, mask=None, fill=0):
     dtypes_i = 1
     for j in range(i+1, N):
         e = flat_obj[j]
-        if ((have_mask and flat_mask[j] == 0) or
-            (not have_mask and e is None)):
+        if ((have_mask and flat_mask[j] == 0) or (not have_mask and e is None)):
             continue
         t = type(e)
         if search_for == SCALAR:
@@ -127,8 +125,7 @@ def quick_squash(obj_arr, mask=None, fill=0):
     result = np.empty((N,) + common_shape, dtype=dtype)
     for i in range(N):
         e = flat_obj[i]
-        if ((have_mask and flat_mask[i] == 0) or
-            (not have_mask and e is None)):
+        if ((have_mask and flat_mask[i] == 0) or (not have_mask and e is None)):
             result[i] = fill
         else:
             result[i] = e

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -279,8 +279,7 @@ cdef _pft_tracker(DirectionGetter dg,
             # or an invalid point (PYERROR)
             break
 
-    if ((stream_status[0] == OUTSIDEIMAGE or stream_status[0] == PYERROR)
-        and i > 1):
+    if ((stream_status[0] == OUTSIDEIMAGE or stream_status[0] == PYERROR) and i > 1):
         i -= 1
     return i
 

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -561,8 +561,10 @@ cdef void prepare_ptt_propagator(TrackerParameters params,
     cdef double tmp_arclength
     stream_data[10] = arclength  # propagator[0]
 
-    if (fabs(stream_data[24]) < params.ptt.k_small
-        and fabs(stream_data[25]) < params.ptt.k_small):
+    if (
+        fabs(stream_data[24]) < params.ptt.k_small
+        and fabs(stream_data[25]) < params.ptt.k_small
+    ):
         stream_data[11] = 0
         stream_data[12] = 0
         stream_data[13] = 1
@@ -751,9 +753,11 @@ cdef TrackerStatus deterministic_propagator(double* point,
 
     newdir = &pmf_gen.vertices[max_idx][0]
     # Update direction
-    if (direction[0] * newdir[0]
+    if (
+        direction[0] * newdir[0]
         + direction[1] * newdir[1]
-        + direction[2] * newdir[2] > 0):
+        + direction[2] * newdir[2] > 0
+    ):
         copy_point(newdir, direction)
     else:
         copy_point(newdir, direction)
@@ -828,9 +832,11 @@ cdef TrackerStatus probabilistic_propagator(double* point,
     idx = where_to_insert(pmf, random_float(rng) * last_cdf, len_pmf)
     newdir = &pmf_gen.vertices[idx][0]
     # Update direction
-    if (direction[0] * newdir[0]
+    if (
+        direction[0] * newdir[0]
         + direction[1] * newdir[1]
-        + direction[2] * newdir[2] > 0):
+        + direction[2] * newdir[2] > 0
+    ):
         copy_point(newdir, direction)
     else:
         copy_point(newdir, direction)

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -261,9 +261,11 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
         fast_numpy.copy_point(point, &stream[(params.max_nbr_pts + i)* 3])
 
         status_forward = sc.check_point_c(point, &rng)
-        if (status_forward == ENDPOINT or
-            status_forward == INVALIDPOINT or
-            status_forward == OUTSIDEIMAGE):
+        if (
+            status_forward == ENDPOINT
+            or status_forward == INVALIDPOINT
+            or status_forward == OUTSIDEIMAGE
+        ):
             break
     stream_idx[1] = params.max_nbr_pts + i - 1
     free(stream_data)
@@ -295,16 +297,20 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
         fast_numpy.copy_point(point, &stream[(params.max_nbr_pts - i)* 3])
 
         status_backward = sc.check_point_c(point, &rng)
-        if (status_backward == ENDPOINT or
-            status_backward == INVALIDPOINT or
-            status_backward == OUTSIDEIMAGE):
+        if (
+            status_backward == ENDPOINT
+            or status_backward == INVALIDPOINT
+            or status_backward == OUTSIDEIMAGE
+        ):
             break
     stream_idx[0] = params.max_nbr_pts - i + 1
     free(stream_data)
 
     # check for valid streamline ending status
-    if ((status_backward == ENDPOINT or status_backward == OUTSIDEIMAGE)
-        and (status_forward == ENDPOINT or status_forward == OUTSIDEIMAGE)):
+    if (
+        (status_backward == ENDPOINT or status_backward == OUTSIDEIMAGE)
+        and (status_forward == ENDPOINT or status_forward == OUTSIDEIMAGE)
+    ):
         return VALIDSTREAMLIME
     return INVALIDSTREAMLIME
 


### PR DESCRIPTION
## Description

Fix indentation of logical statements when spread across lines in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/parzenhist.pyx:523:13: E129
visually indented line with same indent as next logical line
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/33548912839/job/99993212761?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
