### PR TITLE
STYLE: Remove multiple spaces before operator in Cython code

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1487,7 +1487,7 @@ cdef void track_direct_flip_dist(float *a, float *b, long rows, float *out) noex
 
 
 @cython.cdivision(True)
-cdef inline void track_direct_flip_3dist(float *a1, float *b1, float  *c1, float *a2, float *b2, float *c2, float *out) noexcept nogil:
+cdef inline void track_direct_flip_3dist(float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out) noexcept nogil:
     """ Calculate the euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
@@ -1816,7 +1816,7 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
     return C
 
 
-cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1, float  *c1, float *a2, float *b2, float *c2, float *out):
+cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out):
     """ Calculate the average squared euclidean distance between two 3pt tracks
     both direct and flip are given as output
 


### PR DESCRIPTION
## Description

Remove multiple spaces before operator in Cython code. Left behind in commit b0aeff3.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/tracking/distances.pyx:1490:69: E221
multiple spaces before operator
/home/runner/work/dipy/dipy/dipy/tracking/distances.pyx:1819:72: E221
multiple spaces before operator
```

raised in:
https://github.com/dipy/dipy/actions/runs/33548912839/job/99993212761?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
