### PR TITLE
STYLE: Fix remaining E501 line-too-long in Cython files

### DIFF
--- a/dipy/reconst/_force_search.pyx
+++ b/dipy/reconst/_force_search.pyx
@@ -255,7 +255,8 @@ def search_inner_product(
 
     if queries.shape[1] != database.shape[1]:
         raise ValueError(
-            f"Dimension mismatch: queries {queries.shape[1]} != database {database.shape[1]}"
+            f"Dimension mismatch: queries {queries.shape[1]} != "
+            f"database {database.shape[1]}"
         )
 
     if k <= 0:

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -631,14 +631,16 @@ cdef class QuickBundles:
         if not same_shape(features_shape, self.features_shape):
             with gil:
                 raise ValueError(
-                    "All features do not have the same shape! QuickBundles requires this to compute centroids!"
+                    "All features do not have the same shape! QuickBundles "
+                    "requires this to compute centroids!"
                 )
 
         # Check if datum is compatible with the metric
         if not self.metric.c_are_compatible(features_shape, self.features_shape):
             with gil:
                 raise ValueError(
-                    "Data features' shapes must be compatible according to the metric used!"
+                    "Data features' shapes must be compatible according to "
+                    "the metric used!"
                 )
 
         # Find nearest cluster to datum

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -85,7 +85,8 @@ cdef class Metric:
             whether or not shapes are compatible
         """
         raise NotImplementedError(
-            "Metric's subclasses must implement method `are_compatible(self, shape1, shape2)`!"
+            "Metric's subclasses must implement method "
+            "`are_compatible(self, shape1, shape2)`!"
         )
 
     cpdef double dist(Metric self, features1, features2) except -1:
@@ -104,7 +105,8 @@ cdef class Metric:
             Distance between two data points.
         """
         raise NotImplementedError(
-            "Metric's subclasses must implement method `dist(self, features1, features2)`!"
+            "Metric's subclasses must implement method "
+            "`dist(self, features1, features2)`!"
         )
 
 

--- a/dipy/utils/constants.pxd
+++ b/dipy/utils/constants.pxd
@@ -2,8 +2,10 @@ cdef extern from *:
     """
     /* np.finfo('f8').max */
     #define __Pyx_BIGGEST_DOUBLE 1.7976931348623157e+308
-    #define __Pyx_BIGGEST_FLOAT 3.402823e+38f  /* < FLT_MAX (3.4028235e+38); avoids double-to-float overflow */
-    #define __Pyx_SMALLEST_FLOAT (-3.402823e+38f)  /* > -FLT_MAX; avoids double-to-float overflow */
+    /* < FLT_MAX (3.4028235e+38); avoids double-to-float overflow */
+    #define __Pyx_BIGGEST_FLOAT 3.402823e+38f
+    /* > -FLT_MAX; avoids double-to-float overflow */
+    #define __Pyx_SMALLEST_FLOAT (-3.402823e+38f)
     """
     const double BIGGEST_DOUBLE "__Pyx_BIGGEST_DOUBLE"
     const float BIGGEST_FLOAT "__Pyx_BIGGEST_FLOAT"

--- a/src/ctime.pxd
+++ b/src/ctime.pxd
@@ -64,12 +64,14 @@ cdef extern from *:
     ctypedef int64_t PyTime_t "__Pyx_PyTime_t"
 
     ctypedef PyTime_t _PyTime_t "__Pyx_PyTime_t"  # legacy, use "PyTime_t" instead
-    PyTime_t PyTime_TimeUnchecked "__Pyx_PyTime_TimeRaw" () noexcept nogil  # legacy, use "PyTime_TimeRaw" instead
+    # legacy, use "PyTime_TimeRaw" instead
+    PyTime_t PyTime_TimeUnchecked "__Pyx_PyTime_TimeRaw" () noexcept nogil
 
     PyTime_t PyTime_TimeRaw "__Pyx_PyTime_TimeRaw" () noexcept nogil
     PyTime_t PyTime_MonotonicRaw "__Pyx_PyTime_MonotonicRaw" () noexcept nogil
     PyTime_t PyTime_PerfCounterRaw "__Pyx_PyTime_PerfCounterRaw" () noexcept nogil
-    double PyTime_AsSecondsDouble "__Pyx_PyTime_AsSecondsDouble" (PyTime_t t) noexcept nogil
+    double PyTime_AsSecondsDouble "__Pyx_PyTime_AsSecondsDouble" (
+        PyTime_t t) noexcept nogil
 
 
 from libc.time cimport (
@@ -124,7 +126,8 @@ cdef inline tm localtime() except * nogil:
     if result is NULL:
         _raise_from_errno()
     # Fix 0-based date values (and the 1900-based year).
-    # See tmtotuple() in https://github.com/python/cpython/blob/master/Modules/timemodule.c
+    # See tmtotuple() in
+    # https://github.com/python/cpython/blob/master/Modules/timemodule.c
     result.tm_year += 1900
     result.tm_mon += 1
     result.tm_wday = <int> ((result.tm_wday + 6) % 7)


### PR DESCRIPTION
## Description

Wrap the lines flagged as `E501 line too long` by `cython-lint` that were not covered by the previous pass: long exception messages in `clusteringspeed.pyx`, `metricspeed.pyx` and `_force_search.pyx`, and trailing comments in `constants.pxd` and `ctime.pxd`, which are moved above the declaration they document.

## Motivation and Context

#4111 

## How Has This Been Tested?

via cython lint

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
