### PR TITLE
STYLE: Rename ambiguous variable names in Cython code

### DIFF
--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -55,7 +55,7 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
         cnp.npy_intp nrows = v.shape[0]
         cnp.npy_intp ncols = v.shape[1]
         cnp.npy_intp npix = nrows * ncols
-        cnp.npy_intp i, j, l
+        cnp.npy_intp i, j, bin_idx
         double epsilon, delta
         double min_val = -1
         double max_val = -1
@@ -107,9 +107,9 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
         for i in range(nrows):
             for j in range(ncols):
                 if v[i, j] > 0:
-                    l = ifloor((v[i, j] - min_val) / delta)
-                    out[i, j] = l + 1
-                    hist[l + 1] += 1
+                    bin_idx = ifloor((v[i, j] - min_val) / delta)
+                    out[i, j] = bin_idx + 1
+                    hist[bin_idx + 1] += 1
                 else:
                     out[i, j] = 0
                     hist[0] += 1
@@ -157,7 +157,7 @@ def quantize_positive_3d(floating[:, :, :] v, int num_levels):
         cnp.npy_intp nrows = v.shape[1]
         cnp.npy_intp ncols = v.shape[2]
         cnp.npy_intp nvox = nrows * ncols * nslices
-        cnp.npy_intp i, j, k, l
+        cnp.npy_intp i, j, k, bin_idx
         double epsilon, delta
         double min_val = -1
         double max_val = -1
@@ -210,9 +210,9 @@ def quantize_positive_3d(floating[:, :, :] v, int num_levels):
             for i in range(nrows):
                 for j in range(ncols):
                     if v[k, i, j] > 0:
-                        l = ifloor((v[k, i, j] - min_val) / delta)
-                        out[k, i, j] = l + 1
-                        hist[l + 1] += 1
+                        bin_idx = ifloor((v[k, i, j] - min_val) / delta)
+                        out[k, i, j] = bin_idx + 1
+                        hist[bin_idx + 1] += 1
                     else:
                         out[k, i, j] = 0
                         hist[0] += 1

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -1402,10 +1402,12 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                     if constant_jacobian == 0:
                         constant_jacobian = transform._jacobian(theta, x, J)
 
-                    for l in range(n):
-                        prod[l] = (J[0, l] * mgradient[k, i, j, 0] +
-                                   J[1, l] * mgradient[k, i, j, 1] +
-                                   J[2, l] * mgradient[k, i, j, 2])
+                    for param_idx in range(n):
+                        prod[param_idx] = (
+                            J[0, param_idx] * mgradient[k, i, j, 0]
+                            + J[1, param_idx] * mgradient[k, i, j, 1]
+                            + J[2, param_idx] * mgradient[k, i, j, 2]
+                        )
 
                     rn = _bin_normalize(static[k, i, j], smin, sdelta)
                     r = _bin_index(rn, nbins, padding)
@@ -1415,8 +1417,8 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
 
                     for offset in range(1 - padding, padding + 1):
                         val = _cubic_spline_derivative(spline_arg)
-                        for l in range(n):
-                            grad_pdf[r, c + offset, l] -= val * prod[l]
+                        for param_idx in range(n):
+                            grad_pdf[r, c + offset, param_idx] -= val * prod[param_idx]
                         spline_arg += 1.0
 
         norm_factor = <double>valid_points * mdelta

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -88,15 +88,15 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
     """
 
     cdef:
-        cnp.npy_intp i, j, k, I, J, K
+        cnp.npy_intp i, j, k, dim_i, dim_j, dim_k
         double[:, :, ::1] out = np.zeros_like(arr)
         cnp.npy_intp P = patch_radius
         cnp.npy_intp B = block_radius
         int threads_to_use = -1
 
-    I = arr.shape[0]
-    J = arr.shape[1]
-    K = arr.shape[2]
+    dim_i = arr.shape[0]
+    dim_j = arr.shape[1]
+    dim_k = arr.shape[2]
 
     threads_to_use = determine_num_threads(num_threads)
     set_num_threads(threads_to_use)
@@ -104,9 +104,9 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
     # move the block
     with nogil, parallel():
 
-        for i in prange(B, I - B, schedule="dynamic"):
-            for j in range(B, J - B):
-                for k in range(B, K - B):
+        for i in prange(B, dim_i - B, schedule="dynamic"):
+            for j in range(B, dim_j - B):
+                for k in range(B, dim_k - B):
 
                     if mask[i, j, k] == 0:
                         continue

--- a/dipy/denoise/pca_noise_estimate.pyx
+++ b/dipy/denoise/pca_noise_estimate.pyx
@@ -105,7 +105,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
         cnp.npy_intp prz = patch_radius if n2 > 1 else 0
         cnp.npy_intp norm = (2 * prx + 1) * (2 * pry + 1) * (2 * prz + 1)
         double sum_reg, temp1
-        double[:, :, :] I = np.zeros((n0, n1, n2))
+        double[:, :, :] eig_img = np.zeros((n0, n1, n2))
 
     # check dimensions of data
     if (dsm != 1) and (dsm < 2 * patch_radius + 1):
@@ -131,14 +131,14 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
 
         # ref [1]_ method is ambiguous on how to use image-shaped eigvec
         # since eigvec is normalized, used eigval=variance for scale
-        I = V * S[idx]
+        eig_img = V * S[idx]
     else:
         # Project into the data space
         V = X.dot(W)
 
         # Grab the column corresponding to the smallest eigen-vector/-value:
         # #vox(samples) >> #img(features), last eigenvector is meaningful
-        I = V[:, -1].reshape(n0, n1, n2)
+        eig_img = V[:, -1].reshape(n0, n1, n2)
 
     del V, W, X, U, S, Vt
 
@@ -157,7 +157,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
                     for i0 in range(-prx, prx + 1):
                         for j0 in range(-pry, pry + 1):
                             for k0 in range(-prz, prz + 1):
-                                sum_reg += I[i + i0, j + j0, k + k0] / norm
+                                sum_reg += eig_img[i + i0, j + j0, k + k0] / norm
                                 for l0 in range(n3):
                                     temp1 += (data0temp[i + i0, j + j0, k + k0, l0])\
                                              / (norm * n3)
@@ -166,7 +166,7 @@ def pca_noise_estimate(data, gtab, patch_radius=1, correct_bias=True,
                         for j0 in range(-pry, pry + 1):
                             for k0 in range(-prz, prz + 1):
                                 sigma_sq[i + i0, j + j0, k + k0] += (
-                                    I[i + i0, j + j0, k + k0] - sum_reg) ** 2
+                                    eig_img[i + i0, j + j0, k + k0] - sum_reg) ** 2
                                 mean[i + i0, j + j0, k + k0] += temp1
                                 count[i + i0, j + j0, k + k0] += 1
 

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -143,11 +143,11 @@ class ConstantObservationModel:
         nloglike : ndarray
             4D negloglikelihood for each class in each volume
         """
-        cdef int l
+        cdef int idx
         nloglike = np.zeros(image.shape + (nclasses,), dtype=np.float64)
 
-        for l in range(nclasses):
-            _negloglikelihood(image, mu, sigmasq, l, nloglike)
+        for idx in range(nclasses):
+            _negloglikelihood(image, mu, sigmasq, idx, nloglike)
 
         return nloglike
 
@@ -175,18 +175,18 @@ class ConstantObservationModel:
         P_L_Y : ndarray
             4D probability of the label given the input image
         """
-        cdef int l
+        cdef int idx
         P_L_Y = np.zeros_like(P_L_N)
         P_L_Y_norm = np.zeros_like(img)
 
         g = np.empty_like(img)
 
-        for l in range(nclasses):
-            _prob_image(img, g, mu, sigmasq, l, P_L_N, P_L_Y)
-            P_L_Y_norm[:, :, :] += P_L_Y[:, :, :, l]
+        for idx in range(nclasses):
+            _prob_image(img, g, mu, sigmasq, idx, P_L_N, P_L_Y)
+            P_L_Y_norm[:, :, :] += P_L_Y[:, :, :, idx]
 
-        for l in range(nclasses):
-            P_L_Y[:, :, :, l] = P_L_Y[:, :, :, l] / P_L_Y_norm
+        for idx in range(nclasses):
+            P_L_Y[:, :, :, idx] = P_L_Y[:, :, :, idx] / P_L_Y_norm
 
         return P_L_Y
 
@@ -215,18 +215,18 @@ class ConstantObservationModel:
         var_upd : ndarray
                 1 x nclasses, updated variance of each tissue class
         """
-        cdef int l
+        cdef int idx
         mu_upd = np.zeros(nclasses, dtype=np.float64)
         var_upd = np.zeros(nclasses, dtype=np.float64)
         mu_num = np.zeros(image.shape + (nclasses,), dtype=np.float64)
         var_num = np.zeros(image.shape + (nclasses,), dtype=np.float64)
 
-        for l in range(nclasses):
-            mu_num[..., l] = P_L_Y[..., l] * image
-            var_num[..., l] = P_L_Y[..., l] * ((image - mu[l]) ** 2)
+        for idx in range(nclasses):
+            mu_num[..., idx] = P_L_Y[..., idx] * image
+            var_num[..., idx] = P_L_Y[..., idx] * ((image - mu[idx]) ** 2)
 
-            mu_upd[l] = np.sum(mu_num[..., l]) / np.sum(P_L_Y[..., l])
-            var_upd[l] = np.sum(var_num[..., l]) / np.sum(P_L_Y[..., l])
+            mu_upd[idx] = np.sum(mu_num[..., idx]) / np.sum(P_L_Y[..., idx])
+            var_upd[idx] = np.sum(var_num[..., idx]) / np.sum(P_L_Y[..., idx])
 
         return mu_upd, var_upd
 
@@ -306,7 +306,7 @@ cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
         cnp.npy_intp nx = image.shape[0]
         cnp.npy_intp ny = image.shape[1]
         cnp.npy_intp nz = image.shape[2]
-        cnp.npy_intp l = classid
+        cnp.npy_intp cls_idx = classid
         cnp.npy_intp x, y, z
         double eps = 1e-8      # We assume images normalized to 0-1
         double eps_sq = 1e-16  # Maximum precision for double.
@@ -315,19 +315,19 @@ cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
         for y in range(ny):
             for z in range(nz):
 
-                if sigmasq[l] < eps_sq:
+                if sigmasq[cls_idx] < eps_sq:
 
-                    if fabs(image[x, y, z] - mu[l]) < eps:
-                        neglogl[x, y, z, l] = 1 + log(sqrt(2.0 * NPY_PI *
-                                                           sigmasq[l]))
+                    if fabs(image[x, y, z] - mu[cls_idx]) < eps:
+                        neglogl[x, y, z, cls_idx] = 1 + log(sqrt(2.0 * NPY_PI *
+                                                           sigmasq[cls_idx]))
                     else:
-                        neglogl[x, y, z, l] = NPY_INFINITY
+                        neglogl[x, y, z, cls_idx] = NPY_INFINITY
 
                 else:
-                    neglogl[x, y, z, l] = (((image[x, y, z] - mu[l])**2.0) /
-                                           (2.0 * sigmasq[l]))
-                    neglogl[x, y, z, l] += log(sqrt(2.0 * NPY_PI *
-                                                    sigmasq[l]))
+                    neglogl[x, y, z, cls_idx] = (((image[x, y, z] - mu[cls_idx])**2.0) /
+                                           (2.0 * sigmasq[cls_idx]))
+                    neglogl[x, y, z, cls_idx] += log(sqrt(2.0 * NPY_PI *
+                                                    sigmasq[cls_idx]))
 
 
 cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
@@ -365,7 +365,7 @@ cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
         cnp.npy_intp nx = image.shape[0]
         cnp.npy_intp ny = image.shape[1]
         cnp.npy_intp nz = image.shape[2]
-        cnp.npy_intp l = classid
+        cnp.npy_intp cls_idx = classid
         cnp.npy_intp x, y, z
 
         double eps = 1e-8
@@ -375,17 +375,17 @@ cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
         for y in range(ny):
             for z in range(nz):
 
-                if sigmasq[l] < eps_sq:
-                    if fabs(image[x, y, z] - mu[l]) < eps:
+                if sigmasq[cls_idx] < eps_sq:
+                    if fabs(image[x, y, z] - mu[cls_idx]) < eps:
                         gaussian[x, y, z] = 1
                     else:
                         gaussian[x, y, z] = 0
                 else:
                     gaussian[x, y, z] = (
-                        (exp(-((image[x, y, z] - mu[l]) ** 2) /
-                        (2 * sigmasq[l]))) / (sqrt(2 * NPY_PI * sigmasq[l])))
+                        (exp(-((image[x, y, z] - mu[cls_idx]) ** 2) /
+                        (2 * sigmasq[cls_idx]))) / (sqrt(2 * NPY_PI * sigmasq[cls_idx])))
 
-                P_L_Y[x, y, z, l] = gaussian[x, y, z] * P_L_N[x, y, z, l]
+                P_L_Y[x, y, z, cls_idx] = gaussian[x, y, z] * P_L_N[x, y, z, cls_idx]
 
 
 class IteratedConditionalModes:
@@ -491,8 +491,8 @@ class IteratedConditionalModes:
             PLN[:, :, :, classid] = np.exp(- PLN[:, :, :, classid])
             PLN_norm += PLN[:, :, :, classid]
 
-        for l in range(nclasses):
-            PLN[:, :, :, l] = PLN[:, :, :, l] / PLN_norm
+        for cls_idx in range(nclasses):
+            PLN[:, :, :, cls_idx] = PLN[:, :, :, cls_idx] / PLN_norm
 
         return PLN
 
@@ -653,7 +653,7 @@ cdef void _prob_class_given_neighb(cnp.npy_short[:, :, :] seg, double beta,
         cnp.npy_intp ny = seg.shape[1]
         cnp.npy_intp nz = seg.shape[2]
         cnp.npy_intp nneigh = 6
-        cnp.npy_intp l = classid
+        cnp.npy_intp cls_idx = classid
         cnp.npy_intp x, y, z, xx, yy, zz
         double vox_prob
         cnp.npy_intp* dX = [-1, 0, 0, 0,  0, 1]
@@ -677,7 +677,7 @@ cdef void _prob_class_given_neighb(cnp.npy_short[:, :, :] seg, double beta,
                     if zz < 0 or zz >= nz:
                         continue
 
-                    if seg[xx, yy, zz] == l:
+                    if seg[xx, yy, zz] == cls_idx:
                         vox_prob -= beta
                     else:
                         vox_prob += beta


### PR DESCRIPTION
## Description

Rename ambiguous variable names in Cython code.

Rename the `J` and `K` variables in `denspeed.pyx` for the sake of consistency with the renaming of `I`.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/expectmax.pyx:110:21: E741
ambiguous variable name 'l'
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/33548912839/job/99993212761?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
