### PR TITLE
STYLE: Stick to pre-defined line length in Cython code

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -63,11 +63,18 @@ cdef inline int _wrap(int x, int m) noexcept nogil:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef inline void _update_factors(double[:, :, :, :] factors,
-                                 floating[:, :, :] moving,
-                                 floating[:, :, :] static,
-                                 cnp.npy_intp ss, cnp.npy_intp rr, cnp.npy_intp cc,
-                                 cnp.npy_intp s, cnp.npy_intp r, cnp.npy_intp c, int operation)noexcept nogil:
+cdef inline void _update_factors(
+    double[:, :, :, :] factors,
+    floating[:, :, :] moving,
+    floating[:, :, :] static,
+    cnp.npy_intp ss,
+    cnp.npy_intp rr,
+    cnp.npy_intp cc,
+    cnp.npy_intp s,
+    cnp.npy_intp r,
+    cnp.npy_intp c,
+    int operation,
+) noexcept nogil:
     r"""Updates the precomputed CC factors of a rectangular window
 
     Updates the precomputed CC factors of the rectangular window centered

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -1506,9 +1506,15 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                     if mmask is not None and mmask[k, i, j] == 0:
                         continue
                     valid_points += 1
-                    x[0] = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, grid2world)
-                    x[1] = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, grid2world)
-                    x[2] = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, grid2world)
+                    x[0] = _apply_affine_3d_x0(
+                        <double>k, <double>i, <double>j, 1, grid2world
+                    )
+                    x[1] = _apply_affine_3d_x1(
+                        <double>k, <double>i, <double>j, 1, grid2world
+                    )
+                    x[2] = _apply_affine_3d_x2(
+                        <double>k, <double>i, <double>j, 1, grid2world
+                    )
 
                     if constant_jacobian == 0:
                         constant_jacobian = transform._jacobian(theta, x, J)

--- a/dipy/align/transforms.pxd
+++ b/dipy/align/transforms.pxd
@@ -2,6 +2,8 @@ cdef class Transform:
     cdef:
         int number_of_parameters
         int dim
-    cdef int _jacobian(self, double[:] theta, double[:] x, double[:, :] J) noexcept nogil
+    cdef int _jacobian(
+        self, double[:] theta, double[:] x, double[:, :] J
+    ) noexcept nogil
     cdef void _get_identity_parameters(self, double[:] theta) noexcept nogil
     cdef void _param_to_matrix(self, double[:] theta, double[:, :] T) noexcept nogil

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -876,10 +876,18 @@ cdef class RigidIsoScalingTransform3D(Transform):
             double dz = theta[5]
             double sxyz = theta[6]
 
-        R[0, 0], R[0, 1], R[0, 2] = (cc*cb-sc*sa*sb)*sxyz, -sc*ca*sxyz, (cc*sb+sc*sa*cb)*sxyz
-        R[1, 0], R[1, 1], R[1, 2] = (sc*cb+cc*sa*sb)*sxyz, cc*ca*sxyz, (sc*sb-cc*sa*cb)*sxyz
-        R[2, 0], R[2, 1], R[2, 2] = -ca*sb*sxyz, sa*sxyz, ca*cb*sxyz
-        R[3, 0], R[3, 1], R[3, 2] = 0, 0, 0
+        R[0, 0] = (cc*cb-sc*sa*sb)*sxyz
+        R[0, 1] = -sc*ca*sxyz
+        R[0, 2] = (cc*sb+sc*sa*cb)*sxyz
+        R[1, 0] = (sc*cb+cc*sa*sb)*sxyz
+        R[1, 1] = cc*ca*sxyz
+        R[1, 2] = (sc*sb-cc*sa*cb)*sxyz
+        R[2, 0] = -ca*sb*sxyz
+        R[2, 1] = sa*sxyz
+        R[2, 2] = ca*cb*sxyz
+        R[3, 0] = 0
+        R[3, 1] = 0
+        R[3, 2] = 0
         R[0, 3] = dx
         R[1, 3] = dy
         R[2, 3] = dz

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -395,9 +395,15 @@ cdef void _compose_vector_fields_3d(floating[:, :, :, :] d1,
                     diii = <double>i
                     djjj = <double>j
                 else:
-                    dkkk = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, premult_index)
-                    diii = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, premult_index)
-                    djjj = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, premult_index)
+                    dkkk = _apply_affine_3d_x0(
+                        <double>k, <double>i, <double>j, 1, premult_index
+                    )
+                    diii = _apply_affine_3d_x1(
+                        <double>k, <double>i, <double>j, 1, premult_index
+                    )
+                    djjj = _apply_affine_3d_x2(
+                        <double>k, <double>i, <double>j, 1, premult_index
+                    )
 
                 dkkk = dkkk + dk
                 diii = diii + di
@@ -1006,12 +1012,27 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
                         dj = djj
 
                     if affine_idx_out is not None:
-                        out[k, i, j, 0] = dk +\
-                            _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, affine_idx_out) - <double>k
-                        out[k, i, j, 1] = di +\
-                            _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, affine_idx_out) - <double>i
-                        out[k, i, j, 2] = dj +\
-                            _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, affine_idx_out) - <double>j
+                        out[k, i, j, 0] = (
+                            dk
+                            + _apply_affine_3d_x0(
+                                <double>k, <double>i, <double>j, 1, affine_idx_out
+                            )
+                            - <double>k
+                        )
+                        out[k, i, j, 1] = (
+                            di
+                            + _apply_affine_3d_x1(
+                                <double>k, <double>i, <double>j, 1, affine_idx_out
+                            )
+                            - <double>i
+                        )
+                        out[k, i, j, 2] = (
+                            dj
+                            + _apply_affine_3d_x2(
+                                <double>k, <double>i, <double>j, 1, affine_idx_out
+                            )
+                            - <double>j
+                        )
                     else:
                         out[k, i, j, 0] = dk
                         out[k, i, j, 1] = di
@@ -1660,14 +1681,22 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
             for i in range(nrows):
                 for j in range(ncols):
                     if affine is not None:
-                        dkk = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, affine)
-                        dii = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, affine)
-                        djj = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, affine)
+                        dkk = _apply_affine_3d_x0(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
+                        dii = _apply_affine_3d_x1(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
+                        djj = _apply_affine_3d_x2(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
                     else:
                         dkk = <double>k
                         dii = <double>i
                         djj = <double>j
-                    _interpolate_scalar_3d[floating](volume, dkk, dii, djj, &out[k, i, j])
+                    _interpolate_scalar_3d[floating](
+                        volume, dkk, dii, djj, &out[k, i, j]
+                    )
     return np.asarray(out)
 
 
@@ -1910,9 +1939,15 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
             for i in range(nrows):
                 for j in range(ncols):
                     if affine is not None:
-                        dkk = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, affine)
-                        dii = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, affine)
-                        djj = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, affine)
+                        dkk = _apply_affine_3d_x0(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
+                        dii = _apply_affine_3d_x1(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
+                        djj = _apply_affine_3d_x2(
+                            <double>k, <double>i, <double>j, 1, affine
+                        )
                     else:
                         dkk = <double>k
                         dii = <double>i
@@ -2606,9 +2641,15 @@ def create_random_displacement_3d(int[:] from_shape,
 
                 # convert the input point to physical coordinates
                 if from_grid2world is not None:
-                    dk = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, from_grid2world)
-                    di = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, from_grid2world)
-                    dj = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, from_grid2world)
+                    dk = _apply_affine_3d_x0(
+                        <double>k, <double>i, <double>j, 1, from_grid2world
+                    )
+                    di = _apply_affine_3d_x1(
+                        <double>k, <double>i, <double>j, 1, from_grid2world
+                    )
+                    dj = _apply_affine_3d_x2(
+                        <double>k, <double>i, <double>j, 1, from_grid2world
+                    )
                 else:
                     dk = <double>k
                     di = <double>i
@@ -2616,9 +2657,15 @@ def create_random_displacement_3d(int[:] from_shape,
 
                 # convert the output point to physical coordinates
                 if to_grid2world is not None:
-                    dkk = _apply_affine_3d_x0(<double>rk, <double>ri, <double>rj, 1, to_grid2world)
-                    dii = _apply_affine_3d_x1(<double>rk, <double>ri, <double>rj, 1, to_grid2world)
-                    djj = _apply_affine_3d_x2(<double>rk, <double>ri, <double>rj, 1, to_grid2world)
+                    dkk = _apply_affine_3d_x0(
+                        <double>rk, <double>ri, <double>rj, 1, to_grid2world
+                    )
+                    dii = _apply_affine_3d_x1(
+                        <double>rk, <double>ri, <double>rj, 1, to_grid2world
+                    )
+                    djj = _apply_affine_3d_x2(
+                        <double>rk, <double>ri, <double>rj, 1, to_grid2world
+                    )
                 else:
                     dkk = <double>rk
                     dii = <double>ri
@@ -2880,9 +2927,15 @@ def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                 for j in range(ncols):
                     inside[k, i, j] = 1
                     # Compute coordinates of index (k, i, j) in physical space
-                    x[0] = _apply_affine_3d_x0(<double>k, <double>i, <double>j, 1, out_grid2world)
-                    x[1] = _apply_affine_3d_x1(<double>k, <double>i, <double>j, 1, out_grid2world)
-                    x[2] = _apply_affine_3d_x2(<double>k, <double>i, <double>j, 1, out_grid2world)
+                    x[0] = _apply_affine_3d_x0(
+                        <double>k, <double>i, <double>j, 1, out_grid2world
+                    )
+                    x[1] = _apply_affine_3d_x1(
+                        <double>k, <double>i, <double>j, 1, out_grid2world
+                    )
+                    x[2] = _apply_affine_3d_x2(
+                        <double>k, <double>i, <double>j, 1, out_grid2world
+                    )
                     dx[:] = x[:]
                     for p in range(3):
                         # Compute coordinates of point dx on img's grid

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -20,7 +20,8 @@ def rbf_interpolation(data, sphere_origin, sphere_target, *,
     Parameters
     ----------
     data : (..., N) ndarray
-        Values of the spherical function evaluated at the N positions specified by `sphere_origin`.
+        Values of the spherical function evaluated at the N positions
+        specified by `sphere_origin`.
     sphere_origin : Sphere
         N positions on the unit sphere where the spherical function is evaluated.
     sphere_target : Sphere
@@ -32,17 +33,19 @@ def rbf_interpolation(data, sphere_origin, sphere_target, *,
         'multiquadric', 'inverse_multiquadric', 'inverse_quadratic', 'gaussian'}.
     epsilon : float, optional
         Radial basis function spread parameter.
-        Defaults to 1 when `function` is 'linear', 'thin_plate_spline', 'cubic', or 'quintic'.
-        Otherwise, `epsilon` must be specified.
+        Defaults to 1 when `function` is 'linear', 'thin_plate_spline',
+        'cubic', or 'quintic'. Otherwise, `epsilon` must be specified.
     smoothing : float, optional
-        Smoothing parameter. When `smoothing` is 0, the interpolation is exact.
-        As `smoothing` increases, the interpolation approaches a least-squares fit of `data`
-        using the supplied radial basis function. Default: 0.
+        Smoothing parameter. When `smoothing` is 0, the interpolation
+        is exact. As `smoothing` increases, the interpolation
+        approaches a least-squares fit of `data` using the supplied
+        radial basis function. Default: 0.
 
     Returns
     -------
     v : (..., M) ndarray
-        Interpolated values of the spherical function at M positions specified by `sphere_target`.
+        Interpolated values of the spherical function at M positions
+        specified by `sphere_target`.
 
     See Also
     --------
@@ -88,7 +91,9 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
     return summ
 
 
-cdef void splitoffset(float *offset, cnp.npy_intp *index, cnp.npy_intp shape) noexcept nogil:
+cdef void splitoffset(
+    float *offset, cnp.npy_intp *index, cnp.npy_intp shape
+) noexcept nogil:
     """Splits a global offset into an integer index and a relative offset"""
     offset[0] -= .5
     if offset[0] <= 0:

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -132,9 +132,15 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
     return np.sqrt(new)
 
 
-cdef double process_block(double[:, :, ::1] arr,
-                          cnp.npy_intp i, cnp.npy_intp j, cnp.npy_intp k,
-                          cnp.npy_intp B, cnp.npy_intp P, double[:, :, ::1] sigma) nogil:
+cdef double process_block(
+    double[:, :, ::1] arr,
+    cnp.npy_intp i,
+    cnp.npy_intp j,
+    cnp.npy_intp k,
+    cnp.npy_intp B,
+    cnp.npy_intp P,
+    double[:, :, ::1] sigma,
+) nogil:
     """ Process the block with center at (i, j, k)
 
     Parameters
@@ -285,7 +291,11 @@ cdef cnp.npy_intp copy_block_3d(double * dest,
 
     for i in range(I):
         for j in range(J):
-            memcpy(&dest[i * J * K + j * K], &source[i + min_i, j + min_j, min_k], K * sizeof(double))
+            memcpy(
+                &dest[i * J * K + j * K],
+                &source[i + min_i, j + min_j, min_k],
+                K * sizeof(double),
+            )
 
     return 1
 
@@ -394,8 +404,14 @@ cpdef upfir(double[:, :] image, double[:] h):
     return filtered
 
 
-cdef void _average_block(double[:, :, :] image, int center_y, int center_x, int center_z,
-                         double[:, :, :] weighted_average, double weight) noexcept nogil:
+cdef void _average_block(
+    double[:, :, :] image,
+    int center_y,
+    int center_x,
+    int center_z,
+    double[:, :, :] weighted_average,
+    double weight,
+) noexcept nogil:
     """
     Compute the weighted average of the patches in a blockwise manner.
 
@@ -442,9 +458,13 @@ cdef void _average_block(double[:, :, :] image, int center_y, int center_x, int 
 
                 if is_outside_bounds == 1:
                     # Use center voxel value for out-of-bounds locations
-                    weighted_average[offset_y, offset_x, offset_z] += weight * (image[center_y, center_x, center_z]**2)
+                    weighted_average[offset_y, offset_x, offset_z] += weight * (
+                        image[center_y, center_x, center_z] ** 2
+                    )
                 else:
-                    weighted_average[offset_y, offset_x, offset_z] += weight * (image[voxel_y, voxel_x, voxel_z]**2)
+                    weighted_average[offset_y, offset_x, offset_z] += weight * (
+                        image[voxel_y, voxel_x, voxel_z] ** 2
+                    )
 
 
 cdef void _value_block(double[:, :, :] denoised_estimate, double[:, :, :] weight_count,
@@ -454,8 +474,9 @@ cdef void _value_block(double[:, :, :] denoised_estimate, double[:, :, :] weight
     """
     Computes the final denoised estimate for a block and accumulates it.
 
-    This function processes each voxel in a block centered at (center_y, center_x, center_z),
-    computes the denoised value from weighted averages, and accumulates the results.
+    This function processes each voxel in a block centered at
+    (center_y, center_x, center_z), computes the denoised value from
+    weighted averages, and accumulates the results.
 
     Parameters
     ----------
@@ -508,9 +529,15 @@ cdef void _value_block(double[:, :, :] denoised_estimate, double[:, :, :] weight
                     # Compute denoised intensity from weighted average
                     if total_weight > 0:
                         if is_rician:
-                            denoised_intensity = (weighted_average[offset_y, offset_x, offset_z] / total_weight) - noise_variance_doubled
+                            denoised_intensity = (
+                                weighted_average[offset_y, offset_x, offset_z]
+                                / total_weight
+                            ) - noise_variance_doubled
                         else:
-                            denoised_intensity = weighted_average[offset_y, offset_x, offset_z] / total_weight
+                            denoised_intensity = (
+                                weighted_average[offset_y, offset_x, offset_z]
+                                / total_weight
+                            )
 
                         if denoised_intensity > 0:
                             denoised_intensity = sqrt(denoised_intensity)
@@ -521,7 +548,9 @@ cdef void _value_block(double[:, :, :] denoised_estimate, double[:, :, :] weight
 
                     # Accumulate results
                     current_count = weight_count[voxel_y, voxel_x, voxel_z]
-                    denoised_estimate[voxel_y, voxel_x, voxel_z] = current_estimate + denoised_intensity
+                    denoised_estimate[voxel_y, voxel_x, voxel_z] = (
+                        current_estimate + denoised_intensity
+                    )
                     weight_count[voxel_y, voxel_x, voxel_z] = current_count + 1.0
 
 
@@ -614,7 +643,10 @@ cdef double _patch_distance(
                     voxel2_z = 2 * img_depth - voxel2_z - 1
 
                 # Compute squared difference
-                intensity_diff = image[voxel1_y, voxel1_x, voxel1_z] - image[voxel2_y, voxel2_x, voxel2_z]
+                intensity_diff = (
+                    image[voxel1_y, voxel1_x, voxel1_z]
+                    - image[voxel2_y, voxel2_x, voxel2_z]
+                 )
                 squared_distance_sum += intensity_diff * intensity_diff
                 voxel_count += 1
 
@@ -681,13 +713,19 @@ cdef void _process_block_complete(
                     neighbor_y = center_y + offset_y
                     if neighbor_y < 0 or neighbor_y >= img_height:
                         continue
-                    if neighbor_y == center_y and neighbor_x == center_x and neighbor_z == center_z:
+                    if (
+                        neighbor_y == center_y
+                        and neighbor_x == center_x
+                        and neighbor_z == center_z
+                    ):
                         continue
                     if mask[neighbor_y, neighbor_x, neighbor_z] == 0:
                         continue
 
                     neighbor_mean = local_means[neighbor_y, neighbor_x, neighbor_z]
-                    neighbor_variance = local_variances[neighbor_y, neighbor_x, neighbor_z]
+                    neighbor_variance = local_variances[
+                        neighbor_y, neighbor_x, neighbor_z
+                    ]
 
                     # Skip patches with insufficient signal
                     if neighbor_mean <= epsilon or neighbor_variance <= epsilon:
@@ -725,7 +763,14 @@ cdef void _process_block_complete(
                         max_weight = similarity_weight
 
                     # Accumulate weighted averages directly
-                    _average_block(image, neighbor_y, neighbor_x, neighbor_z, workspace, similarity_weight)
+                    _average_block(
+                        image,
+                        neighbor_y,
+                        neighbor_x,
+                        neighbor_z,
+                        workspace,
+                        similarity_weight,
+                    )
                     accumulator_weight += similarity_weight
 
     # Apply accumulated weighted averages to final estimate
@@ -763,7 +808,9 @@ cdef inline void _clear_workspace(double[:, :, :] workspace) noexcept nogil:
                 workspace[i, j, k] = 0.0
 
 
-cdef double _local_mean(double[:, :, :] image, int center_y, int center_x, int center_z, int patch_radius) nogil:
+cdef double _local_mean(
+    double[:, :, :] image, int center_y, int center_x, int center_z, int patch_radius
+) nogil:
     """
     Computes the local mean of a cubic patch centered at (center_y, center_x, center_z).
 
@@ -829,7 +876,8 @@ cdef double _local_variance(
     int patch_radius,
 ) nogil:
     """
-    Computes the local variance of a cubic patch centered at (center_y, center_x, center_z).
+    Computes the local variance of a cubic patch centered at
+    (center_y, center_x, center_z).
 
     Uses reflection padding for boundary handling.
 
@@ -892,7 +940,15 @@ cdef double _local_variance(
         return 0.0
 
 
-def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_radius, int block_radius, noise_sigma, int is_rician, num_threads=None):
+def nlmeans_3d_blockwise(
+    double[:, :, :] image,
+    double[:, :, :] mask,
+    int patch_radius,
+    int block_radius,
+    noise_sigma,
+    int is_rician,
+    num_threads=None,
+):
     """
     Non-Local Means Denoising Using Blockwise Averaging.
 
@@ -993,7 +1049,9 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
 
     # Pre-allocate weighted average workspace (one per potential thread)
     cdef int max_threads = threads_to_use
-    cdef double[:, :, :, :] thread_workspaces = np.zeros((max_threads, block_size, block_size, block_size), dtype=np.float64)
+    cdef double[:, :, :, :] thread_workspaces = (
+        np.zeros((max_threads, block_size, block_size, block_size), dtype=np.float64)
+    )
 
     # Phase 1: Compute local statistics (means and variances) in parallel
     with nogil, parallel():
@@ -1001,7 +1059,9 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
             for center_x in range(img_width):
                 for center_y in range(img_height):
                     if mask[center_y, center_x, center_z] > 0:
-                        current_mean = _local_mean(image, center_y, center_x, center_z, 1)  # 3x3x3 patch
+                        current_mean = _local_mean(
+                            image, center_y, center_x, center_z, 1
+                        )  # 3x3x3 patch
                         local_means[center_y, center_x, center_z] = current_mean
                         local_variances[center_y, center_x, center_z] = _local_variance(
                             image, current_mean, center_y, center_x, center_z, 1)
@@ -1110,7 +1170,9 @@ def nlmeans_3d_blockwise(double[:, :, :] image, double[:, :, :] mask, int patch_
                             weight_counts[center_y, center_x, center_z])
                     else:
                         # Fallback to original value if no similar patches found
-                        denoised_image[center_y, center_x, center_z] = image[center_y, center_x, center_z]
+                        denoised_image[center_y, center_x, center_z] = image[
+                            center_y, center_x, center_z
+                        ]
 
     # Restore default thread count
     restore_default_num_threads()
@@ -1202,13 +1264,16 @@ def nlmeans_3d(arr, mask=None, sigma=None, patch_radius=1,
                 sigma_input = np.ascontiguousarray(sigma, dtype="f8")
             elif sigma.ndim == 1:
                 # 1D sigma for 3D input: take the mean as a fallback.
-                # For 4D inputs, nlmeans.py extracts per-volume scalars before reaching here.
+                # For 4D inputs, nlmeans.py extracts per-volume scalars
+                # before reaching here.
                 sigma_input = float(np.mean(sigma))
             elif sigma.shape == ():
                 # 0-D array (scalar in array form)
                 sigma_input = float(sigma)
             else:
-                raise ValueError(f'Invalid sigma shape {sigma.shape} for blockwise method')
+                raise ValueError(
+                    f"Invalid sigma shape {sigma.shape} for blockwise method"
+                )
         else:
             # Scalar sigma
             sigma_input = float(sigma)

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -184,11 +184,14 @@ cdef class EnhancementKernel:
                                 x[1] = <double>yp
                                 x[2] = <double>zp
 
-                                lookuptablelocal[angv,
-                                                 angr,
-                                                 xp + hn,
-                                                 yp + hn,
-                                                 zp + hn] = self.k2(x, y, orientations[angr, :], orientations[angv, :])
+                                lookuptablelocal[
+                                    angv, angr, xp + hn, yp + hn, zp + hn
+                                ] = self.k2(
+                                    x,
+                                    y,
+                                    orientations[angr, :],
+                                    orientations[angv, :]
+                                )
 
         # save to class member
         self.lookuptable = lookuptablelocal
@@ -348,8 +351,17 @@ cdef class EnhancementKernel:
                 + y * (1 - (beta*beta*sg*sg * (1 - 0.5*q*cotq2)) / (q*q))
             )
             c[2] = (
-                0.5*x*beta*cg + 0.5*y*beta*sg
-                + z * (1 + ((1 - 0.5*q*cotq2) * (-beta*beta*cg*cg - beta*beta*sg*sg)) / (q*q))
+                0.5 * x * beta * cg
+                + 0.5 * y * beta * sg
+                + z
+                * (
+                    1
+                    + (
+                        (1 - 0.5 * q * cotq2)
+                        * (-beta * beta * cg * cg - beta * beta * sg * sg)
+                    )
+                    / (q * q)
+                )
             )
             c[3] = beta * (-sg)
             c[4] = beta * cg
@@ -375,7 +387,19 @@ cdef class EnhancementKernel:
         """
         cdef double output = 1 / (8*sqrt(2))
         output *= sqrt(PI)*self.t*sqrt(self.t*self.D33)*sqrt(self.D33*self.D44)
-        output *= 1 / (16*PI*PI*self.D33*self.D33*self.D44*self.D44*self.t*self.t*self.t*self.t)
+        output *= 1 / (
+            16
+            * PI
+            * PI
+            * self.D33
+            * self.D33
+            * self.D44
+            * self.D44
+            * self.t
+            * self.t
+            * self.t
+            * self.t
+        )
         output *= exp(
             -sqrt(
                 (c[0] * c[0] + c[1] * c[1]) / (self.D33 * self.D44)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -12,7 +12,9 @@ from dipy.utils.deprecator import deprecated_params
 
 
 @deprecated_params("sh_order", new_name="sh_order_max", since="1.9", until="2.0")
-def convolve(odfs_sh, kernel, sh_order_max, test_mode=False, num_threads=None, normalize=True):
+def convolve(
+    odfs_sh, kernel, sh_order_max, test_mode=False, num_threads=None, normalize=True
+):
     """Perform the shift-twist convolution with the ODF data and
     the lookup-table of the kernel.
 
@@ -188,12 +190,22 @@ cdef double [:, :, :, ::1] perform_convolution (double [:, :, :, ::1] odfs,
                                 ):
                                     voxcount[corient, cx, cy, cz] += 1.0
                                     for orient in range(0, OR2):
-                                        totalval[corient, cx, cy, cz] += \
-                                            odfs[x, y, z, orient] * \
-                                            lut[corient, orient, x - (cx - hn), y - (cy - hn), z - (cz - hn)]
+                                        totalval[corient, cx, cy, cz] += (
+                                            odfs[x, y, z, orient]
+                                            * lut[
+                                                corient,
+                                                orient,
+                                                x - (cx - hn),
+                                                y - (cy - hn),
+                                                z - (cz - hn),
+                                            ]
+                                        )
                         if edgeNormalization:
-                            output[cx, cy, cz, corient] = \
-                                totalval[corient, cx, cy, cz] * expectedvox/voxcount[corient, cx, cy, cz]
+                            output[cx, cy, cz, corient] = (
+                                totalval[corient, cx, cy, cz]
+                                * expectedvox
+                                / voxcount[corient, cx, cy, cz]
+                            )
                         else:
                             output[cx, cy, cz, corient] = \
                                 totalval[corient, cx, cy, cz]

--- a/dipy/direction/bootstrap_direction_getter.pyx
+++ b/dipy/direction/bootstrap_direction_getter.pyx
@@ -99,8 +99,16 @@ cdef class BootDirectionGetter(DirectionGetter):
             Angular threshold for excluding ODF peaks.
 
         """
-        return cls(data, model, max_angle, sphere=sphere, max_attempts=max_attempts, sh_order=sh_order,
-                   b_tol=b_tol, **kwargs)
+        return cls(
+            data,
+            model,
+            max_angle,
+            sphere=sphere,
+            max_attempts=max_attempts,
+            sh_order=sh_order,
+            b_tol=b_tol,
+            **kwargs,
+        )
 
     cpdef cnp.ndarray[cnp.float_t, ndim=2] initial_direction(self,
                                                              double[::1] point):

--- a/dipy/reconst/dirspeed.pyx
+++ b/dipy/reconst/dirspeed.pyx
@@ -14,7 +14,11 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
 
 from dipy.core.math cimport f_max, f_array_min
-from dipy.reconst.recspeed cimport local_maxima_c, search_descending_c, remove_similar_vertices_c
+from dipy.reconst.recspeed cimport (
+    local_maxima_c,
+    search_descending_c,
+    remove_similar_vertices_c,
+)
 
 
 cdef cnp.uint16_t peak_directions_c(
@@ -113,7 +117,9 @@ cdef cnp.uint16_t peak_directions_c(
         tmp_buffer[i] -= odf_min
 
     # Remove small peaks
-    n = search_descending_c[cython.double](tmp_buffer, <cnp.npy_intp>count, relative_peak_threshold)
+    n = search_descending_c[cython.double](
+        tmp_buffer, <cnp.npy_intp>count, relative_peak_threshold
+    )
 
     for i in range(n):
         idx = out_indices[i]
@@ -198,13 +204,25 @@ def peak_directions(
     cdef double[:, ::1] directions_out = np.zeros((num_vertices, 3), dtype=np.float64)
     cdef double[::1] values_out = np.zeros(num_vertices, dtype=np.float64)
     cdef cnp.npy_intp[::1] indices_out = np.zeros(num_vertices, dtype=np.intp)
-    cdef cnp.float64_t[:, ::1] unique_vertices = np.empty((num_vertices, 3), dtype=np.float64)
+    cdef cnp.float64_t[:, ::1] unique_vertices = (
+        np.empty((num_vertices, 3), dtype=np.float64)
+    )
     cdef cnp.uint16_t[::1] mapping = None
     cdef cnp.uint16_t[::1] index = np.empty(num_vertices, dtype=np.uint16)
 
     n_unique = peak_directions_c(
-        odf, vertices, edges, relative_peak_threshold, min_separation_angle, is_symmetric,
-        directions_out, values_out, indices_out, unique_vertices, mapping, index
+        odf,
+        vertices,
+        edges,
+        relative_peak_threshold,
+        min_separation_angle,
+        is_symmetric,
+        directions_out,
+        values_out,
+        indices_out,
+        unique_vertices,
+        mapping,
+        index,
     )
 
     if n_unique == 0:

--- a/dipy/reconst/recspeed.pyx
+++ b/dipy/reconst/recspeed.pyx
@@ -51,7 +51,8 @@ cdef void remove_similar_vertices_c(
     cnp.uint16_t* n_unique
 ) noexcept nogil:
     """
-    Optimized Cython version to remove vertices that are less than `theta` degrees from any other.
+    Optimized Cython version to remove vertices that are less than
+    `theta` degrees from any other.
     """
     cdef:
         int n = vertices.shape[0]
@@ -176,7 +177,9 @@ def remove_similar_vertices(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef cnp.npy_intp search_descending_c(cython.floating* arr, cnp.npy_intp size, double relative_threshold) noexcept nogil:
+cdef cnp.npy_intp search_descending_c(
+    cython.floating* arr, cnp.npy_intp size, double relative_threshold
+) noexcept nogil:
     """
     Optimized Cython version of the search_descending function.
 
@@ -192,7 +195,8 @@ cdef cnp.npy_intp search_descending_c(cython.floating* arr, cnp.npy_intp size, d
     Returns
     -------
     cnp.npy_intp
-        Largest index `i` such that all(arr[:i] >= T), where T = arr[0] * relative_threshold.
+        Largest index `i` such that all(arr[:i] >= T), where
+        T = arr[0] * relative_threshold.
     """
     cdef:
         cnp.npy_intp left = 0

--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -46,7 +46,9 @@ def clusters_centroid2clustermap_centroid(ClustersCentroid clusters_list):
         features = <float[:shape.dims[0], :shape.dims[1]]> \
             &clusters_list.centroids[i].features[0][0, 0]
         centroid = np.asarray(features)
-        indices = np.asarray(<int[:clusters_list.clusters_size[i]]> clusters_list.clusters_indices[i]).tolist()
+        indices = np.asarray(
+            <int[:clusters_list.clusters_size[i]]> clusters_list.clusters_indices[i]
+        ).tolist()
         clusters.add_cluster(ClusterCentroid(id=i, centroid=centroid, indices=indices))
 
     return clusters
@@ -101,8 +103,12 @@ def quickbundles(streamlines, Metric metric, double threshold,
     if first_idx is None or len(streamlines) == 0:
         return ClusterMapCentroid()
 
-    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32)))
-    cdef QuickBundles qb = QuickBundles(features_shape, metric, threshold, max_nb_clusters)
+    features_shape = shape2tuple(
+        metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32))
+    )
+    cdef QuickBundles qb = QuickBundles(
+        features_shape, metric, threshold, max_nb_clusters
+    )
     cdef int idx
     for idx in ordering:
         streamline = streamlines[idx]
@@ -153,7 +159,9 @@ def quickbundlesx(streamlines, Metric metric, thresholds, ordering=None):
     if first_idx is None or len(streamlines) == 0:
         return ClusterMapCentroid()
 
-    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32)))
+    features_shape = shape2tuple(
+        metric.feature.c_infer_shape(streamlines[first_idx].astype(np.float32))
+    )
     cdef QuickBundlesX qbx = QuickBundlesX(features_shape, thresholds, metric)
     cdef int idx
 

--- a/dipy/segment/clusteringspeed.pxd
+++ b/dipy/segment/clusteringspeed.pxd
@@ -59,7 +59,9 @@ cdef class Clusters:
     cdef int** clusters_indices
     cdef int* clusters_size
 
-    cdef void c_assign(Clusters self, int id_cluster, int id_element, Data2D element) noexcept nogil
+    cdef void c_assign(
+        Clusters self, int id_cluster, int id_element, Data2D element
+    ) noexcept nogil
     cdef int c_create_cluster(Clusters self) except -1 nogil
     cdef int c_size(Clusters self) noexcept nogil
 
@@ -69,7 +71,9 @@ cdef class ClustersCentroid(Clusters):
     cdef Centroid* _updated_centroids
     cdef Shape _centroid_shape
     cdef float eps
-    cdef void c_assign(ClustersCentroid self, int id_cluster, int id_element, Data2D element) noexcept nogil
+    cdef void c_assign(
+        ClustersCentroid self, int id_cluster, int id_element, Data2D element
+    ) noexcept nogil
     cdef int c_create_cluster(ClustersCentroid self) except -1 nogil
     cdef int c_update(ClustersCentroid self, cnp.npy_intp id_cluster) except -1 nogil
 
@@ -86,8 +90,12 @@ cdef class QuickBundles:
     cdef int bvh
     cdef QuickBundlesStats stats
 
-    cdef NearestCluster find_nearest_cluster(QuickBundles self, Data2D features) noexcept nogil
-    cdef int assignment_step(QuickBundles self, Data2D datum, int datum_id) except -1 nogil
+    cdef NearestCluster find_nearest_cluster(
+        QuickBundles self, Data2D features
+    ) noexcept nogil
+    cdef int assignment_step(
+        QuickBundles self, Data2D datum, int datum_id
+    ) except -1 nogil
     cdef void update_step(QuickBundles self, int cluster_id) noexcept nogil
     cdef object _build_clustermap(self)
 
@@ -106,9 +114,15 @@ cdef class QuickBundlesX:
     cdef StreamlineInfos* current_streamline
 
     cdef int _add_child(self, CentroidNode* node) noexcept nogil
-    cdef void _update_node(self, CentroidNode* node, StreamlineInfos* streamline_infos) noexcept nogil
-    cdef void _insert_in(self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path) noexcept nogil
+    cdef void _update_node(
+        self, CentroidNode* node, StreamlineInfos* streamline_infos
+    ) noexcept nogil
+    cdef void _insert_in(
+        self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path
+    ) noexcept nogil
     cpdef object insert(self, Data2D datum, int datum_idx)
-    cdef void traverse_postorder(self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*))
+    cdef void traverse_postorder(
+        self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*)
+    )
     cdef void _dealloc_node(self, CentroidNode* node)
     cdef object _build_tree_clustermap(self, CentroidNode* node)

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -29,7 +29,10 @@ cdef print_node(CentroidNode* node, prepend=""):
     if node == NULL:
         return ""
     cdef Data2D centroid
-    centroid = <float[:node.centroid_shape.dims[0], :node.centroid_shape.dims[1]]> &node.centroid[0][0, 0]
+    centroid = (
+        <float[:node.centroid_shape.dims[0], :node.centroid_shape.dims[1]]>
+        &node.centroid[0][0, 0]
+    )
     txt = "{}".format(np.asarray(centroid).tolist())
     txt += " {" + ",".join(map(str, np.asarray(<int[:node.size]> node.indices))) + "}"
     txt += " children({})".format(node.nb_children)
@@ -77,7 +80,9 @@ cdef void aabb_creation(Data2D streamline, float* aabb) noexcept nogil:
         aabb[d] = min_[d] + aabb[d + 3]  # center
 
 
-cdef inline int aabb_overlap(float* aabb1, float* aabb2, float padding=0.) noexcept nogil:
+cdef inline int aabb_overlap(
+    float* aabb1, float* aabb2, float padding=0.
+) noexcept nogil:
     """ SIMD optimized AABB-AABB test
 
     Optimized by removing conditional branches
@@ -93,10 +98,14 @@ cdef inline int aabb_overlap(float* aabb1, float* aabb2, float padding=0.) noexc
 cdef CentroidNode* create_empty_node(Shape centroid_shape, float threshold) nogil:
     # Important: because the CentroidNode structure contains an uninitialized memview,
     # we need to zero-initialize the allocated memory (calloc or via memset),
-    # otherwise during assignment CPython will try to call _PYX_XDEC_MEMVIEW on it and segfault.
+    # otherwise during assignment CPython will try to call
+    # _PYX_XDEC_MEMVIEW on it and segfault.
     cdef CentroidNode* node = <CentroidNode*> calloc(1, sizeof(CentroidNode))
     node.centroid = create_memview_2d(centroid_shape.size, centroid_shape.dims)
-    # node.updated_centroid = <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]> calloc(centroid_shape.size, sizeof(float))
+    # node.updated_centroid = (
+    #    <float[:centroid_shape.dims[0], :centroid_shape.dims[1]]>
+    #    calloc(centroid_shape.size, sizeof(float))
+    # )
 
     node.father = NULL
     node.children = NULL
@@ -131,13 +140,21 @@ cdef class QuickBundlesX:
 
         self.level = None
         self.clusters = None
-        self.stats.stats_per_layer = <QuickBundlesXStatsLayer*> calloc(self.nb_levels, sizeof(QuickBundlesXStatsLayer))
-        # Important: because the CentroidNode structure contains an uninitialized memview,
-        # we need to zero-initialize the allocated memory (calloc or via memset),
-        # otherwise during assignment CPython will try to call _PYX_XDEC_MEMVIEW on it and segfault.
+        self.stats.stats_per_layer = <QuickBundlesXStatsLayer*> calloc(
+            self.nb_levels, sizeof(QuickBundlesXStatsLayer)
+        )
+        # Important: because the CentroidNode structure contains an
+        # uninitialized memview, we need to zero-initialize the
+        # allocated memory (calloc or via memset), otherwise during
+        # assignment CPython will try to call _PYX_XDEC_MEMVIEW on it
+        # and segfault.
         self.current_streamline = <StreamlineInfos*> calloc(1, sizeof(StreamlineInfos))
-        self.current_streamline.features = create_memview_2d(self.features_shape.size, self.features_shape.dims)
-        self.current_streamline.features_flip = create_memview_2d(self.features_shape.size, self.features_shape.dims)
+        self.current_streamline.features = create_memview_2d(
+            self.features_shape.size, self.features_shape.dims
+        )
+        self.current_streamline.features_flip = create_memview_2d(
+            self.features_shape.size, self.features_shape.dims
+        )
 
     def __dealloc__(self):
         self.traverse_postorder(self.root, self._dealloc_node)
@@ -165,13 +182,17 @@ cdef class QuickBundlesX:
 
         # Add new child.
         child.father = node
-        node.children = <CentroidNode**> realloc(node.children, (node.nb_children+1)*sizeof(CentroidNode*))
+        node.children = <CentroidNode**> realloc(
+            node.children, (node.nb_children+1)*sizeof(CentroidNode*)
+        )
         node.children[node.nb_children] = child
         node.nb_children += 1
 
         return node.nb_children-1
 
-    cdef void _update_node(self, CentroidNode* node, StreamlineInfos* streamline_infos) noexcept nogil:
+    cdef void _update_node(
+        self, CentroidNode* node, StreamlineInfos* streamline_infos
+    ) noexcept nogil:
         cdef Data2D element = streamline_infos.features[0]
         cdef int C = node.size
         cdef cnp.npy_intp n, d
@@ -194,7 +215,9 @@ cdef class QuickBundlesX:
         # Update AABB
         aabb_creation(centroid, node.aabb)
 
-    cdef void _insert_in(self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path) noexcept nogil:
+    cdef void _insert_in(
+        self, CentroidNode* node, StreamlineInfos* streamline_infos, int[:] path
+    ) noexcept nogil:
         cdef:
             float dist, dist_flip
             cnp.npy_intp k
@@ -212,9 +235,13 @@ cdef class QuickBundlesX:
         for k in range(node.nb_children):
             # Check streamline's aabb colides with the current child.
             self.stats.stats_per_layer[node.level].nb_aabb_calls += 1
-            if aabb_overlap(node.children[k].aabb, streamline_infos.aabb, node.threshold):
+            if aabb_overlap(
+                node.children[k].aabb, streamline_infos.aabb, node.threshold
+            ):
                 self.stats.stats_per_layer[node.level].nb_mdf_calls += 1
-                dist = self.metric.c_dist(node.children[k].centroid[0], streamline_infos.features[0])
+                dist = self.metric.c_dist(
+                    node.children[k].centroid[0], streamline_infos.features[0]
+                )
 
                 # Keep track of the nearest cluster
                 if dist < nearest_cluster.dist:
@@ -223,7 +250,9 @@ cdef class QuickBundlesX:
                     nearest_cluster.flip = 0
 
                 self.stats.stats_per_layer[node.level].nb_mdf_calls += 1
-                dist_flip = self.metric.c_dist(node.children[k].centroid[0], streamline_infos.features_flip[0])
+                dist_flip = self.metric.c_dist(
+                    node.children[k].centroid[0], streamline_infos.features_flip[0]
+                )
                 if dist_flip < nearest_cluster.dist:
                     nearest_cluster.dist = dist_flip
                     nearest_cluster.id = k
@@ -239,7 +268,9 @@ cdef class QuickBundlesX:
 
     cpdef object insert(self, Data2D datum, int datum_idx):
         self.metric.feature.c_extract(datum, self.current_streamline.features[0])
-        self.metric.feature.c_extract(datum[::-1], self.current_streamline.features_flip[0])
+        self.metric.feature.c_extract(
+            datum[::-1], self.current_streamline.features_flip[0]
+        )
         self.current_streamline.idx = datum_idx
 
         aabb_creation(self.current_streamline.features[0], self.current_streamline.aabb)
@@ -250,7 +281,9 @@ cdef class QuickBundlesX:
     def __str__(self):
         return print_node(self.root)
 
-    cdef void traverse_postorder(self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*)):
+    cdef void traverse_postorder(
+        self, CentroidNode* node, void (*visit)(QuickBundlesX, CentroidNode*)
+    ):
         cdef cnp.npy_intp i
         for i in range(node.nb_children):
             self.traverse_postorder(node.children[i], visit)
@@ -271,10 +304,15 @@ cdef class QuickBundlesX:
 
     cdef object _build_tree_clustermap(self, CentroidNode* node):
         cdef Data2D centroid
-        centroid = <float[:self.features_shape.dims[0], :self.features_shape.dims[1]]> &node.centroid[0][0, 0]
-        tree_cluster = TreeCluster(threshold=node.threshold,
-                                   centroid=np.asarray(centroid),
-                                   indices=np.asarray(<int[:node.size]> node.indices).copy())
+        centroid = (
+            <float[:self.features_shape.dims[0], :self.features_shape.dims[1]]>
+            &node.centroid[0][0, 0]
+        )
+        tree_cluster = TreeCluster(
+            threshold=node.threshold,
+            centroid=np.asarray(centroid),
+            indices=np.asarray(<int[:node.size]> node.indices).copy(),
+        )
         cdef cnp.npy_intp i
         for i in range(node.nb_children):
             tree_cluster.add(self._build_tree_clustermap(node.children[i]))
@@ -287,9 +325,13 @@ cdef class QuickBundlesX:
     def get_stats(self):
         stats_per_level = []
         for i in range(self.nb_levels):
-            stats_per_level.append({"nb_mdf_calls": self.stats.stats_per_layer[i].nb_mdf_calls,
-                                    "nb_aabb_calls": self.stats.stats_per_layer[i].nb_aabb_calls,
-                                    "threshold": self.thresholds[i]})
+            stats_per_level.append(
+                {
+                    "nb_mdf_calls": self.stats.stats_per_layer[i].nb_mdf_calls,
+                    "nb_aabb_calls": self.stats.stats_per_layer[i].nb_aabb_calls,
+                    "threshold": self.thresholds[i],
+                 }
+            )
 
         stats = {"stats_per_level": stats_per_level}
 
@@ -322,7 +364,9 @@ cdef class Clusters:
         """ Returns the number of clusters. """
         return self._nb_clusters
 
-    cdef void c_assign(Clusters self, int id_cluster, int id_element, Data2D element) noexcept nogil:
+    cdef void c_assign(
+        Clusters self, int id_cluster, int id_element, Data2D element
+    ) noexcept nogil:
         """ Assigns an element to a cluster.
 
         Parameters
@@ -335,7 +379,9 @@ cdef class Clusters:
             Data of the element to assign.
         """
         cdef cnp.npy_intp C = self.clusters_size[id_cluster]
-        self.clusters_indices[id_cluster] = <int*> realloc(self.clusters_indices[id_cluster], (C+1)*sizeof(int))
+        self.clusters_indices[id_cluster] = <int*> realloc(
+            self.clusters_indices[id_cluster], (C+1)*sizeof(int)
+        )
         self.clusters_indices[id_cluster][C] = id_element
         self.clusters_size[id_cluster] += 1
 
@@ -347,9 +393,13 @@ cdef class Clusters:
         id_cluster : int
             Index of the new cluster.
         """
-        self.clusters_indices = <int**> realloc(self.clusters_indices, (self._nb_clusters+1)*sizeof(int*))
+        self.clusters_indices = <int**> realloc(
+            self.clusters_indices, (self._nb_clusters+1)*sizeof(int*)
+        )
         self.clusters_indices[self._nb_clusters] = <int*> calloc(0, sizeof(int))
-        self.clusters_size = <int*> realloc(self.clusters_size, (self._nb_clusters+1)*sizeof(int))
+        self.clusters_size = <int*> realloc(
+            self.clusters_size, (self._nb_clusters+1)*sizeof(int)
+        )
         self.clusters_size[self._nb_clusters] = 0
 
         self._nb_clusters += 1
@@ -371,7 +421,9 @@ cdef class ClustersCentroid(Clusters):
         Consider the centroid has not changed if the changes per dimension
         are less than this epsilon. (Default: 1e-6)
     """
-    def __init__(ClustersCentroid self, centroid_shape, float eps=1e-6, *args, **kwargs):
+    def __init__(
+        ClustersCentroid self, centroid_shape, float eps=1e-6, *args, **kwargs
+    ):
         Clusters.__init__(self, *args, **kwargs)
         if isinstance(centroid_shape, int):
             centroid_shape = (1, centroid_shape)
@@ -402,7 +454,9 @@ cdef class ClustersCentroid(Clusters):
         free(self._updated_centroids)
         self._updated_centroids = NULL
 
-    cdef void c_assign(ClustersCentroid self, int id_cluster, int id_element, Data2D element) noexcept nogil:
+    cdef void c_assign(
+        ClustersCentroid self, int id_cluster, int id_element, Data2D element
+    ) noexcept nogil:
         """ Assigns an element to a cluster.
 
         In addition of keeping element's index, an updated version of the
@@ -425,7 +479,9 @@ cdef class ClustersCentroid(Clusters):
         cdef cnp.npy_intp N = updated_centroid.shape[0], D = updated_centroid.shape[1]
         for n in range(N):
             for d in range(D):
-                updated_centroid[n, d] = ((updated_centroid[n, d] * C) + element[n, d]) / (C+1)
+                updated_centroid[n, d] = (
+                    (updated_centroid[n, d] * C) + element[n, d]
+                ) / (C+1)
 
         Clusters.c_assign(self, id_cluster, id_element, element)
 
@@ -467,18 +523,29 @@ cdef class ClustersCentroid(Clusters):
         id_cluster : int
             Index of the new cluster.
         """
-        self.centroids = <Centroid*> realloc(self.centroids, (self._nb_clusters+1) * sizeof(Centroid))
+        self.centroids = <Centroid*> realloc(
+            self.centroids, (self._nb_clusters+1) * sizeof(Centroid)
+        )
         # Zero-initialize the Centroid structure
         memset(&self.centroids[self._nb_clusters], 0, sizeof(Centroid))
 
-        self._updated_centroids = <Centroid*> realloc(self._updated_centroids, (self._nb_clusters+1) * sizeof(Centroid))
+        self._updated_centroids = <Centroid*> realloc(
+            self._updated_centroids, (self._nb_clusters+1) * sizeof(Centroid)
+        )
         # Zero-initialize the new Centroid structure
         memset(&self._updated_centroids[self._nb_clusters], 0, sizeof(Centroid))
 
-        self.centroids[self._nb_clusters].features = create_memview_2d(self._centroid_shape.size, self._centroid_shape.dims)
-        self._updated_centroids[self._nb_clusters].features = create_memview_2d(self._centroid_shape.size, self._centroid_shape.dims)
+        self.centroids[self._nb_clusters].features = create_memview_2d(
+            self._centroid_shape.size, self._centroid_shape.dims
+        )
+        self._updated_centroids[self._nb_clusters].features = create_memview_2d(
+            self._centroid_shape.size, self._centroid_shape.dims
+        )
 
-        aabb_creation(self.centroids[self._nb_clusters].features[0], self.centroids[self._nb_clusters].aabb)
+        aabb_creation(
+            self.centroids[self._nb_clusters].features[0],
+            self.centroids[self._nb_clusters].aabb,
+        )
 
         return Clusters.c_create_cluster(self)
 
@@ -497,7 +564,9 @@ cdef class QuickBundles:
         self.stats.nb_mdf_calls = 0
         self.stats.nb_aabb_calls = 0
 
-    cdef NearestCluster find_nearest_cluster(QuickBundles self, Data2D features) noexcept nogil:
+    cdef NearestCluster find_nearest_cluster(
+        QuickBundles self, Data2D features
+    ) noexcept nogil:
         """ Finds the nearest cluster of a datum given its `features` vector.
 
         Parameters
@@ -531,7 +600,9 @@ cdef class QuickBundles:
 
         return nearest_cluster
 
-    cdef int assignment_step(QuickBundles self, Data2D datum, int datum_id) except -1 nogil:
+    cdef int assignment_step(
+        QuickBundles self, Data2D datum, int datum_id
+    ) except -1 nogil:
         """ Compute the assignment step of the QuickBundles algorithm.
 
         It will assign a datum to its closest cluster according to a given
@@ -559,12 +630,16 @@ cdef class QuickBundles:
         # Check if datum is compatible with the metric
         if not same_shape(features_shape, self.features_shape):
             with gil:
-                raise ValueError("All features do not have the same shape! QuickBundles requires this to compute centroids!")
+                raise ValueError(
+                    "All features do not have the same shape! QuickBundles requires this to compute centroids!"
+                )
 
         # Check if datum is compatible with the metric
         if not self.metric.c_are_compatible(features_shape, self.features_shape):
             with gil:
-                raise ValueError("Data features' shapes must be compatible according to the metric used!")
+                raise ValueError(
+                    "Data features' shapes must be compatible according to the metric used!"
+                )
 
         # Find nearest cluster to datum
         self.metric.feature.c_extract(datum, self.features)
@@ -586,7 +661,10 @@ cdef class QuickBundles:
         # or if we already have the maximum number of clusters.
         # If the former or the latter is true, assign datum to its nearest cluster
         # otherwise create a new cluster and assign the datum to it.
-        if not (nearest_cluster.dist < self.threshold or self.clusters.c_size() >= self.max_nb_clusters):
+        if not (
+            nearest_cluster.dist < self.threshold
+            or self.clusters.c_size() >= self.max_nb_clusters
+        ):
             nearest_cluster.id = self.clusters.c_create_cluster()
 
         self.clusters.c_assign(nearest_cluster.id, datum_id, features_to_add)
@@ -615,8 +693,12 @@ cdef class QuickBundles:
         clusters = ClusterMapCentroid()
         cdef int k
         for k in range(self.clusters.c_size()):
-            cluster = ClusterCentroid(np.asarray(self.clusters.centroids[k].features[0]).copy())
-            cluster.indices = np.asarray(<int[:self.clusters.clusters_size[k]]> self.clusters.clusters_indices[k]).copy()
+            cluster = ClusterCentroid(
+                np.asarray(self.clusters.centroids[k].features[0]).copy()
+            )
+            cluster.indices = np.asarray(
+                <int[:self.clusters.clusters_size[k]]> self.clusters.clusters_indices[k]
+            ).copy()
             clusters.add_cluster(cluster)
 
         return clusters
@@ -627,8 +709,22 @@ cdef class QuickBundles:
 
 def evaluate_aabb_checks():
     cdef:
-        Data2D feature1 = np.array([[1, 0, 0], [1, 1, 0], [1 + np.sqrt(2)/2., 1 + np.sqrt(2)/2., 0]], dtype="f4")
-        Data2D feature2 = np.array([[1, 0, 0], [1, 1, 0], [1 + np.sqrt(2)/2., 1 + np.sqrt(2)/2., 0]], dtype="f4") + np.array([0.5, 0, 0], dtype="f4")
+        Data2D feature1 = np.array(
+            [
+                [1, 0, 0],
+                [1, 1, 0],
+                [1 + np.sqrt(2)/2., 1 + np.sqrt(2)/2., 0]
+            ],
+            dtype="f4",
+        )
+        Data2D feature2 = np.array(
+            [
+                [1, 0, 0],
+                [1, 1, 0],
+                [1 + np.sqrt(2)/2., 1 + np.sqrt(2)/2., 0]
+            ],
+            dtype="f4",
+        ) + np.array([0.5, 0, 0], dtype="f4")
         float[6] aabb1
         float[6] aabb2
         int res

--- a/dipy/segment/cythonutils.pxd
+++ b/dipy/segment/cythonutils.pxd
@@ -37,6 +37,8 @@ cdef shape2tuple(Shape shape)
 
 cdef int same_shape(Shape shape1, Shape shape2) noexcept nogil
 
-cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) noexcept nogil
+cdef Data2D* create_memview_2d(
+    Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]
+) noexcept nogil
 
 cdef void free_memview_2d(Data2D* memview) noexcept nogil

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -15,7 +15,9 @@ cdef extern from "stdlib.h" nogil:
     void *calloc(size_t nelem, size_t elsize)
 
 
-cdef Py_ssize_t sizeof_memviewslice = 2 * sizeof(cnp.npy_intp) + 3 * sizeof(cnp.npy_intp) * 8
+cdef Py_ssize_t sizeof_memviewslice = (
+    2 * sizeof(cnp.npy_intp) + 3 * sizeof(cnp.npy_intp) * 8
+)
 
 cdef Shape shape_from_memview(Data data) noexcept nogil:
     """ Retrieves shape from a memoryview object.
@@ -118,7 +120,9 @@ cdef int same_shape(Shape shape1, Shape shape2) noexcept nogil:
     return same_shape
 
 
-cdef Data2D* create_memview_2d(Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]) noexcept nogil:
+cdef Data2D* create_memview_2d(
+    Py_ssize_t buffer_size, Py_ssize_t dims[MAX_NDIM]
+) noexcept nogil:
     """ Create a light version of cython memory view.
 
     Parameters

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -81,7 +81,9 @@ cdef class Feature:
         int, 1-tuple or 2-tuple
             Shape of the features.
         """
-        raise NotImplementedError("Feature's subclasses must implement method `infer_shape(self, datum)`!")
+        raise NotImplementedError(
+            "Feature's subclasses must implement method `infer_shape(self, datum)`!"
+        )
 
     cpdef extract(Feature self, datum):
         """ Extracts features from a sequential datum.
@@ -96,7 +98,9 @@ cdef class Feature:
         2D array
             Features extracted from `datum`.
         """
-        raise NotImplementedError("Feature's subclasses must implement method `extract(self, datum)`!")
+        raise NotImplementedError(
+            "Feature's subclasses must implement method `extract(self, datum)`!"
+        )
 
 
 cdef class CythonFeature(Feature):
@@ -204,7 +208,9 @@ cdef class ResampleFeature(CythonFeature):
         self.nb_points = nb_points
 
         if nb_points <= 0:
-            raise ValueError("ResampleFeature: `nb_points` must be strictly positive: {0}".format(nb_points))
+            raise ValueError(
+                f"ResampleFeature: `nb_points` must be strictly positive: {nb_points}"
+            )
 
     cdef Shape c_infer_shape(ResampleFeature self, Data2D datum) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
@@ -235,7 +241,9 @@ cdef class CenterOfMassFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) noexcept nogil:
+    cdef void c_extract(
+        CenterOfMassFeature self, Data2D datum, Data2D out
+    ) noexcept nogil:
         cdef cnp.npy_intp N = datum.shape[0], D = datum.shape[1]
         cdef cnp.npy_intp i, d
 
@@ -318,7 +326,9 @@ cdef class VectorOfEndpointsFeature(CythonFeature):
     def __init__(VectorOfEndpointsFeature self):
         super(VectorOfEndpointsFeature, self).__init__(is_order_invariant=False)
 
-    cdef Shape c_infer_shape(VectorOfEndpointsFeature self, Data2D datum) noexcept nogil:
+    cdef Shape c_infer_shape(
+        VectorOfEndpointsFeature self, Data2D datum
+    ) noexcept nogil:
         cdef Shape shape = shape_from_memview(datum)
         shape.ndim = 2
         shape.dims[0] = 1
@@ -326,7 +336,9 @@ cdef class VectorOfEndpointsFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(VectorOfEndpointsFeature self, Data2D datum, Data2D out) noexcept nogil:
+    cdef void c_extract(
+        VectorOfEndpointsFeature self, Data2D datum, Data2D out
+    ) noexcept nogil:
         cdef:
             int N = datum.shape[0], D = datum.shape[1]
             int d

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -54,8 +54,16 @@ cdef class Metric:
     cdef double c_dist(Metric self, Data2D features1, Data2D features2) except -1 nogil:
         """ Cython version of `Metric.dist`. """
         with gil:
-            _features1 = np.asarray(<float[:features1.shape[0], :features1.shape[1]]> <float*> features1._data)
-            _features2 = np.asarray(<float[:features2.shape[0], :features2.shape[1]]> <float*> features2._data)
+            _features1 = np.asarray(
+                <float[:features1.shape[0], :features1.shape[1]]>
+                <float*>
+                features1._data
+            )
+            _features2 = np.asarray(
+                <float[:features2.shape[0], :features2.shape[1]]>
+                <float*>
+                features2._data
+            )
             return self.dist(_features1, _features2)
 
     cpdef are_compatible(Metric self, shape1, shape2):
@@ -76,7 +84,9 @@ cdef class Metric:
         are_compatible : bool
             whether or not shapes are compatible
         """
-        raise NotImplementedError("Metric's subclasses must implement method `are_compatible(self, shape1, shape2)`!")
+        raise NotImplementedError(
+            "Metric's subclasses must implement method `are_compatible(self, shape1, shape2)`!"
+        )
 
     cpdef double dist(Metric self, features1, features2) except -1:
         """ Computes a distance between two data points based on their features.
@@ -93,7 +103,9 @@ cdef class Metric:
         double
             Distance between two data points.
         """
-        raise NotImplementedError("Metric's subclasses must implement method `dist(self, features1, features2)`!")
+        raise NotImplementedError(
+            "Metric's subclasses must implement method `dist(self, features1, features2)`!"
+        )
 
 
 cdef class CythonMetric(Metric):
@@ -228,7 +240,9 @@ cdef class SumPointwiseEuclideanMetric(CythonMetric):
     is equal to $a+b+c$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2) except -1 nogil:
+    cdef double c_dist(
+        SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2
+    ) except -1 nogil:
         cdef :
             int N = features1.shape[0], D = features1.shape[1]
             int n, d
@@ -244,7 +258,9 @@ cdef class SumPointwiseEuclideanMetric(CythonMetric):
 
         return dist
 
-    cdef int c_are_compatible(SumPointwiseEuclideanMetric self, Shape shape1, Shape shape2) except -1 nogil:
+    cdef int c_are_compatible(
+        SumPointwiseEuclideanMetric self, Shape shape1, Shape shape2
+    ) except -1 nogil:
         return same_shape(shape1, shape2)
 
 
@@ -280,9 +296,13 @@ cdef class AveragePointwiseEuclideanMetric(SumPointwiseEuclideanMetric):
     is equal to $(a+b+c)/3$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) except -1 nogil:
+    cdef double c_dist(
+        AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2
+    ) except -1 nogil:
         cdef cnp.npy_intp N = features1.shape[0]
-        cdef double dist = SumPointwiseEuclideanMetric.c_dist(self, features1, features2)
+        cdef double dist = SumPointwiseEuclideanMetric.c_dist(
+            self, features1, features2
+        )
         return dist / <double>N
 
 
@@ -318,9 +338,15 @@ cdef class MinimumAverageDirectFlipMetric(AveragePointwiseEuclideanMetric):
         def __get__(MinimumAverageDirectFlipMetric self):
             return True  # Ordering is handled in the distance computation
 
-    cdef double c_dist(MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2) except -1 nogil:
-        cdef double dist_direct = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2)
-        cdef double dist_flipped = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2[::-1])
+    cdef double c_dist(
+        MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2
+    ) except -1 nogil:
+        cdef double dist_direct = AveragePointwiseEuclideanMetric.c_dist(
+            self, features1, features2
+        )
+        cdef double dist_flipped = AveragePointwiseEuclideanMetric.c_dist(
+            self, features1, features2[::-1]
+        )
         return min(dist_direct, dist_flipped)
 
 
@@ -339,10 +365,14 @@ cdef class CosineMetric(CythonMetric):
     def __init__(CosineMetric self, Feature feature):
         super(CosineMetric, self).__init__(feature=feature)
 
-    cdef int c_are_compatible(CosineMetric self, Shape shape1, Shape shape2) except -1 nogil:
+    cdef int c_are_compatible(
+        CosineMetric self, Shape shape1, Shape shape2
+    ) except -1 nogil:
         return same_shape(shape1, shape2) != 0 and shape1.dims[0] == 1
 
-    cdef double c_dist(CosineMetric self, Data2D features1, Data2D features2) except -1 nogil:
+    cdef double c_dist(
+        CosineMetric self, Data2D features1, Data2D features2
+    ) except -1 nogil:
         cdef :
             int d, D = features1.shape[1]
             double sqr_norm_features1 = 0.0, sqr_norm_features2 = 0.0
@@ -401,10 +431,17 @@ cpdef distance_matrix(Metric metric, data1, data2=None):
         Data2D features2 = np.empty(shape, np.float32)
 
     for i in range(len(data1)):
-        datum1 = data1[i] if data1[i].flags.writeable and data1[i].dtype is np.float32 else data1[i].astype(np.float32)
+        datum1 = (
+            data1[i] if data1[i].flags.writeable and data1[i].dtype is np.float32
+            else data1[i].astype(np.float32)
+        )
         metric.feature.c_extract(datum1, features1)
         for j in range(len(data2)):
-            datum2 = data2[j] if data2[j].flags.writeable and data2[j].dtype is np.float32 else data2[j].astype(np.float32)
+            datum2 = (
+                data2[j]
+                if data2[j].flags.writeable and data2[j].dtype is np.float32
+                else data2[j].astype(np.float32)
+            )
             metric.feature.c_extract(datum2, features2)
             distance_matrix[i, j] = metric.c_dist(features1, features2)
 
@@ -431,8 +468,16 @@ cpdef double dist(Metric metric, datum1, datum2) except -1:
     double
         Distance between two data points.
     """
-    datum1 = datum1 if datum1.flags.writeable and datum1.dtype is np.float32 else datum1.astype(np.float32)
-    datum2 = datum2 if datum2.flags.writeable and datum2.dtype is np.float32 else datum2.astype(np.float32)
+    datum1 = (
+        datum1
+        if datum1.flags.writeable and datum1.dtype is np.float32
+        else datum1.astype(np.float32)
+    )
+    datum2 = (
+        datum2
+        if datum2.flags.writeable and datum2.dtype is np.float32
+        else datum2.astype(np.float32)
+    )
 
     cdef:
         Shape shape1 = metric.feature.c_infer_shape(datum1)

--- a/dipy/segment/mrf.pyx
+++ b/dipy/segment/mrf.pyx
@@ -385,7 +385,10 @@ cdef void _prob_image(double[:, :, :] image, double[:, :, :] gaussian,
                         gaussian[x, y, z] = 0
                 else:
                     gaussian[x, y, z] = (
-                        exp(-((image[x, y, z] - mu[cls_idx]) ** 2) / (2 * sigmasq[cls_idx]))
+                        exp(
+                            -((image[x, y, z] - mu[cls_idx]) ** 2)
+                            / (2 * sigmasq[cls_idx])
+                        )
                     ) / (sqrt(2 * NPY_PI * sigmasq[cls_idx]))
                 P_L_Y[x, y, z, cls_idx] = gaussian[x, y, z] * P_L_N[x, y, z, cls_idx]
 

--- a/dipy/sims/_force_core.pyx
+++ b/dipy/sims/_force_core.pyx
@@ -66,7 +66,10 @@ def set_diffusivity_ranges(
         return lo, hi
 
     WM_D_PAR_MIN, WM_D_PAR_MAX = _validate_val_or_pair("wm_d_par_range", wm_d_par_range)
-    WM_D_PERP_MIN, WM_D_PERP_MAX = _validate_val_or_pair("wm_d_perp_range", wm_d_perp_range)
+    (
+        WM_D_PERP_MIN,
+        WM_D_PERP_MAX,
+    ) = _validate_val_or_pair("wm_d_perp_range", wm_d_perp_range)
     GM_D_MIN, GM_D_MAX = _validate_val_or_pair("gm_d_iso_range", gm_d_iso_range)
     CSF_D = float(csf_d)
 
@@ -90,7 +93,9 @@ cdef inline double get_dperp_extra(double d_par, double f_intra) noexcept:
     return d_par * (1.0 - f_intra) / (1.0 + f_intra)
 
 
-cdef inline double fa_stick_zeppelin(double d_par, double d_perp, double f_intra) noexcept:
+cdef inline double fa_stick_zeppelin(
+    double d_par, double d_perp, double f_intra
+) noexcept:
     """
     Compute microFA for stick-zeppelin model.
 
@@ -854,7 +859,14 @@ cpdef tuple create_mixed_signal(
     csf_signal = csf_result[0]
     csf_d_par = csf_result[7]
 
-    odi = wm_fraction * float(wm_disp) + gm_fraction * float(gm_disp) + csf_fraction * 1.0
+    odi = (
+        wm_fraction
+        * float(wm_disp)
+        + gm_fraction
+        * float(gm_disp)
+        + csf_fraction
+        * 1.0
+    )
     nd = wm_fraction * float(wm_nd) + gm_fraction * float(gm_nd)
 
     combined_signal = (

--- a/dipy/tracking/direction_getter.pyx
+++ b/dipy/tracking/direction_getter.pyx
@@ -64,7 +64,9 @@ cdef void _step_to_boundary(
     for i in range(3):
         point[i] += smallest_step * direction[i]
 
-cdef void _fixed_step(double * point, double * direction, double step_size) noexcept nogil:
+cdef void _fixed_step(
+    double * point, double * direction, double step_size
+) noexcept nogil:
     """Updates point by stepping in direction.
 
     Parameters

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -52,7 +52,9 @@ def normalized_3vec(vec):
     """
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_in = as_float_3vec(vec)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
-    cnormalized_3vec(<float *> cnp.PyArray_DATA(vec_in), <float*> cnp.PyArray_DATA(vec_out))
+    cnormalized_3vec(
+        <float *> cnp.PyArray_DATA(vec_in), <float*> cnp.PyArray_DATA(vec_out)
+    )
     return vec_out
 
 
@@ -112,7 +114,9 @@ cdef inline void cnormalized_3vec(float *vec_in, float *vec_out):
 def inner_3vecs(vec1, vec2):
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1 = as_float_3vec(vec1)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec2 = as_float_3vec(vec2)
-    return cinner_3vecs(<float *> cnp.PyArray_DATA(fvec1), <float*> cnp.PyArray_DATA(fvec2))
+    return cinner_3vecs(
+        <float *> cnp.PyArray_DATA(fvec1), <float*> cnp.PyArray_DATA(fvec2)
+    )
 
 
 cdef inline float cinner_3vecs(float *vec1, float *vec2) noexcept nogil:
@@ -427,7 +431,9 @@ def most_similar_track_mam(tracks, metric="avg"):
     track2others = np.zeros((lent,), dtype=np.double)
     # use this buffer also for working space containing summed distances
     # of candidate track to all other tracks
-    cdef cnp.double_t *sum_track2others = <cnp.double_t *> cnp.PyArray_DATA(track2others)
+    cdef cnp.double_t *sum_track2others = (
+        <cnp.double_t *> cnp.PyArray_DATA(track2others)
+    )
     # preallocate buffer array for track distance calculations
     cdef:
         cnp.ndarray [cnp.float32_t, ndim=1] distances_buffer
@@ -468,7 +474,9 @@ def most_similar_track_mam(tracks, metric="avg"):
         t2 = tracks32[j]
         t2_len = cnp.PyArray_DIM(t2, 0)
         t2_ptr = <cnp.float32_t *> cnp.PyArray_DATA(t2)
-        track2others[j] = czhang(t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type)
+        track2others[j] = czhang(
+            t1_len, t1_ptr, t2_len, t2_ptr, min_buffer, metric_type
+        )
     return si, track2others
 
 
@@ -832,8 +840,10 @@ def minimum_closest_distance(xyz1, xyz2):
 
     Let's say we have curves A and B
 
-    for every point in A calculate the minimum distance from every point in B stored in minAB
-    for every point in B calculate the minimum distance from every point in A stored in minBA
+    for every point in A calculate the minimum distance from every
+    point in B stored in minAB
+    for every point in B calculate the minimum distance from every
+    point in A stored in minBA
     find min of minAB stored in min_minAB
     find min of minBA stored in min_minBA
 
@@ -873,7 +883,8 @@ def minimum_closest_distance(xyz1, xyz2):
 
 
 def lee_perpendicular_distance(start0, end0, start1, end1):
-    """ Calculates perpendicular distance metric for the distance between two line segments
+    """ Calculates perpendicular distance metric for the distance
+    between two line segments
 
     Based on Lee , Han & Whang SIGMOD07.
 
@@ -932,7 +943,9 @@ def lee_perpendicular_distance(start0, end0, start1, end1):
                                        <float *> cnp.PyArray_DATA(fvec4))
 
 
-cdef float clee_perpendicular_distance(float *start0, float *end0, float *start1, float *end1):
+cdef float clee_perpendicular_distance(
+    float *start0, float *end0, float *start1, float *end1
+):
     """ This function assumes that norm(end0-start0)>norm(end1-start1)
     """
 
@@ -1119,7 +1132,9 @@ def approx_polygon_track(xyz, alpha=0.392):
         fvec0 = asfp(track[mid_index-1])
         fvec1 = asfp(track[mid_index])
         fvec2 = asfp(track[mid_index+1])
-        # csub_3vecs(<float *> cnp.PyArray_DATA(fvec1),<float *> cnp.PyArray_DATA(fvec0),vec0)
+        # csub_3vecs(
+        #    <float *> cnp.PyArray_DATA(fvec1),<float *> cnp.PyArray_DATA(fvec0),vec0
+        # )
         csub_3vecs(fvec1, fvec0, vec0)
         csub_3vecs(fvec2, fvec1, vec1)
         denom = cnorm_3vec(vec0)*cnorm_3vec(vec1)
@@ -1189,14 +1204,22 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
             # print i
             fvec3 = as_float_3vec(track[i])
             fvec4 = as_float_3vec(track[i+1])
-            cost_par += dpy_log2(clee_perpendicular_distance(<float *> cnp.PyArray_DATA(fvec3),
-                                                             <float *> cnp.PyArray_DATA(fvec4),
-                                                             <float *> cnp.PyArray_DATA(fvec1),
-                                                             <float *> cnp.PyArray_DATA(fvec2)))
-            cost_par += dpy_log2(clee_angle_distance(<float *> cnp.PyArray_DATA(fvec3),
-                                                     <float *> cnp.PyArray_DATA(fvec4),
-                                                     <float *> cnp.PyArray_DATA(fvec1),
-                                                     <float *> cnp.PyArray_DATA(fvec2)))
+            cost_par += dpy_log2(
+                clee_perpendicular_distance(
+                    <float *> cnp.PyArray_DATA(fvec3),
+                    <float *> cnp.PyArray_DATA(fvec4),
+                    <float *> cnp.PyArray_DATA(fvec1),
+                    <float *> cnp.PyArray_DATA(fvec2),
+                )
+            )
+            cost_par += dpy_log2(
+                clee_angle_distance(
+                    <float *> cnp.PyArray_DATA(fvec3),
+                    <float *> cnp.PyArray_DATA(fvec4),
+                    <float *> cnp.PyArray_DATA(fvec1),
+                    <float *> cnp.PyArray_DATA(fvec2),
+                )
+            )
             csub_3vecs(<float *> cnp.PyArray_DATA(fvec4),
                        <float *> cnp.PyArray_DATA(fvec3), tmp)
             cost_nopar += dpy_log2(cinner_3vecs(tmp, tmp))
@@ -1213,7 +1236,8 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
 
 
 def intersect_segment_cylinder(sa, sb, p, q, r):
-    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r
+    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against
+    cylinder specified by p,q and r
 
     See p.197 from Real Time Collision Detection by C. Ericson
 
@@ -1256,8 +1280,11 @@ def intersect_segment_cylinder(sa, sb, p, q, r):
     return tmp, ct[0], ct[1]
 
 
-cdef float cintersect_segment_cylinder(float *sa, float *sb, float *p, float *q, float r, float *t):
-    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p, q and r
+cdef float cintersect_segment_cylinder(
+    float *sa, float *sb, float *p, float *q, float r, float *t
+):
+    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against
+    cylinder specified by p, q and r
 
     Look p.197 from Real Time Collision Detection C. Ericson
 
@@ -1368,7 +1395,9 @@ def point_segment_sq_distance(a, b, c):
 
 
 @cython.cdivision(True)
-cdef inline float cpoint_segment_sq_dist(float * a, float * b, float * c) noexcept nogil:
+cdef inline float cpoint_segment_sq_dist(
+    float * a, float * b, float * c
+) noexcept nogil:
     """ Calculate the squared distance from a point c to a line segment ab.
 
     """
@@ -1436,7 +1465,9 @@ def track_dist_3pts(tracka, trackb):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef void track_direct_flip_dist(float *a, float *b, long rows, float *out) noexcept nogil:
+cdef void track_direct_flip_dist(
+    float *a, float *b, long rows, float *out
+) noexcept nogil:
     r""" Direct and flip average distance between two tracks
 
     Parameters
@@ -1495,7 +1526,9 @@ cdef void track_direct_flip_dist(float *a, float *b, long rows, float *out) noex
 
 
 @cython.cdivision(True)
-cdef inline void track_direct_flip_3dist(float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out) noexcept nogil:
+cdef inline void track_direct_flip_3dist(
+    float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out
+) noexcept nogil:
     """ Calculate the euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
@@ -1506,7 +1539,8 @@ cdef inline void track_direct_flip_3dist(float *a1, float *b1, float *c1, float 
 
     Returns
     -------
-    out : a float[2] array having the euclidean distance and the flipped euclidean distance
+    out : float[2] array
+        Euclidean distance and the flipped Euclidean distance
 
     """
 
@@ -1679,7 +1713,9 @@ def local_skeleton_clustering(tracks, d_thr=10):
                         for j from 0<=j<3:
                             cluster[i_k].hidden[i*3+j]+=ptr[i*3+j]
                 cluster[i_k].N+=1
-                cluster[i_k].indices=<long *>realloc(cluster[i_k].indices, cluster[i_k].N*sizeof(long))
+                cluster[i_k].indices=<long *>realloc(
+                    cluster[i_k].indices, cluster[i_k].N*sizeof(long)
+                )
                 cluster[i_k].indices[cluster[i_k].N-1]=cit
 
             else:  # New cluster added
@@ -1826,7 +1862,9 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
     return C
 
 
-cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out):
+cdef inline void track_direct_flip_3sq_dist(
+    float *a1, float *b1, float *c1, float *a2, float *b2, float *c2, float *out
+):
     """ Calculate the average squared euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
@@ -2090,14 +2128,19 @@ def point_track_sq_distance_check(cnp.ndarray[float, ndim=2] track,
         return False
 
 
-def track_roi_intersection_check(cnp.ndarray[float, ndim=2] track, cnp.ndarray[float, ndim=2] roi, double sq_dist_thr):
+def track_roi_intersection_check(
+    cnp.ndarray[float, ndim=2] track,
+    cnp.ndarray[float, ndim=2] roi,
+    double sq_dist_thr,
+ ):
     """ Check if a track is intersecting a region of interest
 
     Parameters
     ----------
     track: array,float32, shape (N,3)
     roi: array,float32, shape (M,3)
-    sq_dist_thr: double, threshold, check squared euclidean distance from every roi point
+    sq_dist_thr: double
+        threshold, check squared euclidean distance from every roi point
 
     Returns
     -------

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -458,7 +458,9 @@ cdef int initialize_ptt(TrackerParameters params,
     # within the trial limit
     for _ in range(params.ptt.rejection_sampling_max_try):
         initialize_ptt_candidate(params, stream_data, pmf_gen, seed_direction, rng)
-        if (random_float(rng) * max_posterior <= calculate_ptt_data_support(params, stream_data, pmf_gen)):
+        if random_float(rng) * max_posterior <= calculate_ptt_data_support(
+            params, stream_data, pmf_gen
+        ):
             stream_data[22] = stream_data[23]  # last_val = last_val_cand
             return 0
     return 1
@@ -1066,7 +1068,9 @@ cdef TrackerStatus parallel_transport_propagator(
         # k1, k2
         stream_data[24], stream_data[25] = \
             random_point_within_circle(params.max_curvature, rng)
-        if random_float(rng) * max_posterior < calculate_ptt_data_support(params, stream_data, pmf_gen):
+        if random_float(rng) * max_posterior < calculate_ptt_data_support(
+            params, stream_data, pmf_gen
+        ):
             stream_data[22] = stream_data[23]  # last_val = last_val_cand
             # Propagation is successful if a suitable candidate can be sampled
             # within the trial limit

--- a/dipy/tracking/stopping_criterion.pxd
+++ b/dipy/tracking/stopping_criterion.pxd
@@ -13,7 +13,9 @@ cpdef enum StreamlineStatus:
 cdef class StoppingCriterion:
 
     cpdef StreamlineStatus check_point(self, double[::1] point)
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=*) noexcept nogil
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=*
+    ) noexcept nogil
 
 
 cdef class BinaryStoppingCriterion(StoppingCriterion):

--- a/dipy/tracking/stopping_criterion.pyx
+++ b/dipy/tracking/stopping_criterion.pyx
@@ -18,7 +18,9 @@ cdef class StoppingCriterion:
 
         return self.check_point_c(&point[0])
 
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=NULL
+    ) noexcept nogil:
         pass
 
 
@@ -31,7 +33,9 @@ cdef class BinaryStoppingCriterion(StoppingCriterion):
     def __cinit__(self, mask):
         self.mask = (mask > 0).astype("uint8")
 
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=NULL
+    ) noexcept nogil:
         cdef:
             unsigned char result
             int voxel[3]
@@ -59,7 +63,9 @@ cdef class ThresholdStoppingCriterion(StoppingCriterion):
         self.metric_map = np.asarray(metric_map, "float64")
         self.threshold = threshold
 
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=NULL
+    ) noexcept nogil:
         cdef:
             double result
             int err
@@ -178,7 +184,9 @@ cdef class ActStoppingCriterion(AnatomicalStoppingCriterion):
         self.include_map = np.asarray(include_map, "float64")
         self.exclude_map = np.asarray(exclude_map, "float64")
 
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=NULL
+    ) noexcept nogil:
         cdef:
             double include_result, exclude_result
             int include_err, exclude_err
@@ -236,7 +244,9 @@ cdef class CmcStoppingCriterion(AnatomicalStoppingCriterion):
         self.average_voxel_size = average_voxel_size
         self.correction_factor = step_size / average_voxel_size
 
-    cdef StreamlineStatus check_point_c(self, double* point, RNGState* rng=NULL) noexcept nogil:
+    cdef StreamlineStatus check_point_c(
+        self, double* point, RNGState* rng=NULL
+    ) noexcept nogil:
         cdef:
             double include_result, exclude_result
             int include_err, exclude_err

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -328,14 +328,20 @@ def set_number_of_points(streamlines, nb_points=3):
 
         if dtype == np.float32:
             c_set_number_of_points_from_arraysequence[float2d](
-                as_native_array(streamlines._data), streamlines._offsets.astype(np.intp),
-                streamlines._lengths.astype(np.intp), nb_points,
-                new_streamlines._data)
+                as_native_array(streamlines._data),
+                streamlines._offsets.astype(np.intp),
+                streamlines._lengths.astype(np.intp),
+                nb_points,
+                new_streamlines._data,
+            )
         else:
             c_set_number_of_points_from_arraysequence[double2d](
-                as_native_array(streamlines._data), streamlines._offsets.astype(np.intp),
-                streamlines._lengths.astype(np.intp), nb_points,
-                new_streamlines._data)
+                as_native_array(streamlines._data),
+                streamlines._offsets.astype(np.intp),
+                streamlines._lengths.astype(np.intp),
+                nb_points,
+                new_streamlines._data,
+            )
 
         return new_streamlines
 
@@ -623,7 +629,9 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
         shape = streamline.shape
 
         if dtype != np.float32 and dtype != np.float64:
-            dtype = np.float64 if dtype == np.int64 or dtype == np.uint64 else np.float32
+            dtype = (
+                np.float64 if dtype == np.int64 or dtype == np.uint64 else np.float32
+            )
             streamline = streamline.astype(dtype)
 
         if shape[0] <= 2:
@@ -633,11 +641,13 @@ def compress_streamlines(streamlines, tol_error=0.01, max_segment_length=10):
         compressed_streamline = np.empty(shape, dtype)
 
         if dtype == np.float32:
-            nb_points = c_compress_streamline[float2d](streamline, compressed_streamline,
-                                                       tol_error, max_segment_length)
+            nb_points = c_compress_streamline[float2d](
+                streamline, compressed_streamline, tol_error, max_segment_length
+            )
         else:
-            nb_points = c_compress_streamline[double2d](streamline, compressed_streamline,
-                                                        tol_error, max_segment_length)
+            nb_points = c_compress_streamline[double2d](
+                streamline, compressed_streamline, tol_error, max_segment_length
+            )
 
         # HACK: To avoid memleaks we have to recast with astype(dtype).
         compressed_streamlines.append(compressed_streamline[:nb_points].astype(dtype))

--- a/dipy/tracking/tests/test_propspeed.pyx
+++ b/dipy/tracking/tests/test_propspeed.pyx
@@ -259,8 +259,12 @@ def test_offset():
         npt.assert_equal(A.ravel()[4], A[1, 1])
         # Index and strides arrays must be C-continuous. Test this is enforced
         # by using non-contiguous versions of the input arrays.
-        npt.assert_raises(ValueError, ndarray_offset, stepped_1d(index), strides, 2, i_size)
-        npt.assert_raises(ValueError, ndarray_offset, index, stepped_1d(strides), 2, i_size)
+        npt.assert_raises(
+            ValueError, ndarray_offset, stepped_1d(index), strides, 2, i_size
+        )
+        npt.assert_raises(
+            ValueError, ndarray_offset, index, stepped_1d(strides), 2, i_size
+        )
 
 
 def test_eudx_both_directions_errors():

--- a/dipy/tracking/tracker_parameters.pyx
+++ b/dipy/tracking/tracker_parameters.pyx
@@ -129,8 +129,20 @@ cdef class TrackerParameters:
         if pmf_threshold is not None:
             self.sh = ShTrackerParameters(pmf_threshold)
 
-        if probe_length is not None and probe_radius is not None and probe_quality is not None and probe_count is not None and data_support_exponent is not None:
-            self.ptt = ParallelTransportTrackerParameters(probe_length, probe_radius, probe_quality, probe_count, data_support_exponent)
+        if (
+            probe_length is not None
+            and probe_radius is not None
+            and probe_quality is not None
+            and probe_count is not None
+            and data_support_exponent is not None
+        ):
+            self.ptt = ParallelTransportTrackerParameters(
+                probe_length,
+                probe_radius,
+                probe_quality,
+                probe_count,
+                data_support_exponent,
+            )
 
         if (
             peak_values_threshold is not None

--- a/dipy/tracking/tractogen.pyx
+++ b/dipy/tracking/tractogen.pyx
@@ -108,7 +108,10 @@ def generate_tractogram(double[:, ::1] seed_positions,
                 s = np.asarray(<cnp.float_t[:length_arr[i]*3]> streamlines_arr[i])
                 track = s.copy().reshape((-1, 3))
                 if save_seeds:
-                    yield np.dot(track, lin_T) + offset, np.dot(seed_positions[seed_start + i], lin_T) + offset
+                    yield (
+                        np.dot(track, lin_T) + offset,
+                        np.dot(seed_positions[seed_start + i], lin_T) + offset,
+                    )
                 else:
                     yield np.dot(track, lin_T) + offset
             free(streamlines_arr[i])
@@ -169,7 +172,9 @@ cdef void generate_tractogram_c(
     if nbr_threads <= 0:
         nbr_threads = 0
 
-    for i in prange(_len, nogil=True, num_threads=nbr_threads, schedule="dynamic", chunksize=64):
+    for i in prange(
+        _len, nogil=True, num_threads=nbr_threads, schedule="dynamic", chunksize=64
+    ):
         stream = <double*> malloc((params.max_nbr_pts * 3 * 2 + 1) * sizeof(double))
         stream_idx = <int*> malloc(2 * sizeof(int))
 
@@ -181,10 +186,15 @@ cdef void generate_tractogram_c(
                                               params,
                                               pmf_gen)
 
-        # copy the streamlines points from the buffer to a 1d vector of the streamline length
+        # copy the streamlines points from the buffer to a 1d vector of
+        # the streamline length
         lengths[i] = stream_idx[1] - stream_idx[0] + 1
         streamlines[i] = <double*> malloc(lengths[i] * 3 * sizeof(double))
-        memcpy(&streamlines[i][0], &stream[stream_idx[0] * 3], lengths[i] * 3 * sizeof(double))
+        memcpy(
+            &streamlines[i][0],
+            &stream[stream_idx[0] * 3],
+            lengths[i] * 3 * sizeof(double),
+        )
 
         free(stream)
         free(stream_idx)
@@ -255,7 +265,10 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
     memset(stream_data, 0, 100 * sizeof(double))
     status_forward = TRACKPOINT
     for i in range(1, params.max_nbr_pts):
-        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == TrackerStatus.FAIL:
+        if (
+            params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng)
+            == TrackerStatus.FAIL
+        ):
             break
         # update position
         for j in range(3):
@@ -291,7 +304,10 @@ cdef StreamlineStatus generate_local_streamline(double* seed,
 
     status_backward = TRACKPOINT
     for i in range(1, params.max_nbr_pts):
-        if params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng) == TrackerStatus.FAIL:
+        if (
+            params.tracker(&point[0], &voxdir[0], params, stream_data, pmf_gen, &rng)
+            == TrackerStatus.FAIL
+        ):
             break
         # update position
         for j in range(3):

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -284,7 +284,8 @@ cdef cnp.npy_intp _streamline_in_mask(
                 if direction[dim_idx] != 0:
                     length_ratio = fmin(
                         fabs(
-                            (current_edge[dim_idx] - current_pt[dim_idx]) / direction[dim_idx]
+                            (current_edge[dim_idx] - current_pt[dim_idx])
+                            / direction[dim_idx]
                         ),
                         length_ratio,
                     )
@@ -300,7 +301,11 @@ cdef cnp.npy_intp _streamline_in_mask(
             x = <cnp.npy_intp>floor(current_pt[0] + half_ratio * direction[0])
             y = <cnp.npy_intp>floor(current_pt[1] + half_ratio * direction[1])
             z = <cnp.npy_intp>floor(current_pt[2] + half_ratio * direction[2])
-            if 0 <= x < mask.shape[0] and 0 <= y < mask.shape[1] and 0 <= z < mask.shape[2]:
+            if (
+                0 <= x < mask.shape[0]
+                and 0 <= y < mask.shape[1]
+                and 0 <= z < mask.shape[2]
+            ):
                 if mask[x, y, z]:
                     return 1
 

--- a/dipy/utils/constants.pxd
+++ b/dipy/utils/constants.pxd
@@ -1,6 +1,7 @@
 cdef extern from *:
     """
-    #define __Pyx_BIGGEST_DOUBLE 1.7976931348623157e+308  /* np.finfo('f8').max */
+    /* np.finfo('f8').max */
+    #define __Pyx_BIGGEST_DOUBLE 1.7976931348623157e+308
     #define __Pyx_BIGGEST_FLOAT 3.402823e+38f  /* < FLT_MAX (3.4028235e+38); avoids double-to-float overflow */
     #define __Pyx_SMALLEST_FLOAT (-3.402823e+38f)  /* > -FLT_MAX; avoids double-to-float overflow */
     """

--- a/dipy/utils/fast_numpy.pyx
+++ b/dipy/utils/fast_numpy.pyx
@@ -174,7 +174,9 @@ cdef void random_vector(double * out, RNGState* rng=NULL) noexcept nogil:
     normalize(out)
 
 
-cdef void random_perpendicular_vector(double * out, double * v, RNGState* rng=NULL) noexcept nogil:
+cdef void random_perpendicular_vector(
+    double * out, double * v, RNGState* rng=NULL
+) noexcept nogil:
     """Generate a random perpendicular vector
 
     Parameters
@@ -196,7 +198,9 @@ cdef void random_perpendicular_vector(double * out, double * v, RNGState* rng=NU
     normalize(out)
 
 
-cdef (double, double) random_point_within_circle(double r, RNGState* rng=NULL) noexcept nogil:
+cdef (double, double) random_point_within_circle(
+    double r, RNGState* rng=NULL
+) noexcept nogil:
     """Generate a random point within a circle
 
     Parameters


### PR DESCRIPTION
## Description

Stick to pre-defined line length in Cython code.

Fixes:
```
/home/runner/work/dipy/dipy/dipy/align/transforms.pxd:5:89: E501 line
too long (89 > 88 characters)
```

and other similar errors raised in:
https://github.com/dipy/dipy/actions/runs/33913585752/job/101155499494?pr=4111

## Motivation and Context

Remove all style warnings from Cython code.

## How Has This Been Tested?

Relying on GHA CIs.

## Checklist

<!-- Please check all that apply. -->

- [X] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [X] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
