### PR TITLE
STYLE: Remove continuation line over-indentation in Cython code

### DIFF
--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -219,8 +219,9 @@ def quantize_positive_3d(floating[:, :, :] v, int num_levels):
     return np.asarray(out), np.asarray(levels), np.asarray(hist)
 
 
-def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
-                                     int num_labels, int[:, :] labels):
+def compute_masked_class_stats_2d(
+    int[:, :] mask, floating[:, :] v, int num_labels, int[:, :] labels
+):
     r"""Computes the mean and std. for each quantization level.
 
     Computes the mean and standard deviation of the intensities in 'v' for
@@ -286,8 +287,9 @@ def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
     return np.asarray(means), np.asarray(variances)
 
 
-def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
-                                      int num_labels, int[:, :, :] labels):
+def compute_masked_class_stats_3d(
+    int[:, :, :] mask, floating[:, :, :] v, int num_labels, int[:, :, :] labels
+):
     r"""Computes the mean and std. for each quantization level.
 
     Computes the mean and standard deviation of the intensities in 'v' for

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -1897,8 +1897,9 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
         cnp.npy_intp ncols = ref_shape[2]
         double dkk, dii, djj
         cnp.npy_intp k, i, j
-        number[:, :, :] out = np.zeros((nslices, nrows, ncols),
-                                        dtype=np.asarray(volume).dtype)
+        number[:, :, :] out = np.zeros(
+            (nslices, nrows, ncols), dtype=np.asarray(volume).dtype
+        )
 
     if not is_valid_affine(affine, 3):
         raise ValueError("Invalid affine transform matrix")

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -86,9 +86,11 @@ cdef class EnhancementKernel:
             self.sphere = None
 
         # file location of the lut table for saving/loading
-        kernellutpath = os.path.join(gettempdir(),
-                                     "kernel_d33@%4.2f_d44@%4.2f_t@%4.2f_numverts%d.npy"
-                                       % (D33, D44, t, len(self.orientations_list)))
+        kernellutpath = os.path.join(
+            gettempdir(),
+            "kernel_d33@%4.2f_d44@%4.2f_t@%4.2f_numverts%d.npy"
+            % (D33, D44, t, len(self.orientations_list))
+        )
 
         # if LUT exists, load
         if not force_recompute and os.path.isfile(kernellutpath):
@@ -335,15 +337,20 @@ cdef class EnhancementKernel:
             sg = sin(gamma)
             cotq2 = 1.0 / tan(q/2)
 
-            c[0] = -0.5*z*beta*cg + \
-                    x*(1 - (beta*beta*cg*cg * (1 - 0.5*q*cotq2)) / (q*q)) - \
-                    (y*beta*beta*cg*sg * (1 - 0.5*q*cotq2)) / (q*q)
-            c[1] = -0.5*z*beta*sg - \
-                    (x*beta*beta*cg*sg * (1 - 0.5*q*cotq2)) / (q*q) + \
-                    y * (1 - (beta*beta*sg*sg * (1 - 0.5*q*cotq2)) / (q*q))
-            c[2] = 0.5*x*beta*cg + 0.5*y*beta*sg + \
-                   z * (1 + ((1 - 0.5*q*cotq2) * (-beta*beta*cg*cg -
-                        beta*beta*sg*sg)) / (q*q))
+            c[0] = (
+                -0.5*z*beta*cg
+                + x*(1 - (beta*beta*cg*cg * (1 - 0.5*q*cotq2)) / (q*q))
+                - (y*beta*beta*cg*sg * (1 - 0.5*q*cotq2)) / (q*q)
+            )
+            c[1] = (
+                -0.5*z*beta*sg
+                - (x*beta*beta*cg*sg * (1 - 0.5*q*cotq2)) / (q*q)
+                + y * (1 - (beta*beta*sg*sg * (1 - 0.5*q*cotq2)) / (q*q))
+            )
+            c[2] = (
+                0.5*x*beta*cg + 0.5*y*beta*sg
+                + z * (1 + ((1 - 0.5*q*cotq2) * (-beta*beta*cg*cg - beta*beta*sg*sg)) / (q*q))
+            )
             c[3] = beta * (-sg)
             c[4] = beta * cg
             c[5] = 0

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -180,10 +180,12 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                         # loop over kernel x,y,z,orient --> x and r
                         for x in range(int_max(cx - hn, 0),
                                        int_min(cx + hn + 1, ny - 1)):
-                            for y in range(int_max(cy - hn, 0),
-                                            int_min(cy + hn + 1, ny - 1)):
-                                for z in range(int_max(cz - hn, 0),
-                                                int_min(cz + hn + 1, nz - 1)):
+                            for y in range(
+                                int_max(cy - hn, 0), int_min(cy + hn + 1, ny - 1)
+                            ):
+                                for z in range(
+                                    int_max(cz - hn, 0), int_min(cz + hn + 1, nz - 1)
+                                ):
                                     voxcount[corient, cx, cy, cz] += 1.0
                                     for orient in range(0, OR2):
                                         totalval[corient, cx, cy, cz] += \

--- a/dipy/direction/probabilistic_direction_getter.pyx
+++ b/dipy/direction/probabilistic_direction_getter.pyx
@@ -12,8 +12,7 @@ from random import random
 cimport numpy as cnp
 
 from dipy.direction.closest_peak_direction_getter cimport PmfGenDirectionGetter
-from dipy.utils.fast_numpy cimport (copy_point, cumsum, norm, normalize,
-                                     where_to_insert)
+from dipy.utils.fast_numpy cimport copy_point, cumsum, norm, normalize, where_to_insert
 
 
 cdef class ProbabilisticDirectionGetter(PmfGenDirectionGetter):

--- a/dipy/reconst/dkispeed.pxd
+++ b/dipy/reconst/dkispeed.pxd
@@ -4,27 +4,34 @@
 cimport numpy as cnp
 
 # Single-value helper functions (nogil compatible)
-cdef bint positive_evals_single(double L1, double L2, double L3,
-                                 double er=*) noexcept nogil
+cdef bint positive_evals_single(
+    double L1, double L2, double L3, double er=*
+) noexcept nogil
 
-cdef double carlson_rf_single(double x, double y, double z,
-                               double errtol=*) noexcept nogil
+cdef double carlson_rf_single(
+    double x, double y, double z, double errtol=*
+) noexcept nogil
 
-cdef double carlson_rd_single(double x, double y, double z,
-                               double errtol=*) noexcept nogil
+cdef double carlson_rd_single(
+    double x, double y, double z, double errtol=*
+) noexcept nogil
 
-cdef double F1m_single(double a, double b, double c,
-                        double er=*) noexcept nogil
+cdef double F1m_single(
+    double a, double b, double c, double er=*
+) noexcept nogil
 
-cdef double F2m_single(double a, double b, double c,
-                        double er=*) noexcept nogil
+cdef double F2m_single(
+    double a, double b, double c, double er=*
+) noexcept nogil
 
-cdef double G1m_single(double a, double b, double c,
-                        double er=*) noexcept nogil
+cdef double G1m_single(
+    double a, double b, double c, double er=*
+) noexcept nogil
 
-cdef double G2m_single(double a, double b, double c,
-                        double er=*) noexcept nogil
+cdef double G2m_single(
+    double a, double b, double c, double er=*
+) noexcept nogil
 
-cdef double Wrotate_element_single(double[:] kt, int indi, int indj,
-                                    int indk, int indl,
-                                    double[:, :] B) noexcept nogil
+cdef double Wrotate_element_single(
+    double[:] kt, int indi, int indj, int indk, int indl, double[:, :] B
+) noexcept nogil

--- a/dipy/reconst/dkispeed.pyx
+++ b/dipy/reconst/dkispeed.pyx
@@ -63,8 +63,9 @@ cdef inline int get_kt_index(int key) noexcept nogil:
         return 0
 
 
-cdef inline bint positive_evals_single(double L1, double L2, double L3,
-                                        double er=2e-7) noexcept nogil:
+cdef inline bint positive_evals_single(
+    double L1, double L2, double L3, double er=2e-7
+) noexcept nogil:
     """Check if all eigenvalues are significantly larger than zero.
 
     Parameters
@@ -86,8 +87,9 @@ cdef inline bint positive_evals_single(double L1, double L2, double L3,
     return L1 > er and L2 > er and L3 > er
 
 
-cdef double carlson_rf_single(double x, double y, double z,
-                               double errtol=3e-4) noexcept nogil:
+cdef double carlson_rf_single(
+    double x, double y, double z, double errtol=3e-4
+) noexcept nogil:
     """Compute Carlson's incomplete elliptic integral of the first kind
     for a single set of values.
 
@@ -145,8 +147,9 @@ cdef double carlson_rf_single(double x, double y, double z,
     return RF
 
 
-cdef double carlson_rd_single(double x, double y, double z,
-                               double errtol=1e-4) noexcept nogil:
+cdef double carlson_rd_single(
+    double x, double y, double z, double errtol=1e-4
+) noexcept nogil:
     """Compute Carlson's incomplete elliptic integral of the second kind
     for a single set of values.
 
@@ -425,9 +428,9 @@ cdef double G2m_single(double a, double b, double c, double er=2.5e-2) noexcept 
     return G2
 
 
-cdef double Wrotate_element_single(double[:] kt, int indi, int indj,
-                                    int indk, int indl,
-                                    double[:, :] B) noexcept nogil:
+cdef double Wrotate_element_single(
+    double[:] kt, int indi, int indj, int indk, int indl, double[:, :] B
+) noexcept nogil:
     """Compute a single rotated kurtosis tensor element.
 
     Parameters
@@ -462,9 +465,11 @@ cdef double Wrotate_element_single(double[:] kt, int indi, int indj,
     return Wre
 
 
-def mean_kurtosis_analytical(double[:, :] dki_params_flat,
-                              double min_kurtosis=-3.0/7.0,
-                              double max_kurtosis=3.0):
+def mean_kurtosis_analytical(
+    double[:, :] dki_params_flat,
+    double min_kurtosis=-3.0/7.0,
+    double max_kurtosis=3.0
+):
     """Compute mean kurtosis using the analytical solution.
 
     This is the Cython-optimized version of the analytical mean kurtosis
@@ -548,9 +553,11 @@ def mean_kurtosis_analytical(double[:, :] dki_params_flat,
     return np.asarray(MK)
 
 
-def axial_kurtosis_analytical(double[:, :] dki_params_flat,
-                               double min_kurtosis=-3.0/7.0,
-                               double max_kurtosis=10.0):
+def axial_kurtosis_analytical(
+    double[:, :] dki_params_flat,
+    double min_kurtosis=-3.0/7.0,
+    double max_kurtosis=10.0
+):
     """Compute axial kurtosis using the analytical solution.
 
     Parameters
@@ -608,9 +615,11 @@ def axial_kurtosis_analytical(double[:, :] dki_params_flat,
     return np.asarray(AK)
 
 
-def radial_kurtosis_analytical(double[:, :] dki_params_flat,
-                                double min_kurtosis=-3.0/7.0,
-                                double max_kurtosis=10.0):
+def radial_kurtosis_analytical(
+    double[:, :] dki_params_flat,
+    double min_kurtosis=-3.0/7.0,
+    double max_kurtosis=10.0
+):
     """Compute radial kurtosis using the analytical solution.
 
     Parameters
@@ -714,8 +723,14 @@ def kurtosis_fractional_anisotropy_c(double[:, :] dki_params_flat):
             Wxyyz = dki_params_flat[v, 25]
             Wxyzz = dki_params_flat[v, 26]
 
-            W = (1.0 / 5.0) * (Wxxxx + Wyyyy + Wzzzz +
-                                2.0 * Wxxyy + 2.0 * Wxxzz + 2.0 * Wyyzz)
+            W = (1.0 / 5.0) * (
+                Wxxxx
+                + Wyyyy
+                + Wzzzz
+                + 2.0 * Wxxyy
+                + 2.0 * Wxxzz
+                + 2.0 * Wyyzz
+            )
 
             A = ((Wxxxx - W) * (Wxxxx - W) +
                  (Wyyyy - W) * (Wyyyy - W) +

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -456,12 +456,14 @@ cdef long _compare_neighbors(double[:] odf, cnp.uint16_t[:, :] edges,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def le_to_odf(cnp.ndarray[double, ndim=1] odf,
-                 cnp.ndarray[double, ndim=1] LEs,
-                 cnp.ndarray[double, ndim=1] radius,
-                 int odfn,
-                 int radiusn,
-                 int anglesn):
+def le_to_odf(
+    cnp.ndarray[double, ndim=1] odf,
+    cnp.ndarray[double, ndim=1] LEs,
+    cnp.ndarray[double, ndim=1] radius,
+    int odfn,
+    int radiusn,
+    int anglesn,
+):
     """odf for interpolated Laplacian normalized signal
     """
     cdef int m, i, j

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -306,8 +306,9 @@ def cut_plane(tracks, ref):
                     if beta !=0:
                         # alpha = np.inner((p-q),normal)/np.inner((r-q),normal)
                         csub_3vecs(this_ref_p, this_trk_p, pMq)
-                        alpha = (cinner_3vecs(pMq, normal) /
-                                  cinner_3vecs(rMq, normal))
+                        alpha = (
+                            cinner_3vecs(pMq, normal) / cinner_3vecs(rMq, normal)
+                        )
                         if alpha < 1:
                             # hit = q+alpha*(r-q)
                             hit[0] = this_trk_p[0]+alpha*rMq[0]

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -370,8 +370,9 @@ cdef _pft(cnp.float_t[:, :] streamline,
                                   &particle_paths[1, pp, ss, 0])
                         copy_point(&particle_dirs[0, pp, ss, 0],
                                   &particle_dirs[1, pp, ss, 0])
-                    particle_stream_statuses[1, pp] = \
+                    particle_stream_statuses[1, pp] = (
                             particle_stream_statuses[0, pp]
+                    )
                     particle_steps[1, pp] = particle_steps[0, pp]
 
                 # sample N new particle
@@ -388,8 +389,9 @@ cdef _pft(cnp.float_t[:, :] streamline,
                                   &particle_paths[0, pp, ss, 0])
                         copy_point(&particle_dirs[1, p_source, ss, 0],
                                   &particle_dirs[0, pp, ss, 0])
-                    particle_stream_statuses[0, pp] = \
+                    particle_stream_statuses[0, pp] = (
                             particle_stream_statuses[1, p_source]
+                    )
                     particle_steps[0, pp] = particle_steps[1, p_source]
                 for pp in range(particle_count):
                     particle_weights[pp] = 1. / particle_count

--- a/dipy/tracking/propspeed.pxd
+++ b/dipy/tracking/propspeed.pxd
@@ -5,39 +5,55 @@ from dipy.tracking.tracker_parameters cimport TrackerParameters, TrackerStatus
 from dipy.utils.fast_numpy cimport RNGState
 
 
-cdef TrackerStatus deterministic_propagator(double* point,
-                                            double* direction,
-                                            TrackerParameters params,
-                                            double* stream_data,
-                                            PmfGen pmf_gen,
-                                            RNGState* rng) noexcept nogil
+cdef TrackerStatus deterministic_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil
 
 
-cdef TrackerStatus eudx_propagator(double* point,
-                                    double* direction,
-                                    TrackerParameters params,
-                                    double* stream_data,
-                                    PmfGen pmf_gen,
-                                    RNGState* rng) noexcept nogil
+cdef TrackerStatus eudx_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil
 
 
-cdef TrackerStatus probabilistic_propagator(double* point,
-                                            double* direction,
-                                            TrackerParameters params,
-                                            double* stream_data,
-                                            PmfGen pmf_gen,
-                                            RNGState* rng) noexcept nogil
+cdef TrackerStatus probabilistic_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil
 
-cdef TrackerStatus parallel_transport_propagator(double* point,
-                                                 double* direction,
-                                                 TrackerParameters params,
-                                                 double* stream_data,
-                                                 PmfGen pmf_gen,
-                                                 RNGState* rng) noexcept nogil
+cdef TrackerStatus parallel_transport_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil
 
 
-cdef cnp.npy_intp _propagation_direction(double *point, double* prev, double* qa,
-                                double *ind, double *odf_vertices,
-                                double qa_thr, double ang_thr,
-                                cnp.npy_intp *qa_shape, cnp.npy_intp* strides,
-                                double *direction, double total_weight) noexcept nogil
+cdef cnp.npy_intp _propagation_direction(
+    double *point,
+    double* prev,
+    double* qa,
+    double *ind,
+    double *odf_vertices,
+    double qa_thr,
+    double ang_thr,
+    cnp.npy_intp *qa_shape,
+    cnp.npy_intp* strides,
+    double *direction,
+    double total_weight,
+) noexcept nogil

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -847,12 +847,14 @@ cdef TrackerStatus probabilistic_propagator(double* point,
     return TrackerStatus.SUCCESS
 
 
-cdef TrackerStatus eudx_propagator(double* point,
-                                    double* direction,
-                                    TrackerParameters params,
-                                    double* stream_data,
-                                    PmfGen pmf_gen,
-                                    RNGState* rng) noexcept nogil:
+cdef TrackerStatus eudx_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil:
     """EUDX propagator using trilinear interpolation of peak directions.
 
     Parameters

--- a/dipy/utils/tests/test_fast_numpy.pyx
+++ b/dipy/utils/tests/test_fast_numpy.pyx
@@ -3,8 +3,13 @@ import timeit
 
 cimport numpy as cnp
 import numpy as np
-from numpy.testing import (assert_, assert_almost_equal, assert_raises,
-                            assert_array_equal, assert_array_almost_equal)
+from numpy.testing import (
+    assert_,
+    assert_almost_equal,
+    assert_raises,
+    assert_array_equal,
+    assert_array_almost_equal,
+)
 from dipy.utils.fast_numpy import random, seed
 from dipy.utils.fast_numpy cimport (
     cross,


### PR DESCRIPTION
## Description

Remove continuation line over-indentation in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/expectmax.pyx:223:38: E127
continuation line over-indented for visual indent
```

and other similar warnings raised in:
https://github.com/dipy/dipy/actions/runs/33548912839/job/99993212761?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
