### PR TITLE
STYLE: Fix under-indentation on continuation lines in Cython code

### DIFF
--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -534,18 +534,24 @@ def compute_em_demons_step_3d(floating[:, :, :] delta_field,
                                 out[k, i, j, 1] = 0
                                 out[k, i, j, 2] = 0
                             else:
-                                out[k, i, j, 0] = (delta *
-                                    gradient_moving[k, i, j, 0] / nrm2)
-                                out[k, i, j, 1] = (delta *
-                                    gradient_moving[k, i, j, 1] / nrm2)
-                                out[k, i, j, 2] = (delta *
-                                    gradient_moving[k, i, j, 2] / nrm2)
+                                out[k, i, j, 0] = (
+                                    delta * gradient_moving[k, i, j, 0] / nrm2
+                                )
+                                out[k, i, j, 1] = (
+                                    delta * gradient_moving[k, i, j, 1] / nrm2
+                                )
+                                out[k, i, j, 2] = (
+                                    delta * gradient_moving[k, i, j, 2] / nrm2
+                                )
                         else:
                             den = (sigma_sq_x * nrm2 + sigma_sq_i)
-                            out[k, i, j, 0] = (sigma_sq_x * delta *
-                                gradient_moving[k, i, j, 0] / den)
-                            out[k, i, j, 1] = (sigma_sq_x * delta *
-                                gradient_moving[k, i, j, 1] / den)
-                            out[k, i, j, 2] = (sigma_sq_x * delta *
-                                gradient_moving[k, i, j, 2] / den)
+                            out[k, i, j, 0] = (
+                                sigma_sq_x * delta * gradient_moving[k, i, j, 0] / den
+                            )
+                            out[k, i, j, 1] = (
+                                sigma_sq_x * delta * gradient_moving[k, i, j, 1] / den
+                            )
+                            out[k, i, j, 2] = (
+                                sigma_sq_x * delta * gradient_moving[k, i, j, 2] / den
+                            )
     return np.asarray(out), energy

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -359,29 +359,79 @@ class ParzenJointHistogram:
             self.joint_grad = np.zeros((nbins, nbins, n))
         if dim == 2:
             if mgradient.dtype == np.float64:
-                _joint_pdf_gradient_dense_2d[cython.double](theta, transform,
-                    static, moving, grid2world, mgradient, smask, mmask,
-                    self.smin, self.sdelta, self.mmin, self.mdelta,
-                    self.nbins, self.padding, self.joint_grad)
+                _joint_pdf_gradient_dense_2d[cython.double](
+                    theta,
+                    transform,
+                    static,
+                    moving,
+                    grid2world,
+                    mgradient,
+                    smask, mmask,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             elif mgradient.dtype == np.float32:
-                _joint_pdf_gradient_dense_2d[cython.float](theta, transform,
-                    static, moving, grid2world, mgradient, smask, mmask,
-                    self.smin, self.sdelta, self.mmin, self.mdelta,
-                    self.nbins, self.padding, self.joint_grad)
+                _joint_pdf_gradient_dense_2d[cython.float](
+                    theta,
+                    transform,
+                    static,
+                    moving,
+                    grid2world,
+                    mgradient,
+                    smask,
+                    mmask,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             else:
                 raise ValueError("Grad. field dtype must be floating point")
 
         elif dim == 3:
             if mgradient.dtype == np.float64:
-                _joint_pdf_gradient_dense_3d[cython.double](theta, transform,
-                    static, moving, grid2world, mgradient, smask, mmask,
-                    self.smin, self.sdelta, self.mmin, self.mdelta,
-                    self.nbins, self.padding, self.joint_grad)
+                _joint_pdf_gradient_dense_3d[cython.double](
+                    theta,
+                    transform,
+                    static,
+                    moving,
+                    grid2world,
+                    mgradient,
+                    smask,
+                    mmask,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             elif mgradient.dtype == np.float32:
-                _joint_pdf_gradient_dense_3d[cython.float](theta, transform,
-                    static, moving, grid2world, mgradient, smask, mmask,
-                    self.smin, self.sdelta, self.mmin, self.mdelta,
-                    self.nbins, self.padding, self.joint_grad)
+                _joint_pdf_gradient_dense_3d[cython.float](
+                    theta, transform,
+                    static,
+                    moving,
+                    grid2world,
+                    mgradient,
+                    smask,
+                    mmask,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             else:
                 raise ValueError("Grad. field dtype must be floating point")
 
@@ -475,11 +525,25 @@ class ParzenJointHistogram:
             compute_update = _compute_dense_mi_update_3d
 
         self.metric_val = compute_update(
-            static, moving, mgradient, smask, mmask,
-            self.smin, self.sdelta, self.mmin, self.mdelta,
-            self.nbins, self.padding, self.joint, self.smarginal,
-            self.mmarginal, self.local_derivative_by_parzen_bin,
-            self.joint_pdf_index, self.mi_weights, update_field)
+            static,
+            moving,
+            mgradient,
+            smask,
+            mmask,
+            self.smin,
+            self.sdelta,
+            self.mmin,
+            self.mdelta,
+            self.nbins,
+            self.padding,
+            self.joint,
+            self.smarginal,
+            self.mmarginal,
+            self.local_derivative_by_parzen_bin,
+            self.joint_pdf_index,
+            self.mi_weights,
+            update_field,
+        )
 
     def update_gradient_sparse(self, theta, transform, sval, mval,
                                sample_points, mgradient):
@@ -537,29 +601,73 @@ class ParzenJointHistogram:
 
         if dim == 2:
             if mgradient.dtype == np.float64:
-                _joint_pdf_gradient_sparse_2d[cython.double](theta, transform,
-                    sval, mval, sample_points, mgradient, self.smin,
-                    self.sdelta, self.mmin, self.mdelta, self.nbins,
-                    self.padding, self.joint_grad)
+                _joint_pdf_gradient_sparse_2d[cython.double](
+                    theta,
+                    transform,
+                    sval,
+                    mval,
+                    sample_points,
+                    mgradient,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             elif mgradient.dtype == np.float32:
-                _joint_pdf_gradient_sparse_2d[cython.float](theta, transform,
-                    sval, mval, sample_points, mgradient, self.smin,
-                    self.sdelta, self.mmin, self.mdelta, self.nbins,
-                    self.padding, self.joint_grad)
+                _joint_pdf_gradient_sparse_2d[cython.float](
+                    theta,
+                    transform,
+                    sval,
+                    mval,
+                    sample_points,
+                    mgradient,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             else:
                 raise ValueError("Gradients dtype must be floating point")
 
         elif dim == 3:
             if mgradient.dtype == np.float64:
-                _joint_pdf_gradient_sparse_3d[cython.double](theta, transform,
-                    sval, mval, sample_points, mgradient, self.smin,
-                    self.sdelta, self.mmin, self.mdelta, self.nbins,
-                    self.padding, self.joint_grad)
+                _joint_pdf_gradient_sparse_3d[cython.double](
+                    theta,
+                    transform,
+                    sval,
+                    mval,
+                    sample_points,
+                    mgradient,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             elif mgradient.dtype == np.float32:
-                _joint_pdf_gradient_sparse_3d[cython.float](theta, transform,
-                    sval, mval, sample_points, mgradient, self.smin,
-                    self.sdelta, self.mmin, self.mdelta, self.nbins,
-                    self.padding, self.joint_grad)
+                _joint_pdf_gradient_sparse_3d[cython.float](
+                    theta,
+                    transform,
+                    sval,
+                    mval,
+                    sample_points,
+                    mgradient,
+                    self.smin,
+                    self.sdelta,
+                    self.mmin,
+                    self.mdelta,
+                    self.nbins,
+                    self.padding,
+                    self.joint_grad,
+                )
             else:
                 raise ValueError("Gradients dtype must be floating point")
         else:

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -2894,8 +2894,9 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                         q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
                                                    img_world2grid)
                         # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                            q[1], q[2], &out[k, i, j, p])
+                        in_flag = _interpolate_scalar_3d[floating](
+                            img, q[0], q[1], q[2], &out[k, i, j, p]
+                        )
                         if in_flag == 0:
                             out[k, i, j, p] = 0
                             inside[k, i, j] = 0
@@ -2910,8 +2911,9 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                         q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
                                                    img_world2grid)
                         # Interpolate img at q
-                        in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                                                q[1], q[2], &out[k, i, j, p])
+                        in_flag = _interpolate_scalar_3d[floating](
+                            img, q[0], q[1], q[2], &out[k, i, j, p]
+                        )
                         if in_flag == 0:
                             out[k, i, j, p] = 0
                             inside[k, i, j] = 0
@@ -2996,8 +2998,9 @@ def _sparse_gradient_3d(floating[:, :, :] img,
                 q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
                                            img_world2grid)
                 # Interpolate img at q
-                in_flag = _interpolate_scalar_3d[floating](img,
-                                                q[0], q[1], q[2], &out[i, p])
+                in_flag = _interpolate_scalar_3d[floating](
+                    img, q[0], q[1], q[2], &out[i, p]
+                )
                 if in_flag == 0:
                     out[i, p] = 0
                     inside[i] = 0
@@ -3067,8 +3070,9 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                                                    q[1], &out[i, j, p])
+                    in_flag = _interpolate_scalar_2d[floating](
+                        img, q[0], q[1], &out[i, j, p]
+                    )
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0
@@ -3079,8 +3083,9 @@ def _gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                     q[0] = _apply_affine_2d_x0(dx[0], dx[1], 1, img_world2grid)
                     q[1] = _apply_affine_2d_x1(dx[0], dx[1], 1, img_world2grid)
                     # Interpolate img at q
-                    in_flag = _interpolate_scalar_2d[floating](img, q[0],
-                                                    q[1], &out[i, j, p])
+                    in_flag = _interpolate_scalar_2d[floating](
+                        img, q[0], q[1], &out[i, j, p]
+                    )
                     if in_flag == 0:
                         out[i, j, p] = 0
                         inside[i, j] = 0

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -415,8 +415,9 @@ def interpolate_vector_2d(floating[:, :, :] field, double[:, :] locations):
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_vector_2d[floating](field,
-                locations[i, 0], locations[i, 1], &out[i, 0])
+            inside[i] = _interpolate_vector_2d[floating](
+                field, locations[i, 0], locations[i, 1], &out[i, 0]
+            )
     return np.asarray(out), np.asarray(inside)
 
 
@@ -525,8 +526,9 @@ def interpolate_scalar_2d(floating[:, :] image, double[:, :] locations):
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_scalar_2d[floating](image,
-                locations[i, 0], locations[i, 1], &out[i])
+            inside[i] = _interpolate_scalar_2d[floating](
+                image, locations[i, 0], locations[i, 1], &out[i]
+            )
     return np.asarray(out), np.asarray(inside)
 
 
@@ -629,8 +631,9 @@ def interpolate_scalar_nn_2d(number[:, :] image, double[:, :] locations):
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_scalar_nn_2d[number](image,
-                locations[i, 0], locations[i, 1], &out[i])
+            inside[i] = _interpolate_scalar_nn_2d[number](
+                image, locations[i, 0], locations[i, 1], &out[i]
+            )
     return np.asarray(out), np.asarray(inside)
 
 
@@ -722,14 +725,15 @@ def interpolate_scalar_nn_3d(number[:, :, :] image, double[:, :] locations):
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_scalar_nn_3d[number](image,
-                locations[i, 0], locations[i, 1], locations[i, 2], &out[i])
+            inside[i] = _interpolate_scalar_nn_3d[number](
+                image, locations[i, 0], locations[i, 1], locations[i, 2], &out[i]
+            )
     return np.asarray(out), np.asarray(inside)
 
 
-cdef inline int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
-                                         double dii, double djj,
-                                         number *out) noexcept nogil:
+cdef inline int _interpolate_scalar_nn_3d(
+    number[:, :, :] volume, double dkk, double dii, double djj, number *out
+) noexcept nogil:
     r"""Nearest-neighbor interpolation of a 3D scalar image
 
     Interpolates the 3D image at (dkk, dii, djj) using nearest neighbor
@@ -825,8 +829,9 @@ def interpolate_scalar_3d(floating[:, :, :] image, locations):
         double[:, :] _locations = np.array(locations, dtype=np.float64)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_scalar_3d[floating](image,
-                _locations[i, 0], _locations[i, 1], _locations[i, 2], &out[i])
+            inside[i] = _interpolate_scalar_3d[floating](
+                image, _locations[i, 0], _locations[i, 1], _locations[i, 2], &out[i]
+            )
     return np.asarray(out), np.asarray(inside)
 
 
@@ -958,8 +963,9 @@ def interpolate_vector_3d(floating[:, :, :, :] field, double[:, :] locations):
         int[:] inside = np.empty(shape=(n,), dtype=np.int32)
     with nogil:
         for i in range(n):
-            inside[i] = _interpolate_vector_3d[floating](field,
-                locations[i, 0], locations[i, 1], locations[i, 2], &out[i, 0])
+            inside[i] = _interpolate_vector_3d[floating](
+                field, locations[i, 0], locations[i, 1], locations[i, 2], &out[i, 0]
+            )
     return np.asarray(out), np.asarray(inside)
 
 

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -22,8 +22,15 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 
 
-def nlmeans_3d_classic(arr, mask=None, sigma=None, patch_radius=1,
-               block_radius=5, rician=True, num_threads=None):
+def nlmeans_3d_classic(
+    arr,
+    mask=None,
+    sigma=None,
+    patch_radius=1,
+    block_radius=5,
+    rician=True,
+    num_threads=None,
+):
     """ Non-local means for denoising 3D images
 
     Parameters
@@ -518,10 +525,16 @@ cdef void _value_block(double[:, :, :] denoised_estimate, double[:, :, :] weight
                     weight_count[voxel_y, voxel_x, voxel_z] = current_count + 1.0
 
 
-cdef double _patch_distance(double[:, :, :] image,
-                           int patch1_center_y, int patch1_center_x, int patch1_center_z,
-                           int patch2_center_y, int patch2_center_x, int patch2_center_z,
-                           int patch_radius) nogil:
+cdef double _patch_distance(
+    double[:, :, :] image,
+    int patch1_center_y,
+    int patch1_center_x,
+    int patch1_center_z,
+    int patch2_center_y,
+    int patch2_center_x,
+    int patch2_center_z,
+    int patch_radius,
+) nogil:
     """
     Computes the squared distance between two cubic patches in the image.
 
@@ -608,20 +621,29 @@ cdef double _patch_distance(double[:, :, :] image,
     return squared_distance_sum / voxel_count
 
 
-cdef void _process_block_complete(double[:, :, :] image,
-                                double[:, :, :] mask,
-                                double[:, :, :] local_means,
-                                double[:, :, :] local_variances,
-                                double[:, :, :] accumulated_estimates,
-                                double[:, :, :] weight_counts,
-                                double[:, :, :] workspace,
-                                int center_y, int center_x, int center_z,
-                                int patch_radius, int block_radius,
-                                double filtering_strength,
-                                double noise_variance_doubled, int is_rician,
-                                double epsilon, double mean_ratio_threshold,
-                                double variance_ratio_min,
-                                int img_height, int img_width, int img_depth) noexcept nogil:
+cdef void _process_block_complete(
+    double[:, :, :] image,
+    double[:, :, :] mask,
+    double[:, :, :] local_means,
+    double[:, :, :] local_variances,
+    double[:, :, :] accumulated_estimates,
+    double[:, :, :] weight_counts,
+    double[:, :, :] workspace,
+    int center_y,
+    int center_x,
+    int center_z,
+    int patch_radius,
+    int block_radius,
+    double filtering_strength,
+    double noise_variance_doubled,
+    int is_rician,
+    double epsilon,
+    double mean_ratio_threshold,
+    double variance_ratio_min,
+    int img_height,
+    int img_width,
+    int img_depth,
+) noexcept nogil:
     """
     Process a complete block including weight computation and final application.
 
@@ -684,10 +706,16 @@ cdef void _process_block_complete(double[:, :, :] image,
                         continue
 
                     # Compute patch distance
-                    patch_distance = _patch_distance(image,
-                                                    center_y, center_x, center_z,
-                                                    neighbor_y, neighbor_x, neighbor_z,
-                                                    block_radius)
+                    patch_distance = _patch_distance(
+                        image,
+                        center_y,
+                        center_x,
+                        center_z,
+                        neighbor_y,
+                        neighbor_x,
+                        neighbor_z,
+                        block_radius,
+                    )
 
                     # Compute similarity weight using original nlmeans formula
                     # Original: w = exp(-d / (h * h)) where h is the noise sigma
@@ -702,9 +730,17 @@ cdef void _process_block_complete(double[:, :, :] image,
 
     # Apply accumulated weighted averages to final estimate
     if accumulator_weight > 0.0:
-        _value_block(accumulated_estimates, weight_counts,
-                   center_y, center_x, center_z, workspace,
-                   accumulator_weight, noise_variance_doubled, is_rician)
+        _value_block(
+            accumulated_estimates,
+            weight_counts,
+            center_y,
+            center_x,
+            center_z,
+            workspace,
+            accumulator_weight,
+            noise_variance_doubled,
+            is_rician,
+        )
 
 
 cdef inline void _clear_workspace(double[:, :, :] workspace) noexcept nogil:
@@ -784,8 +820,14 @@ cdef double _local_mean(double[:, :, :] image, int center_y, int center_x, int c
     return intensity_sum / voxel_count
 
 
-cdef double _local_variance(double[:, :, :] image, double mean_intensity,
-                           int center_y, int center_x, int center_z, int patch_radius) nogil:
+cdef double _local_variance(
+    double[:, :, :] image,
+    double mean_intensity,
+    int center_y,
+    int center_x,
+    int center_z,
+    int patch_radius,
+) nogil:
     """
     Computes the local variance of a cubic patch centered at (center_y, center_x, center_z).
 
@@ -994,14 +1036,29 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
                         local_noise_variance_doubled = 2.0 * current_sigma_sq
                         local_filtering_strength = current_sigma_sq
 
-                        _process_block_complete(image, mask, local_means, local_variances,
-                                              accumulated_estimates, weight_counts,
-                                              thread_workspaces[thread_id],
-                                              center_y, center_x, center_z,
-                                              patch_radius, block_radius, local_filtering_strength,
-                                              local_noise_variance_doubled, is_rician,
-                                              epsilon, mean_ratio_threshold, variance_ratio_min,
-                                              img_height, img_width, img_depth)
+                        _process_block_complete(
+                            image,
+                            mask,
+                            local_means,
+                            local_variances,
+                            accumulated_estimates,
+                            weight_counts,
+                            thread_workspaces[thread_id],
+                            center_y,
+                            center_x,
+                            center_z,
+                            patch_radius,
+                            block_radius,
+                            local_filtering_strength,
+                            local_noise_variance_doubled,
+                            is_rician,
+                            epsilon,
+                            mean_ratio_threshold,
+                            variance_ratio_min,
+                            img_height,
+                            img_width,
+                            img_depth,
+                        )
     else:
         with nogil, parallel():
             for center_z in prange(0, img_depth, 2, schedule="dynamic"):
@@ -1016,14 +1073,29 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
 
                         _clear_workspace(thread_workspaces[thread_id])
 
-                        _process_block_complete(image, mask, local_means, local_variances,
-                                              accumulated_estimates, weight_counts,
-                                              thread_workspaces[thread_id],
-                                              center_y, center_x, center_z,
-                                              patch_radius, block_radius, fixed_filtering_strength,
-                                              fixed_noise_variance_doubled, is_rician,
-                                              epsilon, mean_ratio_threshold, variance_ratio_min,
-                                              img_height, img_width, img_depth)
+                        _process_block_complete(
+                            image,
+                            mask,
+                            local_means,
+                            local_variances,
+                            accumulated_estimates,
+                            weight_counts,
+                            thread_workspaces[thread_id],
+                            center_y,
+                            center_x,
+                            center_z,
+                            patch_radius,
+                            block_radius,
+                            fixed_filtering_strength,
+                            fixed_noise_variance_doubled,
+                            is_rician,
+                            epsilon,
+                            mean_ratio_threshold,
+                            variance_ratio_min,
+                            img_height,
+                            img_width,
+                            img_depth,
+                        )
 
     # Phase 3: Finalize denoised estimates
     with nogil, parallel():

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -376,10 +376,14 @@ cdef class EnhancementKernel:
         cdef double output = 1 / (8*sqrt(2))
         output *= sqrt(PI)*self.t*sqrt(self.t*self.D33)*sqrt(self.D33*self.D44)
         output *= 1 / (16*PI*PI*self.D33*self.D33*self.D44*self.D44*self.t*self.t*self.t*self.t)
-        output *= exp(-sqrt((c[0]*c[0] + c[1]*c[1]) / (self.D33*self.D44) +
-                   (c[2]*c[2] / self.D33 + (c[3]*c[3]+c[4]*c[4]) / self.D44) *
-                   (c[2]*c[2] / self.D33 + (c[3]*c[3]+c[4]*c[4]) / self.D44) +
-                    c[5]*c[5]/self.D44) / (4*self.t))
+        output *= exp(
+            -sqrt(
+                (c[0] * c[0] + c[1] * c[1]) / (self.D33 * self.D44)
+                + (c[2] * c[2] / self.D33 + (c[3] * c[3] + c[4] * c[4]) / self.D44)
+                * (c[2] * c[2] / self.D33 + (c[3] * c[3] + c[4] * c[4]) / self.D44)
+                + c[5] * c[5] / self.D44
+            ) / (4 * self.t)
+        )
         return output
 
 cdef double PI = 3.1415926535897932

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -166,9 +166,17 @@ cdef class PmfGenDirectionGetter(BasePmfDirectionGetter):
         return cls(pmf_gen, max_angle, sphere, pmf_threshold=pmf_threshold, **kwargs)
 
     @classmethod
-    def from_shcoeff(cls, shcoeff, max_angle, sphere=default_sphere,
-                    pmf_threshold=0.1, basis_type=None, legacy=True,
-                     sh_to_pmf=False, **kwargs):
+    def from_shcoeff(
+        cls,
+        shcoeff,
+        max_angle,
+        sphere=default_sphere,
+        pmf_threshold=0.1,
+        basis_type=None,
+        legacy=True,
+        sh_to_pmf=False,
+        **kwargs,
+    ):
         """Probabilistic direction getter from a distribution of directions
         on the sphere
 

--- a/dipy/direction/ptt_direction_getter.pyx
+++ b/dipy/direction/ptt_direction_getter.pyx
@@ -123,8 +123,14 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         self.rejection_sampling_max_try = 100
         self.rejection_sampling_nbr_sample = 10  # Adaptively set in Trekker.
 
-        ProbabilisticDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
-                                       pmf_threshold=pmf_threshold, **kwargs)
+        ProbabilisticDirectionGetter.__init__(
+            self,
+            pmf_gen,
+            max_angle,
+            sphere,
+            pmf_threshold=pmf_threshold,
+            **kwargs,
+        )
 
     cdef void initialize_candidate(self, double[:] init_dir):
         """"Initialize the parallel transport frame.
@@ -272,9 +278,11 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                 self.last_val_cand = 0
                 if q == self.probe_quality-1:
                     for i in range(3):
-                        binormal[i] = (self.propagator[6] * frame[0][i]
-                                      + self.propagator[7] * frame[1][i]
-                                      + self.propagator[8] * frame[2][i])
+                        binormal[i] = (
+                            self.propagator[6] * frame[0][i]
+                            + self.propagator[7] * frame[1][i]
+                            + self.propagator[8] * frame[2][i]
+                        )
                     cross(&normal[0], &binormal[0], &tangent[0])
 
                 for c in range(self.probe_count):
@@ -362,11 +370,12 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
         self.prepare_propagator(self.step_size)
 
         for i in range(3):
-            self.position[i] = \
-                (self.propagator[0] * self.frame[0][i] * self.inv_voxel_size[i]
+            self.position[i] = (
+                self.propagator[0] * self.frame[0][i] * self.inv_voxel_size[i]
                 + self.propagator[1] * self.frame[1][i] * self.inv_voxel_size[i]
                 + self.propagator[2] * self.frame[2][i] * self.inv_voxel_size[i]
-                + self.position[i])
+                + self.position[i]
+            )
             tangent[i] = (self.propagator[3] * self.frame[0][i]
                           + self.propagator[4] * self.frame[1][i]
                           + self.propagator[5] * self.frame[2][i])
@@ -445,9 +454,10 @@ cdef class PTTDirectionGetter(ProbabilisticDirectionGetter):
                     .check_point_c(<double * > &self.position[0])
                 if stream_status == TRACKPOINT:
                     continue
-                elif (stream_status == ENDPOINT or
-                    stream_status == INVALIDPOINT or
-                    stream_status == OUTSIDEIMAGE
+                elif (
+                    stream_status == ENDPOINT
+                    or stream_status == INVALIDPOINT
+                    or stream_status == OUTSIDEIMAGE
                 ):
                     break
             else:

--- a/dipy/reconst/eudx_direction_getter.pyx
+++ b/dipy/reconst/eudx_direction_getter.pyx
@@ -56,8 +56,9 @@ cdef class EuDXDirectionGetter(DirectionGetter):
 
         self.initialized = True
 
-    cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(self,
-                                                           double[::1] point):
+    cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(
+        self, double[::1] point
+    ):
         """The best starting directions for fiber tracking from point
 
         All the valid peaks in the voxel closest to point are returned as

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -264,8 +264,12 @@ def search_descending(cython.floating[::1] a, double relative_threshold):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef long local_maxima_c(double[:] odf, cnp.uint16_t[:, :] edges, double[::1] out_values,
-        cnp.npy_intp[::1] out_indices) noexcept nogil:
+cdef long local_maxima_c(
+    double[:] odf,
+    cnp.uint16_t[:, :] edges,
+    double[::1] out_values,
+    cnp.npy_intp[::1] out_indices,
+) noexcept nogil:
     cdef:
         long count
         cnp.npy_intp* wpeak = <cnp.npy_intp*>malloc(odf.shape[0] * sizeof(cnp.npy_intp))
@@ -479,9 +483,11 @@ def le_to_odf(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def sum_on_blocks_1d(cnp.ndarray[double, ndim=1] arr,
+def sum_on_blocks_1d(
+    cnp.ndarray[double, ndim=1] arr,
     cnp.ndarray[long, ndim=1] blocks,
-    cnp.ndarray[double, ndim=1] out, int outn,
+    cnp.ndarray[double, ndim=1] out,
+    int outn,
 ):
     """Summations on blocks of 1d array
     """

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -318,16 +318,19 @@ cdef void _negloglikelihood(double[:, :, :] image, double[:] mu,
                 if sigmasq[cls_idx] < eps_sq:
 
                     if fabs(image[x, y, z] - mu[cls_idx]) < eps:
-                        neglogl[x, y, z, cls_idx] = 1 + log(sqrt(2.0 * NPY_PI *
-                                                           sigmasq[cls_idx]))
+                        neglogl[x, y, z, cls_idx] = 1 + log(
+                            sqrt(2.0 * NPY_PI * sigmasq[cls_idx])
+                        )
                     else:
                         neglogl[x, y, z, cls_idx] = NPY_INFINITY
 
                 else:
-                    neglogl[x, y, z, cls_idx] = (((image[x, y, z] - mu[cls_idx])**2.0) /
-                                           (2.0 * sigmasq[cls_idx]))
-                    neglogl[x, y, z, cls_idx] += log(sqrt(2.0 * NPY_PI *
-                                                    sigmasq[cls_idx]))
+                    neglogl[x, y, z, cls_idx] = (
+                        ((image[x, y, z] - mu[cls_idx])**2.0) / (2.0 * sigmasq[cls_idx])
+                    )
+                    neglogl[x, y, z, cls_idx] += log(
+                        sqrt(2.0 * NPY_PI * sigmasq[cls_idx])
+                    )
 
 
 cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
@@ -382,9 +385,8 @@ cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
                         gaussian[x, y, z] = 0
                 else:
                     gaussian[x, y, z] = (
-                        (exp(-((image[x, y, z] - mu[cls_idx]) ** 2) /
-                        (2 * sigmasq[cls_idx]))) / (sqrt(2 * NPY_PI * sigmasq[cls_idx])))
-
+                        exp(-((image[x, y, z] - mu[cls_idx]) ** 2) / (2 * sigmasq[cls_idx]))
+                    ) / (sqrt(2 * NPY_PI * sigmasq[cls_idx]))
                 P_L_Y[x, y, z, cls_idx] = gaussian[x, y, z] * P_L_N[x, y, z, cls_idx]
 
 

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -30,8 +30,9 @@ cdef inline double _stepsize(double point, double increment) noexcept nogil:
     else:
         return dist / increment
 
-cdef void _step_to_boundary(double * point, double * direction,
-                           double overstep) noexcept nogil:
+cdef void _step_to_boundary(
+    double * point, double * direction, double overstep
+) noexcept nogil:
     """Takes a step from point in along direction just past a voxel boundary.
 
     Parameters
@@ -125,9 +126,11 @@ cdef class DirectionGetter:
             stream_status = stopping_criterion.check_point_c(point)
             if stream_status == TRACKPOINT:
                 continue
-            elif (stream_status == ENDPOINT or
-                 stream_status == INVALIDPOINT or
-                 stream_status == OUTSIDEIMAGE):
+            elif (
+                stream_status == ENDPOINT
+                or stream_status == INVALIDPOINT
+                or stream_status == OUTSIDEIMAGE
+            ):
                 break
         else:
             # maximum length of streamline has been reached, return everything

--- a/dipy/tracking/fbcmeasures.pyx
+++ b/dipy/tracking/fbcmeasures.pyx
@@ -57,12 +57,14 @@ cdef class FBCMeasures:
         ----------
         .. footbibliography::
         """
-        self.compute(streamlines,
-                 kernel,
-                 min_fiberlength=min_fiberlength,
-                 max_windowsize=max_windowsize,
-                 num_threads=num_threads,
-                 verbose=verbose)
+        self.compute(
+            streamlines,
+            kernel,
+            min_fiberlength=min_fiberlength,
+            max_windowsize=max_windowsize,
+            num_threads=num_threads,
+            verbose=verbose,
+        )
 
     def get_points_rfbc_thresholded(self, threshold, emphasis=.5, verbose=False):
         """ Set a threshold on the RFBC to remove spurious fibers.

--- a/dipy/tracking/localtrack.pyx
+++ b/dipy/tracking/localtrack.pyx
@@ -366,10 +366,14 @@ cdef _pft(cnp.float_t[:, :] streamline,
                 # copy data in the temp arrays
                 for pp in range(particle_count):
                     for ss in range(pft_nbr_steps):
-                        copy_point(&particle_paths[0, pp, ss, 0],
-                                  &particle_paths[1, pp, ss, 0])
-                        copy_point(&particle_dirs[0, pp, ss, 0],
-                                  &particle_dirs[1, pp, ss, 0])
+                        copy_point(
+                            &particle_paths[0, pp, ss, 0],
+                            &particle_paths[1, pp, ss, 0],
+                        )
+                        copy_point(
+                            &particle_dirs[0, pp, ss, 0],
+                            &particle_dirs[1, pp, ss, 0],
+                        )
                     particle_stream_statuses[1, pp] = (
                             particle_stream_statuses[0, pp]
                     )
@@ -385,10 +389,14 @@ cdef _pft(cnp.float_t[:, :] streamline,
                                                rdm_sample,
                                                particle_count)
                     for ss in range(pft_nbr_steps):
-                        copy_point(&particle_paths[1, p_source, ss, 0],
-                                  &particle_paths[0, pp, ss, 0])
-                        copy_point(&particle_dirs[1, p_source, ss, 0],
-                                  &particle_dirs[0, pp, ss, 0])
+                        copy_point(
+                            &particle_paths[1, p_source, ss, 0],
+                            &particle_paths[0, pp, ss, 0],
+                        )
+                        copy_point(
+                            &particle_dirs[1, p_source, ss, 0],
+                            &particle_dirs[0, pp, ss, 0],
+                        )
                     particle_stream_statuses[0, pp] = (
                             particle_stream_statuses[1, p_source]
                     )

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -525,15 +525,17 @@ cdef void initialize_ptt_candidate(TrackerParameters params,
     else:
         for count in range(params.ptt.probe_count):
             for i in range(3):
-                position[i] = (stream_data[19 + i]
-                              + stream_data[4 + i]
-                              * params.ptt.probe_radius
-                              * cos(count * params.ptt.angular_separation)
-                              * params.inv_voxel_size[i]
-                              + stream_data[7 + i]
-                              * params.ptt.probe_radius
-                              * sin(count * params.ptt.angular_separation)
-                              * params.inv_voxel_size[i])
+                position[i] = (
+                    stream_data[19 + i]
+                    + stream_data[4 + i]
+                    * params.ptt.probe_radius
+                    * cos(count * params.ptt.angular_separation)
+                    * params.inv_voxel_size[i]
+                    + stream_data[7 + i]
+                    * params.ptt.probe_radius
+                    * sin(count * params.ptt.angular_separation)
+                    * params.inv_voxel_size[i]
+                )
 
             fod_amp = pmf_gen.get_pmf_value_c(position,
                                               &stream_data[1])
@@ -584,17 +586,19 @@ cdef void prepare_ptt_propagator(TrackerParameters params,
         # stream_data[10:18] -> propagator
         stream_data[11] = stream_data[24] * tmp_arclength
         stream_data[12] = stream_data[25] * tmp_arclength
-        stream_data[13] = (1 - stream_data[25]
-                          * stream_data[25] * tmp_arclength
-                          - stream_data[24] * stream_data[24]
-                          * tmp_arclength)
+        stream_data[13] = (
+            1 - stream_data[25] * stream_data[25] * tmp_arclength
+            - stream_data[24] * stream_data[24] * tmp_arclength
+        )
         stream_data[14] = stream_data[24] * arclength
         stream_data[15] = stream_data[25] * arclength
         stream_data[16] = -stream_data[25] * arclength
-        stream_data[17] = (-stream_data[24] * stream_data[25]
-                          * tmp_arclength)
-        stream_data[18] = (1 - stream_data[25] * stream_data[25]
-                          * tmp_arclength)
+        stream_data[17] = (
+            -stream_data[24] * stream_data[25] * tmp_arclength
+        )
+        stream_data[18] = (
+            1 - stream_data[25] * stream_data[25] * tmp_arclength
+        )
 
 
 cdef double calculate_ptt_data_support(TrackerParameters params,
@@ -633,21 +637,26 @@ cdef double calculate_ptt_data_support(TrackerParameters params,
     for q in range(1, params.ptt.probe_quality):
         for i in range(3):
             # stream_data[10:18] : propagator
-            position[i] = \
-                (stream_data[10] * frame[0][i] * params.voxel_size[i]
+            position[i] = (
+                stream_data[10] * frame[0][i] * params.voxel_size[i]
                 + stream_data[11] * frame[1][i] * params.voxel_size[i]
                 + stream_data[12] * frame[2][i] * params.voxel_size[i]
-                + position[i])
-            tangent[i] = (stream_data[13] * frame[0][i]
-                         + stream_data[14] * frame[1][i]
-                         + stream_data[15] * frame[2][i])
+                + position[i]
+            )
+            tangent[i] = (
+                stream_data[13] * frame[0][i]
+                + stream_data[14] * frame[1][i]
+                + stream_data[15] * frame[2][i]
+            )
         normalize(&tangent[0])
 
         if q < (params.ptt.probe_quality - 1):
             for i in range(3):
-                binormal[i] = (stream_data[16] * frame[0][i]
-                              + stream_data[17] * frame[1][i]
-                              + stream_data[18] * frame[2][i])
+                binormal[i] = (
+                    stream_data[16] * frame[0][i]
+                    + stream_data[17] * frame[1][i]
+                    + stream_data[18] * frame[2][i]
+                )
             cross(&normal[0], &binormal[0], &tangent[0])
 
             copy_point(&tangent[0], &frame[0][0])
@@ -662,20 +671,26 @@ cdef double calculate_ptt_data_support(TrackerParameters params,
             stream_data[23] = 0  # last_val_cand
             if q == params.ptt.probe_quality - 1:
                 for i in range(3):
-                    binormal[i] = (stream_data[16] * frame[0][i]
-                                  + stream_data[17] * frame[1][i]
-                                  + stream_data[18] * frame[2][i])
+                    binormal[i] = (
+                        stream_data[16] * frame[0][i]
+                        + stream_data[17] * frame[1][i]
+                        + stream_data[18] * frame[2][i]
+                    )
                 cross(&normal[0], &binormal[0], &tangent[0])
 
             for c in range(params.ptt.probe_count):
                 for i in range(3):
-                    new_position[i] = (position[i]
-                                      + normal[i] * params.ptt.probe_radius
-                                      * cos(c * params.ptt.angular_separation)
-                                      * params.inv_voxel_size[i]
-                                      + binormal[i] * params.ptt.probe_radius
-                                      * sin(c * params.ptt.angular_separation)
-                                      * params.inv_voxel_size[i])
+                    new_position[i] = (
+                        position[i]
+                        + normal[i]
+                        * params.ptt.probe_radius
+                        * cos(c * params.ptt.angular_separation)
+                        * params.inv_voxel_size[i]
+                        + binormal[i]
+                        * params.ptt.probe_radius
+                        * sin(c * params.ptt.angular_separation)
+                        * params.inv_voxel_size[i]
+                    )
                 fod_amp = pmf_gen.get_pmf_value_c(new_position, tangent)
                 fod_amp = fod_amp if fod_amp > params.sh.pmf_threshold else 0
                 stream_data[23] += fod_amp  # last_val_cand
@@ -951,12 +966,14 @@ cdef TrackerStatus eudx_propagator(
     return TrackerStatus.SUCCESS
 
 
-cdef TrackerStatus parallel_transport_propagator(double* point,
-                                              double* direction,
-                                              TrackerParameters params,
-                                              double* stream_data,
-                                              PmfGen pmf_gen,
-                                              RNGState* rng) noexcept nogil:
+cdef TrackerStatus parallel_transport_propagator(
+    double* point,
+    double* direction,
+    TrackerParameters params,
+    double* stream_data,
+    PmfGen pmf_gen,
+    RNGState* rng,
+) noexcept nogil:
     """
     Propagates the position by step_size amount. The propagation is using
     the parameters of the last candidate curve. Then, randomly generate
@@ -1010,20 +1027,22 @@ cdef TrackerStatus parallel_transport_propagator(double* point,
 
     for i in range(3):
         #  position
-        stream_data[19 + i] = (stream_data[10] * stream_data[1 + i]
-                               * params.inv_voxel_size[i]
-                               + stream_data[11] * stream_data[4 + i]
-                               * params.inv_voxel_size[i]
-                               + stream_data[12] * stream_data[7 + i]
-                               * params.inv_voxel_size[i]
-                               + stream_data[19 + i])
-        tangent[i] = (stream_data[13] * stream_data[1 + i]
-                      + stream_data[14] * stream_data[4 + i]
-                      + stream_data[15] * stream_data[7 + i])
-        stream_data[7 + i] = \
-            (stream_data[16] * stream_data[1 + i]
+        stream_data[19 + i] = (
+            stream_data[10] * stream_data[1 + i] * params.inv_voxel_size[i]
+            + stream_data[11] * stream_data[4 + i] * params.inv_voxel_size[i]
+            + stream_data[12] * stream_data[7 + i] * params.inv_voxel_size[i]
+            + stream_data[19 + i]
+        )
+        tangent[i] = (
+            stream_data[13] * stream_data[1 + i]
+            + stream_data[14] * stream_data[4 + i]
+            + stream_data[15] * stream_data[7 + i]
+        )
+        stream_data[7 + i] = (
+            stream_data[16] * stream_data[1 + i]
             + stream_data[17] * stream_data[4 + i]
-            + stream_data[18] * stream_data[7 + i])
+            + stream_data[18] * stream_data[7 + i]
+        )
     normalize(&tangent[0])
     cross(&stream_data[4], &stream_data[7], &tangent[0])  # frame1, frame2
     normalize(&stream_data[4])  # frame1

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -483,8 +483,12 @@ cdef double c_segment_length(Streamline streamline,
     return sqrt(segment_length)
 
 
-cdef cnp.npy_intp c_compress_streamline(Streamline streamline, Streamline out,
-                                       double tol_error, double max_segment_length) noexcept nogil:
+cdef cnp.npy_intp c_compress_streamline(
+    Streamline streamline,
+    Streamline out,
+    double tol_error,
+    double max_segment_length,
+) noexcept nogil:
     """ Compresses a streamline (see function `compress_streamlines`)."""
     cdef:
         cnp.npy_intp N = streamline.shape[0]

--- a/dipy/tracking/tests/test_tractogen.pyx
+++ b/dipy/tracking/tests/test_tractogen.pyx
@@ -146,12 +146,14 @@ def test_tracking_max_angle():
     ]:
         for max_angle in [20, 45]:
 
-            params = generate_tracking_parameters("det",
-                                                max_len=500,
-                                                step_size=1,
-                                                voxel_size=np.ones(3),
-                                                max_angle=max_angle,
-                                                random_seed=0)
+            params = generate_tracking_parameters(
+                "det",
+                max_len=500,
+                step_size=1,
+                voxel_size=np.ones(3),
+                max_angle=max_angle,
+                random_seed=0,
+            )
 
             streamlines = generate_disco_streamlines(params, nbr_seeds=100, sphere=sph)
             min_cos_sim = get_min_cos_similarity(streamlines)

--- a/dipy/tracking/tracker_parameters.pyx
+++ b/dipy/tracking/tracker_parameters.pyx
@@ -15,12 +15,24 @@ import numpy as np
 cimport numpy as cnp
 
 
-def generate_tracking_parameters(algo_name, *,
-    int max_len=500, int min_len=2, double step_size=0.2, double[:] voxel_size,
-    double max_angle=20, bint return_all=True, double pmf_threshold=0.1,
-    double probe_length=0.5, double probe_radius=0, int probe_quality=3,
-    int probe_count=1, double data_support_exponent=1, int random_seed=0,
-    double peak_values_threshold=0.0239, double angle_threshold=60,
+def generate_tracking_parameters(
+    algo_name,
+    *,
+    int max_len=500,
+    int min_len=2,
+    double step_size=0.2,
+    double[:] voxel_size,
+    double max_angle=20,
+    bint return_all=True,
+    double pmf_threshold=0.1,
+    double probe_length=0.5,
+    double probe_radius=0,
+    int probe_quality=3,
+    int probe_count=1,
+    double data_support_exponent=1,
+    int random_seed=0,
+    double peak_values_threshold=0.0239,
+    double angle_threshold=60,
     double min_total_weight=0.5,
 ):
 
@@ -140,8 +152,14 @@ cdef class ShTrackerParameters:
 
 cdef class ParallelTransportTrackerParameters:
 
-    def __init__(self, double probe_length, double probe_radius,
-                int probe_quality, int probe_count, double data_support_exponent):
+    def __init__(
+        self,
+        double probe_length,
+        double probe_radius,
+        int probe_quality,
+        int probe_count,
+        double data_support_exponent,
+    ):
         self.probe_length = probe_length
         self.probe_radius = probe_radius
         self.probe_quality = probe_quality

--- a/dipy/tracking/tractogen.pxd
+++ b/dipy/tracking/tractogen.pxd
@@ -5,28 +5,30 @@ from dipy.direction.pmf cimport PmfGen
 from dipy.tracking.tracker_parameters cimport TrackerParameters
 
 
-cdef void generate_tractogram_c(double[:, ::1] seed_positions,
-                                double[:, ::1] seed_directions,
-                                int nbr_threads,
-                                StoppingCriterion sc,
-                                TrackerParameters params,
-                                PmfGen pmf_gen,
-                                double** streamlines,
-                                int* length,
-                                StreamlineStatus* status)
+cdef void generate_tractogram_c(
+    double[:, ::1] seed_positions,
+    double[:, ::1] seed_directions,
+    int nbr_threads,
+    StoppingCriterion sc,
+    TrackerParameters params,
+    PmfGen pmf_gen,
+    double** streamlines,
+    int* length,
+    StreamlineStatus* status,
+)
 
 
-cdef StreamlineStatus generate_local_streamline(double* seed,
-                                   double* position,
-                                   double* stream,
-                                   int* stream_idx,
-                                   StoppingCriterion sc,
-                                   TrackerParameters params,
-                                   PmfGen pmf_gen) noexcept nogil
+cdef StreamlineStatus generate_local_streamline(
+    double* seed,
+    double* position,
+    double* stream,
+    int* stream_idx,
+    StoppingCriterion sc,
+    TrackerParameters params,
+    PmfGen pmf_gen,
+) noexcept nogil
 
 
-cdef void prepare_pmf(double* pmf,
-                      double* point,
-                      PmfGen pmf_gen,
-                      double pmf_threshold,
-                      int pmf_len) noexcept nogil
+cdef void prepare_pmf(
+    double* pmf, double* point, PmfGen pmf_gen, double pmf_threshold, int pmf_len
+) noexcept nogil

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -123,15 +123,17 @@ def generate_tractogram(double[:, ::1] seed_positions,
             seed_end = _len
 
 
-cdef void generate_tractogram_c(double[:, ::1] seed_positions,
-                                double[:, ::1] seed_directions,
-                               int nbr_threads,
-                               StoppingCriterion sc,
-                               TrackerParameters params,
-                               PmfGen pmf_gen,
-                               double** streamlines,
-                               int* lengths,
-                               StreamlineStatus* status):
+cdef void generate_tractogram_c(
+    double[:, ::1] seed_positions,
+    double[:, ::1] seed_directions,
+    int nbr_threads,
+    StoppingCriterion sc,
+    TrackerParameters params,
+    PmfGen pmf_gen,
+    double** streamlines,
+    int* lengths,
+    StreamlineStatus* status,
+):
     """Generate a tractogram from a set of seed points and directions.
 
     This is the C implementation of the generate_tractogram function.

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -283,9 +283,11 @@ cdef cnp.npy_intp _streamline_in_mask(
             for dim_idx in range(3):
                 if direction[dim_idx] != 0:
                     length_ratio = fmin(
-                        fabs((current_edge[dim_idx] - current_pt[dim_idx])
-                            / direction[dim_idx]),
-                        length_ratio)
+                        fabs(
+                            (current_edge[dim_idx] - current_pt[dim_idx]) / direction[dim_idx]
+                        ),
+                        length_ratio,
+                    )
 
             # Check if last point is already on an edge
             remaining_distance -= length_ratio * direction_norm

--- a/dipy/utils/tests/test_fast_numpy.pyx
+++ b/dipy/utils/tests/test_fast_numpy.pyx
@@ -47,8 +47,7 @@ def test_dot():
     for _ in range(10):
         vec_view1 = vec1 = np.random.random(3)
         vec_view2 = vec2 = np.random.random(3)
-        assert_almost_equal(dot(&vec_view1[0], &vec_view2[0]),
-            np.dot(vec1, vec2))
+        assert_almost_equal(dot(&vec_view1[0], &vec_view2[0]), np.dot(vec1, vec2))
 
     vec_view1 = vec1 = np.random.random(3)
     vec_view2 = vec2 = np.random.random(3)


### PR DESCRIPTION
## Description

Fix under-indentation on continuation lines in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/expectmax.pyx:538:37: E128
continuation line under-indented for visual indent
```

and other similar errors raised in:
https://github.com/dipy/dipy/actions/runs/33913585752/job/101155499494?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
