### PR TITLE
ENH: add num_threads to RecoBundles.refine

### DIFF
--- a/dipy/segment/bundles.py
+++ b/dipy/segment/bundles.py
@@ -492,6 +492,7 @@ class RecoBundles:
         slr_method="L-BFGS-B",
         pruning_thr=6,
         pruning_distance="mdf",
+        num_threads=None,
     ):
         """Refine and recognize the model_bundle in self.streamlines
         This method expects once pruned streamlines as input. It refines the
@@ -564,6 +565,12 @@ class RecoBundles:
             Pruning after reducing the search space.
         pruning_distance : string
             Pruning distance type can be mdf or mam.
+        num_threads : int, optional
+            Number of threads to be used for OpenMP parallelization. If None
+            (default) the value of OMP_NUM_THREADS environment variable is used
+            if it is set, otherwise all available threads are used. If < 0 the
+            maximal number of threads minus |num_threads + 1| is used (enter
+            -1 to use as many threads as possible). 0 raises an error.
 
         Returns
         -------
@@ -610,6 +617,7 @@ class RecoBundles:
                 select_model=slr_select[0],
                 select_target=slr_select[1],
                 method=slr_method,
+                num_threads=num_threads,
             )
         if self.verbose:
             logger.info("pruning after 2nd local Slr")

--- a/dipy/segment/tests/test_bundles.py
+++ b/dipy/segment/tests/test_bundles.py
@@ -1,4 +1,5 @@
 import warnings
+from unittest.mock import patch
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
@@ -124,6 +125,34 @@ def test_rb_slr_threads(rng=None):
     # multi-threading prevent an exact match
     for row in D:
         assert_almost_equal(row.min(), 0, decimal=4)
+
+
+def test_rb_refine_slr_threads():
+    rb = RecoBundles(f, greater_than=0, clust_thr=10)
+
+    rec_trans, _ = rb.recognize(
+        model_bundle=f2,
+        model_clust_thr=5.0,
+        reduction_thr=10,
+        slr=False,
+        num_threads=1,
+    )
+
+    with patch.object(
+        rb,
+        "_register_neighb_to_model",
+        wraps=rb._register_neighb_to_model,
+    ) as mock_register:
+        rb.refine(
+            model_bundle=f2,
+            pruned_streamlines=rec_trans,
+            model_clust_thr=5.0,
+            reduction_thr=10,
+            slr=True,
+            num_threads=2,
+        )
+
+    assert_equal(mock_register.call_args.kwargs["num_threads"], 2)
 
 
 def test_rb_no_verbose_and_mam():


### PR DESCRIPTION
## Description

Add a `num_threads` parameter to `RecoBundles.refine()` to allow users to control the number of OpenMP threads used during SLR.

`RecoBundles.recognize()` already exposes `num_threads`, but `RecoBundles.refine()` did not propagate the parameter to `_register_neighb_to_model()`. As a result, `refine()` could use all available OpenMP threads when `OMP_NUM_THREADS` was not set.

This change makes the threading behavior of `recognize()` and `refine()` consistent.

## Changes

* Add `num_threads=None` to `RecoBundles.refine()`.
* Document the parameter in the `refine()` docstring.
* Forward `num_threads` to `_register_neighb_to_model()`.
* Add a test verifying that `refine()` propagates the requested number of threads.

## Testing

* `python -m compileall dipy/segment/bundles.py`
* `python -m compileall dipy/segment/tests/`
* `git diff --check`
* Added a unit test for `num_threads` propagation in `RecoBundles.refine()`.

Full test suite will be checked by CI.
