### PR TITLE
STYLE: Fix logical line continuation indentation in Cython code

### DIFF
--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -448,7 +448,8 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                     continue
                 elif (stream_status == ENDPOINT or
                     stream_status == INVALIDPOINT or
-                    stream_status == OUTSIDEIMAGE):
+                    stream_status == OUTSIDEIMAGE
+                ):
                     break
             else:
                 # maximum length has been reached, return everything

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -479,7 +479,8 @@ def le_to_odf(cnp.ndarray[double, ndim=1] odf,
 @cython.wraparound(False)
 def sum_on_blocks_1d(cnp.ndarray[double, ndim=1] arr,
     cnp.ndarray[long, ndim=1] blocks,
-    cnp.ndarray[double, ndim=1] out, int outn):
+    cnp.ndarray[double, ndim=1] out, int outn,
+):
     """Summations on blocks of 1d array
     """
     cdef:

--- a/dipy/tracking/tracker_parameters.pyx
+++ b/dipy/tracking/tracker_parameters.pyx
@@ -21,7 +21,8 @@ def generate_tracking_parameters(algo_name, *,
     double probe_length=0.5, double probe_radius=0, int probe_quality=3,
     int probe_count=1, double data_support_exponent=1, int random_seed=0,
     double peak_values_threshold=0.0239, double angle_threshold=60,
-    double min_total_weight=0.5):
+    double min_total_weight=0.5,
+):
 
     cdef TrackerParameters params
 

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -12,7 +12,8 @@ cdef void take(
     double* odf,
     cnp.npy_intp* indices,
     cnp.npy_intp n_indices,
-    double* values_out) noexcept nogil:
+    double* values_out,
+) noexcept nogil:
     """
     Mimic np.take(odf, indices) in Cython using pointers.
 


### PR DESCRIPTION
## Description

Fix logical line continuation indentation in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/direction/ptt_direction_getter.pyx:451:21:
E125 continuation line with same indent as next logical line
```

and other similar errors raised in:
https://github.com/dipy/dipy/actions/runs/33548912839/job/99993212761?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
