### PR TITLE
STYLE: Rename variable at declaration in Cython code

### DIFF
--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -1380,7 +1380,7 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
         cnp.npy_intp n = theta.shape[0]
         cnp.npy_intp offset, valid_points
         int constant_jacobian = 0
-        cnp.npy_intp l, k, i, j, r, c
+        cnp.npy_intp i, j, k, param_idx, r, c
         double rn, cn
         double val, spline_arg, norm_factor
         double[:, :] J = np.empty(shape=(3, n), dtype=np.float64)


### PR DESCRIPTION
## Description

Rename variable at declaration in Cython code. The variable is used as a loop index, and was renamed in the loops in commit f6fcb92, but not at its declaration.

Fixes:
```
dipy/align/parzenhist.pyx:1491:22: 'l' defined but unused (try prefixing
with underscore?)
```

raised locally when checking the style of the Cython files.

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
