### PR TITLE
STYLE: Fix E265 block comment in Cython files

### DIFF
--- a/dipy/align/vector_fields.pxd
+++ b/dipy/align/vector_fields.pxd
@@ -1,7 +1,7 @@
 #!python
-#cython: boundscheck=False
-#cython: wraparound=False
-#cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
 
 cdef inline double _apply_affine_3d_x0(double x0, double x1, double x2,
                                        double h, double[:, :] aff) nogil:


### PR DESCRIPTION
## Description

Add the missing space after `#` in the compiler directive comments of `vector_fields.pxd`, flagged as `E265 block comment should start with '# '` by `cython-lint`. The spaced form is what the rest of the Cython sources already use and is equally honored by the Cython compiler.

## Motivation and Context

#4111

## How Has This Been Tested?

cython lint

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
