### PR TITLE
Propagate num_threads from progressive_slr() to all internal StreamlineLinearRegistration instances

### DIFF
--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -948,7 +948,11 @@ def progressive_slr(
         if verbose:
             logger.info(" Translation  (3 parameters)...")
         slr_t = StreamlineLinearRegistration(
-            metric=metric, x0="translation", bounds=bounds[:3], method=method, num_threads=num_threads
+            metric=metric,
+            x0="translation",
+            bounds=bounds[:3],
+            method=method,
+            num_threads=num_threads,
         )
 
         slm_t = slr_t.optimize(static, moving)
@@ -960,7 +964,11 @@ def progressive_slr(
         if verbose:
             logger.info(" Rigid  (6 parameters) ...")
         slr_r = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:6], method=method, num_threads=num_threads
+            metric=metric,
+            x0=x,
+            bounds=bounds[:6],
+            method=method,
+            num_threads=num_threads,
         )
         slm_r = slr_r.optimize(static, moving)
 
@@ -972,7 +980,11 @@ def progressive_slr(
         if verbose:
             logger.info(" Similarity (7 parameters) ...")
         slr_s = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:7], method=method, num_threads=num_threads
+            metric=metric,
+            x0=x,
+            bounds=bounds[:7],
+            method=method,
+            num_threads=num_threads,
         )
         slm_s = slr_s.optimize(static, moving)
 
@@ -985,7 +997,11 @@ def progressive_slr(
             logger.info(" Scaling (9 parameters) ...")
 
         slr_c = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:9], method=method, num_threads=num_threads
+            metric=metric,
+            x0=x,
+            bounds=bounds[:9],
+            method=method,
+            num_threads=num_threads,
         )
         slm_c = slr_c.optimize(static, moving)
 
@@ -998,7 +1014,11 @@ def progressive_slr(
             logger.info(" Affine (12 parameters) ...")
 
         slr_a = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:12], method=method, num_threads=num_threads
+            metric=metric,
+            x0=x,
+            bounds=bounds[:12],
+            method=method,
+            num_threads=num_threads,
         )
         slm_a = slr_a.optimize(static, moving)
 

--- a/dipy/align/streamlinear.py
+++ b/dipy/align/streamlinear.py
@@ -948,7 +948,7 @@ def progressive_slr(
         if verbose:
             logger.info(" Translation  (3 parameters)...")
         slr_t = StreamlineLinearRegistration(
-            metric=metric, x0="translation", bounds=bounds[:3], method=method
+            metric=metric, x0="translation", bounds=bounds[:3], method=method, num_threads=num_threads
         )
 
         slm_t = slr_t.optimize(static, moving)
@@ -960,7 +960,7 @@ def progressive_slr(
         if verbose:
             logger.info(" Rigid  (6 parameters) ...")
         slr_r = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:6], method=method
+            metric=metric, x0=x, bounds=bounds[:6], method=method, num_threads=num_threads
         )
         slm_r = slr_r.optimize(static, moving)
 
@@ -972,7 +972,7 @@ def progressive_slr(
         if verbose:
             logger.info(" Similarity (7 parameters) ...")
         slr_s = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:7], method=method
+            metric=metric, x0=x, bounds=bounds[:7], method=method, num_threads=num_threads
         )
         slm_s = slr_s.optimize(static, moving)
 
@@ -985,7 +985,7 @@ def progressive_slr(
             logger.info(" Scaling (9 parameters) ...")
 
         slr_c = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:9], method=method
+            metric=metric, x0=x, bounds=bounds[:9], method=method, num_threads=num_threads
         )
         slm_c = slr_c.optimize(static, moving)
 
@@ -998,7 +998,7 @@ def progressive_slr(
             logger.info(" Affine (12 parameters) ...")
 
         slr_a = StreamlineLinearRegistration(
-            metric=metric, x0=x, bounds=bounds[:12], method=method
+            metric=metric, x0=x, bounds=bounds[:12], method=method, num_threads=num_threads
         )
         slm_a = slr_a.optimize(static, moving)
 


### PR DESCRIPTION
progressive_slr() already accepts num_threads, but this value was not passed to the StreamlineLinearRegistration instances created during the progressive optimization. As a result, the underlying BundleMinDistanceMetric could fall back to OMP_NUM_THREADS or all available CPU threads.

This change ensures that the requested thread count is consistently respected during progressive SLR.

Changes
Pass num_threads to all StreamlineLinearRegistration instances created by progressive_slr().
No changes to the public API.