### PR TITLE
BF: ODF slice alignment fix

### DIFF
--- a/dipy/viz/skyline/render/sh_billboard.py
+++ b/dipy/viz/skyline/render/sh_billboard.py
@@ -589,16 +589,6 @@ class BillboardSphGlyphShader(MeshShader):
             )
         }
 
-        # Per-glyph slice indices (for sliced rendering)
-        slice_buf = getattr(wobject, "slice_indices_buffer", None)
-        if slice_buf is not None:
-            coeff_bindings[1] = Binding(
-                "s_slice_indices",
-                "buffer/read_only_storage",
-                slice_buf,
-                "VERTEX",
-            )
-
         self.define_bindings(2, coeff_bindings)
         bindings[2] = coeff_bindings
 
@@ -1420,7 +1410,6 @@ def sph_glyph_billboard_sliced(
     obj._sh_mapping_mode = mapping_mode
     obj._sh_requested_lut_res = lut_res
 
-    obj.slice_indices_buffer = Buffer(voxel_coords.ravel().astype(np.int32))
     obj.material.n_coeffs = material_n_coeffs
 
     enable_octahedral_lut(

--- a/dipy/viz/skyline/render/sh_slicer.py
+++ b/dipy/viz/skyline/render/sh_slicer.py
@@ -14,7 +14,6 @@ from dipy.viz.skyline.render.renderer import (
     slice_slider_bounds,
     slice_slider_values_from_state,
     slice_state_from_slider_values,
-    voxel_values_from_slice_state,
 )
 from dipy.viz.skyline.render.sh_billboard import sph_glyph_billboard_sliced
 
@@ -491,10 +490,16 @@ class SHGlyph3D(Visualization):
 
     def set_slices(self):
         """Handle set slices for ``SHGlyph3D``."""
-        voxel_state = voxel_values_from_slice_state(self.state, affine=self.affine)
-        voxel_state = np.clip(voxel_state, 0, np.array(self.shape, dtype=float) - 1)
+        if self.affine is not None:
+            slice_state = np.asarray(self.state[:3], dtype=float)
+        else:
+            slice_state = np.clip(
+                np.asarray(self.state[:3], dtype=float),
+                0,
+                np.array(self.shape, dtype=float) - 1,
+            )
         for i, axis in enumerate(("x", "y", "z")):
-            self._slicer.set_slice(axis, float(voxel_state[i]))
+            self._slicer.set_slice(axis, float(slice_state[i]))
             self._last_state[i] = self.state[i]
 
     def update_state(self, new_state):

--- a/dipy/viz/skyline/render/tests/test_sh_billboard.py
+++ b/dipy/viz/skyline/render/tests/test_sh_billboard.py
@@ -273,3 +273,11 @@ def test_sph_glyph_billboard_sliced_single_glyph():
 
     assert actor is not None
     npt.assert_array_equal(voxel_coords.shape, (1, 3))
+
+
+def test_sph_glyph_billboard_sliced_has_no_slice_indices_buffer():
+    coeffs, centers, voxel_coords = _glyph_inputs()
+
+    actor = sph_glyph_billboard_sliced(coeffs, centers, voxel_coords)
+
+    assert not hasattr(actor, "slice_indices_buffer")

--- a/dipy/viz/skyline/render/tests/test_sh_slicer.py
+++ b/dipy/viz/skyline/render/tests/test_sh_slicer.py
@@ -128,7 +128,7 @@ def test_sh_glyph_actor_is_the_slicer_group():
     assert glyph._slicer._glyph_actor is not None
 
 
-def test_sh_glyph_set_slices_maps_world_state_to_voxel_uniforms():
+def test_sh_glyph_set_slices_passes_world_positions_with_diagonal_affine():
     affine = np.diag([2.0, 2.0, 2.0, 1.0])
     glyph = _glyph(affine=affine)
 
@@ -136,13 +136,33 @@ def test_sh_glyph_set_slices_maps_world_state_to_voxel_uniforms():
     glyph.set_slices()
 
     material = _material(glyph)
-    assert material.active_slice_x == 2.0
-    assert material.active_slice_y == 3.0
-    assert material.active_slice_z == 1.0
+    assert material.active_slice_x == 4.0
+    assert material.active_slice_y == 6.0
+    assert material.active_slice_z == 2.0
     npt.assert_allclose(glyph._last_state, (4.0, 6.0, 2.0))
 
 
-def test_sh_glyph_set_slices_clips_to_the_volume():
+def test_sh_glyph_set_slices_passes_world_positions_with_rotated_affine():
+    affine = np.array(
+        [
+            [-2.5, 0.08, 0.07, 113.64],
+            [0.07, 2.45, -0.49, -104.41],
+            [0.08, 0.49, 2.45, -31.5],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    glyph = _glyph(affine=affine)
+
+    glyph.state = np.array([50.0, -20.0, 10.0])
+    glyph.set_slices()
+
+    material = _material(glyph)
+    assert material.active_slice_x == 50.0
+    assert material.active_slice_y == -20.0
+    assert material.active_slice_z == 10.0
+
+
+def test_sh_glyph_set_slices_does_not_clip_with_affine():
     affine = np.diag([2.0, 2.0, 2.0, 1.0])
     glyph = _glyph(affine=affine)
 
@@ -150,9 +170,22 @@ def test_sh_glyph_set_slices_clips_to_the_volume():
     glyph.set_slices()
 
     material = _material(glyph)
-    assert material.active_slice_x == 0.0
-    assert material.active_slice_z == float(SHAPE[2] - 1)
+    assert material.active_slice_x == -40.0
+    assert material.active_slice_y == 6.0
+    assert material.active_slice_z == 1000.0
     npt.assert_allclose(glyph._last_state, (-40.0, 6.0, 1000.0))
+
+
+def test_sh_glyph_set_slices_clips_to_volume_without_affine():
+    glyph = SHGlyph3D("test", _coeffs(), affine=None, basis_type="descoteaux07")
+
+    glyph.state = np.array([-5.0, 2.0, 100.0])
+    glyph.set_slices()
+
+    material = _material(glyph)
+    assert material.active_slice_x == 0.0
+    assert material.active_slice_y == 2.0
+    assert material.active_slice_z == float(SHAPE[2] - 1)
 
 
 def test_sh_glyph_update_state_moves_the_slices():

--- a/dipy/viz/skyline/wgsl/sh_billboard.wgsl
+++ b/dipy/viz/skyline/wgsl/sh_billboard.wgsl
@@ -1705,7 +1705,7 @@ fn surface_difference_fast(
     var raw_radius = 0.0;
 
     if (dist < 1e-5) {
-        let fallback_dir = normalize(ray_dir);
+        let fallback_dir = normalize((u_wobject.world_transform_inv * vec4<f32>(normalize(ray_dir), 0.0)).xyz);
         if (USE_HERMITE_INTERP && MAPPING_MODE == 5) {
             raw_radius = sample_hermite_cube(glyph_id, fallback_dir);
         } else {
@@ -1755,7 +1755,8 @@ fn surface_difference(
     let offset = position - center;
     let dist = length(offset);
     if (dist < 1e-5) {
-        let raw_radius = get_radius_optimized(glyph_id, coeff_offset, normalize(ray_dir), coeff_limit);
+        let fallback_local = normalize((u_wobject.world_transform_inv * vec4<f32>(normalize(ray_dir), 0.0)).xyz);
+        let raw_radius = get_radius_optimized(glyph_id, coeff_offset, fallback_local, coeff_limit);
         return -clamp_radius(raw_radius);
     }
     let direction = offset / dist;
@@ -1794,10 +1795,11 @@ fn evaluate_surface_analytic(
         result.omega = omega;
         result.rho = rho;
 
+        let local_omega = normalize((u_wobject.world_transform_inv * vec4<f32>(omega, 0.0)).xyz);
         if (USE_HERMITE_INTERP && MAPPING_MODE == 5) {
-            result.r = sample_hermite_cube(glyph_id, omega);
+            result.r = sample_hermite_cube(glyph_id, local_omega);
         } else {
-            result.r = get_radius_optimized(glyph_id, coeff_offset, omega, coeff_limit);
+            result.r = get_radius_optimized(glyph_id, coeff_offset, local_omega, coeff_limit);
         }
         result.grad_s2 = vec3<f32>(0.0);
 
@@ -1811,10 +1813,11 @@ fn evaluate_surface_analytic(
     result.omega = omega;
     result.rho = rho;
 
+    let local_omega = normalize((u_wobject.world_transform_inv * vec4<f32>(omega, 0.0)).xyz);
     if (USE_HERMITE_INTERP && MAPPING_MODE == 5) {
-        result.r = sample_hermite_cube(glyph_id, omega);
+        result.r = sample_hermite_cube(glyph_id, local_omega);
     } else {
-        result.r = get_radius_optimized(glyph_id, coeff_offset, omega, coeff_limit);
+        result.r = get_radius_optimized(glyph_id, coeff_offset, local_omega, coeff_limit);
     }
     result.grad_s2 = vec3<f32>(0.0);
 
@@ -1838,12 +1841,14 @@ fn evaluate_implicit(
     let dist = length(offset);
     if (dist < 1e-5) {
         let fallback_dir = normalize(vec3<f32>(0.577, 0.577, 0.577));
-        let raw_radius = get_radius_optimized(glyph_id, coeff_offset, fallback_dir, coeff_limit);
+        let local_fallback = normalize((u_wobject.world_transform_inv * vec4<f32>(fallback_dir, 0.0)).xyz);
+        let raw_radius = get_radius_optimized(glyph_id, coeff_offset, local_fallback, coeff_limit);
         let radius = clamp_radius(raw_radius);
         return dist - radius;
     }
     let direction = offset / dist;
-    let raw_radius = get_radius_optimized(glyph_id, coeff_offset, direction, coeff_limit);
+    let local_dir = normalize((u_wobject.world_transform_inv * vec4<f32>(direction, 0.0)).xyz);
+    let raw_radius = get_radius_optimized(glyph_id, coeff_offset, local_dir, coeff_limit);
     let radius = clamp_radius(raw_radius);
     return dist - radius;
 }
@@ -2089,10 +2094,11 @@ fn find_surface_intersection(
 
     let position = ray_origin + ray_dir * t;
     let direction = normalize(position - center);
+    let local_dir = normalize((u_wobject.world_transform_inv * vec4<f32>(direction, 0.0)).xyz);
     result.hit = true;
     result.position = position;
     result.direction = direction;
-    result.raw_radius = get_radius_optimized(glyph_id, coeff_offset, direction, coeff_limit);
+    result.raw_radius = get_radius_optimized(glyph_id, coeff_offset, local_dir, coeff_limit);
     return result;
 }
 
@@ -2106,33 +2112,25 @@ fn vs_main(in: VertexInput) -> Varyings {
     // --- Slice-based visibility: discard glyphs not on active slice ---
     {$ if use_slicing == 'true' $}
     {
-        let active_slice = vec3<i32>(
-            i32(round(u_material.active_slice_x)),
-            i32(round(u_material.active_slice_y)),
-            i32(round(u_material.active_slice_z)),
+        let slice_pos = vec3<f32>(
+            u_material.active_slice_x,
+            u_material.active_slice_y,
+            u_material.active_slice_z,
         );
         let visibility = vec3<i32>(u_material.vis_x, u_material.vis_y, u_material.vis_z);
-        let slice_index_offset = u32(billboard_index) * 3u;
-        let voxel_index = vec3<i32>(
-            s_slice_indices[slice_index_offset],
-            s_slice_indices[slice_index_offset + 1u],
-            s_slice_indices[slice_index_offset + 2u],
-        );
+        let w_slice_center = (u_wobject.world_transform * vec4<f32>(raw_center, 1.0)).xyz;
         var is_visible = false;
 
         if (!all(visibility == vec3<i32>(-1))) {
-            if (voxel_index.x == active_slice.x && visibility.x != 0) {
-                raw_center.x = u_material.active_slice_x;
+            if (abs(w_slice_center.x - slice_pos.x) <= abs(u_wobject.world_transform[0][0]) * 0.5 && visibility.x != 0) {
                 is_visible = true;
             }
 
-            if (voxel_index.y == active_slice.y && visibility.y != 0) {
-                raw_center.y = u_material.active_slice_y;
+            if (abs(w_slice_center.y - slice_pos.y) <= abs(u_wobject.world_transform[1][1]) * 0.5 && visibility.y != 0) {
                 is_visible = true;
             }
 
-            if (voxel_index.z == active_slice.z && visibility.z != 0) {
-                raw_center.z = u_material.active_slice_z;
+            if (abs(w_slice_center.z - slice_pos.z) <= abs(u_wobject.world_transform[2][2]) * 0.5 && visibility.z != 0) {
                 is_visible = true;
             }
         } else {
@@ -2312,6 +2310,8 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
         view_dir = normalize(-ray_dir);
     }
 
+    let local_color_dir = normalize((u_wobject.world_transform_inv * vec4<f32>(direction, 0.0)).xyz);
+
     var glyph_color = vec3<f32>(1.0);
     if (COLOR_TYPE == 0) {
         if (raw_radius < 0.0) {
@@ -2320,12 +2320,12 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
             glyph_color = vec3<f32>(1.0, 0.0, 0.0);
         }
     } else {
-        glyph_color = abs(normalize(direction));
+        glyph_color = abs(normalize(local_color_dir));
     }
 
     if (DEBUG_MODE > 0) {
-        let theta = acos(clamp(direction.z, -1.0, 1.0));
-        let phi = atan2(direction.y, direction.x);
+        let theta = acos(clamp(local_color_dir.z, -1.0, 1.0));
+        let phi = atan2(local_color_dir.y, local_color_dir.x);
 
         if (DEBUG_MODE == 1) {
             let norm_radius = clamp(abs(raw_radius) / max(surface_radius, 0.01), 0.0, 2.0) * 0.5;
@@ -2348,12 +2348,12 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
                 glyph_color = vec3<f32>(1.0, 0.0, 1.0);
             }
         } else if (DEBUG_MODE == 6) {
-            let oct_uv = direction_to_octahedral(direction);
+            let oct_uv = direction_to_octahedral(local_color_dir);
             let u = (oct_uv.x + 1.0) * 0.5;
             let v = (oct_uv.y + 1.0) * 0.5;
             glyph_color = vec3<f32>(u, v, 0.5);
         } else if (DEBUG_MODE == 7) {
-            let oct_uv = direction_to_octahedral(direction);
+            let oct_uv = direction_to_octahedral(local_color_dir);
             let l1 = abs(oct_uv.x) + abs(oct_uv.y);
             if (abs(l1 - 1.0) < 0.05) {
                 glyph_color = vec3<f32>(1.0, 0.0, 0.0);
@@ -2377,7 +2377,7 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
             }
         } else if (DEBUG_MODE == 10) {
             let normal_analytic = estimate_surface_normal_analytic(
-                direction,
+                local_color_dir,
                 dist_to_center,
                 intersection.grad_s2,
                 raw_radius,


### PR DESCRIPTION
## Description

Fix ODF (SH glyph) rendering alignment for subjects whose affine matrix contains rotations. Two independent bugs caused misalignment:

1. **Shader direction transform inconsistency**: Several functions in the WGSL ray-marching shader evaluated SH coefficients using world-space directions instead of transforming them to local/voxel space via `world_transform_inv`. The bracketing/bisection functions correctly transformed directions in their main code paths, but fallback paths, Newton refinement (`evaluate_surface_analytic`), finite-difference normals (`evaluate_implicit`), the final intersection result, and directional RGB coloring all operated in world space. This caused incorrect ODF shapes, normals, and colors when the affine contained rotations.

2. **Slice plane coordinate space mismatch**: The image slicer and peaks slicer use **world-axis-aligned** plane tests (flat slices in world space regardless of affine rotation), but the ODF slicer used **voxel-index matching** (integer comparison of per-glyph voxel indices against a target index). With a rotated affine, voxel-aligned slices appear tilted in world space, causing the ODF slice to visually separate from the co-registered image and peaks slices.


### Changes

**WGSL shader** (`sh_billboard.wgsl`):
- Added `world_transform_inv` direction transforms in `surface_difference_fast` (fallback), `surface_difference` (fallback), `evaluate_surface_analytic` (both paths), `evaluate_implicit` (both paths), and `find_surface_intersection` (non-Hermite final result).
- Fragment shader now computes `local_color_dir` for directional RGB coloring and debug visualization modes.
- Replaced integer voxel-index slice visibility test with world-space distance-to-plane test using tolerance `abs(world_transform[i][i]) * 0.5`, matching the approach used by Fury's peaks slicer.

**Python** (`sh_slicer.py`):
- `SHGlyph3D.set_slices()` now passes world-space positions directly to shader uniforms when an affine is present, instead of converting to voxel indices. Without an affine, voxel-space clipping is preserved.

**Python** (`sh_billboard.py`):
- Removed `s_slice_indices` buffer binding and creation — no longer needed since slice visibility is determined by world-space position, not voxel indices.

## Motivation and Context
When loading diffusion MRI data from subjects with non-trivial affine matrices (containing rotations and axis flips, not just scaling and translation), the ODF glyphs rendered by Skyline did not align with the co-registered image slices and peak overlays. The ODFs appeared on tilted slice planes and their shapes/colors were distorted. This is because the affine's rotation component was not consistently handled in two parts of the rendering pipeline: the GPU shader's SH evaluation and the CPU-side slice plane selection logic.

The user's affine that exposed the issue:
```
[[ -2.5    0.08   0.07  113.64]
 [  0.07   2.45  -0.49 -104.41]
 [  0.08   0.49   2.45  -31.5 ]
 [  0.     0.     0.     1.   ]]
```

## How Has This Been Tested?

- Updated existing unit tests that verified voxel-coordinate mapping to instead verify world-coordinate pass-through behavior.
- Added new tests:
  - `test_sh_glyph_set_slices_passes_world_positions_with_rotated_affine` — uses the real rotated affine from the reported case, confirms world positions reach the shader uniforms unchanged.
  - `test_sh_glyph_set_slices_does_not_clip_with_affine` — verifies out-of-range world positions are not clipped when an affine is present (the shader's tolerance-based plane test handles bounds).
  - `test_sh_glyph_set_slices_clips_to_volume_without_affine` — verifies backward compatibility: voxel-space clipping is preserved when no affine is set.
  - `test_sph_glyph_billboard_sliced_has_no_slice_indices_buffer` — confirms the removed buffer is no longer created.
- Visual verification needed with a subject whose affine contains rotations, checking that ODF slices are flat and aligned with image/peaks slices.

## Checklist

<!-- Please check all that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/dipy/dipy/blob/master/.github/CONTRIBUTING.md) guidelines.
- [x] My code follows the [DIPY coding style](https://docs.dipy.org/stable/devel/coding_style_guideline.html).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation accordingly (if applicable).

## Type of Change

<!-- Check the relevant option(s). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Maintenance / CI / Infrastructure
