### PR TITLE
Propagating new metrics

### DIFF
--- a/dipy/align/_public.py
+++ b/dipy/align/_public.py
@@ -24,7 +24,7 @@ from dipy.align.imaffine import (
     transform_centers_of_mass,
 )
 from dipy.align.imwarp import DiffeomorphicMap, SymmetricDiffeomorphicRegistration
-from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
+from dipy.align.metrics import CCMetric, EMMetric, MIMetric, SSDMetric
 from dipy.align.streamlinear import StreamlineLinearRegistration
 from dipy.align.transforms import (
     AffineTransform3D,
@@ -63,7 +63,7 @@ __all__ = [
 ]
 
 # Global dicts for choosing metrics for registration:
-syn_metric_dict = {"CC": CCMetric, "EM": EMMetric, "SSD": SSDMetric}
+syn_metric_dict = {"CC": CCMetric, "EM": EMMetric, "MI": MIMetric, "SSD": SSDMetric}
 
 affine_metric_dict = {
     "CC": CrossCorrelationMetric,
@@ -125,7 +125,7 @@ def syn_registration(
         that is stored in the `data` input. Default: use the affine stored
         in `data`.
     metric : string, optional
-        The metric to be optimized. One of `CC`, `EM`, `SSD`,
+        The metric to be optimized. One of `CC`, `EM`, `MI`, `SSD`
         Default: 'CC' => CCMetric.
     dim: int (either 2 or 3), optional
        The dimensions of the image domain. Default: 3
@@ -706,6 +706,8 @@ def register_series(
     static_mask=None,
     level_iters=None,
     optimizer_options=None,
+    metric="MI",
+    **metric_kwargs,
 ):
     """Register a series to a reference image.
 
@@ -741,6 +743,13 @@ def register_series(
     optimizer_options : dict, optional
         Options to be passed to the optimizer. See `scipy.optimize.minimize`
         documentation for details.
+
+    metric : string, optional
+        The metric to be optimized. One of `CC`, `MI`.
+
+    metric_kwargs : dict, optional
+        Metric initialization arguments forwarded to ``affine_registration``:
+        ``nbins`` and ``sampling_proportion`` for MI, or ``radius`` for CC.
 
     Returns
     -------
@@ -786,6 +795,8 @@ def register_series(
                 static_mask=static_mask,
                 level_iters=level_iters,
                 optimizer_options=optimizer_options,
+                metric=metric,
+                **metric_kwargs,
             )
             xformed[..., ii] = transformed
             affines[..., ii] = reg_affine
@@ -804,6 +815,8 @@ def register_dwi_series(
     static_mask=None,
     level_iters=None,
     optimizer_options=None,
+    metric="MI",
+    **metric_kwargs,
 ):
     """Register a DWI series to the mean of the B0 images in that series.
 
@@ -834,7 +847,8 @@ def register_dwi_series(
 
     static_mask : array, shape (S, R, C) or (R, C), optional
         static image mask that defines which pixels in the static image
-        are used to calculate the mutual information.
+        are used to calculate the mutual information. Not supported when
+        ``metric="CC"``.
 
     level_iters : list of int, optional
         The number of iterations at each level of the Gaussian pyramid.
@@ -844,6 +858,14 @@ def register_dwi_series(
     optimizer_options : dict, optional
         Options to be passed to the optimizer. See `scipy.optimize.minimize`
         documentation for details.
+
+    metric : string, optional
+        The metric to be optimized. One of `CC`, `MI`.
+        CC does not support ``static_mask``.
+
+    metric_kwargs : dict, optional
+        Metric initialization arguments forwarded to ``affine_registration``:
+        ``nbins`` and ``sampling_proportion`` for MI, or ``radius`` for CC.
 
     Returns
     -------
@@ -880,6 +902,8 @@ def register_dwi_series(
             static_mask=static_mask,
             level_iters=level_iters,
             optimizer_options=optimizer_options,
+            metric=metric,
+            **metric_kwargs,
         )
         ref_data = np.mean(trans_b0, -1, keepdims=True)
     else:
@@ -899,6 +923,8 @@ def register_dwi_series(
         static_mask=static_mask,
         level_iters=level_iters,
         optimizer_options=optimizer_options,
+        metric=metric,
+        **metric_kwargs,
     )
     # Cut out the part pertaining to that first volume:
     affines = affines[..., 1:]

--- a/dipy/align/tests/test_api.py
+++ b/dipy/align/tests/test_api.py
@@ -291,17 +291,25 @@ def test_single_transforms():
         npt.assert_almost_equal(affine_mat[:3, :3], np.eye(3), decimal=1)
 
 
-def test_register_series():
+@pytest.mark.parametrize("metric, metric_kwargs", [("MI", {}), ("CC", {"radius": 1})])
+def test_register_series(metric, metric_kwargs):
     fdata, fbval, fbvec = dpd.get_fnames(name="small_64D")
     img = nib.load(fdata)
     gtab = dpg.gradient_table(fbval, bvecs=fbvec)
     ref_idx = np.where(gtab.b0s_mask)[0][0]
-    xformed, affines = register_series(img, ref_idx)
+    xformed, affines = register_series(
+        img,
+        ref_idx,
+        level_iters=[500, 100],
+        metric=metric,
+        **metric_kwargs,
+    )
     npt.assert_(np.all(affines[..., ref_idx] == np.eye(4)))
     npt.assert_(np.all(xformed[..., ref_idx] == img.get_fdata()[..., ref_idx]))
 
 
-def test_register_dwi_series_and_motion_correction(tmp_path):
+@pytest.mark.parametrize("metric, metric_kwargs", [("MI", {}), ("CC", {"radius": 1})])
+def test_register_dwi_series_and_motion_correction(tmp_path, metric, metric_kwargs):
     fdata, fbval, fbvec = dpd.get_fnames(name="small_64D")
 
     # Use an abbreviated data-set:
@@ -314,8 +322,22 @@ def test_register_dwi_series_and_motion_correction(tmp_path):
     np.savetxt(tmp_path / "bvals.txt", bvals[:10])
     np.savetxt(tmp_path / "bvecs.txt", bvecs[:10])
     gtab = dpg.gradient_table(tmp_path / "bvals.txt", bvecs=tmp_path / "bvecs.txt")
-    reg_img, reg_affines = register_dwi_series(data, gtab, affine=img.affine)
-    reg_img_2, reg_affines_2 = motion_correction(data, gtab, affine=img.affine)
+    reg_img, reg_affines = register_dwi_series(
+        data,
+        gtab,
+        affine=img.affine,
+        level_iters=[500, 100],
+        metric=metric,
+        **metric_kwargs,
+    )
+    reg_img_2, reg_affines_2 = motion_correction(
+        data,
+        gtab,
+        affine=img.affine,
+        level_iters=[500, 100],
+        metric=metric,
+        **metric_kwargs,
+    )
     npt.assert_(isinstance(reg_img, nib.Nifti1Image))
 
     npt.assert_array_equal(reg_img.get_fdata(), reg_img_2.get_fdata())

--- a/dipy/workflows/align.py
+++ b/dipy/workflows/align.py
@@ -7,7 +7,7 @@ import numpy as np
 from dipy.align import affine_registration, motion_correction
 from dipy.align.imaffine import AffineMap
 from dipy.align.imwarp import DiffeomorphicMap, SymmetricDiffeomorphicRegistration
-from dipy.align.metrics import CCMetric, EMMetric, SSDMetric
+from dipy.align.metrics import CCMetric, EMMetric, MIMetric, SSDMetric
 from dipy.align.reslice import reslice
 from dipy.align.streamlinear import slr_with_qbx
 from dipy.align.streamwarp import bundlewarp
@@ -452,9 +452,10 @@ class ImageRegistrationFlow(Workflow):
         nbins : int, optional
             Number of bins to discretize the joint and marginal PDF
             for the mutual information metric.
-        sampling_prop : int, optional
-            Number ([0-100]) of voxels for calculating the PDF for the
-            mutual information metric. None implies all voxels.
+        sampling_prop : float, optional
+            Proportion of voxels used to calculate the PDF for the mutual
+            information metric. Must be in the interval (0, 1]. None uses all
+            voxels.
         metric : string, optional
             Similarity metric. Supported values are ``'mi'`` for mutual
             information and ``'cc'`` for local cross-correlation.
@@ -753,6 +754,7 @@ class SynRegistrationFlow(Workflow):
         mopt_q_levels=256,
         mopt_double_gradient=True,
         mopt_step_type="",
+        mopt_nbins=32,
         step_length=0.25,
         ss_sigma_factor=0.2,
         opt_tol=1e-5,
@@ -779,7 +781,7 @@ class SynRegistrationFlow(Workflow):
         metric : string, optional
             The metric to be used.
             metric available: cc (Cross Correlation), ssd (Sum Squared
-            Difference), em (Expectation-Maximization).
+            Difference), em (Expectation-Maximization), mi (Mutual Information).
         mopt_sigma_diff : float, optional
             Metric option applied on Cross correlation (CC).
             The standard deviation of the Gaussian smoothing kernel to be
@@ -789,10 +791,11 @@ class SynRegistrationFlow(Workflow):
             the radius of the squared (cubic) neighborhood at each voxel to
             be considered to compute the cross correlation.
         mopt_smooth : float, optional
-            Metric option applied on Sum Squared Difference (SSD) and
-            Expectation Maximization (EM). Smoothness parameter, the
-            larger the value the smoother the deformation field.
-            (default 1.0 for EM, 4.0 for SSD)
+            Smoothness parameter for Sum Squared Difference (SSD),
+            Expectation Maximization (EM), and Mutual Information (MI).
+            Controls deformation-field smoothness for SSD and EM, and the
+            Gaussian standard deviation for update-field smoothing for MI.
+            Larger values produce smoother fields.
         mopt_inner_iter : int, optional
             Metric option applied on Sum Squared Difference (SSD) and
             Expectation Maximization (EM). This is number of iterations to be
@@ -816,6 +819,8 @@ class SynRegistrationFlow(Workflow):
             (not used if Demons Step is selected). Possible value:
             ('gauss_newton', 'demons'). default: 'gauss_newton' for EM,
             'demons' for SSD.
+        mopt_nbins : int, optional
+            Number of histogram bins for Mutual Information (MI).
         step_length : float, optional
             the length of the maximum displacement vector of the update
             displacement field at each iteration.
@@ -845,10 +850,10 @@ class SynRegistrationFlow(Workflow):
         """
         io_it = self.get_io_iterator()
         metric = metric.lower()
-        if metric not in ["ssd", "cc", "em"]:
+        if metric not in ["ssd", "cc", "em", "mi"]:
             raise ValueError(
                 "Invalid similarity metric: Please"
-                " provide a valid metric like 'ssd', 'cc', 'em'"
+                " provide a valid metric like 'ssd', 'cc', 'em', 'mi'"
             )
 
         logger.info("Starting Diffeomorphic Registration")
@@ -866,6 +871,7 @@ class SynRegistrationFlow(Workflow):
                 "mopt_inner_iter": 5,
                 "mopt_step_type": "gauss_newton",
             },
+            "mi": {"mopt_smooth": 0.0},
         }
 
         mopt_smooth = (
@@ -875,15 +881,15 @@ class SynRegistrationFlow(Workflow):
         )
         mopt_inner_iter = (
             mopt_inner_iter
-            if mopt_inner_iter or metric == "cc"
+            if mopt_inner_iter or metric in ["cc", "mi"]
             else init_param[metric]["mopt_inner_iter"]
         )
 
-        # If using the 'cc' metric, force the `mopt_step_type` parameter to an
-        # empty value since the 'cc' metric does not use it; for the rest of
-        # the metrics, the `step_type` parameter will be initialized to their
-        # corresponding default values in `init_param`.
-        if metric == "cc":
+        # If using the 'cc' or 'mi' metric, force the `mopt_step_type`
+        # parameter to an empty value since neither metric uses it; for the
+        # rest of the metrics, `step_type` will be initialized to its
+        # corresponding default value in `init_param`.
+        if metric in ["cc", "mi"]:
             mopt_step_type = ""
 
         for (
@@ -931,6 +937,7 @@ class SynRegistrationFlow(Workflow):
                     q_levels=mopt_q_levels,
                     double_gradient=mopt_double_gradient,
                 ),
+                "mi": MIMetric(static_image.ndim, nbins=mopt_nbins, smooth=mopt_smooth),
             }
 
             current_metric = l_metric.get(metric.lower())
@@ -983,6 +990,10 @@ class MotionCorrectionFlow(Workflow):
         b0_threshold=50,
         bvecs_tol=0.01,
         level_iters=(1000, 500, 100),
+        metric="mi",
+        nbins=32,
+        sampling_prop=None,
+        radius=4,
         out_dir="",
         out_moved="moved.nii.gz",
         out_affine="affine.txt",
@@ -1006,6 +1017,18 @@ class MotionCorrectionFlow(Workflow):
             b-vectors are unit vectors
         level_iters : variable int, optional
             The number of iterations at each level of the Gaussian pyramid.
+        metric : string, optional
+            Similarity metric. Supported values are ``'mi'`` for mutual
+            information and ``'cc'`` for local cross-correlation.
+        nbins : int, optional
+            Number of bins to discretize the joint and marginal PDF
+            for the mutual information metric.
+        sampling_prop : float, optional
+            Proportion of voxels used to calculate the PDF for the mutual
+            information metric. Must be in the interval (0, 1]. None uses all
+            voxels.
+        radius : int, optional
+            Neighborhood radius for local cross-correlation.
         out_dir : string or Path, optional
             Directory to save the transformed image and the affine matrix.
         out_moved : string, optional
@@ -1021,6 +1044,14 @@ class MotionCorrectionFlow(Workflow):
                 "setting level_iters=[10000, 1000, 100]."
             )
 
+        metric = metric.upper()
+        if metric not in {"MI", "CC"}:
+            raise ValueError(f"Unsupported affine metric {metric!r}. Use MI or CC.")
+        metric_kwargs = (
+            {"nbins": nbins, "sampling_proportion": sampling_prop}
+            if metric == "MI"
+            else {"radius": radius}
+        )
         io_it = self.get_io_iterator()
 
         for dwi, bval, bvec, omoved, oafffine in io_it:
@@ -1044,7 +1075,12 @@ class MotionCorrectionFlow(Workflow):
             )
 
             reg_img, reg_affines = motion_correction(
-                data=data, gtab=gtab, affine=affine, level_iters=level_iters
+                data=data,
+                gtab=gtab,
+                affine=affine,
+                level_iters=level_iters,
+                metric=metric,
+                **metric_kwargs,
             )
 
             # Saving the corrected image file

--- a/dipy/workflows/tests/test_align.py
+++ b/dipy/workflows/tests/test_align.py
@@ -789,7 +789,8 @@ def test_apply_affine_transform(tmp_path):
     assert Path(tmp_path / "transformed_nearest.nii.gz").exists()
 
 
-def test_motion_correction(tmp_path):
+@pytest.mark.parametrize("metric, metric_kwargs", [("mi", {}), ("cc", {"radius": 1})])
+def test_motion_correction(tmp_path, metric, metric_kwargs):
     data_path, fbvals_path, fbvecs_path = get_fnames(name="small_64D")
 
     # Use an abbreviated data-set:
@@ -809,7 +810,10 @@ def test_motion_correction(tmp_path):
         str(tmp_path / "data.nii.gz"),
         str(tmp_path / "bvals.txt"),
         str(tmp_path / "bvecs.txt"),
+        level_iters=[500, 100],
+        metric=metric,
         out_dir=tmp_path,
+        **metric_kwargs,
     )
     out_path = motion_correction_flow.last_generated_outputs["out_moved"]
     corrected = load_nifti_data(out_path)
@@ -843,6 +847,29 @@ def test_syn_registration_flow(tmp_path):
         "metric": "cc",
         "mopt_sigma_diff": 2.0,
         "mopt_radius": 4,
+    }
+    optimizer_optional_args = {
+        "level_iters": [10, 10, 5],
+        "step_length": 0.25,
+        "opt_tol": 1e-5,
+        "inv_iter": 20,
+        "inv_tol": 1e-3,
+        "ss_sigma_factor": 0.2,
+    }
+
+    all_args = dict(metric_optional_args, **optimizer_optional_args)
+    syn_flow.run(*positional_args, out_dir=tmp_path, **all_args)
+
+    warped_path = syn_flow.last_generated_outputs["out_warped"]
+    npt.assert_equal(Path(warped_path).is_file(), True)
+    warped_map_path = syn_flow.last_generated_outputs["out_field"]
+    npt.assert_equal(Path(warped_map_path).is_file(), True)
+
+    # Test the mi metric
+    metric_optional_args = {
+        "metric": "mi",
+        "mopt_nbins": 16,
+        "mopt_smooth": 0.0,
     }
     optimizer_optional_args = {
         "level_iters": [10, 10, 5],

--- a/doc/interfaces/motion_flow.rst
+++ b/doc/interfaces/motion_flow.rst
@@ -47,6 +47,11 @@ and write the artefact-free result to the ``motion_output`` directory.
 In case no output directory is specified, the corrected output volume
 is saved to the current directory by default.
 
+Motion correction supports mutual information (MI), the default metric, and
+local cross-correlation (CC). MI is configured with ``nbins`` and
+``sampling_proportion``, while CC is configured with ``radius``. CC does not
+support static masks.
+
 ----------
 References
 ----------

--- a/doc/interfaces/motion_flow.rst
+++ b/doc/interfaces/motion_flow.rst
@@ -49,8 +49,12 @@ is saved to the current directory by default.
 
 Motion correction supports mutual information (MI), the default metric, and
 local cross-correlation (CC). MI is configured with ``nbins`` and
-``sampling_proportion``, while CC is configured with ``radius``. CC does not
-support static masks.
+``sampling_prop``, while CC is configured with ``radius``.
+
+For example, the metrics can be selected and configured as follows::
+
+    dipy_correct_motion <path_to_dwi> <path_to_bval> <path_to_bvec> --metric "cc" --radius 4
+    dipy_correct_motion <path_to_dwi> <path_to_bval> <path_to_bvec> --metric "mi" --nbins 32
 
 ----------
 References

--- a/doc/interfaces/registration_flow.rst
+++ b/doc/interfaces/registration_flow.rst
@@ -91,9 +91,11 @@ the output directory (``out_dir``) and the file name of the output warped image
 differences), em (expectation-maximization), or mi (mutual information) as metrics.
 
 The symmetric diffeomorphic registration method in DIPY is run through the
-``dipy_align_syn`` command, e.g.::
+``dipy_align_syn`` command. The following examples show how to select
+cross-correlation or mutual information and configure their metric parameters::
 
-    dipy_align_syn <path_to_static_file> <path_to_moving_file> --metric "cc" --out_dir "syn_reg_output" --out_warped "syn_reg_warped.nii.gz"
+    dipy_align_syn <path_to_static_file> <path_to_moving_file> --metric "cc" --mopt_sigma_diff 2.0 --mopt_radius 4 --out_dir "syn_reg_output" --out_warped "syn_reg_warped.nii.gz"
+    dipy_align_syn <path_to_static_file> <path_to_moving_file> --metric "mi" --mopt_nbins 32 --mopt_smooth 0.5 --out_dir "syn_reg_output" --out_warped "syn_reg_warped.nii.gz"
 
 In case you did not specify the output directory, the transformed files would
 be saved in the current directory by default. If you did not specify the file

--- a/doc/interfaces/registration_flow.rst
+++ b/doc/interfaces/registration_flow.rst
@@ -88,7 +88,7 @@ paths to the static image file, and to the moving image file, followed by
 optional arguments. In this case, we will be specifying the metric (``metric``),
 the output directory (``out_dir``) and the file name of the output warped image
 (``out_warped``). You can use cc (cross correlation), ssd (sum squared
-differences) or em (expectation-maximization) as metrics.
+differences), em (expectation-maximization), or mi (mutual information) as metrics.
 
 The symmetric diffeomorphic registration method in DIPY is run through the
 ``dipy_align_syn`` command, e.g.::


### PR DESCRIPTION
## Description

Following #4078 and #4067, this PR exposes MI for SyN and CC for affine registration across the remaining public APIs and workflows. It also updates the related documentation.

## Motivation and Context

The new metrics were available in the underlying registration frameworks but were not consistently exposed through higher-level functions and command-line workflows. This PR completes that integration while preserving existing defaults.

I believe the new metrics are now exposed across all relevant APIs, workflows, and documentation, though there may still be integration points I have overlooked.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Maintenance / CI / Infrastructure
