### PR TITLE
STYLE: Silence false positive unused variable in Cython tests

### DIFF
--- a/dipy/tracking/tests/test_propspeed.pyx
+++ b/dipy/tracking/tests/test_propspeed.pyx
@@ -33,7 +33,7 @@ def test_tracker_deterministic():
     seed_rng(&rng, 12345)
 
     class SillyModel(SphHarmModel):
-        sh_order_max = 4
+        sh_order_max = 4  # no-cython-lint: read by SphHarmModel.sampling_matrix
 
         def fit(self, data, mask=None):
             coeff = np.zeros(data.shape[:-1] + (15,))
@@ -105,7 +105,7 @@ def test_tracker_probabilistic():
     seed_rng(&rng, 12345)
 
     class SillyModel(SphHarmModel):
-        sh_order_max = 4
+        sh_order_max = 4  # no-cython-lint: read by SphHarmModel.sampling_matrix
 
         def fit(self, data, mask=None):
             coeff = np.zeros(data.shape[:-1] + (15,))
@@ -177,7 +177,7 @@ def test_tracker_ptt():
     seed_rng(&rng, 12345)
 
     class SillyModel(SphHarmModel):
-        sh_order_max = 4
+        sh_order_max = 4  # no-cython-lint: read by SphHarmModel.sampling_matrix
 
         def fit(self, data, mask=None):
             coeff = np.zeros(data.shape[:-1] + (15,))


### PR DESCRIPTION
## Description

`cython-lint` reports the `sh_order_max` class attribute of the local `SillyModel` test doubles in `test_propspeed.pyx` as defined but unused: it is read through the `SphHarmModel` base class (`sampling_matrix`), and so cannot be seen from the file itself. Mark the three declarations with `no-cython-lint` rather than renaming them, which would break the tests.

## Motivation and Context

#4111 

## How Has This Been Tested?

via cython lint

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [ ] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Maintenance / CI / Infrastructure
