### PR TITLE
BF: clean up the failed download when raise_on_error is True

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -435,16 +435,15 @@ def fetch_data(
             successful_downloads += 1
         except Exception as e:
             failed_files.append((f, url, str(e)))
+            # Clean up partial download
+            if fullpath.exists():
+                try:
+                    os.remove(fullpath)
+                except OSError:
+                    pass
             if raise_on_error:
                 raise
-            else:
-                logger.warning(f"Failed to download {f}: {e}")
-                # Clean up partial download
-                if fullpath.exists():
-                    try:
-                        os.remove(fullpath)
-                    except OSError:
-                        pass
+            logger.warning(f"Failed to download {f}: {e}")
 
     if all_skip:
         _already_there_msg(folder)

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -317,6 +317,14 @@ def test_fetch_data_raise_on_error_false_cleans_partial(tmp_path, sphere_server)
     assert not (tmp_path / "p.gz").exists()
 
 
+def test_fetch_data_raise_on_error_true_cleans_partial(tmp_path, sphere_server):
+    # The default raise_on_error=True must clean up before it propagates.
+    base_url, name, _ = sphere_server
+    with pytest.raises(FetcherError):
+        fetch_data({"p.gz": (base_url + name, _BAD_MD5)}, tmp_path)
+    assert not (tmp_path / "p.gz").exists()
+
+
 def test_fetch_data_data_size_logged(
     tmp_path, sphere_server, caplog, dipy_log_propagate
 ):


### PR DESCRIPTION
fetch_data cleans up the failed download only when raise_on_error is False; the default True path re-raises and leaves the bad file on disk.
